### PR TITLE
fix: completed state tracking, background grabs, non-English filtering

### DIFF
--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1358,6 +1358,7 @@ async fn run_auto_search_targets(
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     let (_, _, detail) = resolve_series_context(&state.db, request_id)
@@ -1497,6 +1498,7 @@ pub async fn auto_search_series(
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     let (tracked_row, provider_id, detail) = resolve_series_context(&state.db, request_id)
@@ -1544,7 +1546,14 @@ pub async fn auto_search_series(
         &format!("on_disk={}, monitored={}, total={:?}", existing_eps.len(), monitored_eps.len(), detail.episodes),
     ).await;
     let series_id_for_grab = tracked.as_ref().map(|s| s.id);
-    let report = run_auto_search_targets(&state, request_id, targets, true, series_id_for_grab).await?;
+    // Spawn as an independent task so the grab completes even if the client disconnects.
+    let state_clone = state.clone();
+    let handle = tokio::spawn(async move {
+        run_auto_search_targets(&state_clone, request_id, targets, true, series_id_for_grab).await
+    });
+    let report = handle.await
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))?
+        .map_err(|e| e)?;
     Ok(Json(report))
 }
 
@@ -1570,14 +1579,21 @@ pub async fn auto_search_episode(
         &format!("Episode search: series_ref={}, episode={}", request_id, episode_number),
         "allow_batch=false",
     ).await;
-    let report = run_auto_search_targets(
-        &state,
-        request_id,
-        vec![auto_search::SearchTarget::Episode(episode_number)],
-        false,
-        series_id_for_grab,
-    )
-    .await?;
+    // Spawn as an independent task so the grab completes even if the client disconnects.
+    let state_clone = state.clone();
+    let handle = tokio::spawn(async move {
+        run_auto_search_targets(
+            &state_clone,
+            request_id,
+            vec![auto_search::SearchTarget::Episode(episode_number)],
+            false,
+            series_id_for_grab,
+        )
+        .await
+    });
+    let report = handle.await
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))?
+        .map_err(|e| e)?;
     Ok(Json(report))
 }
 
@@ -1619,6 +1635,7 @@ pub async fn search_batch_releases(
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     // Use auto_search::find_best_for_target with batch allowed; then grab if found.
@@ -1712,6 +1729,7 @@ pub async fn interactive_search_episode(
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     let results = auto_search::find_all_for_target(
@@ -1867,20 +1885,29 @@ pub async fn mark_episode_failed(
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
 
-    let _ = tracked_row.ok_or((axum::http::StatusCode::BAD_REQUEST, "Series not in library".to_string()))?;
+    let series_id = tracked_row
+        .ok_or((axum::http::StatusCode::BAD_REQUEST, "Series not in library".to_string()))?
+        .id;
 
     episode_tags::mark_grab_failed(&state.db, form.history_id)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // Re-trigger auto-search for this episode.
-    let report = run_auto_search_targets(
-        &state,
-        request_id,
-        vec![auto_search::SearchTarget::Episode(episode_number)],
-        false,
-        None,
-    ).await?;
+    // Re-trigger auto-search for this episode in the background so it completes
+    // even if the client disconnects.
+    let state_clone = state.clone();
+    let handle = tokio::spawn(async move {
+        run_auto_search_targets(
+            &state_clone,
+            request_id,
+            vec![auto_search::SearchTarget::Episode(episode_number)],
+            false,
+            Some(series_id),
+        ).await
+    });
+    let report = handle.await
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))?
+        .map_err(|e| e)?;
 
     Ok(Json(report))
 }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -86,6 +86,7 @@ fn default_config() -> config::Config {
         post_processing_mode: "hardlink".to_string(),
         auto_grab_on_add: true,
         prefer_subs: true,
+        allow_non_english: false,
     }
 }
 
@@ -182,6 +183,7 @@ pub async fn settings_submit(
         },
         auto_grab_on_add: existing_cfg.as_ref().map(|c| c.auto_grab_on_add).unwrap_or(true),
         prefer_subs: form.prefer_subs == "1",
+        allow_non_english: existing_cfg.as_ref().map(|c| c.allow_non_english).unwrap_or(false),
     };
 
     let active_tab = normalize_settings_tab(form.tab.clone());

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -18,6 +18,7 @@ struct SystemTemplate {
     force_mal_fallback: bool,
     force_kitsu_fallback: bool,
     auto_grab_on_add: bool,
+    allow_non_english: bool,
     debug_message: Option<String>,
     debug_error: Option<String>,
     logs: Vec<log::LogEntry>,
@@ -48,6 +49,7 @@ pub struct DebugSettingsForm {
     force_mal_fallback: Option<String>,
     force_kitsu_fallback: Option<String>,
     auto_grab_on_add: Option<String>,
+    allow_non_english: Option<String>,
 }
 
 fn normalize_system_tab(tab: Option<String>) -> String {
@@ -104,6 +106,7 @@ pub async fn system_page(
     let force_mal_fallback = cfg.as_ref().map(|cfg| cfg.force_mal_fallback).unwrap_or(false);
     let force_kitsu_fallback = cfg.as_ref().map(|cfg| cfg.force_kitsu_fallback).unwrap_or(false);
     let auto_grab_on_add = cfg.as_ref().map(|cfg| cfg.auto_grab_on_add).unwrap_or(true);
+    let allow_non_english = cfg.as_ref().map(|cfg| cfg.allow_non_english).unwrap_or(false);
     let rss_enabled = cfg.as_ref().map(|cfg| cfg.rss_enabled).unwrap_or(false);
     let rss_interval_minutes = cfg.as_ref().map(|cfg| cfg.rss_interval_minutes).unwrap_or(5);
     let rss_last_run = rss::latest_run(&state.db).await.unwrap_or(None);
@@ -139,6 +142,7 @@ rss::recent_decisions(&state.db, 500).await.unwrap_or_default()
         force_mal_fallback,
         force_kitsu_fallback,
         auto_grab_on_add,
+        allow_non_english,
         debug_message: params.message,
         debug_error: params.error,
         logs,
@@ -188,10 +192,12 @@ pub async fn debug_settings_submit(
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     cfg.force_mal_fallback = form.force_mal_fallback.is_some();
     cfg.force_kitsu_fallback = form.force_kitsu_fallback.is_some();
+    cfg.allow_non_english = form.allow_non_english.is_some();
     cfg.auto_grab_on_add = form.auto_grab_on_add.is_some();
 
     let result = config::save_config(&state.db, &cfg).await;
@@ -217,6 +223,7 @@ pub async fn debug_settings_submit(
         force_mal_fallback: cfg.force_mal_fallback,
         force_kitsu_fallback: cfg.force_kitsu_fallback,
         auto_grab_on_add: cfg.auto_grab_on_add,
+        allow_non_english: cfg.allow_non_english,
         debug_message: message,
         debug_error: error,
         logs: Vec::new(),

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -26,6 +26,7 @@ pub struct Config {
     pub post_processing_mode: String,
     pub auto_grab_on_add: bool,
     pub prefer_subs: bool,
+    pub allow_non_english: bool,
 }
 
 #[derive(Debug, FromRow)]
@@ -53,12 +54,13 @@ struct ConfigRow {
     post_processing_mode: String,
     auto_grab_on_add: i64,
     prefer_subs: i64,
+    allow_non_english: i64,
 }
 
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs FROM config WHERE id = 1",
+        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -87,6 +89,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         post_processing_mode: r.post_processing_mode,
         auto_grab_on_add: r.auto_grab_on_add != 0,
         prefer_subs: r.prefer_subs != 0,
+        allow_non_english: r.allow_non_english != 0,
     }))
 }
 
@@ -94,8 +97,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             qbit_url = excluded.qbit_url,
             qbit_user = excluded.qbit_user,
@@ -119,7 +122,8 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             post_processing_enabled = excluded.post_processing_enabled,
             post_processing_mode = excluded.post_processing_mode,
             auto_grab_on_add = excluded.auto_grab_on_add,
-            prefer_subs = excluded.prefer_subs
+            prefer_subs = excluded.prefer_subs,
+            allow_non_english = excluded.allow_non_english
         "#,
     )
     .bind(&config.qbit_url)
@@ -145,6 +149,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(&config.post_processing_mode)
     .bind(if config.auto_grab_on_add { 1_i64 } else { 0_i64 })
     .bind(if config.prefer_subs { 1_i64 } else { 0_i64 })
+    .bind(if config.allow_non_english { 1_i64 } else { 0_i64 })
     .execute(db)
     .await?;
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -122,6 +122,26 @@ pub async fn get_grab_history(
         .collect())
 }
 
+/// Mark episode quality tags as "completed" for the given episodes of a series.
+/// Called by post-processing after a torrent is successfully imported.
+pub async fn mark_completed(
+    db: &SqlitePool,
+    series_id: i64,
+    episode_numbers: &[i32],
+) -> Result<(), sqlx::Error> {
+    for &ep in episode_numbers {
+        sqlx::query(
+            "UPDATE episode_quality_tags SET state = 'completed', updated_at = CURRENT_TIMESTAMP
+             WHERE series_id = ? AND episode_number = ? AND state = 'grabbed'",
+        )
+        .bind(series_id)
+        .bind(ep)
+        .execute(db)
+        .await?;
+    }
+    Ok(())
+}
+
 /// Clear the current quality tag for an episode (e.g. after file deletion).
 pub async fn clear_episode_tag(
     db: &SqlitePool,

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -672,6 +672,12 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // allow_non_english: when false (default), reject releases with CJK characters from auto grabs.
+    sqlx::query("ALTER TABLE config ADD COLUMN allow_non_english INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS scheduled_task_runs (

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -87,8 +87,10 @@ pub async fn find_best_for_target(
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
+    let allow_non_english = config.allow_non_english;
+
     // Phase 1: standard queries (alias + episode variants).
-    run_queries(&queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &mut seen, &mut candidates).await;
+    run_queries(&queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, allow_non_english, &mut seen, &mut candidates).await;
 
     // Phase 2: if no candidate from a preferred group, try group-prefixed queries.
     let has_preferred_hit = !preferred_groups.is_empty()
@@ -98,7 +100,7 @@ pub async fn find_best_for_target(
 
     if !has_preferred_hit && !preferred_groups.is_empty() {
         let group_queries = build_group_queries(detail, target, &preferred_groups);
-        run_queries(&group_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &mut seen, &mut candidates).await;
+        run_queries(&group_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, allow_non_english, &mut seen, &mut candidates).await;
     }
 
     // Phase 3: for finished series with BD preference, probe for BD releases.
@@ -109,7 +111,7 @@ pub async fn find_best_for_target(
 
         if !has_bd_candidate {
             let bd_queries = quality::bd_probe_queries(&aliases);
-            run_queries(&bd_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &mut seen, &mut candidates).await;
+            run_queries(&bd_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, allow_non_english, &mut seen, &mut candidates).await;
         }
     }
 
@@ -141,6 +143,7 @@ async fn run_queries(
     expected_season: i32,
     is_finished: bool,
     season_year: Option<i32>,
+    allow_non_english: bool,
     seen: &mut HashSet<String>,
     candidates: &mut Vec<SearchResult>,
 ) {
@@ -170,6 +173,9 @@ async fn run_queries(
                 continue;
             }
             if !allow_batch && result.is_batch {
+                continue;
+            }
+            if !allow_non_english && quality::is_non_english_release(&result.title) {
                 continue;
             }
             if !matches_target(&result.title, aliases, target, expected_season) {

--- a/src/services/monitoring.rs
+++ b/src/services/monitoring.rs
@@ -66,6 +66,7 @@ pub async fn recompute_series_monitoring(db: &SqlitePool, series_id: i64) -> Res
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name);

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -423,6 +423,13 @@ pub async fn run_once(state: &AppState) {
             Ok(true) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
+                // Update episode quality tags from "grabbed" to "completed" so the UI
+                // shows the quality label instead of a stale progress bar on revisit.
+                let _ = episode_tags::mark_completed(
+                    &state.db,
+                    grab.series_id,
+                    &grab.episode_numbers,
+                ).await;
             }
             Ok(false) => {
                 // Torrent complete but no video files yet — leave as pending.

--- a/src/services/quality.rs
+++ b/src/services/quality.rs
@@ -261,6 +261,29 @@ pub fn parse_group_list(value: &str) -> Vec<String> {
         .collect()
 }
 
+/// Check if a release title appears to be non-English based on CJK characters.
+/// Looks at the portion outside brackets (the main title text) — group names
+/// inside brackets like [喵萌奶茶屋&LoliHouse] will also trigger this since
+/// they indicate a non-English release.
+pub fn is_non_english_release(title: &str) -> bool {
+    for ch in title.chars() {
+        if is_cjk(ch) {
+            return true;
+        }
+    }
+    false
+}
+
+fn is_cjk(ch: char) -> bool {
+    matches!(ch as u32,
+        0x2E80..=0x9FFF   // CJK radicals, kangxi, ideographs
+        | 0xAC00..=0xD7AF // Hangul syllables
+        | 0xF900..=0xFAFF // CJK compat ideographs
+        | 0xFF01..=0xFF60 // Fullwidth forms
+        | 0x20000..=0x2FA1F // CJK extension B+
+    )
+}
+
 /// Build Nyaa search queries to probe for BD releases of a series.
 pub fn bd_probe_queries(aliases: &[String]) -> Vec<String> {
     let mut queries = Vec::new();

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -240,6 +240,7 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
             prefer_subs: true,
+            allow_non_english: false,
         });
 
     let items = fetch_feed().await?;
@@ -290,6 +291,13 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
         if group_matches_blacklist(&item.group, &blacklist) {
             skipped += 1;
             let reason = format!("Blocked group: {} | {}", item.group, build_match_diag(&item, Some(&found), 0));
+            let _ = rss::record_decision(&state.db, &item_key, &item.title, &item.link, Some(found.series.id), &found.series.title, &item.group, item.is_batch, "rejected", &reason, "rss").await;
+            continue;
+        }
+
+        if !cfg.allow_non_english && quality::is_non_english_release(&item.title) {
+            skipped += 1;
+            let reason = format!("Non-English release rejected | {}", build_match_diag(&item, Some(&found), 0));
             let _ = rss::record_decision(&state.db, &item_key, &item.title, &item.link, Some(found.series.id), &found.series.title, &item.group, item.is_batch, "rejected", &reason, "rss").await;
             continue;
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1322,7 +1322,7 @@ fieldset legend {
 
 .ep-missing-label {
     font-size: 11px;
-    color: var(--accent);
+    color: var(--red);
     opacity: 0.6;
 }
 

--- a/templates/series.html
+++ b/templates/series.html
@@ -257,6 +257,8 @@
                         {% if ep.quality_state == "grabbed" %}data-original-html="<span class='tag tag-quality-grabbed'>{{ ep.quality }}</span>"{% endif %}>
                         {% if ep.quality_state == "grabbed" %}
                         <div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:0%"></div></div><span class="dl-progress-text">0.0%</span></div>
+                        {% else if ep.quality_state == "completed" %}
+                        <span class="tag tag-quality">{{ ep.quality }}</span>
                         {% else if !ep.quality.is_empty() %}
                             {% if ep.quality_state == "failed" %}
                             <span class="tag tag-quality-failed">{{ ep.quality }} ✗</span>

--- a/templates/system.html
+++ b/templates/system.html
@@ -362,6 +362,13 @@ function runRssSync(btn) {
                 </label>
                 <span class="form-hint">When enabled (default), Ryokan automatically searches for and grabs all monitored episodes after you add a series to the library. Disable to add series without triggering an immediate download.</span>
             </div>
+            <div class="form-group">
+                <label class="checkbox-row">
+                    <input type="checkbox" name="allow_non_english" id="allow_non_english" {% if allow_non_english %}checked{% endif %}>
+                    <span>Allow non-English releases in auto grabs</span>
+                </label>
+                <span class="form-hint">When disabled (default), releases with CJK characters (Chinese, Japanese, Korean) in the title are rejected from auto-search and RSS grabs. Enable to allow all languages. Interactive search is not affected.</span>
+            </div>
             <div class="debug-actions-group">
                 <div class="debug-action-row">
                     <button type="button" class="btn btn-secondary" onclick="reconcileFallbacks(this)">Reconcile fallback entries</button>


### PR DESCRIPTION
## Summary
- **Completed state**: Add "completed" episode quality state so finished downloads show their quality tag instead of a stale 0% progress bar on revisit
- **Background grabs**: Wrap auto-search grabs in `tokio::spawn` so downloads survive page navigation and refresh
- **Non-English filtering**: Filter releases with CJK characters from auto-search and RSS grabs (debug toggle on system page to allow them)
- **Missing label color**: Revert to red
- **Re-grab fix**: Fix `mark_episode_failed` passing `series_id: None` which caused re-grabs not to be tracked

## Test plan
- [x] Add a series, grab an episode, wait for post-processing — verify quality tag shows instead of progress bar on revisit
- [x] Start an auto-search, navigate away mid-grab — verify the grab completes
- [x] Trigger RSS sync with a CJK-titled release available — verify it gets rejected
- [x] Enable "Allow non-English releases" on system page — verify CJK releases are allowed
- [x] Check missing episodes show red label
- [x] Mark a torrent as failed — verify the re-grab is tracked in grabbed_torrents

🤖 Generated with [Claude Code](https://claude.ai/code)