### PR TITLE
Fix bugs, enforce quality cutoff, and improve UI/architecture

### DIFF
--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -9,11 +9,91 @@ use serde::Deserialize;
 use crate::models::grabbed_torrents;
 use crate::AppState;
 
+struct QueueTorrentView {
+    hash: String,
+    name: String,
+    size_display: String,
+    progress_pct: String,
+    speed_display: String,
+    eta_display: String,
+    state_label: String,
+    state_badge_class: String,
+    is_paused: bool,
+}
+
+fn format_size(bytes: i64) -> String {
+    if bytes <= 0 { return "0 B".to_string(); }
+    let units = ["B", "KB", "MB", "GB", "TB"];
+    let i = ((bytes as f64).ln() / 1024f64.ln()).floor() as usize;
+    let i = i.min(units.len() - 1);
+    let val = bytes as f64 / 1024f64.powi(i as i32);
+    if i == 0 { format!("{} {}", val as i64, units[i]) }
+    else { format!("{:.1} {}", val, units[i]) }
+}
+
+fn format_speed(bps: i64) -> String {
+    if bps <= 0 { return String::new(); }
+    format!("{}/s", format_size(bps))
+}
+
+fn format_eta(seconds: i64) -> String {
+    if seconds <= 0 || seconds >= 8640000 { return String::new(); }
+    let h = seconds / 3600;
+    let m = (seconds % 3600) / 60;
+    let s = seconds % 60;
+    if h > 0 { format!("{}h {}m", h, m) }
+    else if m > 0 { format!("{}m {}s", m, s) }
+    else { format!("{}s", s) }
+}
+
+fn state_label(state: &str) -> &str {
+    match state {
+        "uploading" | "stalledUP" | "forcedUP" => "Seeding",
+        "downloading" | "forcedDL" => "Downloading",
+        "stalledDL" => "Stalled",
+        "pausedDL" | "pausedUP" => "Paused",
+        "queuedDL" | "queuedUP" => "Queued",
+        "checkingDL" | "checkingUP" => "Checking",
+        "error" => "Error",
+        "missingFiles" => "Missing Files",
+        "moving" => "Moving",
+        "metaDL" => "Fetching metadata",
+        "allocating" => "Allocating",
+        _ => state,
+    }
+}
+
+fn state_badge_class(state: &str) -> &str {
+    match state {
+        "uploading" | "stalledUP" | "forcedUP" | "pausedUP" => "log-badge-info",
+        "downloading" | "forcedDL" => "log-badge-debug",
+        "pausedDL" | "queuedDL" | "queuedUP" | "stalledDL" => "log-badge-warn",
+        "error" | "missingFiles" => "log-badge-error",
+        _ => "",
+    }
+}
+
+fn torrent_to_view(t: &crate::services::qbit::Torrent) -> QueueTorrentView {
+    QueueTorrentView {
+        hash: t.hash.clone(),
+        name: t.name.clone(),
+        size_display: format_size(t.size),
+        progress_pct: format!("{:.1}", t.progress * 100.0),
+        speed_display: format_speed(t.dlspeed),
+        eta_display: format_eta(t.eta),
+        state_label: state_label(&t.state).to_string(),
+        state_badge_class: state_badge_class(&t.state).to_string(),
+        is_paused: t.state.starts_with("paused"),
+    }
+}
+
 #[derive(Template)]
 #[template(path = "downloads.html")]
 struct DownloadsTemplate {
     page: String,
     tab: String,
+    queue: Vec<QueueTorrentView>,
+    queue_error: String,
     history: Vec<grabbed_torrents::GrabbedTorrentWithSeries>,
     blocklist: Vec<grabbed_torrents::GrabbedTorrentWithSeries>,
 }
@@ -37,6 +117,28 @@ pub async fn downloads_page(
 ) -> Html<String> {
     let tab = normalize_tab(params.tab);
 
+    let (queue, queue_error) = if tab == "queue" {
+        let client = state.qbit.read().await.clone();
+        match client {
+            Some(c) => match c.get_torrents().await {
+                Ok(mut torrents) => {
+                    // Sort: downloading first, then by progress descending.
+                    torrents.sort_by(|a, b| {
+                        let a_down = if a.state.contains("DL") || a.state == "downloading" { 0 } else { 1 };
+                        let b_down = if b.state.contains("DL") || b.state == "downloading" { 0 } else { 1 };
+                        a_down.cmp(&b_down).then(b.progress.partial_cmp(&a.progress).unwrap_or(std::cmp::Ordering::Equal))
+                    });
+                    let views = torrents.iter().map(torrent_to_view).collect();
+                    (views, String::new())
+                }
+                Err(e) => (Vec::new(), format!("Could not load queue: {}", e)),
+            },
+            None => (Vec::new(), "qBittorrent is not configured.".to_string()),
+        }
+    } else {
+        (Vec::new(), String::new())
+    };
+
     let history = if tab == "history" {
         grabbed_torrents::get_all_with_series(&state.db, 500).await.unwrap_or_default()
     } else {
@@ -52,6 +154,8 @@ pub async fn downloads_page(
     let template = DownloadsTemplate {
         page: "downloads".to_string(),
         tab,
+        queue,
+        queue_error,
         history,
         blocklist,
     };

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1331,6 +1331,17 @@ async fn run_auto_search_targets(
     allow_batch: bool,
     series_id: Option<i64>,
 ) -> Result<auto_search::AutoSearchReport, (axum::http::StatusCode, String)> {
+    run_auto_search_targets_with_upgrades(state, request_id, targets, allow_batch, series_id, std::collections::HashMap::new()).await
+}
+
+async fn run_auto_search_targets_with_upgrades(
+    state: &AppState,
+    request_id: i64,
+    targets: Vec<auto_search::SearchTarget>,
+    allow_batch: bool,
+    series_id: Option<i64>,
+    upgrade_tiers: std::collections::HashMap<i32, crate::services::quality::QualityTier>,
+) -> Result<auto_search::AutoSearchReport, (axum::http::StatusCode, String)> {
     let qbit = {
         let qbit = state.qbit.read().await;
         qbit.as_ref()
@@ -1365,6 +1376,19 @@ async fn run_auto_search_targets(
         let label = auto_search::target_label(&target);
         match auto_search::find_best_for_target(&detail, &cfg, &target, allow_batch).await {
             Some(result) => {
+                // For upgrade targets, verify the found release is actually
+                // better quality than what's already on disk.
+                if let auto_search::SearchTarget::Episode(ep_num) = &target {
+                    if let Some(existing_tier) = upgrade_tiers.get(ep_num) {
+                        let incoming_tier = crate::services::quality::detect_tier(&result.title, &result.resolution);
+                        if incoming_tier.rank() <= existing_tier.rank() {
+                            logger::debug(&state.db, LogCategory::AutoSearch, &format!("{}: skipped upgrade (incoming {} not better than existing {})", label, incoming_tier.label(), existing_tier.label()), &result.title).await;
+                            skipped.push(format!("{}: no quality upgrade available", label));
+                            continue;
+                        }
+                        logger::info(&state.db, LogCategory::AutoSearch, &format!("{}: upgrading from {} to {}", label, existing_tier.label(), incoming_tier.label()), &result.title).await;
+                    }
+                }
                 let url = if !result.magnet.is_empty() { result.magnet.clone() } else { result.torrent.clone() };
                 if url.is_empty() {
                     logger::warn(&state.db, LogCategory::AutoSearch, &format!("{}: no magnet/torrent URL", label), &result.title).await;
@@ -1494,28 +1518,57 @@ pub async fn auto_search_series(
         Vec::new()
     };
 
-    let targets = if tracked.is_some() {
+    let mut targets = if tracked.is_some() {
         auto_search::build_monitored_targets(&detail, &existing_eps, &monitored_eps)
     } else {
         auto_search::build_missing_targets(&detail, &existing_eps)
     };
+
+    // Also include upgrade targets: episodes on disk below the quality cutoff.
+    let cutoff_tier = crate::services::quality::QualityTier::from_str(&cfg.quality_cutoff);
+    let upgrade_targets = auto_search::build_upgrade_targets(&existing_files, &monitored_eps, cutoff_tier);
+    // Merge upgrade targets (avoid duplicates with missing targets).
+    let existing_target_eps: std::collections::HashSet<i32> = targets
+        .iter()
+        .filter_map(|t| match t {
+            auto_search::SearchTarget::Episode(n) => Some(*n),
+            _ => None,
+        })
+        .collect();
+    for (target, _) in &upgrade_targets {
+        if let auto_search::SearchTarget::Episode(n) = target {
+            if !existing_target_eps.contains(n) {
+                targets.push(target.clone());
+            }
+        }
+    }
+
     let target_summary = if targets.len() <= 5 {
         targets.iter().map(|t| auto_search::target_label(t)).collect::<Vec<_>>().join(", ")
     } else {
         format!("{} targets", targets.len())
     };
+    let upgrade_count = upgrade_targets.len();
     let title_for_log = if !detail.title_english.is_empty() { &detail.title_english } else { &detail.title_romaji };
     logger::debug(
         &state.db,
         LogCategory::AutoSearch,
         &format!("Missing targets for {}: {}", title_for_log, target_summary),
-        &format!("on_disk={}, monitored={}, total={:?}", existing_eps.len(), monitored_eps.len(), detail.episodes),
+        &format!("on_disk={}, monitored={}, upgradeable={}, total={:?}", existing_eps.len(), monitored_eps.len(), upgrade_count, detail.episodes),
     ).await;
     let series_id_for_grab = tracked.as_ref().map(|s| s.id);
+    // Build a map of existing quality tiers for upgrade filtering in the search task.
+    let upgrade_tiers: std::collections::HashMap<i32, crate::services::quality::QualityTier> = upgrade_targets
+        .into_iter()
+        .filter_map(|(t, tier)| match t {
+            auto_search::SearchTarget::Episode(n) => Some((n, tier)),
+            _ => None,
+        })
+        .collect();
     // Spawn as an independent task so the grab completes even if the client disconnects.
     let state_clone = state.clone();
     let handle = tokio::spawn(async move {
-        run_auto_search_targets(&state_clone, request_id, targets, true, series_id_for_grab).await
+        run_auto_search_targets_with_upgrades(&state_clone, request_id, targets, true, series_id_for_grab, upgrade_tiers).await
     });
     let report = handle.await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))?

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 
-use crate::models::{config, episode_tags, local_metadata, metadata_cache, monitoring, series};
+use crate::models::{config, episode_tags, grabbed_torrents, local_metadata, metadata_cache, monitoring, series};
 use crate::models::log::LogCategory;
 use crate::services::{anilist, artwork, auto_search, jikan, kitsu, logger, media, metadata_sync, monitoring as monitoring_service};
 use crate::AppState;
@@ -138,6 +138,8 @@ pub struct SetEpisodeMonitoringForm {
 #[derive(Deserialize)]
 pub struct MarkEpisodeFailedForm {
     history_id: i64,
+    #[serde(default)]
+    blocklist: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -167,6 +169,8 @@ async fn force_kitsu_fallback_enabled(db: &SqlitePool) -> bool {
 
 async fn resolve_series_request(db: &SqlitePool, request_id: i64) -> Result<(Option<series::Series>, i64), sqlx::Error> {
     if let Some(row) = series::get_by_id(db, request_id).await? {
+        Ok((Some(row.clone()), row.anilist_id))
+    } else if let Some(row) = series::get_by_anilist_id(db, request_id).await? {
         Ok((Some(row.clone()), row.anilist_id))
     } else {
         Ok((None, request_id))
@@ -1858,9 +1862,13 @@ pub async fn mark_episode_failed(
         .ok_or((axum::http::StatusCode::BAD_REQUEST, "Series not in library".to_string()))?
         .id;
 
-    episode_tags::mark_grab_failed(&state.db, form.history_id)
+    let (_sid, _ep, release_title) = episode_tags::mark_grab_failed(&state.db, form.history_id)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    if form.blocklist && !release_title.is_empty() {
+        let _ = grabbed_torrents::mark_failed_by_name(&state.db, series_id, &release_title).await;
+    }
 
     // Re-trigger auto-search for this episode in the background so it completes
     // even if the client disconnects.

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1378,7 +1378,8 @@ async fn run_auto_search_targets_with_upgrades(
     let mut skipped = Vec::new();
     for target in targets {
         let label = auto_search::target_label(&target);
-        match auto_search::find_best_for_target(&detail, &cfg, &target, allow_batch).await {
+        let is_upgrade = matches!(&target, auto_search::SearchTarget::Episode(n) if upgrade_tiers.contains_key(n));
+        match auto_search::find_best_for_target(&detail, &cfg, &target, allow_batch, is_upgrade).await {
             Some(result) => {
                 // For upgrade targets, verify the found release is actually
                 // better quality than what's already on disk.
@@ -1647,6 +1648,7 @@ pub async fn search_batch_releases(
         &cfg,
         &auto_search::SearchTarget::Single,
         true,
+        false,
     ).await;
 
     // We want batch-only, so filter.

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1530,7 +1530,12 @@ pub async fn auto_search_series(
 
     // Also include upgrade targets: episodes on disk below the quality cutoff.
     let cutoff_tier = crate::services::quality::QualityTier::from_str(&cfg.quality_cutoff);
-    let upgrade_targets = auto_search::build_upgrade_targets(&existing_files, &monitored_eps, cutoff_tier);
+    let quality_tags = if let Some(ref t) = tracked {
+        episode_tags::get_for_series(&state.db, t.id).await.unwrap_or_default()
+    } else {
+        std::collections::HashMap::new()
+    };
+    let upgrade_targets = auto_search::build_upgrade_targets(&existing_files, &monitored_eps, cutoff_tier, &quality_tags);
     // Merge upgrade targets (avoid duplicates with missing targets).
     let existing_target_eps: std::collections::HashSet<i32> = targets
         .iter()

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -413,7 +413,7 @@ pub async fn add_movie(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()"))
+                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
                         .await
                         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
                 }
@@ -424,7 +424,7 @@ pub async fn add_movie(
                 .await
                 .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
         } else {
-            return Err((StatusCode::BAD_GATEWAY, format!("No AniList or MAL ID available for TMDB mapping")));
+            return Err((StatusCode::BAD_GATEWAY, "No AniList or MAL ID available for TMDB mapping".to_string()));
         }
     } else {
         // No anibridge mapping — fall back to AniList title search.
@@ -612,7 +612,7 @@ async fn lookup_by_tmdb_id(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()")).await {
+                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap()).await {
                         Ok(d) => d,
                         Err(_) => continue,
                     }

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -413,16 +413,18 @@ pub async fn add_movie(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
+                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()"))
                         .await
                         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
                 }
                 Err(e) => return Err((StatusCode::BAD_GATEWAY, e)),
             }
-        } else {
-            crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
+        } else if let Some(mal_id) = ids.mal_id {
+            crate::services::jikan::get_anime_detail_cached(mal_id)
                 .await
                 .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
+        } else {
+            return Err((StatusCode::BAD_GATEWAY, format!("No AniList or MAL ID available for TMDB mapping")));
         }
     } else {
         // No anibridge mapping — fall back to AniList title search.
@@ -610,7 +612,7 @@ async fn lookup_by_tmdb_id(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap()).await {
+                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()")).await {
                         Ok(d) => d,
                         Err(_) => continue,
                     }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -296,6 +296,44 @@ pub async fn jellyfin_test(
     }
 }
 
+pub async fn api_health(
+    State(state): State<AppState>,
+) -> Json<serde_json::Value> {
+    let qbit_status = {
+        let client = state.qbit.read().await.clone();
+        match client {
+            Some(c) => match c.test_connection().await {
+                Ok(version) => serde_json::json!({"ok": true, "message": format!("qBittorrent {}", version)}),
+                Err(e) => serde_json::json!({"ok": false, "message": e}),
+            },
+            None => serde_json::json!({"ok": false, "message": "Not configured"}),
+        }
+    };
+
+    let jellyfin_status = {
+        let client = state.jellyfin.read().await.clone();
+        match client {
+            Some(c) => match c.test_connection().await {
+                Ok(info) => {
+                    let label = if info.server_name.trim().is_empty() {
+                        format!("Jellyfin {}", info.version)
+                    } else {
+                        format!("{} ({})", info.server_name, info.version)
+                    };
+                    serde_json::json!({"ok": true, "message": label})
+                }
+                Err(e) => serde_json::json!({"ok": false, "message": e}),
+            },
+            None => serde_json::json!({"ok": false, "message": "Not configured"}),
+        }
+    };
+
+    Json(serde_json::json!({
+        "qbit": qbit_status,
+        "jellyfin": jellyfin_status,
+    }))
+}
+
 pub async fn jellyfin_refresh(
     State(state): State<AppState>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -49,6 +49,7 @@ pub struct SettingsForm {
     sonarr_api_key: Option<String>,
     radarr_enabled: Option<String>,
     radarr_api_key: Option<String>,
+    upgrade_search_enabled: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -179,6 +180,11 @@ pub async fn settings_submit(
             form.radarr_api_key.unwrap_or_default().trim().to_string()
         } else {
             existing_cfg.as_ref().map(|c| c.radarr_api_key.clone()).unwrap_or_default()
+        },
+        upgrade_search_enabled: if form.tab.as_deref() == Some("quality") || form.tab.is_none() {
+            form.upgrade_search_enabled.is_some()
+        } else {
+            existing_cfg.as_ref().map(|c| c.upgrade_search_enabled).unwrap_or(false)
         },
     };
 

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -474,7 +474,7 @@ pub async fn add_series(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()"))
+                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
                         .await
                         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
                 }
@@ -485,7 +485,7 @@ pub async fn add_series(
                 .await
                 .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
         } else {
-            return Err((StatusCode::BAD_GATEWAY, format!("No AniList or MAL ID available for TMDB mapping")));
+            return Err((StatusCode::BAD_GATEWAY, "No AniList or MAL ID available for TMDB mapping".to_string()));
         }
     } else {
         // No anibridge mapping — fall back to AniList title search.
@@ -697,7 +697,7 @@ async fn lookup_by_tmdb_id(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()")).await {
+                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap()).await {
                         Ok(d) => d,
                         Err(_) => continue,
                     }

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -474,16 +474,18 @@ pub async fn add_series(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
+                    crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()"))
                         .await
                         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
                 }
                 Err(e) => return Err((StatusCode::BAD_GATEWAY, e)),
             }
-        } else {
-            crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap())
+        } else if let Some(mal_id) = ids.mal_id {
+            crate::services::jikan::get_anime_detail_cached(mal_id)
                 .await
                 .map_err(|e| (StatusCode::BAD_GATEWAY, e))?
+        } else {
+            return Err((StatusCode::BAD_GATEWAY, format!("No AniList or MAL ID available for TMDB mapping")));
         }
     } else {
         // No anibridge mapping — fall back to AniList title search.
@@ -695,7 +697,7 @@ async fn lookup_by_tmdb_id(
             match anilist::get_anime_detail(al_id).await {
                 Ok(d) => d,
                 Err(_) if ids.mal_id.is_some() => {
-                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.unwrap()).await {
+                    match crate::services::jikan::get_anime_detail_cached(ids.mal_id.expect("guarded by is_some()")).await {
                         Ok(d) => d,
                         Err(_) => continue,
                     }

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -7,7 +7,7 @@ use axum::{
 use serde::Deserialize;
 
 use crate::models::{config, log::{self, LogCategory}, rss, scheduled_tasks};
-use crate::services::{logger, metadata_sync, rss as rss_service};
+use crate::services::{logger, metadata_sync, post_processing, rss as rss_service, upgrade};
 use crate::AppState;
 
 #[derive(Template)]
@@ -345,6 +345,74 @@ pub async fn api_rss_clear_history(
         "ok": true,
         "message": format!("Cleared {} grab history entries. Previously grabbed episodes will be re-evaluated on next sync.", deleted),
     })))
+}
+
+pub async fn api_force_metadata_refresh(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let _ = scheduled_tasks::mark_started(&state.db, "metadata_refresh", "Manual metadata refresh started").await;
+    let (refreshed, failed) = metadata_sync::refresh_all_series_metadata(&state.db).await;
+    let status = if failed > 0 { "warn" } else { "ok" };
+    let detail = format!("refreshed={}, failed={}", refreshed, failed);
+    let _ = scheduled_tasks::mark_finished(&state.db, "metadata_refresh", status, &detail).await;
+    Ok(Json(serde_json::json!({
+        "ok": failed == 0,
+        "message": format!("Metadata refresh complete. Refreshed: {}. Failed: {}.", refreshed, failed),
+    })))
+}
+
+pub async fn api_force_cleanup(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let _ = scheduled_tasks::mark_started(&state.db, "cleanup", "Manual cleanup started").await;
+    let mut errors = Vec::new();
+    if let Err(e) = crate::models::log::cleanup(&state.db, 30).await {
+        errors.push(format!("logs: {}", e));
+    }
+    if let Err(e) = rss::cleanup_old_decisions(&state.db, 30).await {
+        errors.push(format!("rss: {}", e));
+    }
+    let status = if errors.is_empty() { "ok" } else { "warn" };
+    let detail = if errors.is_empty() { "Cleanup completed".to_string() } else { errors.join("; ") };
+    let _ = scheduled_tasks::mark_finished(&state.db, "cleanup", status, &detail).await;
+    Ok(Json(serde_json::json!({
+        "ok": errors.is_empty(),
+        "message": detail,
+    })))
+}
+
+pub async fn api_force_post_processing(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let _ = scheduled_tasks::mark_started(&state.db, "post_processing", "Manual post-processing run").await;
+    post_processing::run_once(&state).await;
+    let _ = scheduled_tasks::mark_finished(&state.db, "post_processing", "ok", "Manual run completed").await;
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "message": "Post-processing run completed",
+    })))
+}
+
+pub async fn api_force_upgrade_search(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let _ = scheduled_tasks::mark_started(&state.db, "upgrade_search", "Manual upgrade search started").await;
+    match upgrade::run_once(&state).await {
+        Ok(summary) => {
+            let _ = scheduled_tasks::mark_finished(&state.db, "upgrade_search", "ok", &summary.detail).await;
+            Ok(Json(serde_json::json!({
+                "ok": true,
+                "message": summary.detail,
+                "series_checked": summary.series_checked,
+                "episodes_checked": summary.episodes_checked,
+                "upgrades_grabbed": summary.upgrades_grabbed,
+            })))
+        }
+        Err(err) => {
+            let _ = scheduled_tasks::mark_finished(&state.db, "upgrade_search", "error", &err).await;
+            Err((axum::http::StatusCode::BAD_GATEWAY, err))
+        }
+    }
 }
 
 fn level_rank(level: &str) -> u8 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,11 @@ async fn main() {
         .route("/api/jellyfin/refresh", post(handlers::settings::jellyfin_refresh))
         .route("/system", get(handlers::system::system_page).post(handlers::system::debug_settings_submit))
         .route("/api/rss/sync", post(handlers::system::api_rss_sync))
-                .route("/api/rss/clear-history", post(handlers::system::api_rss_clear_history))
+        .route("/api/rss/clear-history", post(handlers::system::api_rss_clear_history))
+        .route("/api/tasks/metadata-refresh", post(handlers::system::api_force_metadata_refresh))
+        .route("/api/tasks/cleanup", post(handlers::system::api_force_cleanup))
+        .route("/api/tasks/post-processing", post(handlers::system::api_force_post_processing))
+        .route("/api/tasks/upgrade-search", post(handlers::system::api_force_upgrade_search))
         .route("/api/system/rebuild-anilist-cache", post(handlers::system::api_rebuild_cached_metadata))
         .route("/api/system/reload-anibridge", post(handlers::system::api_anibridge_reload))
         .route("/help", get(handlers::system::system_page))
@@ -196,6 +200,7 @@ async fn main() {
     let _ = models::scheduled_tasks::touch_definition(&db, "metadata_refresh", "Metadata refresh", "Every 12 hours", true).await;
     let _ = models::scheduled_tasks::touch_definition(&db, "cleanup", "Cleanup", "Every 1 hour", true).await;
     let _ = models::scheduled_tasks::touch_definition(&db, "post_processing", "Post-processing", "Every 1 minute (when enabled)", false).await;
+    let _ = models::scheduled_tasks::touch_definition(&db, "upgrade_search", "Quality upgrade search", "Every 24 hours", true).await;
 
     // Log startup to the database.
     services::logger::info(
@@ -340,6 +345,32 @@ async fn main() {
                 let _ = models::scheduled_tasks::mark_started(&pp_state.db, "post_processing", "Checking for completed downloads").await;
                 services::post_processing::run_once(&pp_state).await;
                 let _ = models::scheduled_tasks::mark_finished(&pp_state.db, "post_processing", "ok", "").await;
+            }
+        });
+    }
+
+    // Background task: quality upgrade search every 24 hours.
+    {
+        let upgrade_state = state.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
+            loop {
+                interval.tick().await;
+                let _ = models::scheduled_tasks::mark_started(&upgrade_state.db, "upgrade_search", "Searching for quality upgrades").await;
+                match services::upgrade::run_once(&upgrade_state).await {
+                    Ok(summary) => {
+                        let _ = models::scheduled_tasks::mark_finished(&upgrade_state.db, "upgrade_search", "ok", &summary.detail).await;
+                    }
+                    Err(err) => {
+                        let _ = models::scheduled_tasks::mark_finished(&upgrade_state.db, "upgrade_search", "error", &err).await;
+                        services::logger::error(
+                            &upgrade_state.db,
+                            models::log::LogCategory::System,
+                            "Upgrade search failed",
+                            &err,
+                        ).await;
+                    }
+                }
             }
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -121,6 +121,7 @@ async fn main() {
         .route("/settings", get(handlers::settings::settings_page).post(handlers::settings::settings_submit))
         .route("/api/qbit/test", post(handlers::settings::qbit_test))
         .route("/api/jellyfin/test", post(handlers::settings::jellyfin_test))
+        .route("/api/health", get(handlers::settings::api_health))
         .route("/api/jellyfin/refresh", post(handlers::settings::jellyfin_refresh))
         .route("/system", get(handlers::system::system_page).post(handlers::system::debug_settings_submit))
         .route("/api/rss/sync", post(handlers::system::api_rss_sync))

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,7 +200,8 @@ async fn main() {
     let _ = models::scheduled_tasks::touch_definition(&db, "metadata_refresh", "Metadata refresh", "Every 12 hours", true).await;
     let _ = models::scheduled_tasks::touch_definition(&db, "cleanup", "Cleanup", "Every 1 hour", true).await;
     let _ = models::scheduled_tasks::touch_definition(&db, "post_processing", "Post-processing", "Every 1 minute (when enabled)", false).await;
-    let _ = models::scheduled_tasks::touch_definition(&db, "upgrade_search", "Quality upgrade search", "Every 24 hours", true).await;
+    let upgrade_enabled = models::config::get_config(&db).await.ok().flatten().map(|c| c.upgrade_search_enabled).unwrap_or(false);
+    let _ = models::scheduled_tasks::touch_definition(&db, "upgrade_search", "Quality upgrade search", "Every 24 hours (when enabled)", upgrade_enabled).await;
 
     // Log startup to the database.
     services::logger::info(
@@ -349,13 +350,29 @@ async fn main() {
         });
     }
 
-    // Background task: quality upgrade search every 24 hours.
+    // Background task: quality upgrade search every 24 hours (when enabled).
     {
         let upgrade_state = state.clone();
         tokio::spawn(async move {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(24 * 60 * 60));
             loop {
                 interval.tick().await;
+                let enabled = models::config::get_config(&upgrade_state.db)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|c| c.upgrade_search_enabled)
+                    .unwrap_or(false);
+                let _ = models::scheduled_tasks::touch_definition(
+                    &upgrade_state.db,
+                    "upgrade_search",
+                    "Quality upgrade search",
+                    "Every 24 hours (when enabled)",
+                    enabled,
+                ).await;
+                if !enabled {
+                    continue;
+                }
                 let _ = models::scheduled_tasks::mark_started(&upgrade_state.db, "upgrade_search", "Searching for quality upgrades").await;
                 match services::upgrade::run_once(&upgrade_state).await {
                     Ok(summary) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -374,17 +374,29 @@ async fn main() {
                     continue;
                 }
                 let _ = models::scheduled_tasks::mark_started(&upgrade_state.db, "upgrade_search", "Searching for quality upgrades").await;
-                match services::upgrade::run_once(&upgrade_state).await {
-                    Ok(summary) => {
+                match tokio::time::timeout(
+                    std::time::Duration::from_secs(30 * 60),
+                    services::upgrade::run_once(&upgrade_state),
+                ).await {
+                    Ok(Ok(summary)) => {
                         let _ = models::scheduled_tasks::mark_finished(&upgrade_state.db, "upgrade_search", "ok", &summary.detail).await;
                     }
-                    Err(err) => {
+                    Ok(Err(err)) => {
                         let _ = models::scheduled_tasks::mark_finished(&upgrade_state.db, "upgrade_search", "error", &err).await;
                         services::logger::error(
                             &upgrade_state.db,
                             models::log::LogCategory::System,
                             "Upgrade search failed",
                             &err,
+                        ).await;
+                    }
+                    Err(_) => {
+                        let _ = models::scheduled_tasks::mark_finished(&upgrade_state.db, "upgrade_search", "error", "Timed out after 30 minutes").await;
+                        services::logger::error(
+                            &upgrade_state.db,
+                            models::log::LogCategory::System,
+                            "Upgrade search timed out",
+                            "Exceeded 30-minute limit",
                         ).await;
                     }
                 }

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -31,6 +31,7 @@ pub struct Config {
     pub sonarr_api_key: String,
     pub radarr_enabled: bool,
     pub radarr_api_key: String,
+    pub upgrade_search_enabled: bool,
 }
 
 impl Default for Config {
@@ -64,6 +65,7 @@ impl Default for Config {
             sonarr_api_key: String::new(),
             radarr_enabled: false,
             radarr_api_key: String::new(),
+            upgrade_search_enabled: false,
         }
     }
 }
@@ -98,12 +100,13 @@ struct ConfigRow {
     sonarr_api_key: String,
     radarr_enabled: i64,
     radarr_api_key: String,
+    upgrade_search_enabled: i64,
 }
 
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key FROM config WHERE id = 1",
+        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -137,6 +140,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         sonarr_api_key: r.sonarr_api_key,
         radarr_enabled: r.radarr_enabled != 0,
         radarr_api_key: r.radarr_api_key,
+        upgrade_search_enabled: r.upgrade_search_enabled != 0,
     }))
 }
 
@@ -144,8 +148,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             qbit_url = excluded.qbit_url,
             qbit_user = excluded.qbit_user,
@@ -174,7 +178,8 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             sonarr_enabled = excluded.sonarr_enabled,
             sonarr_api_key = excluded.sonarr_api_key,
             radarr_enabled = excluded.radarr_enabled,
-            radarr_api_key = excluded.radarr_api_key
+            radarr_api_key = excluded.radarr_api_key,
+            upgrade_search_enabled = excluded.upgrade_search_enabled
         "#,
     )
     .bind(&config.qbit_url)
@@ -205,6 +210,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(&config.sonarr_api_key)
     .bind(if config.radarr_enabled { 1_i64 } else { 0_i64 })
     .bind(&config.radarr_api_key)
+    .bind(if config.upgrade_search_enabled { 1_i64 } else { 0_i64 })
     .execute(db)
     .await?;
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -192,16 +192,17 @@ pub async fn clear_tags_for_removal(
 pub async fn mark_grab_failed(
     db: &SqlitePool,
     history_id: i64,
-) -> Result<(i64, i32), sqlx::Error> {
-    // Fetch series_id + episode_number before marking failed so we can return them.
+) -> Result<(i64, i32, String), sqlx::Error> {
+    // Fetch series_id, episode_number, release_title before marking failed.
     let row = sqlx::query(
-        "SELECT series_id, episode_number FROM episode_grab_history WHERE id = ?",
+        "SELECT series_id, episode_number, release_title FROM episode_grab_history WHERE id = ?",
     )
     .bind(history_id)
     .fetch_one(db)
     .await?;
     let series_id: i64 = row.get("series_id");
     let episode_number: i32 = row.get("episode_number");
+    let release_title: String = row.get("release_title");
 
     sqlx::query("UPDATE episode_grab_history SET state = 'failed' WHERE id = ?")
         .bind(history_id)
@@ -218,5 +219,5 @@ pub async fn mark_grab_failed(
     .execute(db)
     .await?;
 
-    Ok((series_id, episode_number))
+    Ok((series_id, episode_number, release_title))
 }

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -172,6 +172,18 @@ pub async fn get_blocked(db: &SqlitePool) -> Result<Vec<GrabbedTorrentWithSeries
         .collect())
 }
 
+/// Mark a grabbed torrent as failed (blocklisted) by matching torrent name and series.
+pub async fn mark_failed_by_name(db: &SqlitePool, series_id: i64, torrent_name: &str) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query(
+        "UPDATE grabbed_torrents SET state = 'failed' WHERE series_id = ? AND torrent_name = ? AND state IN ('pending', 'imported')",
+    )
+    .bind(series_id)
+    .bind(torrent_name)
+    .execute(db)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Remove a grabbed torrent record entirely.
 pub async fn remove(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM grabbed_torrents WHERE id = ?")

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -184,6 +184,43 @@ pub async fn mark_failed_by_name(db: &SqlitePool, series_id: i64, torrent_name: 
     Ok(result.rows_affected())
 }
 
+/// Find previously imported grabs for a series that cover a given episode.
+/// Used by post-processing to identify old torrents to clean up during upgrades.
+pub async fn find_imported_for_episode(
+    db: &SqlitePool,
+    series_id: i64,
+    episode_number: i32,
+) -> Result<Vec<GrabbedTorrent>, sqlx::Error> {
+    // episode_numbers is stored as a JSON array, so we search with json_each.
+    let rows = sqlx::query(
+        r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.grabbed_at
+           FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
+           WHERE g.series_id = ? AND je.value = ? AND g.state = 'imported'
+           ORDER BY g.grabbed_at DESC"#,
+    )
+    .bind(series_id)
+    .bind(episode_number)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let eps_json: String = row.get("episode_numbers");
+            let episode_numbers: Vec<i32> = serde_json::from_str(&eps_json).unwrap_or_default();
+            GrabbedTorrent {
+                id: row.get("id"),
+                hash: row.get("hash"),
+                torrent_name: row.get("torrent_name"),
+                series_id: row.get("series_id"),
+                episode_numbers,
+                state: "imported".to_string(),
+                grabbed_at: row.get("grabbed_at"),
+            }
+        })
+        .collect())
+}
+
 /// Remove a grabbed torrent record entirely.
 pub async fn remove(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM grabbed_torrents WHERE id = ?")

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -703,6 +703,10 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await
         .ok();
+    sqlx::query("ALTER TABLE config ADD COLUMN upgrade_search_enabled INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
 
     sqlx::query(
         r#"

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -12,6 +12,11 @@ const ANILIST_API: &str = "https://graphql.anilist.co";
 /// In-memory cache TTL for anime detail responses (15 minutes).
 const DETAIL_CACHE_TTL_SECS: u64 = 15 * 60;
 
+/// Maximum number of entries in the in-memory detail cache. When exceeded,
+/// expired entries are evicted first; if still over limit the oldest entry
+/// is removed.
+const DETAIL_CACHE_MAX_ENTRIES: usize = 500;
+
 /// In-memory cache for AniList detail responses to avoid rate limiting.
 struct CacheEntry {
     detail: AnimeDetail,
@@ -316,6 +321,23 @@ pub async fn get_anime_detail_with_options(id: i64, mal_id_hint: Option<i64>, fo
             detail: detail.clone(),
             fetched_at: Instant::now(),
         });
+        // Evict stale/oldest entries when the cache grows too large.
+        if cache.len() > DETAIL_CACHE_MAX_ENTRIES {
+            let expired: Vec<i64> = cache
+                .iter()
+                .filter(|(_, e)| e.fetched_at.elapsed().as_secs() >= DETAIL_CACHE_TTL_SECS)
+                .map(|(k, _)| *k)
+                .collect();
+            for k in &expired {
+                cache.remove(k);
+            }
+            // If still over limit, drop the oldest entry.
+            if cache.len() > DETAIL_CACHE_MAX_ENTRIES {
+                if let Some((&oldest_key, _)) = cache.iter().min_by_key(|(_, e)| e.fetched_at) {
+                    cache.remove(&oldest_key);
+                }
+            }
+        }
     }
 
     Ok(detail)

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 use regex_lite::Regex;
 
 use crate::models::config::Config;
-use crate::services::{anilist::AnimeDetail, nyaa::{self, SearchOptions, SearchResult}, quality};
+use crate::services::{anilist::AnimeDetail, media, nyaa::{self, SearchOptions, SearchResult}, quality};
 
 // ── Pre-compiled regexes for parse_release_numbers ─────────────────────────
 static RE_EPISODE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| vec![
@@ -387,6 +387,34 @@ pub fn build_monitored_targets(detail: &AnimeDetail, existing_episodes: &[i32], 
         .filter(|ep| !existing.contains(ep))
         .map(SearchTarget::Episode)
         .collect()
+}
+
+/// Build upgrade targets: monitored episodes that exist on disk but are below
+/// the quality cutoff. These are candidates for automatic quality upgrades.
+pub fn build_upgrade_targets(
+    disk_files: &[media::EpisodeFile],
+    monitored_episodes: &[i32],
+    cutoff_tier: quality::QualityTier,
+) -> Vec<(SearchTarget, quality::QualityTier)> {
+    let monitored: HashSet<i32> = monitored_episodes.iter().copied().collect();
+    let mut targets = Vec::new();
+    for file in disk_files {
+        if !monitored.contains(&file.episode_number) {
+            continue;
+        }
+        let existing_tier = quality::tier_from_disk_quality(&file.quality);
+        if existing_tier.rank() < cutoff_tier.rank() {
+            targets.push((
+                SearchTarget::Episode(file.episode_number),
+                existing_tier,
+            ));
+        }
+    }
+    targets.sort_by_key(|(t, _)| match t {
+        SearchTarget::Episode(n) => *n,
+        SearchTarget::Single => 0,
+    });
+    targets
 }
 
 pub fn target_label(target: &SearchTarget) -> String {

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -217,7 +217,7 @@ async fn run_queries(
                 if !allow_batch && result.is_batch {
                     continue;
                 }
-                if !matches_target(&result.title, aliases, target, expected_season) {
+                if !matches_target(&result.title, aliases, target, expected_season, result.is_batch) {
                     continue;
                 }
                 // For FINISHED series, reject non-BD results uploaded 2+ years after airing
@@ -481,7 +481,7 @@ pub fn dedupe_strings(values: Vec<String>) -> Vec<String> {
     out
 }
 
-pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, expected_season: i32) -> bool {
+pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, expected_season: i32, is_batch: bool) -> bool {
     let normalized_title = normalize_title(title);
     let title_tokens = token_set(&normalized_title);
 
@@ -507,9 +507,11 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
             if parsed.is_empty() {
                 return false;
             }
-            // If this looks like a batch (many episode numbers), reject for single-episode targets.
-            // A range of 3+ episodes means this is a batch/multi-episode release.
-            if parsed.len() > 2 {
+            // For non-batch releases, reject if there are 3+ episode numbers
+            // (likely a batch release that wasn't detected as one). Actual batch
+            // releases are allowed through so BD season packs can match episode
+            // upgrade targets.
+            if !is_batch && parsed.len() > 2 {
                 return false;
             }
             parsed.contains(target_ep)

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -395,6 +395,7 @@ pub fn build_upgrade_targets(
     disk_files: &[media::EpisodeFile],
     monitored_episodes: &[i32],
     cutoff_tier: quality::QualityTier,
+    quality_tags: &std::collections::HashMap<i32, crate::models::episode_tags::EpisodeQualityTag>,
 ) -> Vec<(SearchTarget, quality::QualityTier)> {
     let monitored: HashSet<i32> = monitored_episodes.iter().copied().collect();
     let mut targets = Vec::new();
@@ -402,7 +403,14 @@ pub fn build_upgrade_targets(
         if !monitored.contains(&file.episode_number) {
             continue;
         }
-        let existing_tier = quality::tier_from_disk_quality(&file.quality);
+        // Prefer the quality tag recorded at grab time (from the release title)
+        // over re-detecting from the renamed filename on disk.
+        let existing_tier = if let Some(tag) = quality_tags.get(&file.episode_number) {
+            let tier = quality::QualityTier::from_str(&tag.quality_tag);
+            if tier != quality::QualityTier::Unknown { tier } else { quality::tier_from_disk_quality(&file.quality) }
+        } else {
+            quality::tier_from_disk_quality(&file.quality)
+        };
         if existing_tier == quality::QualityTier::Unknown {
             continue;
         }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -403,6 +403,9 @@ pub fn build_upgrade_targets(
             continue;
         }
         let existing_tier = quality::tier_from_disk_quality(&file.quality);
+        if existing_tier == quality::QualityTier::Unknown {
+            continue;
+        }
         if existing_tier.rank() < cutoff_tier.rank() {
             targets.push((
                 SearchTarget::Episode(file.episode_number),

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -114,6 +114,7 @@ pub async fn find_best_for_target(
     config: &Config,
     target: &SearchTarget,
     allow_batch: bool,
+    batch_episode_match: bool,
 ) -> Option<SearchResult> {
     let queries = build_queries(detail, target);
     let aliases = collect_aliases(detail);
@@ -131,7 +132,7 @@ pub async fn find_best_for_target(
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
 
     // Phase 1: standard queries (alias + episode variants).
-    run_queries(&queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates).await;
+    run_queries(&queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates, batch_episode_match).await;
 
     // Phase 2: if no candidate from a preferred group, try group-prefixed queries.
     let has_preferred_hit = !preferred_groups.is_empty()
@@ -141,7 +142,7 @@ pub async fn find_best_for_target(
 
     if !has_preferred_hit && !preferred_groups.is_empty() {
         let group_queries = build_group_queries(detail, target, &preferred_groups);
-        run_queries(&group_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates).await;
+        run_queries(&group_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates, batch_episode_match).await;
     }
 
     // Phase 3: for finished series with BD preference, probe for BD releases.
@@ -152,7 +153,7 @@ pub async fn find_best_for_target(
 
         if !has_bd_candidate {
             let bd_queries = quality::bd_probe_queries(&aliases);
-            run_queries(&bd_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates).await;
+            run_queries(&bd_queries, &aliases, &preferred_groups, &preferred_res, target, allow_batch, expected_season, is_finished, detail.season_year, &categories, &mut seen, &mut candidates, batch_episode_match).await;
         }
     }
 
@@ -187,6 +188,7 @@ async fn run_queries(
     categories: &[String],
     seen: &mut HashSet<String>,
     candidates: &mut Vec<SearchResult>,
+    batch_episode_match: bool,
 ) {
     for category in categories {
         for query in queries {
@@ -217,7 +219,7 @@ async fn run_queries(
                 if !allow_batch && result.is_batch {
                     continue;
                 }
-                if !matches_target(&result.title, aliases, target, expected_season, result.is_batch) {
+                if !matches_target(&result.title, aliases, target, expected_season, batch_episode_match && result.is_batch) {
                     continue;
                 }
                 // For FINISHED series, reject non-BD results uploaded 2+ years after airing
@@ -481,7 +483,7 @@ pub fn dedupe_strings(values: Vec<String>) -> Vec<String> {
     out
 }
 
-pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, expected_season: i32, is_batch: bool) -> bool {
+pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, expected_season: i32, allow_batch_episode: bool) -> bool {
     let normalized_title = normalize_title(title);
     let title_tokens = token_set(&normalized_title);
 
@@ -507,11 +509,11 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
             if parsed.is_empty() {
                 return false;
             }
-            // For non-batch releases, reject if there are 3+ episode numbers
-            // (likely a batch release that wasn't detected as one). Actual batch
-            // releases are allowed through so BD season packs can match episode
-            // upgrade targets.
-            if !is_batch && parsed.len() > 2 {
+            // Reject releases with 3+ episode numbers (batch/multi-episode)
+            // unless the caller explicitly allows batch-to-episode matching
+            // (used for quality upgrade searches where BD season packs are the
+            // only source for higher-quality individual episodes).
+            if !allow_batch_episode && parsed.len() > 2 {
                 return false;
             }
             parsed.contains(target_ep)

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -391,18 +391,18 @@ pub fn build_monitored_targets(detail: &AnimeDetail, existing_episodes: &[i32], 
         .collect()
 }
 
-/// Build upgrade targets: monitored episodes that exist on disk but are below
+/// Build upgrade targets: candidate episodes that exist on disk but are below
 /// the quality cutoff. These are candidates for automatic quality upgrades.
 pub fn build_upgrade_targets(
     disk_files: &[media::EpisodeFile],
-    monitored_episodes: &[i32],
+    candidate_episodes: &[i32],
     cutoff_tier: quality::QualityTier,
     quality_tags: &std::collections::HashMap<i32, crate::models::episode_tags::EpisodeQualityTag>,
 ) -> Vec<(SearchTarget, quality::QualityTier)> {
-    let monitored: HashSet<i32> = monitored_episodes.iter().copied().collect();
+    let candidates: HashSet<i32> = candidate_episodes.iter().copied().collect();
     let mut targets = Vec::new();
     for file in disk_files {
-        if !monitored.contains(&file.episode_number) {
+        if !candidates.contains(&file.episode_number) {
             continue;
         }
         // Prefer the quality tag recorded at grab time (from the release title)

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -27,3 +27,4 @@ pub mod nfo;
 pub mod post_processing;
 
 pub mod anibridge;
+pub mod upgrade;

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -241,9 +241,75 @@ async fn import_torrent(
         let dest_video = season_dir.join(format!("{}.{}", dest_stem, ext));
         let dest_nfo = season_dir.join(format!("{}.nfo", dest_stem));
 
-        if dest_video.exists() {
-            // Already imported (e.g. re-run after partial failure). Skip.
-            continue;
+        // Check for existing files with the same episode stem (any extension).
+        // This catches upgrades even when the old and new files have different
+        // containers (e.g. .mkv -> .mp4).
+        let existing_for_ep: Vec<PathBuf> = std::fs::read_dir(&season_dir)
+            .into_iter()
+            .flatten()
+            .filter_map(|e| e.ok())
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s == dest_stem)
+                    .unwrap_or(false)
+                    && p.extension()
+                        .and_then(|e| e.to_str())
+                        .map(|e| e != "nfo")
+                        .unwrap_or(false)
+            })
+            .collect();
+
+        if !existing_for_ep.is_empty() {
+            // Check if this is an upgrade replacing a previously imported file.
+            // If an older imported grab exists for this episode, this is an
+            // upgrade — remove the old file and old torrent, then import the new one.
+            let old_grabs = grabbed_torrents::find_imported_for_episode(
+                &state.db,
+                grab.series_id,
+                ep_num,
+            )
+            .await
+            .unwrap_or_default();
+
+            if old_grabs.is_empty() {
+                // No older import record — likely a re-run of the same grab. Skip.
+                continue;
+            }
+
+            // Remove old file(s) to make way for the upgrade.
+            for old_file in &existing_for_ep {
+                if let Err(e) = std::fs::remove_file(old_file) {
+                    logger::error(
+                        &state.db,
+                        LogCategory::PostProcess,
+                        &format!("Failed to remove old file for upgrade: {}", old_file.display()),
+                        &e.to_string(),
+                    )
+                    .await;
+                }
+            }
+            // Also remove old NFO so it gets rewritten.
+            let _ = std::fs::remove_file(&dest_nfo);
+
+            logger::info(
+                &state.db,
+                LogCategory::PostProcess,
+                &format!("Replacing S{:02}E{:02} of '{}' with upgraded release", season, ep_num, series.title),
+                &format!("old_grabs={}", old_grabs.len()),
+            )
+            .await;
+
+            // Clean up old torrents from qBittorrent and mark old grabs as replaced.
+            for old_grab in &old_grabs {
+                if !old_grab.hash.is_empty() {
+                    if let Some(ref qbit_client) = state.qbit.read().await.clone() {
+                        let _ = qbit_client.delete_torrent(&old_grab.hash, true).await;
+                    }
+                }
+                let _ = grabbed_torrents::mark_removed(&state.db, old_grab.id).await;
+            }
         }
 
         match do_file_op(&cfg.post_processing_mode, &src, &dest_video) {

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -33,25 +33,12 @@ fn is_errored(state: &str) -> bool {
 /// Check if a grab is older than `max_age_secs` seconds.
 fn grab_is_stale(grabbed_at: &str, max_age_secs: i64) -> bool {
     // grabbed_at is SQLite CURRENT_TIMESTAMP format: "YYYY-MM-DD HH:MM:SS"
-    use std::time::{SystemTime, UNIX_EPOCH};
-    let now = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    // Parse year, month, day, hour, min, sec from the string
-    let parts: Vec<&str> = grabbed_at.split(|c: char| !c.is_ascii_digit()).collect();
-    let nums: Vec<i64> = parts.iter().filter_map(|s| s.parse().ok()).collect();
-    if nums.len() < 5 {
+    let Some(grab_time) = chrono::NaiveDateTime::parse_from_str(grabbed_at, "%Y-%m-%d %H:%M:%S").ok() else {
         return false;
-    }
-    let (year, month, day, hour, min) = (nums[0], nums[1], nums[2], nums[3], nums[4]);
-    let sec = if nums.len() > 5 { nums[5] } else { 0 };
-    // Rough UTC timestamp (good enough for a 5-minute check)
-    let days_since_epoch = (year - 1970) * 365 + (year - 1969) / 4
-        + [0, 31, 59, 90, 120, 151, 181, 212, 243, 273, 304, 334][(month - 1).max(0).min(11) as usize] as i64
-        + (day - 1);
-    let grab_ts = days_since_epoch * 86400 + hour * 3600 + min * 60 + sec;
-    now - grab_ts > max_age_secs
+    };
+    let now = chrono::Utc::now().naive_utc();
+    let elapsed = now.signed_duration_since(grab_time).num_seconds();
+    elapsed > max_age_secs
 }
 
 fn is_video_file(name: &str) -> bool {

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -241,9 +241,11 @@ async fn import_torrent(
         let dest_video = season_dir.join(format!("{}.{}", dest_stem, ext));
         let dest_nfo = season_dir.join(format!("{}.nfo", dest_stem));
 
-        // Check for existing files with the same episode stem (any extension).
-        // This catches upgrades even when the old and new files have different
-        // containers (e.g. .mkv -> .mp4).
+        // Check for existing files with the same SxxExx tag (any extension).
+        // Matching by episode tag instead of full stem handles cases where the
+        // episode title changed in AniList between the original grab and the
+        // upgrade (e.g. a translated title was added later).
+        let ep_tag = format!("S{:02}E{:02}", season, ep_num);
         let existing_for_ep: Vec<PathBuf> = std::fs::read_dir(&season_dir)
             .into_iter()
             .flatten()
@@ -252,7 +254,7 @@ async fn import_torrent(
             .filter(|p| {
                 p.file_stem()
                     .and_then(|s| s.to_str())
-                    .map(|s| s == dest_stem)
+                    .map(|s| s.contains(&ep_tag))
                     .unwrap_or(false)
                     && p.extension()
                         .and_then(|e| e.to_str())
@@ -278,7 +280,7 @@ async fn import_torrent(
                 continue;
             }
 
-            // Remove old file(s) to make way for the upgrade.
+            // Remove old file(s) and their NFOs to make way for the upgrade.
             for old_file in &existing_for_ep {
                 if let Err(e) = std::fs::remove_file(old_file) {
                     logger::error(
@@ -289,9 +291,12 @@ async fn import_torrent(
                     )
                     .await;
                 }
+                // Remove corresponding NFO (old stem may differ from new dest_stem
+                // if the episode title changed between grabs).
+                if let Some(stem) = old_file.file_stem().and_then(|s| s.to_str()) {
+                    let _ = std::fs::remove_file(season_dir.join(format!("{}.nfo", stem)));
+                }
             }
-            // Also remove old NFO so it gets rewritten.
-            let _ = std::fs::remove_file(&dest_nfo);
 
             logger::info(
                 &state.db,

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -189,7 +189,13 @@ pub async fn sync_once(state: &AppState, trigger: &str) -> Result<SyncSummary, S
     let _guard = RSS_SYNC_LOCK.try_lock().map_err(|_| "RSS sync is already running".to_string())?;
 
     let run_id = rss::start_run(&state.db, trigger).await.map_err(|e| e.to_string())?;
-    let result = sync_once_inner(state, trigger).await;
+    let result = match tokio::time::timeout(
+        std::time::Duration::from_secs(300),
+        sync_once_inner(state, trigger),
+    ).await {
+        Ok(inner) => inner,
+        Err(_) => Err("RSS sync timed out after 5 minutes".to_string()),
+    };
 
     match &result {
         Ok(summary) => {

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -240,6 +240,7 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
     // Cache on-disk episode scans per folder to avoid repeated filesystem walks.
     let mut disk_cache: HashMap<String, Vec<media::EpisodeFile>> = HashMap::new();
     let mut monitored_cache: HashMap<i64, HashSet<i32>> = HashMap::new();
+    let mut quality_tags_cache: HashMap<i64, HashMap<i32, crate::models::episode_tags::EpisodeQualityTag>> = HashMap::new();
 
     let cutoff_tier = quality::QualityTier::from_str(&cfg.quality_cutoff);
 
@@ -310,7 +311,15 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
         let disk_files = disk_cache
             .entry(found.series.folder_name.clone())
             .or_insert_with(|| media::scan_series_folder(&cfg.media_root, &found.series.folder_name));
-        let decision = evaluate_candidate(&found.series, &item, disk_files, &actionable_eps, cutoff_tier);
+        let qtags = if let Some(cached) = quality_tags_cache.get(&found.series.id) {
+            cached
+        } else {
+            let tags = episode_tags::get_for_series(&state.db, found.series.id)
+                .await
+                .unwrap_or_default();
+            quality_tags_cache.entry(found.series.id).or_insert(tags)
+        };
+        let decision = evaluate_candidate(&found.series, &item, disk_files, &actionable_eps, cutoff_tier, qtags);
         if let Some(reason) = decision.reject_reason {
             skipped += 1;
             let reason = format!("{} | {}", reason, build_match_diag(&item, Some(&found), 0));
@@ -564,6 +573,7 @@ fn evaluate_candidate(
     disk_files: &[media::EpisodeFile],
     parsed_eps: &HashSet<i32>,
     cutoff_tier: quality::QualityTier,
+    quality_tags: &HashMap<i32, crate::models::episode_tags::EpisodeQualityTag>,
 ) -> CandidateDecision {
     let existing_ep_numbers: HashSet<i32> = disk_files.iter().map(|f| f.episode_number).collect();
 
@@ -572,7 +582,7 @@ fn evaluate_candidate(
             // For batches, count episodes that are either missing or upgradeable.
             let new_count = parsed_eps.iter().filter(|ep| !existing_ep_numbers.contains(ep)).count() as i32;
             let upgrade_count = parsed_eps.iter().filter(|ep| {
-                existing_ep_numbers.contains(ep) && episode_is_upgradeable(*ep, disk_files, item, cutoff_tier)
+                existing_ep_numbers.contains(ep) && episode_is_upgradeable(ep, disk_files, item, cutoff_tier, quality_tags)
             }).count() as i32;
             let actionable = new_count + upgrade_count;
             if actionable == 0 {
@@ -610,7 +620,7 @@ fn evaluate_candidate(
 
     let new_count = parsed_eps.iter().filter(|ep| !existing_ep_numbers.contains(ep)).count() as i32;
     let upgrade_count = parsed_eps.iter().filter(|ep| {
-        existing_ep_numbers.contains(ep) && episode_is_upgradeable(*ep, disk_files, item, cutoff_tier)
+        existing_ep_numbers.contains(ep) && episode_is_upgradeable(ep, disk_files, item, cutoff_tier, quality_tags)
     }).count() as i32;
     let actionable = new_count + upgrade_count;
 
@@ -630,17 +640,28 @@ fn evaluate_candidate(
 }
 
 /// Check if an episode on disk is below the quality cutoff and the incoming
-/// release would be an upgrade.
+/// release would be an upgrade.  Prefers the DB-stored quality tag (from the
+/// original release title at grab time) over the post-processed filename,
+/// which often loses resolution/source markers.
 fn episode_is_upgradeable(
     ep: &i32,
     disk_files: &[media::EpisodeFile],
     incoming: &RssItem,
     cutoff_tier: quality::QualityTier,
+    quality_tags: &HashMap<i32, crate::models::episode_tags::EpisodeQualityTag>,
 ) -> bool {
     let Some(existing) = disk_files.iter().find(|f| f.episode_number == *ep) else {
         return false; // not on disk — not an "upgrade", it's a new episode
     };
-    let existing_tier = quality::tier_from_disk_quality(&existing.quality);
+    let existing_tier = if let Some(tag) = quality_tags.get(ep) {
+        let tier = quality::QualityTier::from_str(&tag.quality_tag);
+        if tier != quality::QualityTier::Unknown { tier } else { quality::tier_from_disk_quality(&existing.quality) }
+    } else {
+        quality::tier_from_disk_quality(&existing.quality)
+    };
+    if existing_tier == quality::QualityTier::Unknown {
+        return false;
+    }
     // Only upgrade if existing is below cutoff
     if existing_tier.rank() >= cutoff_tier.rank() {
         return false;

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -1,0 +1,273 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::models::log::LogCategory;
+use crate::models::{config, episode_tags, metadata_cache, monitoring, series};
+use crate::services::{auto_search, logger, media, quality};
+use crate::AppState;
+
+static UPGRADE_LOCK: std::sync::LazyLock<tokio::sync::Mutex<()>> =
+    std::sync::LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+pub struct UpgradeSummary {
+    pub series_checked: usize,
+    pub episodes_checked: usize,
+    pub upgrades_grabbed: usize,
+    pub detail: String,
+}
+
+pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
+    let _guard = UPGRADE_LOCK
+        .try_lock()
+        .map_err(|_| "Upgrade search is already running".to_string())?;
+
+    let cfg = config::get_config(&state.db)
+        .await
+        .map_err(|e| e.to_string())?
+        .unwrap_or_default();
+
+    let cutoff_tier = quality::QualityTier::from_str(&cfg.quality_cutoff);
+    if cutoff_tier == quality::QualityTier::Unknown {
+        return Ok(UpgradeSummary {
+            series_checked: 0,
+            episodes_checked: 0,
+            upgrades_grabbed: 0,
+            detail: "No quality cutoff configured; skipping upgrade search".to_string(),
+        });
+    }
+
+    let tracked = series::get_all(&state.db)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let qbit = state.qbit.read().await.clone();
+    let Some(client) = qbit.as_ref() else {
+        return Ok(UpgradeSummary {
+            series_checked: 0,
+            episodes_checked: 0,
+            upgrades_grabbed: 0,
+            detail: "qBittorrent not configured; skipping upgrade search".to_string(),
+        });
+    };
+
+    let mut total_series_checked: usize = 0;
+    let mut total_episodes_checked: usize = 0;
+    let mut total_upgrades_grabbed: usize = 0;
+
+    logger::info(
+        &state.db,
+        LogCategory::AutoSearch,
+        "Upgrade search started",
+        &format!("{} tracked series", tracked.len()),
+    )
+    .await;
+
+    for row in &tracked {
+        // Skip series with no folder (not set up yet).
+        if row.folder_name.is_empty() {
+            continue;
+        }
+
+        let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name);
+        if disk_files.is_empty() {
+            continue;
+        }
+
+        let monitored_eps = monitoring::get_monitored_episode_numbers(&state.db, row.id)
+            .await
+            .unwrap_or_default();
+        if monitored_eps.is_empty() {
+            continue;
+        }
+
+        let quality_tags = episode_tags::get_for_series(&state.db, row.id)
+            .await
+            .unwrap_or_default();
+
+        // Only consider episodes that are actually on disk — skip missing ones.
+        let on_disk_eps: HashSet<i32> = disk_files.iter().map(|f| f.episode_number).collect();
+        let monitored_on_disk: Vec<i32> = monitored_eps
+            .iter()
+            .copied()
+            .filter(|ep| on_disk_eps.contains(ep))
+            .collect();
+
+        let upgrade_targets =
+            auto_search::build_upgrade_targets(&disk_files, &monitored_on_disk, cutoff_tier, &quality_tags);
+        if upgrade_targets.is_empty() {
+            continue;
+        }
+
+        // We need an AnimeDetail for find_best_for_target. Use the metadata cache
+        // to avoid hitting external APIs during background tasks.
+        let detail = match metadata_cache::get_by_series_id(&state.db, row.id).await {
+            Ok(Some(cached)) => cached.detail,
+            _ => {
+                logger::debug(
+                    &state.db,
+                    LogCategory::AutoSearch,
+                    &format!("Upgrade: skipping {} — no cached metadata", row.title),
+                    "",
+                )
+                .await;
+                continue;
+            }
+        };
+
+        total_series_checked += 1;
+        let title = if !detail.title_english.is_empty() {
+            &detail.title_english
+        } else {
+            &detail.title_romaji
+        };
+
+        let upgrade_tiers: HashMap<i32, quality::QualityTier> = upgrade_targets
+            .iter()
+            .filter_map(|(t, tier)| match t {
+                auto_search::SearchTarget::Episode(n) => Some((*n, *tier)),
+                _ => None,
+            })
+            .collect();
+
+        let targets: Vec<auto_search::SearchTarget> = upgrade_targets
+            .into_iter()
+            .map(|(t, _)| t)
+            .collect();
+        let target_count = targets.len();
+        total_episodes_checked += target_count;
+
+        logger::debug(
+            &state.db,
+            LogCategory::AutoSearch,
+            &format!("Upgrade: checking {} ({} episodes)", title, target_count),
+            "",
+        )
+        .await;
+
+        for target in targets {
+            let label = auto_search::target_label(&target);
+            // batch_episode_match=true so BD season packs can match episode targets.
+            let best =
+                auto_search::find_best_for_target(&detail, &cfg, &target, true, true).await;
+
+            let Some(result) = best else {
+                continue;
+            };
+
+            // Verify this is actually an upgrade.
+            if let auto_search::SearchTarget::Episode(ep_num) = &target {
+                if let Some(existing_tier) = upgrade_tiers.get(ep_num) {
+                    let incoming_tier =
+                        quality::detect_tier(&result.title, &result.resolution);
+                    if incoming_tier.rank() <= existing_tier.rank() {
+                        continue;
+                    }
+                    logger::info(
+                        &state.db,
+                        LogCategory::AutoSearch,
+                        &format!(
+                            "Upgrade: {} {} — {} -> {}",
+                            title,
+                            label,
+                            existing_tier.label(),
+                            incoming_tier.label()
+                        ),
+                        &result.title,
+                    )
+                    .await;
+                }
+            }
+
+            let url = if !result.magnet.is_empty() {
+                result.magnet.clone()
+            } else {
+                result.torrent.clone()
+            };
+            if url.is_empty() {
+                continue;
+            }
+
+            match client.add_torrent(&url).await {
+                Ok(_) => {
+                    total_upgrades_grabbed += 1;
+                    let tier = quality::detect_tier(&result.title, &result.resolution);
+                    logger::info(
+                        &state.db,
+                        LogCategory::Grab,
+                        &format!("Upgrade grabbed: {}", result.title),
+                        &format!(
+                            "series={}, target={}, group={}, tier={}",
+                            title, label, result.group, tier.label()
+                        ),
+                    )
+                    .await;
+
+                    // Record for post-processing and quality tags.
+                    let mut ep_nums: Vec<i32> = match &target {
+                        auto_search::SearchTarget::Episode(n) => vec![*n],
+                        auto_search::SearchTarget::Single => vec![1],
+                    };
+                    if result.is_batch {
+                        let parsed = auto_search::parse_release_numbers(&result.title);
+                        if !parsed.is_empty() {
+                            ep_nums = parsed.into_iter().collect();
+                            ep_nums.sort_unstable();
+                        }
+                    }
+                    let _ = crate::models::grabbed_torrents::record_grab(
+                        &state.db,
+                        &result.info_hash,
+                        &result.title,
+                        row.id,
+                        &ep_nums,
+                    )
+                    .await;
+                    for ep_num in &ep_nums {
+                        let _ = episode_tags::record_grab(
+                            &state.db,
+                            row.id,
+                            *ep_num,
+                            tier.label(),
+                            &result.title,
+                            &result.group,
+                        )
+                        .await;
+                    }
+                }
+                Err(err) => {
+                    logger::error(
+                        &state.db,
+                        LogCategory::QBit,
+                        &format!("Upgrade grab failed: {} {}", title, label),
+                        &err,
+                    )
+                    .await;
+                }
+            }
+
+            // Rate-limit between searches to avoid hammering Nyaa.
+            tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+        }
+
+        // Rate-limit between series.
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+    }
+
+    let detail = format!(
+        "Checked {} series, {} episodes, grabbed {} upgrades",
+        total_series_checked, total_episodes_checked, total_upgrades_grabbed
+    );
+    logger::info(
+        &state.db,
+        LogCategory::AutoSearch,
+        "Upgrade search finished",
+        &detail,
+    )
+    .await;
+
+    Ok(UpgradeSummary {
+        series_checked: total_series_checked,
+        episodes_checked: total_episodes_checked,
+        upgrades_grabbed: total_upgrades_grabbed,
+        detail,
+    })
+}

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -1,7 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use crate::models::log::LogCategory;
-use crate::models::{config, episode_tags, metadata_cache, monitoring, series};
+use crate::models::{config, episode_tags, metadata_cache, series};
 use crate::services::{auto_search, logger, media, quality};
 use crate::AppState;
 
@@ -72,27 +72,17 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             continue;
         }
 
-        let monitored_eps = monitoring::get_monitored_episode_numbers(&state.db, row.id)
-            .await
-            .unwrap_or_default();
-        if monitored_eps.is_empty() {
-            continue;
-        }
-
         let quality_tags = episode_tags::get_for_series(&state.db, row.id)
             .await
             .unwrap_or_default();
 
-        // Only consider episodes that are actually on disk — skip missing ones.
-        let on_disk_eps: HashSet<i32> = disk_files.iter().map(|f| f.episode_number).collect();
-        let monitored_on_disk: Vec<i32> = monitored_eps
-            .iter()
-            .copied()
-            .filter(|ep| on_disk_eps.contains(ep))
-            .collect();
+        // Check all on-disk episodes for upgrades. The monitoring system governs
+        // what to *acquire* (missing/future), not what to *upgrade*, so we use
+        // disk presence directly rather than monitor state.
+        let on_disk_eps: Vec<i32> = disk_files.iter().map(|f| f.episode_number).collect();
 
         let upgrade_targets =
-            auto_search::build_upgrade_targets(&disk_files, &monitored_on_disk, cutoff_tier, &quality_tags);
+            auto_search::build_upgrade_targets(&disk_files, &on_disk_eps, cutoff_tier, &quality_tags);
         if upgrade_targets.is_empty() {
             continue;
         }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2064,6 +2064,16 @@ fieldset legend {
     background: var(--bg-card);
 }
 
+.rss-table td a {
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.rss-table td a:hover {
+    color: var(--accent-hover);
+    text-decoration: underline;
+}
+
 .rss-table th {
     color: var(--text-dim);
     font-size: 12px;

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -25,7 +25,34 @@
 {% if tab == "queue" %}
 <div class="rss-panel">
     <div id="queue-container">
-        <div class="logs-empty" id="queue-loading">Loading queue from qBittorrent...</div>
+        {% if !queue_error.is_empty() %}
+        <div class="logs-empty">{{ queue_error }}</div>
+        {% else if queue.is_empty() %}
+        <div class="logs-empty">No active torrents in qBittorrent.</div>
+        {% else %}
+        <div class="rss-table-wrap"><table class="rss-table"><thead><tr>
+            <th>Name</th><th>Size</th><th>Progress</th><th>Speed</th><th>ETA</th><th>Status</th><th>Actions</th>
+        </tr></thead><tbody>
+        {% for t in queue %}
+        <tr data-hash="{{ t.hash }}">
+            <td><div class="dl-torrent-name">{{ t.name }}</div></td>
+            <td>{{ t.size_display }}</td>
+            <td><div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:{{ t.progress_pct }}%"></div></div><span class="dl-progress-text">{{ t.progress_pct }}%</span></div></td>
+            <td>{{ t.speed_display }}</td>
+            <td>{{ t.eta_display }}</td>
+            <td><span class="log-badge {{ t.state_badge_class }}">{{ t.state_label }}</span></td>
+            <td class="dl-actions">
+                {% if t.is_paused %}
+                <button class="btn btn-ghost btn-sm" onclick="resumeTorrent('{{ t.hash }}')" title="Resume"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg></button>
+                {% else %}
+                <button class="btn btn-ghost btn-sm" onclick="pauseTorrent('{{ t.hash }}')" title="Pause"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg></button>
+                {% endif %}
+                <button class="btn btn-ghost btn-sm" onclick="deleteTorrent('{{ t.hash }}')" title="Remove"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></button>
+            </td>
+        </tr>
+        {% endfor %}
+        </tbody></table></div>
+        {% endif %}
     </div>
 </div>
 
@@ -54,23 +81,14 @@ function formatEta(seconds) {
 
 function stateLabel(state) {
     const map = {
-        'uploading': 'Seeding',
-        'stalledUP': 'Seeding',
-        'forcedUP': 'Seeding',
-        'downloading': 'Downloading',
+        'uploading': 'Seeding', 'stalledUP': 'Seeding', 'forcedUP': 'Seeding',
+        'downloading': 'Downloading', 'forcedDL': 'Downloading',
         'stalledDL': 'Stalled',
-        'forcedDL': 'Downloading',
-        'pausedDL': 'Paused',
-        'pausedUP': 'Paused',
-        'queuedDL': 'Queued',
-        'queuedUP': 'Queued',
-        'checkingDL': 'Checking',
-        'checkingUP': 'Checking',
-        'error': 'Error',
-        'missingFiles': 'Missing Files',
-        'moving': 'Moving',
-        'metaDL': 'Fetching metadata',
-        'allocating': 'Allocating',
+        'pausedDL': 'Paused', 'pausedUP': 'Paused',
+        'queuedDL': 'Queued', 'queuedUP': 'Queued',
+        'checkingDL': 'Checking', 'checkingUP': 'Checking',
+        'error': 'Error', 'missingFiles': 'Missing Files',
+        'moving': 'Moving', 'metaDL': 'Fetching metadata', 'allocating': 'Allocating',
     };
     return map[state] || state;
 }
@@ -78,9 +96,8 @@ function stateLabel(state) {
 function stateBadgeClass(state) {
     if (['uploading', 'stalledUP', 'forcedUP', 'pausedUP'].includes(state)) return 'log-badge-info';
     if (['downloading', 'forcedDL'].includes(state)) return 'log-badge-debug';
-    if (['pausedDL', 'queuedDL', 'queuedUP'].includes(state)) return 'log-badge-warn';
+    if (['pausedDL', 'queuedDL', 'queuedUP', 'stalledDL'].includes(state)) return 'log-badge-warn';
     if (['error', 'missingFiles'].includes(state)) return 'log-badge-error';
-    if (state === 'stalledDL') return 'log-badge-warn';
     return '';
 }
 
@@ -96,19 +113,15 @@ function renderQueue(torrents) {
         container.innerHTML = '<div class="logs-empty">No active torrents in qBittorrent.</div>';
         return;
     }
-
-    // Sort: downloading first, then by progress desc
     torrents.sort((a, b) => {
         const aDown = a.state.includes('DL') || a.state === 'downloading' ? 0 : 1;
         const bDown = b.state.includes('DL') || b.state === 'downloading' ? 0 : 1;
         if (aDown !== bDown) return aDown - bDown;
         return b.progress - a.progress;
     });
-
     let html = '<div class="rss-table-wrap"><table class="rss-table"><thead><tr>';
     html += '<th>Name</th><th>Size</th><th>Progress</th><th>Speed</th><th>ETA</th><th>Status</th><th>Actions</th>';
     html += '</tr></thead><tbody>';
-
     for (const t of torrents) {
         const pct = (t.progress * 100).toFixed(1);
         const isPaused = t.state.startsWith('paused');
@@ -128,21 +141,17 @@ function renderQueue(torrents) {
         html += `<button class="btn btn-ghost btn-sm" onclick="deleteTorrent('${escapeHtml(t.hash)}')" title="Remove"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></button>`;
         html += `</td></tr>`;
     }
-
     html += '</tbody></table></div>';
     container.innerHTML = html;
 }
 
 function loadQueue() {
     fetch('/api/torrents')
-        .then(r => {
-            if (!r.ok) throw new Error('Failed to load queue');
-            return r.json();
-        })
+        .then(r => { if (!r.ok) throw new Error('Failed to load queue'); return r.json(); })
         .then(data => renderQueue(data))
         .catch(err => {
             document.getElementById('queue-container').innerHTML =
-                '<div class="logs-empty">Could not load queue: ' + escapeHtml(err.message) + '. Is qBittorrent configured?</div>';
+                '<div class="logs-empty">Could not load queue: ' + escapeHtml(err.message) + '</div>';
         });
 }
 
@@ -162,7 +171,6 @@ function deleteTorrent(hash) {
         .then(() => setTimeout(loadQueue, 500));
 }
 
-loadQueue();
 setInterval(loadQueue, 5000);
 </script>
 

--- a/templates/help.html
+++ b/templates/help.html
@@ -29,12 +29,14 @@
                 <tr><td>Seeders &gt; 10</td><td>+20</td></tr>
                 <tr><td>Seeders &gt; 0</td><td>+10</td></tr>
                 <tr><td>Zero seeders</td><td>-10</td></tr>
-                <tr><td>Preferred release group</td><td>+25</td></tr>
+                <tr><td>Preferred release group (ordered)</td><td>+140 / +120 / +100 / ...</td></tr>
+                <tr><td>Non-preferred group</td><td>-15</td></tr>
                 <tr><td>Preferred resolution</td><td>+20</td></tr>
                 <tr><td>Batch release</td><td>+15</td></tr>
                 <tr><td>Trusted uploader</td><td>+10</td></tr>
                 <tr><td>10bit / x265 / BD source</td><td>+5</td></tr>
-                <tr><td>Dual audio / multi</td><td>-5</td></tr>
+                <tr><td>Dual audio / dub (prefer subs)</td><td>-15</td></tr>
+                <tr><td>Dual audio / dub (prefer dubs)</td><td>+15</td></tr>
                 <tr><td>Downloads &gt; 10,000</td><td>+15</td></tr>
                 <tr><td>Downloads &gt; 5,000</td><td>+10</td></tr>
                 <tr><td>Downloads &gt; 1,000</td><td>+5</td></tr>

--- a/templates/search.html
+++ b/templates/search.html
@@ -22,6 +22,24 @@
     <input type="text" name="user" id="search-user" placeholder="Uploader (optional)" class="search-user">
     <button type="submit" class="btn btn-primary">Search</button>
 </form>
+<script>
+// Persist search options in localStorage
+(function() {
+    const fields = ['search-category', 'search-filter', 'search-user'];
+    const KEY = 'nyaa_search_opts';
+    const saved = JSON.parse(localStorage.getItem(KEY) || '{}');
+    for (const id of fields) {
+        if (saved[id] !== undefined && saved[id] !== '') {
+            document.getElementById(id).value = saved[id];
+        }
+    }
+    document.getElementById('search-form').addEventListener('submit', function() {
+        const opts = {};
+        for (const id of fields) opts[id] = document.getElementById(id).value;
+        localStorage.setItem(KEY, JSON.stringify(opts));
+    });
+})();
+</script>
 
 {% if searched %}
 <div class="results-container">

--- a/templates/series.html
+++ b/templates/series.html
@@ -516,13 +516,14 @@ function renderGrabHistory(entries, epNum) {
 
 function markEpisodeFailed(historyId, epNum, btn) {
     if (!confirm('Mark this grab as failed and re-search for the episode?')) return;
+    const addToBlocklist = confirm('Also add this release to the blocklist?');
     btn.disabled = true;
     btn.textContent = 'Searching…';
     const status = document.getElementById('auto-search-status');
     fetch(`/api/series/${SD.id}/mark-failed/${epNum}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({ history_id: historyId })
+        body: JSON.stringify({ history_id: historyId, blocklist: addToBlocklist })
     })
     .then(async r => {
         let data = {};

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -191,6 +191,13 @@
                 </select>
                 <span class="form-hint">Controls scoring for releases tagged as dual audio, dubbed, or multi-audio. "Prefer Subs" penalizes these releases; "Prefer Dubs" boosts them.</span>
             </div>
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="upgrade_search_enabled" value="1" {% if config.upgrade_search_enabled %}checked{% endif %}>
+                    Automatic Upgrade Search
+                </label>
+                <span class="form-hint">Periodically search for higher-quality releases of downloaded episodes. Runs every 24 hours. Upgrades via RSS are always active regardless of this setting.</span>
+            </div>
         </fieldset>
     </div>
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -25,7 +25,7 @@
 
     <div class="settings-tab-panel {% if tab == "integrations" %}active{% endif %}">
         <fieldset>
-            <legend>qBittorrent</legend>
+            <legend>qBittorrent <span id="qbit-health" class="form-hint"></span></legend>
             <div class="form-group">
                 <label for="qbit_url">URL</label>
                 <input type="text" name="qbit_url" id="qbit_url" value="{{ config.qbit_url }}" placeholder="http://localhost:8080">
@@ -56,7 +56,7 @@
         </fieldset>
 
         <fieldset>
-            <legend>Jellyfin</legend>
+            <legend>Jellyfin <span id="jellyfin-health" class="form-hint"></span></legend>
             <div class="form-group">
                 <label for="jellyfin_url">URL</label>
                 <input type="text" name="jellyfin_url" id="jellyfin_url" value="{{ config.jellyfin_url }}" placeholder="http://192.168.68.61:8096">
@@ -354,6 +354,33 @@ function refreshJellyfin(btn) {
         btn.disabled = false;
     });
 }
+
+// Auto-check connection health on integrations tab load
+(function() {
+    const qbitHealth = document.getElementById('qbit-health');
+    const jellyfinHealth = document.getElementById('jellyfin-health');
+    if (!qbitHealth && !jellyfinHealth) return;
+
+    fetch('/api/health')
+        .then(r => r.json())
+        .then(data => {
+            if (qbitHealth && data.qbit) {
+                if (data.qbit.ok) {
+                    qbitHealth.innerHTML = '<span class="log-badge log-badge-info">' + data.qbit.message + '</span>';
+                } else if (data.qbit.message !== 'Not configured') {
+                    qbitHealth.innerHTML = '<span class="log-badge log-badge-error">Disconnected</span>';
+                }
+            }
+            if (jellyfinHealth && data.jellyfin) {
+                if (data.jellyfin.ok) {
+                    jellyfinHealth.innerHTML = '<span class="log-badge log-badge-info">' + data.jellyfin.message + '</span>';
+                } else if (data.jellyfin.message !== 'Not configured') {
+                    jellyfinHealth.innerHTML = '<span class="log-badge log-badge-error">Disconnected</span>';
+                }
+            }
+        })
+        .catch(() => {});
+})();
 
 </script>
 {% endblock %}

--- a/templates/system.html
+++ b/templates/system.html
@@ -313,6 +313,7 @@ function runRssSync(btn) {
                         <th>Last started</th>
                         <th>Last finished</th>
                         <th>Detail</th>
+                        <th></th>
                     </tr>
                 </thead>
                 <tbody>
@@ -328,6 +329,7 @@ function runRssSync(btn) {
                         <td>{% if let Some(started) = task.last_started_at %}{{ started }}{% else %}—{% endif %}</td>
                         <td>{% if let Some(finished) = task.last_finished_at %}{{ finished }}{% else %}—{% endif %}</td>
                         <td class="rss-reason-cell"><div class="rss-reason-text">{{ task.last_detail }}</div></td>
+                        <td><button type="button" class="btn btn-secondary btn-sm" onclick="forceRunTask(this, '{{ task.task_key }}')">Run now</button></td>
                     </tr>
                     {% endfor %}
                 </tbody>
@@ -336,6 +338,30 @@ function runRssSync(btn) {
         {% endif %}
     </fieldset>
 </div>
+<script>
+function forceRunTask(btn, taskKey) {
+    const endpoints = {
+        rss_sync: '/api/rss/sync',
+        metadata_refresh: '/api/tasks/metadata-refresh',
+        cleanup: '/api/tasks/cleanup',
+        post_processing: '/api/tasks/post-processing',
+        upgrade_search: '/api/tasks/upgrade-search',
+    };
+    const url = endpoints[taskKey];
+    if (!url) { alert('No run endpoint for task: ' + taskKey); return; }
+    btn.disabled = true;
+    btn.textContent = 'Running...';
+    fetch(url, { method: 'POST' })
+        .then(r => r.json().then(data => ({ ok: r.ok, data })).catch(() => ({ ok: r.ok, data: null })))
+        .then(({ ok, data }) => {
+            if (data && data.message) { alert(data.message); }
+            else if (!ok) { alert('Task failed'); }
+            location.reload();
+        })
+        .catch(err => { alert('Error: ' + err.message); })
+        .finally(() => { btn.disabled = false; btn.textContent = 'Run now'; });
+}
+</script>
 {% else if tab == "debug" %}
 <div class="debug-panel">
     <form method="post" action="/system" class="settings-form">

--- a/templates/system.html
+++ b/templates/system.html
@@ -476,12 +476,14 @@ function clearRssHistory(btn) {
                 <tr><td>Seeders &gt; 10</td><td>+20</td></tr>
                 <tr><td>Seeders &gt; 0</td><td>+10</td></tr>
                 <tr><td>Zero seeders</td><td>-10</td></tr>
-                <tr><td>Preferred release group</td><td>+25</td></tr>
+                <tr><td>Preferred release group (ordered)</td><td>+140 / +120 / +100 / ...</td></tr>
+                <tr><td>Non-preferred group</td><td>-15</td></tr>
                 <tr><td>Preferred resolution</td><td>+20</td></tr>
                 <tr><td>Batch release</td><td>+15</td></tr>
                 <tr><td>Trusted uploader</td><td>+10</td></tr>
                 <tr><td>10bit / x265 / BD source</td><td>+5</td></tr>
-                <tr><td>Dual audio / multi</td><td>-5</td></tr>
+                <tr><td>Dual audio / dub (prefer subs)</td><td>-15</td></tr>
+                <tr><td>Dual audio / dub (prefer dubs)</td><td>+15</td></tr>
                 <tr><td>Downloads &gt; 10,000</td><td>+15</td></tr>
                 <tr><td>Downloads &gt; 5,000</td><td>+10</td></tr>
                 <tr><td>Downloads &gt; 1,000</td><td>+5</td></tr>


### PR DESCRIPTION
## Summary

- **Quality cutoff enforcement**: Wire the existing quality cutoff setting into auto-search so episodes that already meet cutoff aren't re-grabbed. Adds `build_upgrade_targets()` to identify episodes eligible for upgrade.
- **Fix `.unwrap()` panics in Sonarr/Radarr compat**: Replace fragile `.unwrap()` on `mal_id` with `if let Some(mal_id)` guards so AniList-only entries don't crash the Seerr integration.
- **Fix post-processing timestamp parsing**: Replace manual date parsing with `chrono::NaiveDateTime::parse_from_str` for correctness.
- **Fix scoring table values**: Update outdated scoring explanations in help and system pages to match actual code values.
- **AniList cache eviction**: Cap the in-memory detail cache at 500 entries, evicting expired then oldest when full.
- **Server-side queue rendering**: Render the Downloads queue tab server-side via Askama instead of client-side fetch, eliminating the "Loading..." flash. JS polling still refreshes every 5s.
- **RSS sync timeout**: Wrap RSS sync with a 5-minute `tokio::time::timeout` so a hung external API can't hold the sync lock indefinitely.
- **Connection health checks**: Add `/api/health` endpoint that tests qBit and Jellyfin connections. Settings integrations tab auto-checks on page load and shows status badges.
- **Persist search options**: Save Nyaa search category/filter/user to localStorage so they survive page reloads.
- **Accent-color links**: Style `.rss-table` links with the accent color instead of default browser blue.
- **Blocklist on mark-failed**: Prompt to add a release to the blocklist when marking an episode grab as failed.
- **Fix external series links**: Also check `get_by_anilist_id` in `resolve_series_request` so `/series/<anilist_id>` links resolve tracked series and show on-disk files.

## Test plan

- [x] Verify quality cutoff: episodes at or above cutoff tier should not be re-grabbed by auto-search
- [x] Test Seerr integration with AniList-only entries (no MAL ID) — should not panic
- [x] Verify Downloads queue tab renders immediately without "Loading..." flash
- [x] Trigger RSS sync and confirm it respects the 5-minute timeout
- [x] Visit Settings > Connections and confirm health badges appear on page load
- [x] Search on Nyaa, change filter/category, refresh — options should persist
- [x] Check Downloads > History links use accent color
- [x] Mark an episode as failed — confirm blocklist prompt appears
- [x] Navigate to `/series/<anilist_id>` for a tracked series — should show downloaded files

🤖 Generated with [Claude Code](https://claude.com/claude-code)