### PR TITLE
feat: Custom Formats + SeaDex integration

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,57 @@
+name: Publish Docker image
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY: ghcr.io
+  # Lowercased because GHCR requires lowercase image names and the repo is "Ryokan".
+  IMAGE_NAME: johnthreekay/ryokan
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -284,6 +284,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -688,6 +703,17 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -2158,6 +2184,7 @@ dependencies = [
  "bcrypt",
  "chrono",
  "dotenvy",
+ "fancy-regex",
  "hex",
  "rand",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,13 @@ chrono = { version = "0.4", features = ["serde"] }
 dotenvy = "0.15"
 urlencoding = "2"
 regex-lite = "0.1"
+# fancy-regex is used only by the Custom Formats parser (Sonarr-v4
+# compat). Trash-guides anime CFs rely on look-around and nested
+# character classes, which regex-lite (and even the main `regex` crate)
+# do not support — fancy-regex adds PCRE-style backtracking. We keep
+# regex-lite as the default for Ryokan's own internal regexes because
+# they don't need look-around and we want the linear-time guarantee.
+fancy-regex = "0.14"
 sha2 = "0.10"
 ammonia = "4"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   ryokan:
-    build: .
+    image: ghcr.io/johnthreekay/ryokan:latest
     container_name: ryokan
     ports:
       - "8978:8978"

--- a/fixtures/trash-guides-anime/10bit.json
+++ b/fixtures/trash-guides-anime/10bit.json
@@ -1,0 +1,25 @@
+{
+  "trash_id": "b2550eb333d27b75833e25b8c2557b38",
+  "name": "10bit",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "10bit",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "10[.-]?bit"
+      }
+    },
+    {
+      "name": "hi10p",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "hi10p"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-01.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-01.json
@@ -1,0 +1,127 @@
+{
+  "trash_id": "949c16fe0a8147f50ba82cc2df9411c9",
+  "trash_scores": {
+    "default": 1400
+  },
+  "name": "Anime BD Tier 01",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "DemiHuman",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DemiHuman)\\b"
+      }
+    },
+    {
+      "name": "FLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FLE)\\b"
+      }
+    },
+    {
+      "name": "Flugel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Flugel)\\b"
+      }
+    },
+    {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
+      "name": "Moxie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Moxie\\]|-Moxie\\b"
+      }
+    },
+    {
+      "name": "NAN0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "(?<=remux).*\\b(NAN0)\\b"
+      }
+    },
+    {
+      "name": "sam",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[sam\\]|-sam\\b"
+      }
+    },
+    {
+      "name": "smol",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[smol\\]|-smol\\b"
+      }
+    },
+    {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b|-ZR-"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-02.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-02.json
@@ -1,0 +1,208 @@
+{
+  "trash_id": "ed7f1e315e000aef424a58517fa48727",
+  "trash_scores": {
+    "default": 1300
+  },
+  "name": "Anime BD Tier 02",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "Aergia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Aergia\\]|-Aergia(?!-raws)\\b"
+      }
+    },
+    {
+      "name": "Arg0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Arg0)\\b"
+      }
+    },
+    {
+      "name": "Arid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Arid\\]|-Arid\\b"
+      }
+    },
+    {
+      "name": "FateSucks",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FateSucks)\\b"
+      }
+    },
+    {
+      "name": "hydes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(hydes)\\b"
+      }
+    },
+    {
+      "name": "hchcsen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(hchcsen)\\b"
+      }
+    },
+    {
+      "name": "JOHNTiTOR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(JOHNTiTOR)\\b"
+      }
+    },
+    {
+      "name": "JySzE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(JySzE)\\b"
+      }
+    },
+    {
+      "name": "koala",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[koala\\]|-koala\\b"
+      }
+    },
+    {
+      "name": "Kulot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kulot)\\b"
+      }
+    },
+    {
+      "name": "LostYears",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LostYears)\\b"
+      }
+    },
+    {
+      "name": "Lulu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Lulu\\]|-Lulu\\b"
+      }
+    },
+    {
+      "name": "Meakes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Meakes)\\b"
+      }
+    },
+    {
+      "name": "Orphan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Orphan\\]|-Orphan\\b"
+      }
+    },
+    {
+      "name": "PMR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?=.*\\b(PMR)\\b)(?=.*\\b(Remux)\\b)"
+      }
+    },
+    {
+      "name": "Vodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vodes\\]|(?<!Not)-Vodes\\b"
+      }
+    },
+    {
+      "name": "WAP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WAP)\\b"
+      }
+    },
+    {
+      "name": "YURI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[YURI\\]|-YURI\\b"
+      }
+    },
+    {
+      "name": "ZeroBuild",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZeroBuild)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-03.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-03.json
@@ -1,0 +1,307 @@
+{
+  "trash_id": "096e406c92baa713da4a72d88030b815",
+  "trash_scores": {
+    "default": 1200
+  },
+  "name": "Anime BD Tier 03",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "ARC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[ARC\\]|-ARC\\b"
+      }
+    },
+    {
+      "name": "BBT-RMX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BBT-RMX)\\b"
+      }
+    },
+    {
+      "name": "cappybara",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[cappybara\\]|-cappybara\\b"
+      }
+    },
+    {
+      "name": "ChucksMux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ChucksMux)\\b"
+      }
+    },
+    {
+      "name": "CRUCiBLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[CRUCiBLE\\]|-CRUCiBLE\\b"
+      }
+    },
+    {
+      "name": "CUNNY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CUNNY)\\b"
+      }
+    },
+    {
+      "name": "Cunnysseur",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cunnysseur)\\b"
+      }
+    },
+    {
+      "name": "Doc",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Doc\\]|-Doc\\b"
+      }
+    },
+    {
+      "name": "fig",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[fig\\]|-fig\\b"
+      }
+    },
+    {
+      "name": "Headpatter",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Headpatter\\]|-Headpatter\\b"
+      }
+    },
+    {
+      "name": "Inka-Subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Inka-Subs)\\b"
+      }
+    },
+    {
+      "name": "LaCroiX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LaCroiX)\\b"
+      }
+    },
+    {
+      "name": "Legion",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Legion\\]|-Legion\\b"
+      }
+    },
+    {
+      "name": "Mehul",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Mehul\\]|-Mehul\\b"
+      }
+    },
+    {
+      "name": "MTBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MTBB)\\b"
+      }
+    },
+    {
+      "name": "Mysteria",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Mysteria\\]|-Mysteria\\b"
+      }
+    },
+    {
+      "name": "Netaro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Netaro)\\b"
+      }
+    },
+    {
+      "name": "Noiy",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Noiy)\\b"
+      }
+    },
+    {
+      "name": "npz",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(npz)\\b"
+      }
+    },
+    {
+      "name": "NTRX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NTRX)\\b"
+      }
+    },
+    {
+      "name": "Okay-Subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Okay-Subs)\\b"
+      }
+    },
+    {
+      "name": "P9",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(P9)\\b"
+      }
+    },
+    {
+      "name": "RUDY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[RUDY\\]|-RUDY\\b"
+      }
+    },
+    {
+      "name": "RaiN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[RaiN\\]|-RaiN\\b"
+      }
+    },
+    {
+      "name": "RMX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RMX)\\b"
+      }
+    },
+    {
+      "name": "Sekkon",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Sekkon)\\b"
+      }
+    },
+    {
+      "name": "Serendipity",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Serendipity\\]|-Serendipity\\b"
+      }
+    },
+    {
+      "name": "sgt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[sgt\\]|-sgt\\b"
+      }
+    },
+    {
+      "name": "SubsMix",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SubsMix)\\b"
+      }
+    },
+    {
+      "name": "uba",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[uba\\]|-uba\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-04.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-04.json
@@ -1,0 +1,361 @@
+{
+  "trash_id": "30feba9da3030c5ed1e0f7d610bcadc4",
+  "trash_scores": {
+    "default": 1100
+  },
+  "name": "Anime BD Tier 04",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "ABdex",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ABdex)\\b"
+      }
+    },
+    {
+      "name": "Afro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Afro\\]|-Afro\\b"
+      }
+    },
+    {
+      "name": "aRMX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(aRMX)\\b"
+      }
+    },
+    {
+      "name": "BiRJU",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BiRJU)\\b"
+      }
+    },
+    {
+      "name": "BKC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BKC)\\b"
+      }
+    },
+    {
+      "name": "CBT",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CBT)\\b"
+      }
+    },
+    {
+      "name": "Chimera",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chimera\\]|-Chimera\\b"
+      }
+    },
+    {
+      "name": "derp",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[derp\\]|-derp\\b"
+      }
+    },
+    {
+      "name": "DIY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[DIY\\]|-DIY\\b"
+      }
+    },
+    {
+      "name": "EXP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EXP\\]|-EXP\\b"
+      }
+    },
+    {
+      "name": "Foxtrot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Foxtrot\\]|-Foxtrot\\b"
+      }
+    },
+    {
+      "name": "grimf",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(grimf)\\b"
+      }
+    },
+    {
+      "name": "IK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(IK)\\b"
+      }
+    },
+    {
+      "name": "Iznjie Biznjie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Iznjie[ .-]Biznjie)\\b"
+      }
+    },
+    {
+      "name": "Kaleido-subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaleido-subs)\\b"
+      }
+    },
+    {
+      "name": "Kametsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kametsu)\\b"
+      }
+    },
+    {
+      "name": "Kawatare",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kawatare\\]|-Kawatare\\b"
+      }
+    },
+    {
+      "name": "KH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KH)\\b"
+      }
+    },
+    {
+      "name": "LazyRemux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LazyRemux)\\b"
+      }
+    },
+    {
+      "name": "Metal",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Metal\\]|-Metal\\b"
+      }
+    },
+    {
+      "name": "MK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MK)\\b"
+      }
+    },
+    {
+      "name": "neko-kBaraka",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(neko-kBaraka)\\b"
+      }
+    },
+    {
+      "name": "OZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(OZR)\\b"
+      }
+    },
+    {
+      "name": "Pizza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pizza\\]|-Pizza\\b"
+      }
+    },
+    {
+      "name": "pog42",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(pog42)\\b"
+      }
+    },
+    {
+      "name": "Quetzal",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Quetzal)\\b"
+      }
+    },
+    {
+      "name": "Reza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reza)\\b"
+      }
+    },
+    {
+      "name": "SCY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCY)\\b"
+      }
+    },
+    {
+      "name": "Shimatta",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Shimatta)\\b"
+      }
+    },
+    {
+      "name": "Smoke",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Smoke\\]|-Smoke\\b"
+      }
+    },
+    {
+      "name": "Spirale",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Spirale)\\b"
+      }
+    },
+    {
+      "name": "UDF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(UDF)\\b"
+      }
+    },
+    {
+      "name": "UQW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(UQW)\\b"
+      }
+    },
+    {
+      "name": "Virtuality",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Virtuality)\\b"
+      }
+    },
+    {
+      "name": "Vanilla",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vanilla\\]|-Vanilla\\b"
+      }
+    },
+    {
+      "name": "VULCAN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[VULCAN\\]|-VULCAN\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-05.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-05.json
@@ -1,0 +1,307 @@
+{
+  "trash_id": "545a76b14ddc349b8b185a6344e28b04",
+  "trash_scores": {
+    "default": 1000
+  },
+  "name": "Anime BD Tier 05",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "Animorphs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Animorphs)\\b"
+      }
+    },
+    {
+      "name": "AOmundson",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AOmundson)\\b"
+      }
+    },
+    {
+      "name": "ASC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ASC)\\b"
+      }
+    },
+    {
+      "name": "Baws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Baws|McBalls)\\b"
+      }
+    },
+    {
+      "name": "Beatrice",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Beatrice\\]|-Beatrice(?!-raws)\\b"
+      }
+    },
+    {
+      "name": "B00BA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(B00BA)\\b"
+      }
+    },
+    {
+      "name": "Cait-Sidhe",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cait-Sidhe)\\b"
+      }
+    },
+    {
+      "name": "CsS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CsS)\\b"
+      }
+    },
+    {
+      "name": "CTR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CTR)\\b"
+      }
+    },
+    {
+      "name": "D4C",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(D4C)\\b"
+      }
+    },
+    {
+      "name": "deanzel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(deanzel)\\b"
+      }
+    },
+    {
+      "name": "Drag",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Drag\\]|-Drag\\b"
+      }
+    },
+    {
+      "name": "eldon",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(eldon)\\b"
+      }
+    },
+    {
+      "name": "Freehold",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Freehold)\\b"
+      }
+    },
+    {
+      "name": "GHS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GHS)\\b"
+      }
+    },
+    {
+      "name": "Hark0N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hark0N)\\b"
+      }
+    },
+    {
+      "name": "Holomux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Holomux)\\b"
+      }
+    },
+    {
+      "name": "Judgement",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Judgment\\]|-Judgment\\b"
+      }
+    },
+    {
+      "name": "MC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MC)\\b"
+      }
+    },
+    {
+      "name": "mottoj",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mottoj)\\b"
+      }
+    },
+    {
+      "name": "NH",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NH)\\b"
+      }
+    },
+    {
+      "name": "NTRM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NTRM)\\b"
+      }
+    },
+    {
+      "name": "o7",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(o7)\\b"
+      }
+    },
+    {
+      "name": "QM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(QM)\\b"
+      }
+    },
+    {
+      "name": "Thighs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Thighs\\]|-Thighs\\b"
+      }
+    },
+    {
+      "name": "TTGA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TTGA)\\b"
+      }
+    },
+    {
+      "name": "UltraRemux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(UltraRemux)\\b"
+      }
+    },
+    {
+      "name": "WBDP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WBDP)\\b"
+      }
+    },
+    {
+      "name": "WSE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WSE)\\b"
+      }
+    },
+    {
+      "name": "Yuki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yuki\\]|-Yuki\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-06.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-06.json
@@ -1,0 +1,172 @@
+{
+  "trash_id": "25d2afecab632b1582eaf03b63055f72",
+  "trash_scores": {
+    "default": 900
+  },
+  "name": "Anime BD Tier 06",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "ANE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[ANE\\]|-ANE$"
+      }
+    },
+    {
+      "name": "Bunny-Apocalypse",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Bunny-Apocalypse)\\b"
+      }
+    },
+    {
+      "name": "CyC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CyC)\\b"
+      }
+    },
+    {
+      "name": "Datte13",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Datte13)\\b"
+      }
+    },
+    {
+      "name": "EJF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(EJF)\\b"
+      }
+    },
+    {
+      "name": "GetItTwisted",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GetItTwisted)\\b"
+      }
+    },
+    {
+      "name": "GSK_kun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GSK[._-]kun)\\b"
+      }
+    },
+    {
+      "name": "iKaos",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iKaos)\\b"
+      }
+    },
+    {
+      "name": "karios",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(karios)\\b"
+      }
+    },
+    {
+      "name": "Pookie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Pookie)\\b"
+      }
+    },
+    {
+      "name": "RASETSU",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RASETSU)\\b"
+      }
+    },
+    {
+      "name": "Starbez",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Starbez)\\b"
+      }
+    },
+    {
+      "name": "Tsundere",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
+      }
+    },
+    {
+      "name": "Yoghurt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Yoghurt)\\b"
+      }
+    },
+    {
+      "name": "YURASUKA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[YURASUKA\\]|-YURASUKA\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-07.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-07.json
@@ -1,0 +1,343 @@
+{
+  "trash_id": "0329044e3d9137b08502a9f84a7e58db",
+  "trash_scores": {
+    "default": 800
+  },
+  "name": "Anime BD Tier 07",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "9volt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(9volt)\\b"
+      }
+    },
+    {
+      "name": "AC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[AC\\]|-AC$"
+      }
+    },
+    {
+      "name": "Almighty",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Almighty\\]|-Almighty\\b"
+      }
+    },
+    {
+      "name": "Asakura",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Asakura\\]|-Asakura\\b"
+      }
+    },
+    {
+      "name": "Asenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Asenshi)\\b"
+      }
+    },
+    {
+      "name": "BlurayDesuYo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlurayDesuYo)\\b"
+      }
+    },
+    {
+      "name": "Bolshevik",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Bolshevik\\]|-Bolshevik\\b"
+      }
+    },
+    {
+      "name": "Brrrrrrr",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Brrrrrrr)\\b"
+      }
+    },
+    {
+      "name": "Chihiro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chihiro\\]|-Chihiro\\b"
+      }
+    },
+    {
+      "name": "Commie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Commie)\\b"
+      }
+    },
+    {
+      "name": "Crow",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Crow\\]|-Crow\\b"
+      }
+    },
+    {
+      "name": "Dae",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Dae)\\b"
+      }
+    },
+    {
+      "name": "Dekinai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Dekinai\\]|-Dekinai\\b"
+      }
+    },
+    {
+      "name": "Dragon-Releases",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Dragon-Releases)\\b"
+      }
+    },
+    {
+      "name": "DragsterPS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DragsterPS)\\b"
+      }
+    },
+    {
+      "name": "Exiled-Destiny",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Exiled-Destiny|E-D)\\b"
+      }
+    },
+    {
+      "name": "FFF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FFF)\\b"
+      }
+    },
+    {
+      "name": "Final8",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Final8)\\b"
+      }
+    },
+    {
+      "name": "Geonope",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Geonope)\\b"
+      }
+    },
+    {
+      "name": "GJM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GJM)\\b"
+      }
+    },
+    {
+      "name": "iAHD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iAHD)\\b"
+      }
+    },
+    {
+      "name": "inid4c",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(inid4c)\\b"
+      }
+    },
+    {
+      "name": "Koten_Gars",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Koten[ ._-]Gars)\\b"
+      }
+    },
+    {
+      "name": "kuchikirukia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(kuchikirukia)\\b"
+      }
+    },
+    {
+      "name": "LCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LCE)\\b"
+      }
+    },
+    {
+      "name": "NTW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NTW)\\b"
+      }
+    },
+    {
+      "name": "orz",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(orz)\\b"
+      }
+    },
+    {
+      "name": "RAI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RAI)\\b"
+      }
+    },
+    {
+      "name": "REVO",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(REVO)\\b"
+      }
+    },
+    {
+      "name": "SCP-2223",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCP-2223)\\b"
+      }
+    },
+    {
+      "name": "Senjou",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Senjou\\]|-Senjou\\b"
+      }
+    },
+    {
+      "name": "SEV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SEV)\\b"
+      }
+    },
+    {
+      "name": "THORA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(THORA)\\b"
+      }
+    },
+    {
+      "name": "Vivid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vivid\\]|-Vivid\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-bd-tier-08.json
+++ b/fixtures/trash-guides-anime/anime-bd-tier-08.json
@@ -1,0 +1,127 @@
+{
+  "trash_id": "c81bbfb47fed3d5a3ad027d077f889de",
+  "trash_scores": {
+    "default": 700
+  },
+  "name": "Anime BD Tier 08",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Bluray",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 6
+      }
+    },
+    {
+      "name": "Bluray Remux",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 7
+      }
+    },
+    {
+      "name": "DVD",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 5
+      }
+    },
+    {
+      "name": "AkihitoSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AkihitoSubs)\\b"
+      }
+    },
+    {
+      "name": "Arukoru",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Arukoru)\\b"
+      }
+    },
+    {
+      "name": "EDGE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EDGE\\]|-EDGE\\b"
+      }
+    },
+    {
+      "name": "EMBER",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[EMBER\\]|-EMBER\\b"
+      }
+    },
+    {
+      "name": "GHOST",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[GHOST\\]|-GHOST\\b"
+      }
+    },
+    {
+      "name": "Judas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Judas\\]|-Judas"
+      }
+    },
+    {
+      "name": "naiyas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[naiyas\\]|-naiyas\\b"
+      }
+    },
+    {
+      "name": "Nep_Blanc",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nep[ ._-]Blanc)\\b"
+      }
+    },
+    {
+      "name": "Prof",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Prof\\]|-Prof\\b"
+      }
+    },
+    {
+      "name": "Shirσ",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Shirσ)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-dual-audio.json
+++ b/fixtures/trash-guides-anime/anime-dual-audio.json
@@ -1,0 +1,53 @@
+{
+  "trash_id": "418f50b10f1907201b6cfdf881f467b7",
+  "trash_regex": "https://regex101.com/r/m6phZx/7",
+  "name": "Anime Dual Audio",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Dual Audio",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "dual[ ._-]?(audio)|[([]dual[])]|\\b(JA|ZH|KO)(?= ?\\+ ?.*?\\b(EN))|\\b(EN)(?= ?\\+ ?.*?\\b(JA|ZH|KO))|\\b(Japanese|Chinese|Korean) ?[ ._\\+&-] ?\\b(English)|\\b(English) ?[ ._\\+&-] ?\\b(Japanese|Chinese|Korean)|\\b(\\d{3,4}(p|i)|4K|U(ltra)?HD)\\b.*\\b(DUAL)\\b(?!.*\\(|\\))"
+      }
+    },
+    {
+      "name": "Not Single Language Only",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "\\[(JA|ZH|KO)\\]"
+      }
+    },
+    {
+      "name": "Japanese Language",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 8
+      }
+    },
+    {
+      "name": "Chinese Language",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 10
+      }
+    },
+    {
+      "name": "Korean Language",
+      "implementation": "LanguageSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 21
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-lq-groups.json
+++ b/fixtures/trash-guides-anime/anime-lq-groups.json
@@ -1,0 +1,1244 @@
+{
+  "trash_id": "e3515e519f3b1360cbfc17651944354c",
+  "trash_scores": {
+    "default": -10000,
+    "german-anime": -35000
+  },
+  "name": "Anime LQ Groups",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "$tore-Chill",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(\\$tore-Chill)\\b"
+      }
+    },
+    {
+      "name": "0neshot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(0neshot)\\b"
+      }
+    },
+    {
+      "name": "224",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[224\\]|-224\\b"
+      }
+    },
+    {
+      "name": "A-Destiny",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(A-Destiny)\\b"
+      }
+    },
+    {
+      "name": "AceAres",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AceAres)\\b"
+      }
+    },
+    {
+      "name": "AhmadDev",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AhmadDev)\\b"
+      }
+    },
+    {
+      "name": "Anime Chap",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Chap)\\b"
+      }
+    },
+    {
+      "name": "Anime Land",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Land)\\b"
+      }
+    },
+    {
+      "name": "Anime Time",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anime[ .-]?Time)\\b"
+      }
+    },
+    {
+      "name": "AnimeDynastyEN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeDynastyEN)\\b"
+      }
+    },
+    {
+      "name": "AnimeKuro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeKuro)\\b"
+      }
+    },
+    {
+      "name": "AnimeRG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeRG)\\b"
+      }
+    },
+    {
+      "name": "Animesubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Animesubs)\\b"
+      }
+    },
+    {
+      "name": "AnimeTR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnimeTR)\\b"
+      }
+    },
+    {
+      "name": "Anitsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Anitsu)\\b"
+      }
+    },
+    {
+      "name": "AniVoid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AniVoid)\\b"
+      }
+    },
+    {
+      "name": "ArataEnc",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ArataEnc)\\b"
+      }
+    },
+    {
+      "name": "AREY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AREY)\\b"
+      }
+    },
+    {
+      "name": "Ari",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Ari\\]|-Ari\\b"
+      }
+    },
+    {
+      "name": "ASW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ASW)\\b"
+      }
+    },
+    {
+      "name": "BJX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BJX)\\b"
+      }
+    },
+    {
+      "name": "BlackLuster",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlackLuster)\\b"
+      }
+    },
+    {
+      "name": "bonkai77",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(bonkai77)\\b"
+      }
+    },
+    {
+      "name": "CameEsp",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CameEsp)\\b"
+      }
+    },
+    {
+      "name": "Cat66",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cat66)\\b"
+      }
+    },
+    {
+      "name": "CBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CBB)\\b"
+      }
+    },
+    {
+      "name": "Cerberus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cerberus\\]|-Cerberus\\b"
+      }
+    },
+    {
+      "name": "Cleo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cleo\\]|-Cleo"
+      }
+    },
+    {
+      "name": "CuaP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(CuaP)\\b"
+      }
+    },
+    {
+      "name": "DaddySubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Daddy(Subs)?\\]|-Daddy(Subs)?\\b"
+      }
+    },
+    {
+      "name": "DARKFLiX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DARKFLiX)\\b"
+      }
+    },
+    {
+      "name": "DB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[DB\\]"
+      }
+    },
+    {
+      "name": "DBArabic",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DBArabic)\\b"
+      }
+    },
+    {
+      "name": "Deadmau- RAWS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Deadmau[ .-]?[ .-]?RAWS)\\b"
+      }
+    },
+    {
+      "name": "DKB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DKB)\\b"
+      }
+    },
+    {
+      "name": "DP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DP)\\b"
+      }
+    },
+    {
+      "name": "DsunS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DsunS)\\b"
+      }
+    },
+    {
+      "name": "Emmid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Emmid\\]|-Emmid\\b"
+      }
+    },
+    {
+      "name": "ExREN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ExREN)\\b"
+      }
+    },
+    {
+      "name": "FAV",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[FAV\\]|-FAV\\b"
+      }
+    },
+    {
+      "name": "Fish",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b((Baked|Dead|Space)Fish)\\b"
+      }
+    },
+    {
+      "name": "FunArts",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FunArts)\\b"
+      }
+    },
+    {
+      "name": "GERMini",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GERMini)\\b"
+      }
+    },
+    {
+      "name": "Hakata Ramen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hakata[ .-]?Ramen)\\b"
+      }
+    },
+    {
+      "name": "Hall_of_C",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Hall_of_C)\\b"
+      }
+    },
+    {
+      "name": "Hatsuyuki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Hatsuyuki\\]|-Hatsuyuki\\b"
+      }
+    },
+    {
+      "name": "HAV1T",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HAV1T)\\b"
+      }
+    },
+    {
+      "name": "HENiL",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HENiL)\\b"
+      }
+    },
+    {
+      "name": "Hitoku",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Hitoku\\]|-Hitoku\\b"
+      }
+    },
+    {
+      "name": "HollowRoxas",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HollowRoxas)\\b"
+      }
+    },
+    {
+      "name": "HR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[HR\\]|-HR\\b"
+      }
+    },
+    {
+      "name": "ICEBLUE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ICEBLUE)\\b"
+      }
+    },
+    {
+      "name": "iPUNISHER",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(iPUNISHER)\\b"
+      }
+    },
+    {
+      "name": "JacobSwaggedUp",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(JacobSwaggedUp)\\b"
+      }
+    },
+    {
+      "name": "Johnny-englishsubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Johnny-englishsubs)\\b"
+      }
+    },
+    {
+      "name": "Kallango",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kallango\\]|-Kallango\\b"
+      }
+    },
+    {
+      "name": "Kanjouteki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kanjouteki)\\b"
+      }
+    },
+    {
+      "name": "KEKMASTERS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KEKMASTERS)\\b"
+      }
+    },
+    {
+      "name": "Kirion",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kirion)\\b"
+      }
+    },
+    {
+      "name": "KQRM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KQRM)\\b"
+      }
+    },
+    {
+      "name": "KRP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KRP)\\b"
+      }
+    },
+    {
+      "name": "LoliHouse",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LoliHouse)\\b"
+      }
+    },
+    {
+      "name": "M@nI",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(M@nI)\\b"
+      }
+    },
+    {
+      "name": "mal lu zen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mal[ .-]lu[ .-]zen)\\b"
+      }
+    },
+    {
+      "name": "Man.K",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Man\\.K)\\b"
+      }
+    },
+    {
+      "name": "Maximus",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Maximus\\]|-Maximus\\b"
+      }
+    },
+    {
+      "name": "MD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[MD\\]|-MD\\b"
+      }
+    },
+    {
+      "name": "mdcx",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(mdcx)\\b"
+      }
+    },
+    {
+      "name": "Metaljerk",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Metaljerk)\\b"
+      }
+    },
+    {
+      "name": "MGD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MGD)\\b"
+      }
+    },
+    {
+      "name": "MiniFreeza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MiniFreeza)\\b"
+      }
+    },
+    {
+      "name": "MiniMTBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MiniMTBB)\\b"
+      }
+    },
+    {
+      "name": "MinisCuba",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MinisCuba)\\b"
+      }
+    },
+    {
+      "name": "MiniTheatre",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MiniTheatre)\\b"
+      }
+    },
+    {
+      "name": "Mites",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mites)\\b"
+      }
+    },
+    {
+      "name": "Modders Bay",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Modders[ .-]?Bay)\\b"
+      }
+    },
+    {
+      "name": "Mr. Deadpool",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Mr\\.Deadpool)\\b"
+      }
+    },
+    {
+      "name": "NemDiggers",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NemDiggers)\\b"
+      }
+    },
+    {
+      "name": "neoHEVC",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(neoHEVC)\\b"
+      }
+    },
+    {
+      "name": "Nokou",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nokou)\\b"
+      }
+    },
+    {
+      "name": "NoobSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(N[eo][wo]b[ ._-]?Subs)\\b"
+      }
+    },
+    {
+      "name": "NS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NS)\\b"
+      }
+    },
+    {
+      "name": "Nyanpasu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Nyanpasu)\\b"
+      }
+    },
+    {
+      "name": "OldCastle",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(OldCastle)\\b"
+      }
+    },
+    {
+      "name": "Pantsu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pantsu\\]|-Pantsu\\b"
+      }
+    },
+    {
+      "name": "Pao",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pao\\]|-Pao\\b"
+      }
+    },
+    {
+      "name": "phazer11",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(phazer11)\\b"
+      }
+    },
+    {
+      "name": "Pixel",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pixel\\]|-Pixel\\b"
+      }
+    },
+    {
+      "name": "Plex Friendly",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Plex[ .-]?Friendly)\\b"
+      }
+    },
+    {
+      "name": "PnPSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PnPSubs)\\b"
+      }
+    },
+    {
+      "name": "Polarwindz",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Polarwindz)\\b"
+      }
+    },
+    {
+      "name": "Project-gxs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Project-gxs)\\b"
+      }
+    },
+    {
+      "name": "PuyaSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PuyaSubs)\\b"
+      }
+    },
+    {
+      "name": "QaS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(QAS)\\b"
+      }
+    },
+    {
+      "name": "QCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(QCE)\\b"
+      }
+    },
+    {
+      "name": "Rando235",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Rando235)\\b"
+      }
+    },
+    {
+      "name": "Ranger",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Ranger\\]|-Ranger\\b"
+      }
+    },
+    {
+      "name": "Rapta",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Rapta\\]|-Rapta\\b"
+      }
+    },
+    {
+      "name": "Raw Files",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(M2TS|BDMV|BDVD)\\b"
+      }
+    },
+    {
+      "name": "Raze",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Raze\\]|-Raze\\b"
+      }
+    },
+    {
+      "name": "Reaktor",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reaktor)\\b"
+      }
+    },
+    {
+      "name": "RightShiftBy2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(RightShiftBy2)\\b"
+      }
+    },
+    {
+      "name": "Rip Time",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Rip[ .-]?Time)\\b"
+      }
+    },
+    {
+      "name": "SAD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SAD\\]|-SAD\\b"
+      }
+    },
+    {
+      "name": "Salieri",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Salieri)\\b"
+      }
+    },
+    {
+      "name": "Samir755",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Samir755)\\b"
+      }
+    },
+    {
+      "name": "SanKyuu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SanKyuu)\\b"
+      }
+    },
+    {
+      "name": "SEiN",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SEiN\\]|-SEiN\\b"
+      }
+    },
+    {
+      "name": "sekkusu&ok",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(sekkusu&ok)\\b"
+      }
+    },
+    {
+      "name": "SHFS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SHFS)\\b"
+      }
+    },
+    {
+      "name": "shincaps",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(shincaps)\\b"
+      }
+    },
+    {
+      "name": "SLAX",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SLAX)\\b"
+      }
+    },
+    {
+      "name": "Sokudo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Sokudo\\]|-Sokudo\\b"
+      }
+    },
+    {
+      "name": "SRW",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SRW)\\b"
+      }
+    },
+    {
+      "name": "SSA",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SSA)\\b"
+      }
+    },
+    {
+      "name": "StrayGods",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(StrayGods)\\b"
+      }
+    },
+    {
+      "name": "Suki Desu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Suki[ .-]?Desu\\]|-Suki[ .-]?Desu\\b"
+      }
+    },
+    {
+      "name": "TeamTurquoize",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TeamTurquoize)\\b"
+      }
+    },
+    {
+      "name": "Tenrai Sensei",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Tenrai[ .-]?Sensei)\\b"
+      }
+    },
+    {
+      "name": "TnF",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TnF)\\b"
+      }
+    },
+    {
+      "name": "TOPKEK",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(TOPKEK)\\b"
+      }
+    },
+    {
+      "name": "Trix",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Trix\\]|-Trix\\b"
+      }
+    },
+    {
+      "name": "U3-Web",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(U3-Web)\\b"
+      }
+    },
+    {
+      "name": "UNBIASED",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[UNBIASED\\]|-UNBIASED\\b"
+      }
+    },
+    {
+      "name": "uP",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[uP\\]"
+      }
+    },
+    {
+      "name": "USD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[USD\\]|-USD\\b"
+      }
+    },
+    {
+      "name": "Valenciano",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Valenciano)\\b"
+      }
+    },
+    {
+      "name": "VipapkStudios",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(VipapkStudios)\\b"
+      }
+    },
+    {
+      "name": "Wardevil",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Wardevil\\]|-Wardevil\\b"
+      }
+    },
+    {
+      "name": "WtF Anime",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(WtF[ ._-]?Anime)\\b"
+      }
+    },
+    {
+      "name": "xiao-av1",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(xiao-av1)\\b"
+      }
+    },
+    {
+      "name": "Yabai_Desu_NeRandomRemux",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Yabai_Desu_NeRandomRemux)\\b"
+      }
+    },
+    {
+      "name": "YakuboEncodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(YakuboEncodes)\\b"
+      }
+    },
+    {
+      "name": "youshikibi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(youshikibi)\\b"
+      }
+    },
+    {
+      "name": "YuiSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(YuiSubs)\\b"
+      }
+    },
+    {
+      "name": "Yun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yun\\]|-Yun\\b"
+      }
+    },
+    {
+      "name": "zza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[zza\\]|-zza\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-raws.json
+++ b/fixtures/trash-guides-anime/anime-raws.json
@@ -1,0 +1,209 @@
+{
+  "trash_id": "b4a1b3d705159cdca36d71e57ca86871",
+  "trash_scores": {
+    "default": -10000,
+    "german-anime": -35000
+  },
+  "name": "Anime Raws",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "AsukaRaws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Asuka[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Beatrice-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Beatrice[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Daddy-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Daddy[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Fumi-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Fumi[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "IrizaRaws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Iriza[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Kawaiika-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Kawaiika[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "km",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[km\\]|-km\\b"
+      }
+    },
+    {
+      "name": "Koi-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Koi[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Lilith-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Lilith[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "LowPower-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "LowPower[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Moozzi2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Moozzi2)\\b"
+      }
+    },
+    {
+      "name": "NanakoRaws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Nanako[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "NC-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "NC[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "neko-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "neko[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "New-raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "New[ ._-]?(raws)"
+      }
+    },
+    {
+      "name": "Ohys-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Ohys[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Pandoratv-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Pandoratv[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Raws-Maji",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Raws-Maji)\\b"
+      }
+    },
+    {
+      "name": "ReinForce",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ReinForce)\\b"
+      }
+    },
+    {
+      "name": "Scryous-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Scryous[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Seicher-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Seicher[ ._-]?(Raws)"
+      }
+    },
+    {
+      "name": "Shiniori-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "Shiniori[ ._-]?(Raws)"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-01.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-01.json
@@ -1,0 +1,172 @@
+{
+  "trash_id": "e0014372773c8f0e1bef8824f00c7dc4",
+  "trash_scores": {
+    "default": 600
+  },
+  "name": "Anime Web Tier 01",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "Arg0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Arg0)\\b"
+      }
+    },
+    {
+      "name": "Arid",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Arid\\]|-Arid\\b"
+      }
+    },
+    {
+      "name": "Baws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Baws)\\b"
+      }
+    },
+    {
+      "name": "FLE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(FLE)\\b"
+      }
+    },
+    {
+      "name": "LostYears",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LostYears)\\b"
+      }
+    },
+    {
+      "name": "LYS1TH3A",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(LYS1TH3A)\\b"
+      }
+    },
+    {
+      "name": "McBalls",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(McBalls)\\b"
+      }
+    },
+    {
+      "name": "sam",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[sam\\]|-sam\\b"
+      }
+    },
+    {
+      "name": "SCY",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SCY)\\b"
+      }
+    },
+    {
+      "name": "Setsugen",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Setsugen)\\b"
+      }
+    },
+    {
+      "name": "smol",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[smol\\]|-smol\\b"
+      }
+    },
+    {
+      "name": "SoM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[SoM\\]|-SoM\\b"
+      }
+    },
+    {
+      "name": "Vodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Vodes\\]|(?<!Not)-Vodes\\b"
+      }
+    },
+    {
+      "name": "Z4ST1N",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Z4ST1N)\\b"
+      }
+    },
+    {
+      "name": "ZeroBuild",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZeroBuild)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-02.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-02.json
@@ -1,0 +1,208 @@
+{
+  "trash_id": "19180499de5ef2b84b6ec59aae444696",
+  "trash_scores": {
+    "default": 500
+  },
+  "name": "Anime Web Tier 02",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "0x539",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(0x539)\\b"
+      }
+    },
+    {
+      "name": "Asakura",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Asakura\\]|-Asakura\\b"
+      }
+    },
+    {
+      "name": "Cyan",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Cyan\\]|-Cyan\\b"
+      }
+    },
+    {
+      "name": "Cytox",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Cytox)\\b"
+      }
+    },
+    {
+      "name": "Dae",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Dae\\]|-Dae\\b"
+      }
+    },
+    {
+      "name": "Foxtrot",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Foxtrot\\]|-Foxtrot\\b"
+      }
+    },
+    {
+      "name": "Gao",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Gao\\]|-Gao\\b"
+      }
+    },
+    {
+      "name": "GSK_kun",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GSK[._-]kun)\\b"
+      }
+    },
+    {
+      "name": "Half-Baked",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Half-Baked)\\b"
+      }
+    },
+    {
+      "name": "HatSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HatSubs)\\b"
+      }
+    },
+    {
+      "name": "MALD",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MALD)\\b"
+      }
+    },
+    {
+      "name": "MTBB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(MTBB)\\b"
+      }
+    },
+    {
+      "name": "Not-Vodes",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Not-Vodes\\]|-Not-Vodes\\b"
+      }
+    },
+    {
+      "name": "Okay-Subs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Okay-Subs)\\b"
+      }
+    },
+    {
+      "name": "Pizza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Pizza\\]|-Pizza\\b"
+      }
+    },
+    {
+      "name": "Reza",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Reza)\\b"
+      }
+    },
+    {
+      "name": "Slyfox",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Slyfox)\\b"
+      }
+    },
+    {
+      "name": "SoLCE",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SoLCE)\\b"
+      }
+    },
+    {
+      "name": "Tenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[tenshi\\]|-tenshi$"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-03.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-03.json
@@ -1,0 +1,82 @@
+{
+  "trash_id": "c27f2ae6a4e82373b0f1da094e2489ad",
+  "trash_scores": {
+    "default": 400
+  },
+  "name": "Anime Web Tier 03",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "AnoZu",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(AnoZu)\\b"
+      }
+    },
+    {
+      "name": "Dooky",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Dooky)\\b"
+      }
+    },
+    {
+      "name": "Kitsune",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kitsune\\]|-Kitsune\\b"
+      }
+    },
+    {
+      "name": "SubsPlus+",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SubsPlus\\+?)\\b"
+      }
+    },
+    {
+      "name": "ZR",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ZR)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-04.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-04.json
@@ -1,0 +1,64 @@
+{
+  "trash_id": "4fd5528a3a8024e6b49f9c67053ea5f3",
+  "trash_scores": {
+    "default": 300
+  },
+  "name": "Anime Web Tier 04",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "Erai-Raws",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Erai-raws)\\b"
+      }
+    },
+    {
+      "name": "ToonsHub",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(ToonsHub)\\b"
+      }
+    },
+    {
+      "name": "VARYG",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(VARYG)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-05.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-05.json
@@ -1,0 +1,163 @@
+{
+  "trash_id": "29c2a13d091144f63307e4a8ce963a39",
+  "trash_scores": {
+    "default": 200
+  },
+  "name": "Anime Web Tier 05",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "BlueLobster",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(BlueLobster)\\b"
+      }
+    },
+    {
+      "name": "GST",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GST)\\b"
+      }
+    },
+    {
+      "name": "HorribleRips",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HorribleRips)\\b"
+      }
+    },
+    {
+      "name": "HorribleSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(HorribleSubs)\\b"
+      }
+    },
+    {
+      "name": "KAN3D2M",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KAN3D2M)\\b"
+      }
+    },
+    {
+      "name": "KiyoshiStar",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KS|KiyoshiStar)\\b"
+      }
+    },
+    {
+      "name": "Lia",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Lia\\]|-Lia\\b"
+      }
+    },
+    {
+      "name": "NanDesuKa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(NanDesuKa)\\b"
+      }
+    },
+    {
+      "name": "PlayWeb",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(PlayWeb)\\b"
+      }
+    },
+    {
+      "name": "SobsPlease",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SobsPlease)\\b"
+      }
+    },
+    {
+      "name": "Some-Stuffs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Some-Stuffs)\\b"
+      }
+    },
+    {
+      "name": "SubsPlease",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(SubsPlease)\\b"
+      }
+    },
+    {
+      "name": "URANIME",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(URANIME)\\b"
+      }
+    },
+    {
+      "name": "ZigZag",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[ZigZag\\]|-ZigZab\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/anime-web-tier-06.json
+++ b/fixtures/trash-guides-anime/anime-web-tier-06.json
@@ -1,0 +1,136 @@
+{
+  "trash_id": "dc262f88d74c651b12e9d90b39f6c753",
+  "trash_scores": {
+    "default": 100
+  },
+  "name": "Anime Web Tier 06",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "WEBDL",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 3
+      }
+    },
+    {
+      "name": "WEBRIP",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 4
+      }
+    },
+    {
+      "name": "WEB",
+      "implementation": "SourceSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": 1
+      }
+    },
+    {
+      "name": "9volt",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(9volt)\\b"
+      }
+    },
+    {
+      "name": "Asenshi",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Asenshi)\\b"
+      }
+    },
+    {
+      "name": "Chihiro",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Chihiro\\]|-Chihiro\\b"
+      }
+    },
+    {
+      "name": "Commie",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Commie)\\b"
+      }
+    },
+    {
+      "name": "DameDesuYo",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(DameDesuYo)\\b"
+      }
+    },
+    {
+      "name": "Doki",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Doki\\]|-Doki\\b"
+      }
+    },
+    {
+      "name": "GJM",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(GJM)\\b"
+      }
+    },
+    {
+      "name": "Kaleido",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Kaleido)\\b"
+      }
+    },
+    {
+      "name": "Kantai",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Kantai\\]|-Kantai\\b"
+      }
+    },
+    {
+      "name": "KawaSubs",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KawaSubs)\\b"
+      }
+    },
+    {
+      "name": "Tsundere",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Tsundere\\]|-Tsundere(?!-)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/bad-dual-groups.json
+++ b/fixtures/trash-guides-anime/bad-dual-groups.json
@@ -1,0 +1,265 @@
+{
+  "trash_id": "32b367365729d530ca1c124a0b180c64",
+  "trash_scores": {
+    "default": -10000,
+    "french-multi-vf": 0,
+    "french-multi-vo": 0,
+    "german": -35000
+  },
+  "name": "Bad Dual Groups",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "alfaHD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(alfaHD.*)$"
+      }
+    },
+    {
+      "name": "BAT",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BAT)$"
+      }
+    },
+    {
+      "name": "BiOMA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BiOMA)$"
+      }
+    },
+    {
+      "name": "BlackBit",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BlackBit)$"
+      }
+    },
+    {
+      "name": "BNd",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(BNd)$"
+      }
+    },
+    {
+      "name": "C.A.A",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(C\\.A\\.A)$"
+      }
+    },
+    {
+      "name": "Cory",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Cory)$"
+      }
+    },
+    {
+      "name": "EXTREME",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(EXTREME)$"
+      }
+    },
+    {
+      "name": "FF",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FF)$"
+      }
+    },
+    {
+      "name": "FOXX",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(FOXX)$"
+      }
+    },
+    {
+      "name": "G4RiS",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(G4RiS)$"
+      }
+    },
+    {
+      "name": "GUEIRA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(GUEIRA)$"
+      }
+    },
+    {
+      "name": "LCD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(LCD)$"
+      }
+    },
+    {
+      "name": "N3G4N",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(N3G4N)$"
+      }
+    },
+    {
+      "name": "PD",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PD)$"
+      }
+    },
+    {
+      "name": "PTHome",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(PTHome)$"
+      }
+    },
+    {
+      "name": "RiPER",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RiPER)$"
+      }
+    },
+    {
+      "name": "RK",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(RK)$"
+      }
+    },
+    {
+      "name": "SiGLA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(SiGLA)$"
+      }
+    },
+    {
+      "name": "Tars",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Tars)$"
+      }
+    },
+    {
+      "name": "tokar86a",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(tokar86a)$"
+      }
+    },
+    {
+      "name": "TURG",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(TURG)$"
+      }
+    },
+    {
+      "name": "vnlls",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(vnlls)$"
+      }
+    },
+    {
+      "name": "WTV",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(WTV)$"
+      }
+    },
+    {
+      "name": "Yatogam1",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(Yatogam1)$"
+      }
+    },
+    {
+      "name": "YusukeFLA",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(YusukeFLA)$"
+      }
+    },
+    {
+      "name": "ZigZag",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZigZag)$"
+      }
+    },
+    {
+      "name": "ZNM",
+      "implementation": "ReleaseGroupSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(ZNM)$"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/dubs-only.json
+++ b/fixtures/trash-guides-anime/dubs-only.json
@@ -1,0 +1,73 @@
+{
+  "trash_id": "9c14d194486c4014d422adc64092d794",
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "Dubs Only",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "Dubbed",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?!.*(Dual|Multi)[-_. ]?Audio).*((?<!multi-)\\b(dub(bed)?)\\b|(funi|eng(lish)?)_?dub)"
+      }
+    },
+    {
+      "name": "Golumpa",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(Golumpa)\\b"
+      }
+    },
+    {
+      "name": "KaiDubs (Not Dual Audio)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?!.*(dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO))).*\\b(KaiDubs)\\b"
+      }
+    },
+    {
+      "name": "KamiFS",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(KamiFS)\\b"
+      }
+    },
+    {
+      "name": "KS (Not Dual Audio)",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "^(?!.*(dual[ ._-]?audio|[([]dual[])]|(JA|ZH|KO)\\+EN|EN\\+(JA|ZH|KO))).*\\bKS\\b"
+      }
+    },
+    {
+      "name": "torenter69",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\b(torenter69)\\b"
+      }
+    },
+    {
+      "name": "Yameii",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": false,
+      "fields": {
+        "value": "\\[Yameii\\]|-Yameii\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/fansub.json
+++ b/fixtures/trash-guides-anime/fansub.json
@@ -1,0 +1,16 @@
+{
+  "trash_id": "84f0acbda9c0c9de783894fb66df25aa",
+  "name": "FanSUB",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "FanSUB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(FanSUB)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/fastsub.json
+++ b/fixtures/trash-guides-anime/fastsub.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "ea0bb4b6ba388992fad1092703b5ff7b",
+  "trash_scores": {
+    "default": -10000
+  },
+  "name": "FastSUB",
+  "includeCustomFormatWhenRenaming": false,
+  "specifications": [
+    {
+      "name": "FastSUB",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(FastSUB)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/uncensored.json
+++ b/fixtures/trash-guides-anime/uncensored.json
@@ -1,0 +1,16 @@
+{
+  "trash_id": "026d5aadd1a6b4e550b134cb6c72b3ca",
+  "name": "Uncensored",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "Uncensored",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "\\b(Uncut|Unrated|Uncensored|AT[-_. ]?X)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/v0.json
+++ b/fixtures/trash-guides-anime/v0.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "d2d7b8a9d39413da5f44054080e028a3",
+  "trash_scores": {
+    "default": -51
+  },
+  "name": "v0",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v0",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v0)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/v1.json
+++ b/fixtures/trash-guides-anime/v1.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "273bd326df95955e1b6c26527d1df89b",
+  "trash_scores": {
+    "default": 1
+  },
+  "name": "v1",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v1",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v1)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/v2.json
+++ b/fixtures/trash-guides-anime/v2.json
@@ -1,0 +1,28 @@
+{
+  "trash_id": "228b8ee9aa0a609463efca874524a6b8",
+  "trash_scores": {
+    "default": 2
+  },
+  "name": "v2",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v2",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v2)\\b|\\b(Repack|Proper|Rerip)\\b"
+      }
+    },
+    {
+      "name": "Not Higher Versions",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v[3-4])\\b|\\b((repack|proper)[23])\\b|\\bREAL\\.(REAL\\.)?(PROPER|REPACK)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/v3.json
+++ b/fixtures/trash-guides-anime/v3.json
@@ -1,0 +1,28 @@
+{
+  "trash_id": "0e5833d3af2cc5fa96a0c29cd4477feb",
+  "trash_scores": {
+    "default": 3
+  },
+  "name": "v3",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v3",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v3)\\b|\\b((repack|proper)2)\\b|\\b(REAL\\.(PROPER|REPACK))\\b"
+      }
+    },
+    {
+      "name": "Not Higher Versions",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": true,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v[4])\\b|\\b((repack|proper)3)\\b|\\bREAL\\.(REAL\\.)(PROPER|REPACK)\\b"
+      }
+    }
+  ]
+}

--- a/fixtures/trash-guides-anime/v4.json
+++ b/fixtures/trash-guides-anime/v4.json
@@ -1,0 +1,19 @@
+{
+  "trash_id": "4fc15eeb8f2f9a749f918217d4234ad8",
+  "trash_scores": {
+    "default": 4
+  },
+  "name": "v4",
+  "includeCustomFormatWhenRenaming": true,
+  "specifications": [
+    {
+      "name": "v4",
+      "implementation": "ReleaseTitleSpecification",
+      "negate": false,
+      "required": true,
+      "fields": {
+        "value": "(\\b|\\d)(v4)\\b|\\b((repack|proper)3)\\b|\\b(REAL\\.REAL\\.(PROPER|REPACK))\\b"
+      }
+    }
+  ]
+}

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1830,6 +1830,254 @@ pub async fn list_folders(
     Ok(Json(folders))
 }
 
+/// Phase 2: sibling auto-expansion for multi-series batch releases.
+///
+/// Called after a successful grab when the user targeted a series
+/// that belongs to a franchise. Detects sibling entries
+/// (sequels, prequels, side stories, etc.) in the torrent's file
+/// list, upserts each detected sibling into the tracked series
+/// table, and writes `grabbed_torrent_series` route rows so
+/// post-processing can move each file into the correct sibling's
+/// media folder.
+///
+/// Gated on AniList provenance (enforced inside
+/// [`auto_search::detect_sibling_entries_in_pack`]) — Jikan-sourced
+/// details are skipped to avoid duplicate library rows from MAL's
+/// finer-grained splits (e.g. JoJo Stone Ocean, which MAL splits
+/// into 3 cours but AL keeps as a single entry). When AL is down at
+/// grab time the grab itself still succeeds; sibling detection just
+/// returns an empty vec and the 12h metadata refresh can
+/// retroactively run detection later if needed.
+///
+/// Errors here are soft: the grab has already completed and
+/// post-processing's legacy fallback (no route rows → route
+/// everything to `parent_series_id`) keeps the grab functional even
+/// when auto-expand fails partway through. Any failures get logged
+/// at warn level.
+///
+/// Returns the number of siblings *newly added* to the library
+/// (upserts that hit an existing row don't count).
+#[allow(clippy::too_many_arguments)]
+async fn auto_expand_library_from_pack(
+    db: &SqlitePool,
+    qbit: &crate::services::qbit::QbitClient,
+    info_hash: &str,
+    parent_detail: &anilist::AnimeDetail,
+    parent_series_id: i64,
+    parent_episode_numbers: &[i32],
+    grab_id: i64,
+    torrent_title: &str,
+) -> usize {
+    if parent_detail.id <= 0 || info_hash.is_empty() {
+        return 0;
+    }
+
+    // Wait for qBit metadata before asking for the file list. Fresh
+    // grabs via `add_torrent` don't block on metadata discovery, so
+    // a naive `get_torrent_files` right after add returns empty.
+    // The 60s ceiling matches `add_torrent_with_file_filter`.
+    let files = match qbit
+        .wait_for_metadata(info_hash, std::time::Duration::from_secs(60))
+        .await
+    {
+        Ok(files) => files,
+        Err(e) => {
+            logger::warn(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "auto-expand: metadata wait failed for '{}', skipping sibling detection",
+                    torrent_title
+                ),
+                &e,
+            )
+            .await;
+            return 0;
+        }
+    };
+    let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
+
+    let siblings = auto_search::detect_sibling_entries_in_pack(&filenames, parent_detail);
+    if siblings.is_empty() {
+        return 0;
+    }
+
+    let mut added = 0_usize;
+    let mut claimed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut routes: Vec<grabbed_torrents::GrabSeriesRoute> = Vec::new();
+
+    for sibling in siblings {
+        let primary_title = if !sibling.title_english.is_empty() {
+            sibling.title_english.clone()
+        } else {
+            sibling.title_romaji.clone()
+        };
+
+        // Upsert dedups by mal_id then anilist_id, so reconciled
+        // entries that already have both IDs populated update
+        // in place instead of duplicating.
+        let upsert_result = series::upsert(
+            db,
+            series::SeriesCore {
+                anilist_id: sibling.anilist_id,
+                mal_id: sibling.mal_id,
+                title: &primary_title,
+                title_romaji: &sibling.title_romaji,
+                title_english: &sibling.title_english,
+                title_native: &sibling.title_native,
+                cover_url: &sibling.cover_url,
+                format: &sibling.format,
+                status: &sibling.status,
+                episodes: sibling.episodes,
+                season_year: sibling.season_year,
+                // Relation cards don't carry end_year — the
+                // background metadata refresh populates it.
+                end_year: None,
+            },
+        )
+        .await;
+        let (sibling_id, created) = match upsert_result {
+            Ok(pair) => pair,
+            Err(e) => {
+                logger::warn(
+                    db,
+                    LogCategory::Library,
+                    &format!("auto-expand: failed to upsert sibling '{}'", primary_title),
+                    &e.to_string(),
+                )
+                .await;
+                continue;
+            }
+        };
+
+        if created {
+            added += 1;
+            logger::info(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "Auto-expand: added sibling '{}' from batch '{}'",
+                    primary_title, torrent_title
+                ),
+                &format!(
+                    "anilist_id={}, matched_subtitle={:?}, files={}",
+                    sibling.anilist_id,
+                    sibling.matched_subtitle,
+                    sibling.file_indices.len()
+                ),
+            )
+            .await;
+
+            // Kick off a background metadata refresh so the full
+            // detail (description, artwork, end_year, etc.) gets
+            // hydrated for the UI. Fire-and-forget — the route is
+            // already recorded below either way.
+            let db_clone = db.clone();
+            tokio::spawn(async move {
+                if let Ok(Some(tracked)) = series::get_by_id(&db_clone, sibling_id).await {
+                    let force_fallback = config::get_config(&db_clone)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|c| c.force_mal_fallback)
+                        .unwrap_or(false);
+                    let _ = metadata_sync::refresh_series_metadata(
+                        &db_clone,
+                        &tracked,
+                        force_fallback,
+                    )
+                    .await;
+                }
+            });
+        }
+
+        // Derive episode numbers per sibling so
+        // find_imported_for_episode can locate this route when
+        // an upgrade later targets one of the sibling's episodes.
+        let mut ep_nums: Vec<i32> = Vec::new();
+        for &file_idx in &sibling.file_indices {
+            if let Some(name) = filenames.get(file_idx) {
+                if let Some((_, n)) = media::parse_episode_number(&name.to_lowercase()) {
+                    ep_nums.push(n);
+                }
+            }
+        }
+        ep_nums.sort_unstable();
+        ep_nums.dedup();
+
+        for &i in &sibling.file_indices {
+            claimed.insert(i);
+        }
+        routes.push(grabbed_torrents::GrabSeriesRoute {
+            grab_id,
+            series_id: sibling_id,
+            file_indices: sibling.file_indices,
+            episode_numbers: ep_nums,
+            matched_subtitle: sibling.matched_subtitle,
+        });
+    }
+
+    // Parent route: every media file not claimed by a sibling
+    // routes to the parent series. Unclaimed files are expected for
+    // franchise-root grabs (JoJo S1 in a S1-S5 pack won't match any
+    // sibling subtitle) but can also indicate extras or a missed
+    // sibling — log a warn either way so the operator can spot
+    // regressions.
+    let parent_file_indices: Vec<usize> = (0..filenames.len())
+        .filter(|i| {
+            filenames
+                .get(*i)
+                .map(|n| auto_search::is_media_filename(n))
+                .unwrap_or(false)
+                && !claimed.contains(i)
+        })
+        .collect();
+
+    if !routes.is_empty() && !parent_file_indices.is_empty() {
+        logger::warn(
+            db,
+            LogCategory::Library,
+            &format!(
+                "Auto-expand: {} unclaimed file(s) in batch '{}' routed to parent series",
+                parent_file_indices.len(),
+                torrent_title,
+            ),
+            &format!(
+                "parent_id={}, siblings_added={}, unclaimed_count={}",
+                parent_series_id,
+                added,
+                parent_file_indices.len()
+            ),
+        )
+        .await;
+
+        routes.push(grabbed_torrents::GrabSeriesRoute {
+            grab_id,
+            series_id: parent_series_id,
+            file_indices: parent_file_indices,
+            episode_numbers: parent_episode_numbers.to_vec(),
+            matched_subtitle: String::new(),
+        });
+    }
+
+    if !routes.is_empty() {
+        if let Err(e) = grabbed_torrents::record_grab_series_routes(db, &routes).await {
+            logger::warn(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "auto-expand: failed to write route rows for '{}'",
+                    torrent_title
+                ),
+                &e.to_string(),
+            )
+            .await;
+        }
+    }
+
+    added
+}
+
 async fn run_auto_search_targets(
     state: &AppState,
     request_id: i64,
@@ -1917,19 +2165,74 @@ async fn run_auto_search_targets_with_upgrades(
                         logger::info(&state.db, LogCategory::AutoSearch, &format!("{}: upgrading from {} to {}", label, existing.label(), incoming_classification.label()), &result.title).await;
                     }
                 }
-                let url = if !result.magnet.is_empty() { result.magnet.clone() } else { result.torrent.clone() };
+                // For selective downloads, prefer the `.torrent` URL
+                // over the magnet: qBit can parse metadata straight
+                // from the file instead of waiting on DHT/trackers.
+                let wants_selective = !result.info_hash.is_empty()
+                    && auto_search::has_selective_discriminator(&detail);
+                let url = if wants_selective && !result.torrent.is_empty() {
+                    result.torrent.clone()
+                } else if !result.magnet.is_empty() {
+                    result.magnet.clone()
+                } else {
+                    result.torrent.clone()
+                };
                 if url.is_empty() {
                     logger::warn(&state.db, LogCategory::AutoSearch, &format!("{}: no magnet/torrent URL", label), &result.title).await;
                     skipped.push(format!("{}: no magnet/torrent URL", label));
                     continue;
                 }
-                match qbit.add_torrent(&url).await {
-                    Ok(_) => {
+                // Selective-file path for multi-part / multi-season
+                // packs. `pick_wanted_file_indices` narrows by part
+                // number (Kizumonogatari II in a Monogatari megapack)
+                // or positive subtitle match (Stardust Crusaders in a
+                // JoJo S1–S5 pack). The gate only runs this branch
+                // when the detail has an actual discriminator to try,
+                // so single-entry series fall through to the plain
+                // add. Franchise roots without their own subtitle
+                // (JoJo S1) also fall through — they're handled by
+                // the multi-series auto-expand path below, which
+                // downloads the full pack and routes each sibling's
+                // files to its own library entry. On filter error,
+                // fall back to a full add rather than dropping the
+                // grab entirely.
+                let selective_outcome: Result<Option<Vec<usize>>, String> = if wants_selective {
+                    let detail_clone = detail.clone();
+                    let info_hash_clone = result.info_hash.clone();
+                    match qbit
+                        .add_torrent_with_file_filter(&url, &info_hash_clone, move |files| {
+                            auto_search::pick_wanted_file_indices(files, &detail_clone)
+                        })
+                        .await
+                    {
+                        Ok(crate::services::qbit::SelectiveOutcome::Filtered(kept)) => Ok(Some(kept)),
+                        Ok(crate::services::qbit::SelectiveOutcome::FullDownload) => Ok(None),
+                        Err(e) => {
+                            logger::warn(
+                                &state.db,
+                                LogCategory::Grab,
+                                &format!("{}: selective download failed, falling back to full grab", label),
+                                &e,
+                            )
+                            .await;
+                            qbit.add_torrent(&url).await.map(|_| None)
+                        }
+                    }
+                } else {
+                    qbit.add_torrent(&url).await.map(|_| None)
+                };
+                match selective_outcome {
+                    Ok(kept) => {
+                        let selective_suffix = match (&kept, wants_selective) {
+                            (Some(ids), _) => format!(", selective={}", ids.len()),
+                            (None, true) => ", selective=full(timeout)".to_string(),
+                            (None, false) => String::new(),
+                        };
                         logger::info(
                             &state.db,
                             LogCategory::Grab,
                             &format!("Grabbed: {}", result.title),
-                            &format!("target={}, group={}, score={}, tier={}, batch={}", label, result.group, result.score, incoming_classification.label(), result.is_batch),
+                            &format!("target={}, group={}, score={}, tier={}, batch={}{}", label, result.group, result.score, incoming_classification.label(), result.is_batch, selective_suffix),
                         ).await;
                         // Record for post-processing and episode quality tags.
                         if let Some(sid) = series_id {
@@ -1946,14 +2249,14 @@ async fn run_auto_search_targets_with_upgrades(
                                     ep_nums.sort_unstable();
                                 }
                             }
-                            let _ = crate::models::grabbed_torrents::record_grab(
+                            let grab_id = crate::models::grabbed_torrents::record_grab(
                                 &state.db,
                                 &result.info_hash,
                                 &result.title,
                                 sid,
                                 &ep_nums,
                                 result.is_batch,
-                            ).await;
+                            ).await.ok().flatten();
                             for ep_num in &ep_nums {
                                 let _ = episode_tags::record_grab(
                                     &state.db,
@@ -1963,6 +2266,28 @@ async fn run_auto_search_targets_with_upgrades(
                                     &result.title,
                                     &result.group,
                                 ).await;
+                            }
+                            // Phase 2 sibling auto-expand: when the
+                            // grab is a batch covering a franchise
+                            // (e.g. JoJo S1-S5), detect sibling
+                            // entries in the file list and add them
+                            // to the library so post-processing can
+                            // route each file to the correct series.
+                            // Only runs on fresh grabs (existing
+                            // grab_id skips the route-write path).
+                            if result.is_batch {
+                                if let Some(grab_id) = grab_id {
+                                    let _ = auto_expand_library_from_pack(
+                                        &state.db,
+                                        &qbit,
+                                        &result.info_hash,
+                                        &detail,
+                                        sid,
+                                        &ep_nums,
+                                        grab_id,
+                                        &result.title,
+                                    ).await;
+                                }
                             }
                         }
                     }
@@ -2433,8 +2758,43 @@ pub async fn grab_batch_result(
             .clone()
     };
 
-    qbit.add_torrent(&url).await
-        .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+    // Same selective-file path as `grab_interactive_result`: narrow
+    // a megapack to just the target if it has its own subtitle or
+    // part number. Franchise roots (JoJo S1) deliberately fall
+    // through so the multi-series auto-expand path below can route
+    // each sibling's files into its own library entry instead.
+    let wants_selective = !info_hash.is_empty()
+        && auto_search::has_selective_discriminator(&detail);
+    let selective_outcome: Option<Vec<usize>> = if wants_selective {
+        let detail_clone = detail.clone();
+        match qbit
+            .add_torrent_with_file_filter(&url, &info_hash, move |files| {
+                auto_search::pick_wanted_file_indices(files, &detail_clone)
+            })
+            .await
+        {
+            Ok(crate::services::qbit::SelectiveOutcome::Filtered(kept)) => Some(kept),
+            Ok(crate::services::qbit::SelectiveOutcome::FullDownload) => None,
+            Err(e) => {
+                logger::warn(
+                    &state.db,
+                    LogCategory::Grab,
+                    &format!("Selective batch download failed, falling back to full grab: {}", title),
+                    &e,
+                )
+                .await;
+                qbit.add_torrent(&url)
+                    .await
+                    .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+                None
+            }
+        }
+    } else {
+        qbit.add_torrent(&url)
+            .await
+            .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+        None
+    };
 
     // Classify so the log line carries the actual quality tier. Pass the
     // chosen release as a batch in NyaaContext (Layer 4 uses this for the
@@ -2455,20 +2815,44 @@ pub async fn grab_batch_result(
         }),
     ).await;
 
+    let selective_suffix = match (&selective_outcome, wants_selective) {
+        (Some(kept), _) => format!(", selective={}", kept.len()),
+        (None, true) => ", selective=full(timeout)".to_string(),
+        (None, false) => String::new(),
+    };
     logger::info(
         &state.db,
         LogCategory::Grab,
         &format!("Grabbed batch (interactive): {}", title),
-        &format!("group={}, tier={}", group, classification.label()),
+        &format!("group={}, tier={}{}", group, classification.label(), selective_suffix),
     ).await;
 
     if let Some(sid) = series_id {
-        let _ = crate::models::grabbed_torrents::record_grab(
+        let grab_id = crate::models::grabbed_torrents::record_grab(
             &state.db, &info_hash, &title, sid, &[], true,
-        ).await;
+        ).await.ok().flatten();
+        // Phase 2 sibling auto-expand. Always true here because this
+        // is the batch-grab path.
+        if let Some(grab_id) = grab_id {
+            let _ = auto_expand_library_from_pack(
+                &state.db,
+                &qbit,
+                &info_hash,
+                &detail,
+                sid,
+                &[],
+                grab_id,
+                &title,
+            ).await;
+        }
     }
 
-    Ok(Json(serde_json::json!({"ok": true, "title": title, "tier": classification.label()})))
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "title": title,
+        "tier": classification.label(),
+        "selective_files": selective_outcome,
+    })))
 }
 
 /// Grab a specific release chosen from the interactive search.
@@ -2494,7 +2878,7 @@ pub async fn grab_interactive_result(
     Path((request_id, episode_number)): Path<(i64, i32)>,
     Json(body): Json<serde_json::Value>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let (tracked_row, _, _detail) = resolve_series_context(&state.db, request_id)
+    let (tracked_row, _, detail) = resolve_series_context(&state.db, request_id)
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
 
@@ -2516,8 +2900,45 @@ pub async fn grab_interactive_result(
             .clone()
     };
 
-    qbit.add_torrent(&url).await
-        .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+    // If the target is a multi-part entry ("Kizumonogatari II") OR a
+    // subtitled season of a franchise ("Stardust Crusaders"), try the
+    // selective-file download path so a megapack release only pulls
+    // the files the user is tracking. Franchise roots without their
+    // own subtitle return `false` here and fall through to the plain
+    // `add_torrent` path — interactive single-episode grabs don't
+    // auto-expand the library (that's `grab_batch_result`'s job).
+    let wants_selective = !info_hash.is_empty()
+        && auto_search::has_selective_discriminator(&detail);
+    let selective_outcome: Option<Vec<usize>> = if wants_selective {
+        let detail_clone = detail.clone();
+        match qbit
+            .add_torrent_with_file_filter(&url, &info_hash, move |files| {
+                auto_search::pick_wanted_file_indices(files, &detail_clone)
+            })
+            .await
+        {
+            Ok(crate::services::qbit::SelectiveOutcome::Filtered(kept)) => Some(kept),
+            Ok(crate::services::qbit::SelectiveOutcome::FullDownload) => None,
+            Err(e) => {
+                logger::warn(
+                    &state.db,
+                    LogCategory::Grab,
+                    &format!("Selective download failed, falling back to full grab: {}", title),
+                    &e,
+                )
+                .await;
+                qbit.add_torrent(&url)
+                    .await
+                    .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+                None
+            }
+        }
+    } else {
+        qbit.add_torrent(&url)
+            .await
+            .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+        None
+    };
 
     // Interactive grab: the frontend doesn't currently round-trip the Nyaa
     // view URL, so Layer 2 is skipped here. These grabs are user-initiated
@@ -2538,11 +2959,19 @@ pub async fn grab_interactive_result(
         None,
         series_ctx,
     ).await;
+    let selective_suffix = match (&selective_outcome, wants_selective) {
+        (Some(kept), _) => format!(", selective={}", kept.len()),
+        (None, true) => ", selective=full(timeout)".to_string(),
+        (None, false) => String::new(),
+    };
     logger::info(
         &state.db,
         LogCategory::Grab,
         &format!("Interactive grab: {}", title),
-        &format!("episode={}, group={}, tier={}", episode_number, group, classification.label()),
+        &format!(
+            "episode={}, group={}, tier={}{}",
+            episode_number, group, classification.label(), selective_suffix
+        ),
     ).await;
 
     if let Some(sid) = series_id {
@@ -2555,7 +2984,10 @@ pub async fn grab_interactive_result(
         ).await;
     }
 
-    Ok(Json(serde_json::json!({"ok": true})))
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "selective_files": selective_outcome,
+    })))
 }
 
 /// Delete an episode file from disk.

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2275,7 +2275,22 @@ async fn run_auto_search_targets_with_upgrades(
                             // route each file to the correct series.
                             // Only runs on fresh grabs (existing
                             // grab_id skips the route-write path).
-                            if result.is_batch {
+                            //
+                            // Skip auto-expand when selective narrowing
+                            // successfully applied — the user is
+                            // explicitly targeting one sibling inside a
+                            // megapack (e.g. Stardust Crusaders in a
+                            // JoJo pack), so the other siblings' files
+                            // are marked priority=0 in qBit and will
+                            // never land. Creating ghost library rows
+                            // for them would leave dangling entries
+                            // with no imported files. The
+                            // `kept.is_none()` fallback path
+                            // (selective filter timed out → full
+                            // download) still auto-expands because the
+                            // whole pack is actually downloading.
+                            let selective_narrowed = wants_selective && kept.is_some();
+                            if result.is_batch && !selective_narrowed {
                                 if let Some(grab_id) = grab_id {
                                     let _ = auto_expand_library_from_pack(
                                         &state.db,
@@ -2831,19 +2846,29 @@ pub async fn grab_batch_result(
         let grab_id = crate::models::grabbed_torrents::record_grab(
             &state.db, &info_hash, &title, sid, &[], true,
         ).await.ok().flatten();
-        // Phase 2 sibling auto-expand. Always true here because this
-        // is the batch-grab path.
-        if let Some(grab_id) = grab_id {
-            let _ = auto_expand_library_from_pack(
-                &state.db,
-                &qbit,
-                &info_hash,
-                &detail,
-                sid,
-                &[],
-                grab_id,
-                &title,
-            ).await;
+        // Phase 2 sibling auto-expand. Skip when selective narrowing
+        // successfully applied — the user picked a specific sibling
+        // (e.g. Stardust Crusaders) out of a megapack and the other
+        // siblings' files are marked priority=0 in qBit and won't
+        // land. Creating library entries for them would leave ghost
+        // rows with no imported files. The `selective_outcome.is_none()
+        // && wants_selective` fallback (filter timed out → full
+        // download) still auto-expands because the whole pack is
+        // actually downloading.
+        let selective_narrowed = wants_selective && selective_outcome.is_some();
+        if !selective_narrowed {
+            if let Some(grab_id) = grab_id {
+                let _ = auto_expand_library_from_pack(
+                    &state.db,
+                    &qbit,
+                    &info_hash,
+                    &detail,
+                    sid,
+                    &[],
+                    grab_id,
+                    &title,
+                ).await;
+            }
         }
     }
 

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1876,12 +1876,16 @@ async fn run_auto_search_targets_with_upgrades(
         &format!("{} target(s), allow_batch={}", targets.len(), allow_batch),
     ).await;
 
+    // Clone the compiled-CF Arc out from under the read lock so the
+    // scoring loop below runs without holding it.
+    let cfs = state.custom_formats.read().await.clone();
+
     let mut grabbed = Vec::new();
     let mut skipped = Vec::new();
     for target in targets {
         let label = auto_search::target_label(&target);
         let is_upgrade = matches!(&target, auto_search::SearchTarget::Episode(n) if upgrade_classifications.contains_key(n));
-        match auto_search::find_best_for_target(&state.db, &detail, &cfg, &target, allow_batch, is_upgrade).await {
+        match auto_search::find_best_for_target(&state.db, &detail, &cfg, &target, allow_batch, is_upgrade, &cfs).await {
             Some(result) => {
                 // Classify up front so both upgrade-verification and log labels
                 // read the same result.
@@ -2215,6 +2219,8 @@ pub async fn search_batch_releases(
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .unwrap_or_default();
 
+    let cfs = state.custom_formats.read().await.clone();
+
     // Pick the best *batch* — filtering to is_batch pre-selection instead
     // of post-selection. The old code called find_best_for_target and
     // post-filtered, which returned None whenever the top-scored result
@@ -2225,6 +2231,7 @@ pub async fn search_batch_releases(
         &detail,
         &cfg,
         &auto_search::SearchTarget::Single,
+        &cfs,
     ).await;
 
     let qbit = {
@@ -2315,6 +2322,8 @@ pub async fn interactive_search_episode(
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .unwrap_or_default();
 
+    let cfs = state.custom_formats.read().await.clone();
+
     // Same single-entry collapse as auto_search_episode — the interactive
     // picker otherwise returns zero results for movies.
     let target = auto_search::SearchTarget::for_episode(&detail, episode_number);
@@ -2324,6 +2333,7 @@ pub async fn interactive_search_episode(
         &cfg,
         &target,
         false,
+        &cfs,
     ).await;
 
     Ok(Json(results))
@@ -2361,11 +2371,14 @@ pub async fn interactive_search_batches(
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .unwrap_or_default();
 
+    let cfs = state.custom_formats.read().await.clone();
+
     let results = auto_search::collect_scored_batches_for_target(
         &state.db,
         &detail,
         &cfg,
         &auto_search::SearchTarget::Single,
+        &cfs,
     ).await;
 
     Ok(Json(results))

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -2,10 +2,23 @@ use askama::Template;
 use axum::{extract::{Query, State}, response::{Html, Redirect}, Form, Json};
 use serde::Deserialize;
 
-use crate::models::{config, group_source_map};
+use crate::models::{config, custom_formats as cf_model, group_source_map};
 use crate::models::log::LogCategory;
-use crate::services::{jellyfin::JellyfinClient, logger, qbit::QbitClient, source::Source};
+use crate::services::{
+    custom_formats as cf_service, jellyfin::JellyfinClient, logger, qbit::QbitClient,
+    source::Source,
+};
 use crate::AppState;
+
+/// View-model wrapper rendered on the Custom Formats tab. Pairs each
+/// stored CF row with its parsed spec count (or parse error), so the
+/// table can surface "3 specs" next to well-formed rows and a red
+/// "parse error: ..." marker next to ones the user needs to fix.
+pub struct CustomFormatView {
+    pub row: cf_model::CustomFormatRow,
+    pub specs_count: usize,
+    pub parse_error: Option<String>,
+}
 
 #[derive(Template)]
 #[template(path = "settings.html")]
@@ -15,13 +28,36 @@ struct SettingsTemplate {
     config: config::Config,
     groups: Vec<group_source_map::GroupSourceEntry>,
     suggestions: Vec<group_source_map::GroupSuggestion>,
+    custom_formats: Vec<CustomFormatView>,
+    custom_format_edit: Option<cf_model::CustomFormatRow>,
+    /// Pre-rendered string for the minimum-score input. Empty when the
+    /// floor is the `i32::MIN` "no floor" sentinel. Computed here so the
+    /// Askama template doesn't need to compare against an integer path.
+    custom_format_min_score_display: String,
     message: Option<String>,
     error: Option<String>,
+}
+
+fn min_score_display(score: i32) -> String {
+    if score == i32::MIN {
+        String::new()
+    } else {
+        score.to_string()
+    }
 }
 
 #[derive(Deserialize)]
 pub struct SettingsQuery {
     tab: Option<String>,
+    /// When the Custom Formats tab is active and `edit_id` is set, the
+    /// upsert form prefills from the existing row so the user can fix
+    /// the JSON in place rather than deleting and re-pasting.
+    edit_id: Option<i64>,
+    /// Optional flash message / error surfaced after a POST-redirect.
+    /// Kept minimal — detailed validation errors skip the redirect path
+    /// and re-render inline so the form state is preserved.
+    msg: Option<String>,
+    err: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -53,6 +89,7 @@ pub struct SettingsForm {
     radarr_enabled: Option<String>,
     radarr_api_key: Option<String>,
     upgrade_search_enabled: Option<String>,
+    seadex_enabled: Option<String>,
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -73,10 +110,35 @@ pub struct JellyfinTestForm {
 fn normalize_settings_tab(tab: Option<String>) -> String {
     match tab.as_deref() {
         Some("quality") => "quality".to_string(),
+        Some("custom_formats") => "custom_formats".to_string(),
         Some("groups") => "groups".to_string(),
         Some("general") => "general".to_string(),
         _ => "integrations".to_string(),
     }
+}
+
+/// Load every CF row and annotate each one with its parsed spec count
+/// (or the parse error string, if compilation fails). Used by the
+/// Custom Formats tab to surface broken rows in the list view so the
+/// user can find and fix them without trawling logs.
+async fn load_custom_formats_view(db: &sqlx::SqlitePool) -> Vec<CustomFormatView> {
+    let rows = cf_model::list_with_scores(db).await.unwrap_or_default();
+    rows.into_iter()
+        .map(|row| {
+            match cf_service::compile_from_json(&row.json, row.score as i32, row.id) {
+                Ok(cf) => CustomFormatView {
+                    specs_count: cf.specs.len(),
+                    parse_error: None,
+                    row,
+                },
+                Err(e) => CustomFormatView {
+                    specs_count: 0,
+                    parse_error: Some(e),
+                    row,
+                },
+            }
+        })
+        .collect()
 }
 
 async fn load_groups(
@@ -147,15 +209,28 @@ pub async fn settings_page(
 
     let groups = load_groups(&state.db).await;
     let suggestions = load_suggestions(&state.db).await;
+    let custom_formats = load_custom_formats_view(&state.db).await;
 
+    // Prefill the CF edit form only when the query param points at a row
+    // that actually exists — stale edit links just fall through to the
+    // "Add new" form, which is the safer default.
+    let custom_format_edit = match params.edit_id {
+        Some(id) => cf_model::get_by_id(&state.db, id).await.ok().flatten(),
+        None => None,
+    };
+
+    let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
     let template = SettingsTemplate {
         page: "settings".to_string(),
         tab: normalize_settings_tab(params.tab),
         config: cfg,
         groups,
         suggestions,
-        message: None,
-        error: None,
+        custom_formats,
+        custom_format_edit,
+        custom_format_min_score_display,
+        message: params.msg,
+        error: params.err,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -248,16 +323,17 @@ pub async fn settings_submit(
         } else {
             existing_cfg.as_ref().map(|c| c.upgrade_search_enabled).unwrap_or(false)
         },
-        // Carried forward from the existing row — edited through the
-        // dedicated Custom Formats settings page (Phase 7), not this form.
+        // Carried forward from the existing row — edited via the
+        // dedicated Custom Formats tab's minimum-score form, not here.
         custom_format_minimum_score: existing_cfg
             .as_ref()
             .map(|c| c.custom_format_minimum_score)
             .unwrap_or(i32::MIN),
-        seadex_enabled: existing_cfg
-            .as_ref()
-            .map(|c| c.seadex_enabled)
-            .unwrap_or(false),
+        seadex_enabled: if form.tab.as_deref() == Some("quality") || form.tab.is_none() {
+            form.seadex_enabled.is_some()
+        } else {
+            existing_cfg.as_ref().map(|c| c.seadex_enabled).unwrap_or(false)
+        },
     };
 
     let active_tab = normalize_settings_tab(form.tab.clone());
@@ -266,12 +342,17 @@ pub async fn settings_submit(
         logger::error(&state.db, LogCategory::System, "Failed to save settings", &e.to_string()).await;
         let groups = load_groups(&state.db).await;
         let suggestions = load_suggestions(&state.db).await;
+        let custom_formats = load_custom_formats_view(&state.db).await;
+        let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
         let template = SettingsTemplate {
             page: "settings".to_string(),
             tab: active_tab,
             config: cfg,
             groups,
             suggestions,
+            custom_formats,
+            custom_format_edit: None,
+            custom_format_min_score_display,
             message: None,
             error: Some(format!("Failed to save: {}", e)),
         };
@@ -333,12 +414,17 @@ pub async fn settings_submit(
 
     let groups = load_groups(&state.db).await;
     let suggestions = load_suggestions(&state.db).await;
+    let custom_formats = load_custom_formats_view(&state.db).await;
+    let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
     let template = SettingsTemplate {
         page: "settings".to_string(),
         tab: active_tab,
         config: cfg,
         groups,
         suggestions,
+        custom_formats,
+        custom_format_edit: None,
+        custom_format_min_score_display,
         message: Some(notices.join("<br>")),
         error: None,
     };
@@ -437,6 +523,430 @@ pub async fn settings_groups_delete(
         }
     }
     Redirect::to("/settings?tab=groups")
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Custom Formats CRUD
+// ─────────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct CustomFormatUpsertForm {
+    /// `None` = create a new row; `Some(n)` = update existing row `n`.
+    /// Hidden input on the edit form prefill.
+    id: Option<i64>,
+    name: String,
+    score: i32,
+    trash_id: Option<String>,
+    json: String,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct CustomFormatDeleteForm {
+    id: i64,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct CustomFormatMinScoreForm {
+    /// Blank string = clear the floor (`i32::MIN`). Numeric strings are
+    /// parsed; anything else falls back to the current value so a fat-
+    /// finger save can't silently wipe the user's threshold.
+    minimum_score: String,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct CustomFormatImportForm {
+    /// Pasted Sonarr v4 CF JSON export — either a single CF object or
+    /// an array of them. Each entry compiles through the same
+    /// `compile_from_json` path as the create form; failures are
+    /// counted and reported but don't abort the whole import.
+    payload: String,
+}
+
+/// Create or update a Custom Format row. Validates the supplied JSON
+/// via `compile_from_json` before touching the database — if the parse
+/// fails, the user is bounced back to the CF tab with the error and
+/// the edit form re-prefilled from the attempted id so their work
+/// isn't lost. On success, rebuilds the compiled-CF cache so the next
+/// scoring pass sees the change.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/upsert",
+    tag = "Settings",
+    summary = "Create or update a Custom Format",
+    description = "Upsert a Sonarr v4-compatible Custom Format and its V1-profile score. Validates the JSON via the CF compiler before writing to the database. On success, rebuilds the compiled-CF cache so the next scoring pass sees the change. Redirects back to the Custom Formats settings tab with a flash message.",
+    request_body(content = CustomFormatUpsertForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_upsert(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatUpsertForm>,
+) -> Redirect {
+    let name = form.name.trim();
+    if name.is_empty() {
+        return Redirect::to(&cf_redirect(
+            form.id,
+            None,
+            Some("Custom Format name cannot be blank."),
+        ));
+    }
+    let trash_id = form.trash_id.as_ref().map(|s| s.trim()).filter(|s| !s.is_empty());
+    let json_trimmed = form.json.trim();
+
+    // Validate against the real compiler so a CF that would fail to
+    // parse on startup also fails to save through the UI.
+    if let Err(e) = cf_service::compile_from_json(json_trimmed, form.score, form.id.unwrap_or(0)) {
+        return Redirect::to(&cf_redirect(form.id, None, Some(&format!("Parse error: {e}"))));
+    }
+
+    let save_result = if let Some(id) = form.id {
+        cf_model::update(&state.db, id, name, trash_id, json_trimmed, form.score)
+            .await
+            .map(|_| id)
+    } else {
+        cf_model::insert(&state.db, name, trash_id, json_trimmed, form.score).await
+    };
+
+    match save_result {
+        Ok(id) => {
+            cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Custom Format saved: {name} (id={id})"),
+                "",
+            )
+            .await;
+            Redirect::to(&cf_redirect(None, Some(&format!("Saved '{name}'.")), None))
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Custom Format save failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to(&cf_redirect(
+                form.id,
+                None,
+                Some(&format!("Database error: {e}")),
+            ))
+        }
+    }
+}
+
+/// Delete a Custom Format row by id. Score row is dropped automatically
+/// via the `ON DELETE CASCADE` on `custom_format_scores`.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/delete",
+    tag = "Settings",
+    summary = "Delete a Custom Format",
+    description = "Delete a Custom Format row by id. The associated score row is dropped automatically via ON DELETE CASCADE. Rebuilds the compiled-CF cache on success. Redirects back to the Custom Formats settings tab.",
+    request_body(content = CustomFormatDeleteForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_delete(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatDeleteForm>,
+) -> Redirect {
+    match cf_model::delete(&state.db, form.id).await {
+        Ok(_) => {
+            cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Custom Format deleted: id={}", form.id),
+                "",
+            )
+            .await;
+            Redirect::to(&cf_redirect(None, Some("Custom Format deleted."), None))
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Custom Format delete failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Delete failed: {e}")),
+            ))
+        }
+    }
+}
+
+/// Update the global `custom_format_minimum_score` floor. Blank input
+/// clears the floor (sets it back to `i32::MIN`, the "no floor"
+/// sentinel). Non-numeric input falls through to the existing value so
+/// a typo can't silently wipe the threshold.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/minimum-score",
+    tag = "Settings",
+    summary = "Set the Custom Format minimum-score floor",
+    description = "Update the global minimum-score threshold. Auto-search drops releases whose summed CF score falls below this value; interactive search still shows everything. Blank clears the floor. Redirects back to the Custom Formats settings tab.",
+    request_body(content = CustomFormatMinScoreForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_minimum_score(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatMinScoreForm>,
+) -> Redirect {
+    let existing = config::get_config(&state.db).await.ok().flatten();
+    let Some(mut cfg) = existing else {
+        return Redirect::to(&cf_redirect(None, None, Some("Config not initialized.")));
+    };
+
+    let trimmed = form.minimum_score.trim();
+    let new_floor = if trimmed.is_empty() {
+        i32::MIN
+    } else {
+        match trimmed.parse::<i32>() {
+            Ok(n) => n,
+            Err(_) => {
+                return Redirect::to(&cf_redirect(
+                    None,
+                    None,
+                    Some("Minimum score must be an integer (leave blank for 'no floor')."),
+                ));
+            }
+        }
+    };
+
+    cfg.custom_format_minimum_score = new_floor;
+    match config::save_config(&state.db, &cfg).await {
+        Ok(_) => {
+            let msg = if new_floor == i32::MIN {
+                "Minimum score cleared (no floor).".to_string()
+            } else {
+                format!("Minimum score set to {new_floor}.")
+            };
+            Redirect::to(&cf_redirect(None, Some(&msg), None))
+        }
+        Err(e) => Redirect::to(&cf_redirect(None, None, Some(&format!("Save failed: {e}")))),
+    }
+}
+
+/// Import a Sonarr v4 CF JSON export. Accepts either a single object
+/// or an array of them; per-entry parse / insert failures are counted
+/// and reported but don't abort the whole import. After a successful
+/// run the compiled cache is rebuilt so the imported CFs are live on
+/// the next scoring pass.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/import",
+    tag = "Settings",
+    summary = "Import Custom Formats from Sonarr v4 JSON",
+    description = "Import one or more Custom Formats from a Sonarr v4 JSON export. Accepts either a single object or an array. Each entry is compiled via the standard CF parser; per-entry failures are counted and the first error is surfaced in the flash message, but valid entries still import. Rebuilds the compiled-CF cache on success. Redirects back to the Custom Formats settings tab.",
+    request_body(content = CustomFormatImportForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_import(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatImportForm>,
+) -> Redirect {
+    let payload = form.payload.trim();
+    if payload.is_empty() {
+        return Redirect::to(&cf_redirect(None, None, Some("Import payload is empty.")));
+    }
+
+    let value: serde_json::Value = match serde_json::from_str(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Import failed: invalid JSON ({e})")),
+            ));
+        }
+    };
+
+    // Normalize single-object imports into a one-element array so the
+    // loop below handles both shapes identically.
+    let entries: Vec<serde_json::Value> = match value {
+        serde_json::Value::Array(items) => items,
+        serde_json::Value::Object(_) => vec![value],
+        _ => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some("Import failed: top-level must be an object or array."),
+            ));
+        }
+    };
+
+    let mut imported = 0usize;
+    let mut failed = 0usize;
+    let mut first_error: Option<String> = None;
+
+    for entry in entries {
+        // Pull out the Sonarr-shape fields we care about. `specifications`
+        // lives inside the same blob we'll persist, so we re-serialize
+        // the whole object verbatim to keep round-trip exports faithful.
+        let name = entry.get("name").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
+        let trash_id = entry
+            .get("trash_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        // Sonarr exports keep the score inside a sibling `score` or
+        // `trash_score` field; both are optional. Default to 0 when
+        // neither is present so the user can set the score later.
+        let score = entry
+            .get("score")
+            .and_then(|v| v.as_i64())
+            .or_else(|| entry.get("trash_score").and_then(|v| v.as_i64()))
+            .unwrap_or(0) as i32;
+
+        if name.is_empty() {
+            failed += 1;
+            if first_error.is_none() {
+                first_error = Some("one entry is missing a `name` field".to_string());
+            }
+            continue;
+        }
+
+        let raw_json = entry.to_string();
+        if let Err(e) = cf_service::compile_from_json(&raw_json, score, 0) {
+            failed += 1;
+            if first_error.is_none() {
+                first_error = Some(format!("'{name}': {e}"));
+            }
+            continue;
+        }
+
+        match cf_model::insert(&state.db, &name, trash_id.as_deref(), &raw_json, score).await {
+            Ok(_) => imported += 1,
+            Err(e) => {
+                failed += 1;
+                if first_error.is_none() {
+                    first_error = Some(format!("'{name}': {e}"));
+                }
+            }
+        }
+    }
+
+    if imported > 0 {
+        cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+    }
+
+    let summary = match (imported, failed) {
+        (0, 0) => "Nothing to import.".to_string(),
+        (n, 0) => format!("Imported {n} Custom Format(s)."),
+        (0, m) => format!(
+            "Import failed ({m} rejected). First error: {}",
+            first_error.unwrap_or_default()
+        ),
+        (n, m) => format!(
+            "Imported {n}, skipped {m}. First error: {}",
+            first_error.unwrap_or_default()
+        ),
+    };
+
+    if imported == 0 && failed > 0 {
+        Redirect::to(&cf_redirect(None, None, Some(&summary)))
+    } else {
+        Redirect::to(&cf_redirect(None, Some(&summary), None))
+    }
+}
+
+/// Export every Custom Format as a JSON array download. The payload
+/// keeps each row's raw `json` column verbatim so re-importing the
+/// file into Sonarr (or another Ryokan instance) round-trips cleanly.
+#[utoipa::path(
+    get,
+    path = "/settings/custom-formats/export",
+    tag = "Settings",
+    summary = "Export all Custom Formats as JSON",
+    description = "Download every saved Custom Format as a JSON array. Each row's raw Sonarr v4 object is merged with the persisted V1-profile score, so the export round-trips cleanly into Sonarr or another Ryokan instance. Served with `Content-Disposition: attachment; filename=\"ryokan-custom-formats.json\"`.",
+    responses(
+        (status = 200, description = "JSON array of Custom Formats", body = serde_json::Value, content_type = "application/json"),
+        (status = 500, description = "Database error"),
+    ),
+)]
+pub async fn settings_custom_formats_export(
+    State(state): State<AppState>,
+) -> Result<(axum::http::HeaderMap, String), (axum::http::StatusCode, String)> {
+    let rows = cf_model::list_with_scores(&state.db)
+        .await
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    // Parse each row's stored JSON back into a `Value` so the exported
+    // array is real JSON (not a string-of-strings). Unparseable rows
+    // are skipped — they wouldn't import cleanly into a target Sonarr
+    // anyway, and logging the skip is enough of a breadcrumb.
+    let mut out: Vec<serde_json::Value> = Vec::with_capacity(rows.len());
+    for row in rows {
+        match serde_json::from_str::<serde_json::Value>(&row.json) {
+            Ok(mut v) => {
+                // Merge the persisted score into the exported object so
+                // the importer doesn't have to re-key scores by name.
+                // Sonarr ignores unknown fields on import, so this is
+                // safe to ship even when re-importing into Sonarr.
+                if let serde_json::Value::Object(ref mut map) = v {
+                    map.insert(
+                        "score".to_string(),
+                        serde_json::Value::Number(row.score.into()),
+                    );
+                }
+                out.push(v);
+            }
+            Err(e) => {
+                tracing::warn!(
+                    "custom_formats export: skipping id={} name={} — parse error: {}",
+                    row.id,
+                    row.name,
+                    e
+                );
+            }
+        }
+    }
+
+    let body = serde_json::to_string_pretty(&serde_json::Value::Array(out))
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::CONTENT_TYPE,
+        axum::http::HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        axum::http::header::CONTENT_DISPOSITION,
+        axum::http::HeaderValue::from_static(
+            "attachment; filename=\"ryokan-custom-formats.json\"",
+        ),
+    );
+    Ok((headers, body))
+}
+
+/// Build a redirect target for the Custom Formats tab. Optionally
+/// carries an `edit_id` (to re-open the failed row's form), a success
+/// `msg`, or an `err`. Query values are URL-encoded so arbitrary error
+/// strings survive the round-trip safely.
+fn cf_redirect(edit_id: Option<i64>, msg: Option<&str>, err: Option<&str>) -> String {
+    let mut url = String::from("/settings?tab=custom_formats");
+    if let Some(id) = edit_id {
+        url.push_str(&format!("&edit_id={id}"));
+    }
+    if let Some(m) = msg {
+        url.push_str(&format!("&msg={}", urlencoding::encode(m)));
+    }
+    if let Some(e) = err {
+        url.push_str(&format!("&err={}", urlencoding::encode(e)));
+    }
+    url
 }
 
 #[utoipa::path(

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -1,5 +1,9 @@
 use askama::Template;
-use axum::{extract::{Query, State}, response::{Html, Redirect}, Form, Json};
+use axum::{
+    extract::{Query, State},
+    response::{Html, IntoResponse, Redirect, Response},
+    Form, Json,
+};
 use serde::Deserialize;
 
 use crate::models::{config, custom_formats as cf_model, group_source_map};
@@ -20,6 +24,31 @@ pub struct CustomFormatView {
     pub parse_error: Option<String>,
 }
 
+/// View-model wrapper rendered when the Custom Formats tab is in edit
+/// mode. Holds the full row plus any `trash_description` extracted
+/// from the row's JSON body. Plan §5.7.6 wants descriptions to persist
+/// through round-trips and surface in the edit drawer so the user
+/// keeps the Trash Guides context that originally shipped the CF.
+pub struct CustomFormatEditView {
+    pub row: cf_model::CustomFormatRow,
+    pub trash_description: Option<String>,
+}
+
+/// Parse a stored CF's JSON body and return the `trash_description`
+/// string if it's present, non-empty, and a string. Silently returns
+/// `None` on parse error — the row itself still renders via the raw
+/// `edit.json` textarea, so the description is a nice-to-have, not a
+/// blocker.
+fn extract_trash_description(json: &str) -> Option<String> {
+    let value: serde_json::Value = serde_json::from_str(json).ok()?;
+    let desc = value.get("trash_description")?.as_str()?.trim();
+    if desc.is_empty() {
+        None
+    } else {
+        Some(desc.to_string())
+    }
+}
+
 #[derive(Template)]
 #[template(path = "settings.html")]
 struct SettingsTemplate {
@@ -29,13 +58,34 @@ struct SettingsTemplate {
     groups: Vec<group_source_map::GroupSourceEntry>,
     suggestions: Vec<group_source_map::GroupSuggestion>,
     custom_formats: Vec<CustomFormatView>,
-    custom_format_edit: Option<cf_model::CustomFormatRow>,
+    custom_format_edit: Option<CustomFormatEditView>,
     /// Pre-rendered string for the minimum-score input. Empty when the
     /// floor is the `i32::MIN` "no floor" sentinel. Computed here so the
     /// Askama template doesn't need to compare against an integer path.
     custom_format_min_score_display: String,
+    /// Populated when the import flow hit a name collision. The CF tab
+    /// renders a review block with per-collision radio buttons so the
+    /// user can pick overwrite/rename/skip for each conflicting CF.
+    /// See plan §6.2.
+    custom_format_import_review: Option<ImportReviewView>,
     message: Option<String>,
     error: Option<String>,
+}
+
+/// Per-collision entry shown on the import review block. `index` is
+/// the position of the CF inside the parsed payload so the resolve
+/// handler can find the right entry after re-parsing the payload.
+pub struct ImportCollision {
+    pub index: usize,
+    pub name: String,
+}
+
+/// View model for the import review block. Holds the original payload
+/// (echoed back into a hidden field so the resolve handler can re-parse
+/// it) plus the list of collisions the user needs to act on.
+pub struct ImportReviewView {
+    pub payload: String,
+    pub collisions: Vec<ImportCollision>,
 }
 
 fn min_score_display(score: i32) -> String {
@@ -197,10 +247,21 @@ fn validate_resolution(value: &str, default: &str) -> String {
     }
 }
 
-pub async fn settings_page(
-    State(state): State<AppState>,
-    Query(params): Query<SettingsQuery>,
-) -> Html<String> {
+/// Build a fully-populated `SettingsTemplate` with the same loading
+/// logic the main settings page uses. Extracted so the CF import
+/// handler can re-render the settings page in place on a name
+/// collision without duplicating every DB query the normal page
+/// renderer runs. Callers override the `tab`, `edit_id`, `msg`, `err`,
+/// and optional import-review fields to tailor the resulting page.
+#[allow(clippy::too_many_arguments)]
+async fn build_settings_template(
+    state: &AppState,
+    tab: Option<String>,
+    edit_id: Option<i64>,
+    msg: Option<String>,
+    err: Option<String>,
+    import_review: Option<ImportReviewView>,
+) -> SettingsTemplate {
     let cfg = config::get_config(&state.db)
         .await
         .ok()
@@ -214,24 +275,50 @@ pub async fn settings_page(
     // Prefill the CF edit form only when the query param points at a row
     // that actually exists — stale edit links just fall through to the
     // "Add new" form, which is the safer default.
-    let custom_format_edit = match params.edit_id {
-        Some(id) => cf_model::get_by_id(&state.db, id).await.ok().flatten(),
+    let custom_format_edit = match edit_id {
+        Some(id) => cf_model::get_by_id(&state.db, id)
+            .await
+            .ok()
+            .flatten()
+            .map(|row| {
+                let trash_description = extract_trash_description(&row.json);
+                CustomFormatEditView {
+                    row,
+                    trash_description,
+                }
+            }),
         None => None,
     };
 
     let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
-    let template = SettingsTemplate {
+    SettingsTemplate {
         page: "settings".to_string(),
-        tab: normalize_settings_tab(params.tab),
+        tab: normalize_settings_tab(tab),
         config: cfg,
         groups,
         suggestions,
         custom_formats,
         custom_format_edit,
         custom_format_min_score_display,
-        message: params.msg,
-        error: params.err,
-    };
+        custom_format_import_review: import_review,
+        message: msg,
+        error: err,
+    }
+}
+
+pub async fn settings_page(
+    State(state): State<AppState>,
+    Query(params): Query<SettingsQuery>,
+) -> Html<String> {
+    let template = build_settings_template(
+        &state,
+        params.tab,
+        params.edit_id,
+        params.msg,
+        params.err,
+        None,
+    )
+    .await;
     Html(template.render().unwrap_or_default())
 }
 
@@ -353,6 +440,7 @@ pub async fn settings_submit(
             custom_formats,
             custom_format_edit: None,
             custom_format_min_score_display,
+            custom_format_import_review: None,
             message: None,
             error: Some(format!("Failed to save: {}", e)),
         };
@@ -425,6 +513,7 @@ pub async fn settings_submit(
         custom_formats,
         custom_format_edit: None,
         custom_format_min_score_display,
+        custom_format_import_review: None,
         message: Some(notices.join("<br>")),
         error: None,
     };
@@ -605,7 +694,15 @@ pub async fn settings_custom_formats_upsert(
             .await
             .map(|_| id)
     } else {
-        cf_model::insert(&state.db, name, trash_id, json_trimmed, form.score).await
+        cf_model::insert(
+            &state.db,
+            name,
+            trash_id,
+            json_trimmed,
+            form.score,
+            cf_model::ORIGIN_MANUAL,
+        )
+        .await
     };
 
     match save_result {
@@ -737,65 +834,41 @@ pub async fn settings_custom_formats_minimum_score(
     }
 }
 
-/// Import a Sonarr v4 CF JSON export. Accepts either a single object
-/// or an array of them; per-entry parse / insert failures are counted
-/// and reported but don't abort the whole import. After a successful
-/// run the compiled cache is rebuilt so the imported CFs are live on
-/// the next scoring pass.
-#[utoipa::path(
-    post,
-    path = "/settings/custom-formats/import",
-    tag = "Settings",
-    summary = "Import Custom Formats from Sonarr v4 JSON",
-    description = "Import one or more Custom Formats from a Sonarr v4 JSON export. Accepts either a single object or an array. Each entry is compiled via the standard CF parser; per-entry failures are counted and the first error is surfaced in the flash message, but valid entries still import. Rebuilds the compiled-CF cache on success. Redirects back to the Custom Formats settings tab.",
-    request_body(content = CustomFormatImportForm, content_type = "application/x-www-form-urlencoded"),
-    responses(
-        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
-    ),
-)]
-pub async fn settings_custom_formats_import(
-    State(state): State<AppState>,
-    Form(form): Form<CustomFormatImportForm>,
-) -> Redirect {
-    let payload = form.payload.trim();
-    if payload.is_empty() {
-        return Redirect::to(&cf_redirect(None, None, Some("Import payload is empty.")));
-    }
+/// Per-import decision on a name collision (plan §6.2). Derived from
+/// the review form's radio-button values. `Skip` keeps the existing
+/// row untouched; `Overwrite` replaces it in place; `Rename` writes a
+/// new row under the user-supplied rename_to value.
+#[derive(Clone, Debug)]
+enum CollisionDecision {
+    Skip,
+    Overwrite,
+    Rename(String),
+}
 
-    let value: serde_json::Value = match serde_json::from_str(payload) {
-        Ok(v) => v,
-        Err(e) => {
-            return Redirect::to(&cf_redirect(
-                None,
-                None,
-                Some(&format!("Import failed: invalid JSON ({e})")),
-            ));
-        }
-    };
-
-    // Normalize single-object imports into a one-element array so the
-    // loop below handles both shapes identically.
-    let entries: Vec<serde_json::Value> = match value {
-        serde_json::Value::Array(items) => items,
-        serde_json::Value::Object(_) => vec![value],
-        _ => {
-            return Redirect::to(&cf_redirect(
-                None,
-                None,
-                Some("Import failed: top-level must be an object or array."),
-            ));
-        }
-    };
-
+/// Loop body shared between the no-collision fast path and the resolve
+/// handler. Takes a set of (entry, decision) pairs plus the existing
+/// name → id map, and performs the insert / update / skip for each.
+/// Returns (imported, skipped_for_collision, failed, first_error).
+async fn apply_import_entries(
+    state: &AppState,
+    entries: Vec<(serde_json::Value, CollisionDecision)>,
+    existing_by_name: &std::collections::HashMap<String, i64>,
+) -> (usize, usize, usize, Option<String>) {
     let mut imported = 0usize;
+    let mut skipped = 0usize;
     let mut failed = 0usize;
     let mut first_error: Option<String> = None;
 
-    for entry in entries {
+    for (mut entry, decision) in entries {
         // Pull out the Sonarr-shape fields we care about. `specifications`
         // lives inside the same blob we'll persist, so we re-serialize
         // the whole object verbatim to keep round-trip exports faithful.
-        let name = entry.get("name").and_then(|v| v.as_str()).unwrap_or("").trim().to_string();
+        let original_name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
         let trash_id = entry
             .get("trash_id")
             .and_then(|v| v.as_str())
@@ -810,7 +883,7 @@ pub async fn settings_custom_formats_import(
             .or_else(|| entry.get("trash_score").and_then(|v| v.as_i64()))
             .unwrap_or(0) as i32;
 
-        if name.is_empty() {
+        if original_name.is_empty() {
             failed += 1;
             if first_error.is_none() {
                 first_error = Some("one entry is missing a `name` field".to_string());
@@ -818,43 +891,401 @@ pub async fn settings_custom_formats_import(
             continue;
         }
 
+        // Determine the effective name + the existing-row id (if any)
+        // we should target based on the user's decision.
+        let (effective_name, existing_id) = match decision {
+            CollisionDecision::Skip => {
+                // User chose to keep the existing row. Count it toward
+                // the skipped tally and move on.
+                skipped += 1;
+                continue;
+            }
+            CollisionDecision::Overwrite => {
+                let id = existing_by_name.get(&original_name).copied();
+                (original_name.clone(), id)
+            }
+            CollisionDecision::Rename(new_name) => {
+                let trimmed = new_name.trim();
+                if trimmed.is_empty() {
+                    failed += 1;
+                    if first_error.is_none() {
+                        first_error = Some(format!(
+                            "'{original_name}': rename target is empty"
+                        ));
+                    }
+                    continue;
+                }
+                if existing_by_name.contains_key(trimmed) {
+                    failed += 1;
+                    if first_error.is_none() {
+                        first_error = Some(format!(
+                            "'{original_name}': rename target '{trimmed}' also collides"
+                        ));
+                    }
+                    continue;
+                }
+                // Mutate the in-memory JSON so the new name is persisted
+                // into both the `name` column and the `json` column —
+                // plan §6.2 requires that exports after a rename reflect
+                // the new name, not the upstream one.
+                if let serde_json::Value::Object(ref mut map) = entry {
+                    map.insert(
+                        "name".to_string(),
+                        serde_json::Value::String(trimmed.to_string()),
+                    );
+                }
+                (trimmed.to_string(), None)
+            }
+        };
+
         let raw_json = entry.to_string();
         if let Err(e) = cf_service::compile_from_json(&raw_json, score, 0) {
             failed += 1;
             if first_error.is_none() {
-                first_error = Some(format!("'{name}': {e}"));
+                first_error = Some(format!("'{effective_name}': {e}"));
             }
             continue;
         }
 
-        match cf_model::insert(&state.db, &name, trash_id.as_deref(), &raw_json, score).await {
+        let save_result = if let Some(id) = existing_id {
+            cf_model::update(
+                &state.db,
+                id,
+                &effective_name,
+                trash_id.as_deref(),
+                &raw_json,
+                score,
+            )
+            .await
+            .map(|_| id)
+        } else {
+            cf_model::insert(
+                &state.db,
+                &effective_name,
+                trash_id.as_deref(),
+                &raw_json,
+                score,
+                cf_model::ORIGIN_IMPORT,
+            )
+            .await
+        };
+
+        match save_result {
             Ok(_) => imported += 1,
             Err(e) => {
                 failed += 1;
                 if first_error.is_none() {
-                    first_error = Some(format!("'{name}': {e}"));
+                    first_error = Some(format!("'{effective_name}': {e}"));
                 }
             }
         }
     }
 
+    (imported, skipped, failed, first_error)
+}
+
+/// Build a summary flash message from the four counters produced by
+/// `apply_import_entries`.
+fn import_summary(
+    imported: usize,
+    skipped: usize,
+    failed: usize,
+    first_error: Option<String>,
+) -> String {
+    match (imported, skipped, failed) {
+        (0, 0, 0) => "Nothing to import.".to_string(),
+        (n, 0, 0) => format!("Imported {n} Custom Format(s)."),
+        (n, s, 0) => format!("Imported {n}, skipped {s} on collision."),
+        (0, _, f) => format!(
+            "Import failed ({f} rejected). First error: {}",
+            first_error.unwrap_or_default()
+        ),
+        (n, s, f) => format!(
+            "Imported {n}, skipped {s}, failed {f}. First error: {}",
+            first_error.unwrap_or_default()
+        ),
+    }
+}
+
+/// Import a Sonarr v4 CF JSON export. Accepts a single object, a bare
+/// array, or a `{custom_formats: [...]}` wrapper (plan §6.2). On a
+/// name collision the handler re-renders the settings page with an
+/// inline review block so the user can pick overwrite / rename / skip
+/// per conflicting CF. With no collisions it commits the full batch
+/// and redirects back with a flash summary.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/import",
+    tag = "Settings",
+    summary = "Import Custom Formats from Sonarr v4 JSON",
+    description = "Import one or more Custom Formats from a Sonarr v4 JSON export. Accepts a single object, an array, or a `{custom_formats:[…]}` wrapper. On a name collision the page re-renders with an inline review block; the user picks overwrite/rename/skip per conflict and submits to the resolve endpoint. Rebuilds the compiled-CF cache on success.",
+    request_body(content = CustomFormatImportForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 200, description = "Review page rendered (collisions exist)"),
+        (status = 303, description = "Redirect back to the Custom Formats settings tab (no collisions)"),
+    ),
+)]
+pub async fn settings_custom_formats_import(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatImportForm>,
+) -> Response {
+    let payload = form.payload.trim();
+    if payload.is_empty() {
+        return Redirect::to(&cf_redirect(None, None, Some("Import payload is empty.")))
+            .into_response();
+    }
+
+    let value: serde_json::Value = match serde_json::from_str(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Import failed: invalid JSON ({e})")),
+            ))
+            .into_response();
+        }
+    };
+
+    let entries: Vec<serde_json::Value> = match normalize_cf_import_entries(value) {
+        Ok(entries) => entries,
+        Err(msg) => {
+            return Redirect::to(&cf_redirect(None, None, Some(&msg))).into_response();
+        }
+    };
+
+    // Build the name → id map once up-front so both the collision
+    // scan and the apply loop can read from it without re-querying.
+    let existing_rows = match cf_model::list_with_scores(&state.db).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Failed to read existing CFs: {e}")),
+            ))
+            .into_response();
+        }
+    };
+    let existing_by_name: std::collections::HashMap<String, i64> = existing_rows
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+
+    // Scan for collisions before touching the database. If any exist,
+    // render the review page inline — the user picks a decision per
+    // conflict and submits the resolve form.
+    let mut collisions: Vec<ImportCollision> = Vec::new();
+    for (idx, entry) in entries.iter().enumerate() {
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if !name.is_empty() && existing_by_name.contains_key(&name) {
+            collisions.push(ImportCollision { index: idx, name });
+        }
+    }
+
+    if !collisions.is_empty() {
+        // Re-render the settings page with the review block populated.
+        // The original payload rides along in a hidden form field so the
+        // resolve handler can re-parse it without server-side state.
+        let review = ImportReviewView {
+            payload: payload.to_string(),
+            collisions,
+        };
+        let template = build_settings_template(
+            &state,
+            Some("custom_formats".to_string()),
+            None,
+            None,
+            None,
+            Some(review),
+        )
+        .await;
+        return Html(template.render().unwrap_or_default()).into_response();
+    }
+
+    // No collisions — every entry defaults to Overwrite semantics,
+    // but since no existing row shares the name, the overwrite branch
+    // falls through to a plain insert.
+    let decisions: Vec<(serde_json::Value, CollisionDecision)> = entries
+        .into_iter()
+        .map(|e| (e, CollisionDecision::Overwrite))
+        .collect();
+    let (imported, skipped, failed, first_error) =
+        apply_import_entries(&state, decisions, &existing_by_name).await;
+
     if imported > 0 {
         cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
     }
 
-    let summary = match (imported, failed) {
-        (0, 0) => "Nothing to import.".to_string(),
-        (n, 0) => format!("Imported {n} Custom Format(s)."),
-        (0, m) => format!(
-            "Import failed ({m} rejected). First error: {}",
-            first_error.unwrap_or_default()
-        ),
-        (n, m) => format!(
-            "Imported {n}, skipped {m}. First error: {}",
-            first_error.unwrap_or_default()
-        ),
+    let summary = import_summary(imported, skipped, failed, first_error);
+    if imported == 0 && failed > 0 {
+        Redirect::to(&cf_redirect(None, None, Some(&summary))).into_response()
+    } else {
+        Redirect::to(&cf_redirect(None, Some(&summary), None)).into_response()
+    }
+}
+
+/// Form for the import-resolve step. Carries the original payload
+/// verbatim (echoed from a hidden field) plus two parallel lists of
+/// actions and rename targets, each keyed by the collision's entry
+/// index inside the parsed payload.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct CustomFormatImportResolveForm {
+    payload: String,
+    /// One entry per collision: `"<index>:<action>"` where action is
+    /// `skip`, `overwrite`, or `rename`. Serialized as a newline-
+    /// delimited string to avoid the axum Form-extractor's complicated
+    /// multi-value handling.
+    decisions: String,
+    /// One entry per rename collision: `"<index>:<new_name>"`. Only
+    /// read when the corresponding `decisions` line has action `rename`.
+    /// Also newline-delimited.
+    renames: String,
+}
+
+/// Parse the newline-delimited decisions string into a HashMap keyed
+/// by entry index. Unknown actions are mapped to `Skip` (the safest
+/// default) and unknown indices are silently dropped.
+fn parse_collision_decisions(
+    decisions: &str,
+    renames: &str,
+) -> std::collections::HashMap<usize, CollisionDecision> {
+    let mut rename_map: std::collections::HashMap<usize, String> =
+        std::collections::HashMap::new();
+    for line in renames.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if let Some((idx_str, new_name)) = line.split_once(':') {
+            if let Ok(idx) = idx_str.trim().parse::<usize>() {
+                rename_map.insert(idx, new_name.trim().to_string());
+            }
+        }
+    }
+
+    let mut out: std::collections::HashMap<usize, CollisionDecision> =
+        std::collections::HashMap::new();
+    for line in decisions.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Some((idx_str, action)) = line.split_once(':') else {
+            continue;
+        };
+        let Ok(idx) = idx_str.trim().parse::<usize>() else {
+            continue;
+        };
+        let decision = match action.trim() {
+            "overwrite" => CollisionDecision::Overwrite,
+            "rename" => {
+                let new_name = rename_map
+                    .get(&idx)
+                    .cloned()
+                    .unwrap_or_default();
+                CollisionDecision::Rename(new_name)
+            }
+            _ => CollisionDecision::Skip,
+        };
+        out.insert(idx, decision);
+    }
+    out
+}
+
+/// Resolve a staged CF import by applying the user's per-collision
+/// decisions to the original payload. The handler re-parses the
+/// payload from the hidden form field, looks up each collision's
+/// decision by entry index, and runs the same `apply_import_entries`
+/// loop as the fast path.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/import-resolve",
+    tag = "Settings",
+    summary = "Resolve a staged CF import with per-collision decisions",
+    description = "Second step of the CF import flow: re-parses the original payload (echoed from a hidden field) and applies the user's overwrite/rename/skip decision for each name collision. Entries with no collision default to plain insert. Rebuilds the compiled-CF cache and redirects back to the Custom Formats settings tab.",
+    request_body(content = CustomFormatImportResolveForm, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_import_resolve(
+    State(state): State<AppState>,
+    Form(form): Form<CustomFormatImportResolveForm>,
+) -> Redirect {
+    let payload = form.payload.trim();
+    if payload.is_empty() {
+        return Redirect::to(&cf_redirect(
+            None,
+            None,
+            Some("Import resolve: payload is empty."),
+        ));
+    }
+
+    let value: serde_json::Value = match serde_json::from_str(payload) {
+        Ok(v) => v,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Import resolve: invalid JSON ({e})")),
+            ));
+        }
     };
 
+    let entries: Vec<serde_json::Value> = match normalize_cf_import_entries(value) {
+        Ok(entries) => entries,
+        Err(msg) => {
+            return Redirect::to(&cf_redirect(None, None, Some(&msg)));
+        }
+    };
+
+    let existing_rows = match cf_model::list_with_scores(&state.db).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Failed to read existing CFs: {e}")),
+            ));
+        }
+    };
+    let existing_by_name: std::collections::HashMap<String, i64> = existing_rows
+        .into_iter()
+        .map(|r| (r.name, r.id))
+        .collect();
+
+    let decisions_map = parse_collision_decisions(&form.decisions, &form.renames);
+
+    // Attach a decision to every entry. Entries that aren't in the
+    // decisions map weren't collisions in the first place — default
+    // them to Overwrite, which falls through to a plain insert since
+    // no existing row shares the name.
+    let decisions: Vec<(serde_json::Value, CollisionDecision)> = entries
+        .into_iter()
+        .enumerate()
+        .map(|(idx, entry)| {
+            let decision = decisions_map
+                .get(&idx)
+                .cloned()
+                .unwrap_or(CollisionDecision::Overwrite);
+            (entry, decision)
+        })
+        .collect();
+
+    let (imported, skipped, failed, first_error) =
+        apply_import_entries(&state, decisions, &existing_by_name).await;
+
+    if imported > 0 {
+        cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+    }
+
+    let summary = import_summary(imported, skipped, failed, first_error);
     if imported == 0 && failed > 0 {
         Redirect::to(&cf_redirect(None, None, Some(&summary)))
     } else {
@@ -862,15 +1293,330 @@ pub async fn settings_custom_formats_import(
     }
 }
 
-/// Export every Custom Format as a JSON array download. The payload
-/// keeps each row's raw `json` column verbatim so re-importing the
-/// file into Sonarr (or another Ryokan instance) round-trips cleanly.
+/// Counts returned by `install_default_cfs_core`. Shared between the
+/// install-defaults and reset-defaults handlers so the summary-string
+/// construction can live in one place.
+struct InstallDefaultsReport {
+    installed: usize,
+    skipped: usize,
+    failed: usize,
+    first_error: Option<String>,
+}
+
+/// Do the heavy lifting of loading the bundled defaults file, looping
+/// over entries, and inserting each one with `ORIGIN_DEFAULTS`. Returns
+/// either counts (even when `installed == 0` — e.g. the user clicked
+/// install-defaults a second time) or a fatal error string that the
+/// caller should surface as a flash message. The caller is responsible
+/// for rebuilding the compiled-CF cache if `installed > 0`.
+async fn install_default_cfs_core(state: &AppState) -> Result<InstallDefaultsReport, String> {
+    // Baked into the binary at compile time via `include_str!` so the
+    // handler can't ever fail to find the file at runtime. Parsing is
+    // still done once per click rather than at startup — the defaults
+    // payload is a few KB, the user rarely clicks this, and
+    // compile-time validation doesn't catch field-level typos anyway.
+    const DEFAULTS_JSON: &str = include_str!("../../static/default_custom_formats.json");
+
+    let value: serde_json::Value = serde_json::from_str(DEFAULTS_JSON)
+        .map_err(|e| format!("Defaults file is malformed: {e}"))?;
+    let entries = match value {
+        serde_json::Value::Array(items) => items,
+        _ => return Err("Defaults file is not a JSON array.".to_string()),
+    };
+
+    // Collect existing names so we can skip conflicts without a
+    // per-entry SELECT round-trip.
+    let existing: std::collections::HashSet<String> = cf_model::list_with_scores(&state.db)
+        .await
+        .map_err(|e| format!("Failed to read existing CFs: {e}"))?
+        .into_iter()
+        .map(|r| r.name)
+        .collect();
+
+    let mut report = InstallDefaultsReport {
+        installed: 0,
+        skipped: 0,
+        failed: 0,
+        first_error: None,
+    };
+
+    for entry in entries {
+        let name = entry
+            .get("name")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if name.is_empty() {
+            report.failed += 1;
+            if report.first_error.is_none() {
+                report.first_error = Some("defaults entry missing `name`".to_string());
+            }
+            continue;
+        }
+        if existing.contains(&name) {
+            report.skipped += 1;
+            continue;
+        }
+        let trash_id = entry
+            .get("trash_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let score = entry
+            .get("score")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+
+        let raw_json = entry.to_string();
+        if let Err(e) = cf_service::compile_from_json(&raw_json, score, 0) {
+            report.failed += 1;
+            if report.first_error.is_none() {
+                report.first_error = Some(format!("'{name}': {e}"));
+            }
+            continue;
+        }
+
+        match cf_model::insert(
+            &state.db,
+            &name,
+            trash_id.as_deref(),
+            &raw_json,
+            score,
+            cf_model::ORIGIN_DEFAULTS,
+        )
+        .await
+        {
+            Ok(_) => report.installed += 1,
+            Err(e) => {
+                report.failed += 1;
+                if report.first_error.is_none() {
+                    report.first_error = Some(format!("'{name}': {e}"));
+                }
+            }
+        }
+    }
+
+    Ok(report)
+}
+
+/// Install the bundled default Custom Format set (plan §7.2). The JSON
+/// file lives at `static/default_custom_formats.json` and is embedded in
+/// the binary via `include_str!` so the handler doesn't touch the
+/// filesystem at runtime — the file is baked at compile time like every
+/// other `static/` asset in Ryokan. Existing CFs with the same name are
+/// skipped (not overwritten), so clicking the button twice is a no-op
+/// on the second click. Installing is opt-in: the defaults ship dormant,
+/// the user has to click through on the settings page to get them.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/install-defaults",
+    tag = "Settings",
+    summary = "Install the bundled default Custom Format set",
+    description = "One-click install for the bundled anime-tuned default CF set (see plan §7.2). Reads from the compile-time embedded `static/default_custom_formats.json`. CFs whose name already exists are skipped (not overwritten), so repeated clicks are idempotent. Rebuilds the compiled-CF cache on success. Redirects back to the Custom Formats settings tab with a flash message.",
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_install_defaults(
+    State(state): State<AppState>,
+) -> Redirect {
+    let report = match install_default_cfs_core(&state).await {
+        Ok(r) => r,
+        Err(msg) => return Redirect::to(&cf_redirect(None, None, Some(&msg))),
+    };
+
+    if report.installed > 0 {
+        cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+        logger::info(
+            &state.db,
+            LogCategory::System,
+            &format!(
+                "Installed {} default Custom Format(s)",
+                report.installed
+            ),
+            &format!("skipped={}, failed={}", report.skipped, report.failed),
+        )
+        .await;
+    }
+
+    let summary = match (report.installed, report.skipped, report.failed) {
+        (0, _, 0) => "All defaults already present — nothing to install.".to_string(),
+        (n, 0, 0) => format!("Installed {n} default Custom Format(s)."),
+        (n, s, 0) => format!("Installed {n}, skipped {s} already-present."),
+        (0, _, f) => format!(
+            "Install failed ({f} rejected). First error: {}",
+            report.first_error.unwrap_or_default()
+        ),
+        (n, s, f) => format!(
+            "Installed {n}, skipped {s}, failed {f}. First error: {}",
+            report.first_error.unwrap_or_default()
+        ),
+    };
+
+    if report.installed == 0 && report.failed > 0 {
+        Redirect::to(&cf_redirect(None, None, Some(&summary)))
+    } else {
+        Redirect::to(&cf_redirect(None, Some(&summary), None))
+    }
+}
+
+/// Reset the bundled default Custom Format set. Deletes every row whose
+/// origin is `defaults` (leaving `manual` and `import` rows untouched),
+/// then re-runs the install-defaults body so the bundled set lands on
+/// disk in its current shape. This is the user's escape hatch if they
+/// changed a default CF and want the original score/spec list back.
+#[utoipa::path(
+    post,
+    path = "/settings/custom-formats/reset-defaults",
+    tag = "Settings",
+    summary = "Reset the bundled default Custom Format set",
+    description = "Drops every CF row whose origin is `defaults` and reinstalls the bundled set from `static/default_custom_formats.json`. User-authored (`manual`) and imported (`import`) rows are left untouched. Rebuilds the compiled-CF cache on success. Redirects back to the Custom Formats settings tab with a flash message.",
+    responses(
+        (status = 303, description = "Redirect back to the Custom Formats settings tab"),
+    ),
+)]
+pub async fn settings_custom_formats_reset_defaults(
+    State(state): State<AppState>,
+) -> Redirect {
+    let deleted = match cf_model::delete_defaults(&state.db).await {
+        Ok(n) => n,
+        Err(e) => {
+            return Redirect::to(&cf_redirect(
+                None,
+                None,
+                Some(&format!("Reset failed (delete step): {e}")),
+            ));
+        }
+    };
+
+    let report = match install_default_cfs_core(&state).await {
+        Ok(r) => r,
+        Err(msg) => return Redirect::to(&cf_redirect(None, None, Some(&msg))),
+    };
+
+    // Always rebuild the cache here — either a row was dropped or a
+    // fresh one was inserted, and in the edge case where both are
+    // zero (a user with an empty database hit the button), rebuilding
+    // a cache over zero rows is effectively free.
+    cf_service::rebuild_cf_cache(&state.custom_formats, &state.db).await;
+    logger::info(
+        &state.db,
+        LogCategory::System,
+        &format!(
+            "Reset defaults: dropped {} old, installed {} fresh",
+            deleted, report.installed
+        ),
+        &format!(
+            "skipped={}, failed={}",
+            report.skipped, report.failed
+        ),
+    )
+    .await;
+
+    let summary = if report.failed > 0 {
+        format!(
+            "Reset: dropped {}, installed {}, failed {}. First error: {}",
+            deleted,
+            report.installed,
+            report.failed,
+            report.first_error.unwrap_or_default()
+        )
+    } else {
+        format!(
+            "Reset complete: dropped {} old default(s), installed {} fresh.",
+            deleted, report.installed
+        )
+    };
+
+    if report.failed > 0 && report.installed == 0 {
+        Redirect::to(&cf_redirect(None, None, Some(&summary)))
+    } else {
+        Redirect::to(&cf_redirect(None, Some(&summary), None))
+    }
+}
+
+/// Query parameters for the CF export endpoint. `mode` selects between
+/// the default Ryokan-compatible export (keeps `Ryokan.`-namespaced
+/// specs verbatim) and the Sonarr-safe variant (drops entire CFs that
+/// contain any Ryokan-only spec so the file imports cleanly into a
+/// vanilla Sonarr v4 instance). See plan §5.7.5.
+#[derive(Deserialize)]
+pub struct CfExportQuery {
+    /// `"sonarr-safe"` triggers the Sonarr-safe branch; anything else
+    /// (or absent) falls through to the default Ryokan-compatible mode.
+    mode: Option<String>,
+}
+
+/// Normalize a parsed CF import payload into a flat list of per-CF
+/// entries. Plan §6.2 requires that every shape Sonarr v4 might emit
+/// imports cleanly:
+///
+/// - `[{…}, {…}]`         — bare array (what Sonarr's "Export" emits)
+/// - `{…}`                 — bare single object
+/// - `{"custom_formats": [{…}, {…}]}` — wrapped array (some third-party tools)
+/// - `{"custom_formats": {…}}`        — wrapped single object (paranoid fallback)
+///
+/// Returns a human-readable error string that can be surfaced as a
+/// flash message on the settings redirect.
+fn normalize_cf_import_entries(
+    value: serde_json::Value,
+) -> Result<Vec<serde_json::Value>, String> {
+    match value {
+        serde_json::Value::Array(items) => Ok(items),
+        serde_json::Value::Object(ref map) => {
+            if let Some(inner) = map.get("custom_formats") {
+                match inner {
+                    serde_json::Value::Array(items) => Ok(items.clone()),
+                    serde_json::Value::Object(_) => Ok(vec![inner.clone()]),
+                    _ => Err(
+                        "Import failed: `custom_formats` must be an object or array."
+                            .to_string(),
+                    ),
+                }
+            } else {
+                // Bare single-CF object (legacy shape).
+                Ok(vec![value])
+            }
+        }
+        _ => Err("Import failed: top-level must be an object or array.".to_string()),
+    }
+}
+
+/// Returns `true` if this CF's `specifications` array contains any spec
+/// whose `implementation` begins with `"Ryokan."` — i.e. a Ryokan-only
+/// kind that a vanilla Sonarr v4 install wouldn't recognize.
+fn cf_has_ryokan_spec(cf: &serde_json::Value) -> bool {
+    let Some(specs) = cf.get("specifications").and_then(|v| v.as_array()) else {
+        return false;
+    };
+    specs.iter().any(|spec| {
+        spec.get("implementation")
+            .and_then(|v| v.as_str())
+            .map(|s| s.starts_with("Ryokan."))
+            .unwrap_or(false)
+    })
+}
+
+/// Export every Custom Format as a JSON array download. Supports two
+/// modes via the `mode` query parameter:
+///
+/// - **Ryokan-compatible** (default): keeps each row's raw `json`
+///   column verbatim, so the file round-trips into another Ryokan
+///   instance with `Ryokan.`-namespaced specs intact.
+/// - **Sonarr-safe** (`?mode=sonarr-safe`): drops any CF containing a
+///   `Ryokan.`-prefixed spec so the remainder imports cleanly into a
+///   vanilla Sonarr v4 instance. Dropped CF names are written to the
+///   System log category so the user can see what was stripped.
 #[utoipa::path(
     get,
     path = "/settings/custom-formats/export",
     tag = "Settings",
     summary = "Export all Custom Formats as JSON",
-    description = "Download every saved Custom Format as a JSON array. Each row's raw Sonarr v4 object is merged with the persisted V1-profile score, so the export round-trips cleanly into Sonarr or another Ryokan instance. Served with `Content-Disposition: attachment; filename=\"ryokan-custom-formats.json\"`.",
+    description = "Download every saved Custom Format as a JSON array. Default mode keeps Ryokan-namespaced specs verbatim; `?mode=sonarr-safe` drops entire CFs containing `Ryokan.`-only specs so the file imports into vanilla Sonarr v4. Each row's persisted V1-profile score is merged into the exported object.",
+    params(
+        ("mode" = Option<String>, Query, description = "`sonarr-safe` to drop Ryokan-only CFs"),
+    ),
     responses(
         (status = 200, description = "JSON array of Custom Formats", body = serde_json::Value, content_type = "application/json"),
         (status = 500, description = "Database error"),
@@ -878,7 +1624,14 @@ pub async fn settings_custom_formats_import(
 )]
 pub async fn settings_custom_formats_export(
     State(state): State<AppState>,
+    Query(query): Query<CfExportQuery>,
 ) -> Result<(axum::http::HeaderMap, String), (axum::http::StatusCode, String)> {
+    let sonarr_safe = query
+        .mode
+        .as_deref()
+        .map(|s| s.eq_ignore_ascii_case("sonarr-safe"))
+        .unwrap_or(false);
+
     let rows = cf_model::list_with_scores(&state.db)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -888,9 +1641,20 @@ pub async fn settings_custom_formats_export(
     // are skipped — they wouldn't import cleanly into a target Sonarr
     // anyway, and logging the skip is enough of a breadcrumb.
     let mut out: Vec<serde_json::Value> = Vec::with_capacity(rows.len());
+    let mut dropped_for_sonarr: Vec<String> = Vec::new();
     for row in rows {
         match serde_json::from_str::<serde_json::Value>(&row.json) {
             Ok(mut v) => {
+                // In Sonarr-safe mode, drop the whole CF if any spec
+                // uses a `Ryokan.`-prefixed implementation. This is the
+                // conservative reading of plan §5.7.5 — partial strips
+                // would change the CF's semantics silently, so whole-CF
+                // drops are safer even if they produce a smaller file.
+                if sonarr_safe && cf_has_ryokan_spec(&v) {
+                    dropped_for_sonarr.push(row.name.clone());
+                    continue;
+                }
+
                 // Merge the persisted score into the exported object so
                 // the importer doesn't have to re-key scores by name.
                 // Sonarr ignores unknown fields on import, so this is
@@ -914,6 +1678,23 @@ pub async fn settings_custom_formats_export(
         }
     }
 
+    // Surface dropped CFs to the Logs tab (System category) so the user
+    // can see what was stripped. The export response itself is a file
+    // download, so there's no flash-message slot to use here — the log
+    // entry + the form-hint on the settings page is the whole UX path.
+    if sonarr_safe && !dropped_for_sonarr.is_empty() {
+        logger::info(
+            &state.db,
+            LogCategory::System,
+            &format!(
+                "Sonarr-safe CF export dropped {} CF(s) containing Ryokan-only specs",
+                dropped_for_sonarr.len()
+            ),
+            &dropped_for_sonarr.join(", "),
+        )
+        .await;
+    }
+
     let body = serde_json::to_string_pretty(&serde_json::Value::Array(out))
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -922,11 +1703,14 @@ pub async fn settings_custom_formats_export(
         axum::http::header::CONTENT_TYPE,
         axum::http::HeaderValue::from_static("application/json"),
     );
+    let disposition = if sonarr_safe {
+        "attachment; filename=\"ryokan-custom-formats-sonarr-safe.json\""
+    } else {
+        "attachment; filename=\"ryokan-custom-formats.json\""
+    };
     headers.insert(
         axum::http::header::CONTENT_DISPOSITION,
-        axum::http::HeaderValue::from_static(
-            "attachment; filename=\"ryokan-custom-formats.json\"",
-        ),
+        axum::http::HeaderValue::from_static(disposition),
     );
     Ok((headers, body))
 }
@@ -1087,4 +1871,265 @@ pub async fn jellyfin_refresh(
         .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
 
     Ok(Json(serde_json::json!({"ok": true, "message": "Jellyfin library refresh queued"})))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A CF whose specs are all vanilla Sonarr v4 implementations must
+    /// be kept in Sonarr-safe mode (plan §5.7.5).
+    #[test]
+    fn cf_has_ryokan_spec_returns_false_for_pure_sonarr_cf() {
+        let cf = serde_json::json!({
+            "name": "Synthetic BluRay CF",
+            "specifications": [
+                {
+                    "name": "Is BluRay",
+                    "implementation": "SourceSpecification",
+                    "negate": false,
+                    "required": true,
+                    "fields": [{"name": "value", "value": 6}]
+                }
+            ]
+        });
+        assert!(!cf_has_ryokan_spec(&cf));
+    }
+
+    /// Any `Ryokan.`-prefixed `implementation` must flip the flag so
+    /// the whole CF gets dropped from a Sonarr-safe export.
+    #[test]
+    fn cf_has_ryokan_spec_returns_true_when_any_spec_is_ryokan_only() {
+        let cf = serde_json::json!({
+            "name": "SeaDex Best",
+            "specifications": [
+                {
+                    "name": "Is BluRay",
+                    "implementation": "SourceSpecification",
+                    "negate": false,
+                    "required": false,
+                    "fields": [{"name": "value", "value": 6}]
+                },
+                {
+                    "name": "SeaDex best",
+                    "implementation": "Ryokan.SeaDexBestSpecification",
+                    "negate": false,
+                    "required": true,
+                    "fields": []
+                }
+            ]
+        });
+        assert!(cf_has_ryokan_spec(&cf));
+    }
+
+    /// Guard against CFs with an empty or missing `specifications`
+    /// array — the helper must default to `false` rather than panic.
+    #[test]
+    fn cf_has_ryokan_spec_handles_missing_or_empty_specs() {
+        let empty = serde_json::json!({ "name": "Empty", "specifications": [] });
+        assert!(!cf_has_ryokan_spec(&empty));
+
+        let missing = serde_json::json!({ "name": "Missing" });
+        assert!(!cf_has_ryokan_spec(&missing));
+    }
+
+    /// Case sensitivity: `Ryokan.` is the exact namespace prefix.
+    /// A spec named `ryokan.…` (lowercase) shouldn't match and
+    /// neither should a spec that merely contains `Ryokan` somewhere
+    /// in the middle of the string.
+    #[test]
+    fn cf_has_ryokan_spec_requires_exact_prefix() {
+        let cf = serde_json::json!({
+            "name": "Edge",
+            "specifications": [
+                {
+                    "implementation": "ryokan.SeaDexBestSpecification",
+                    "fields": []
+                },
+                {
+                    "implementation": "SomeRyokanThing",
+                    "fields": []
+                }
+            ]
+        });
+        assert!(!cf_has_ryokan_spec(&cf));
+    }
+
+    /// A bare array of CF objects should pass through untouched — this
+    /// is the exact shape Sonarr v4's "Export" button emits.
+    #[test]
+    fn normalize_cf_import_entries_accepts_bare_array() {
+        let input = serde_json::json!([
+            {"name": "First", "specifications": []},
+            {"name": "Second", "specifications": []},
+        ]);
+        let entries = normalize_cf_import_entries(input).expect("array shape must be accepted");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["name"], "First");
+        assert_eq!(entries[1]["name"], "Second");
+    }
+
+    /// A bare single object should be wrapped in a one-element vec so
+    /// the caller loop handles it identically to the array shape.
+    #[test]
+    fn normalize_cf_import_entries_wraps_bare_single_object() {
+        let input = serde_json::json!({"name": "Solo", "specifications": []});
+        let entries = normalize_cf_import_entries(input).expect("object shape must be accepted");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["name"], "Solo");
+    }
+
+    /// The `{custom_formats: [...]}` wrapper is what some third-party
+    /// export tools emit. It must be unwrapped transparently.
+    #[test]
+    fn normalize_cf_import_entries_unwraps_custom_formats_wrapper() {
+        let input = serde_json::json!({
+            "custom_formats": [
+                {"name": "Wrapped One", "specifications": []},
+                {"name": "Wrapped Two", "specifications": []},
+            ]
+        });
+        let entries = normalize_cf_import_entries(input).expect("wrapper shape must be accepted");
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0]["name"], "Wrapped One");
+        assert_eq!(entries[1]["name"], "Wrapped Two");
+    }
+
+    /// The wrapper shape with a single-object inner value should also
+    /// unwrap and wrap-as-vec in one step.
+    #[test]
+    fn normalize_cf_import_entries_unwraps_single_object_inside_wrapper() {
+        let input = serde_json::json!({
+            "custom_formats": {"name": "Wrapped Solo", "specifications": []}
+        });
+        let entries = normalize_cf_import_entries(input).expect("wrapped object must be accepted");
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0]["name"], "Wrapped Solo");
+    }
+
+    /// Scalar top-level values (string, number, bool, null) must be
+    /// rejected with a human-readable error string.
+    #[test]
+    fn normalize_cf_import_entries_rejects_scalar_top_level() {
+        let err = normalize_cf_import_entries(serde_json::json!("not a cf"))
+            .expect_err("scalar must be rejected");
+        assert!(err.contains("top-level"), "got error: {err}");
+    }
+
+    /// If the wrapper's inner value is a scalar, that's a malformed
+    /// payload — report it rather than silently treating it as empty.
+    #[test]
+    fn normalize_cf_import_entries_rejects_scalar_inner_wrapper() {
+        let input = serde_json::json!({"custom_formats": 42});
+        let err =
+            normalize_cf_import_entries(input).expect_err("scalar inside wrapper must be rejected");
+        assert!(err.contains("custom_formats"), "got error: {err}");
+    }
+
+    /// A Sonarr/Trash Guides CF that carries a `trash_description`
+    /// should be surfaced verbatim so the edit drawer can render it.
+    #[test]
+    fn extract_trash_description_returns_string_when_present() {
+        let json = serde_json::json!({
+            "name": "Example",
+            "trash_description": "This CF matches high-quality BluRay releases.",
+            "specifications": []
+        })
+        .to_string();
+        assert_eq!(
+            extract_trash_description(&json),
+            Some("This CF matches high-quality BluRay releases.".to_string())
+        );
+    }
+
+    /// Absent, empty, whitespace-only, wrong-typed, or unparseable
+    /// payloads should all return `None` so the template simply
+    /// doesn't render the description block.
+    #[test]
+    fn extract_trash_description_returns_none_for_missing_or_invalid() {
+        let no_field = serde_json::json!({"name": "X", "specifications": []}).to_string();
+        assert_eq!(extract_trash_description(&no_field), None);
+
+        let empty = serde_json::json!({"trash_description": ""}).to_string();
+        assert_eq!(extract_trash_description(&empty), None);
+
+        let whitespace = serde_json::json!({"trash_description": "   "}).to_string();
+        assert_eq!(extract_trash_description(&whitespace), None);
+
+        let wrong_type = serde_json::json!({"trash_description": 42}).to_string();
+        assert_eq!(extract_trash_description(&wrong_type), None);
+
+        assert_eq!(extract_trash_description("not json at all"), None);
+    }
+
+    /// A well-formed decisions string with all three action types
+    /// should round-trip into the expected `CollisionDecision` enum
+    /// values keyed by index.
+    #[test]
+    fn parse_collision_decisions_handles_all_three_actions() {
+        let decisions = "0:skip\n1:overwrite\n2:rename";
+        let renames = "2:My New Name";
+        let out = parse_collision_decisions(decisions, renames);
+
+        assert_eq!(out.len(), 3);
+        assert!(matches!(out.get(&0), Some(CollisionDecision::Skip)));
+        assert!(matches!(out.get(&1), Some(CollisionDecision::Overwrite)));
+        match out.get(&2) {
+            Some(CollisionDecision::Rename(name)) => assert_eq!(name, "My New Name"),
+            other => panic!("expected Rename, got {other:?}"),
+        }
+    }
+
+    /// Unknown action strings should fall back to `Skip` — the safest
+    /// default, since `Skip` never touches the existing row.
+    #[test]
+    fn parse_collision_decisions_treats_unknown_actions_as_skip() {
+        let out = parse_collision_decisions("7:nonsense", "");
+        assert!(matches!(out.get(&7), Some(CollisionDecision::Skip)));
+    }
+
+    /// Malformed lines (missing colon, non-numeric index, blank) must
+    /// be silently dropped so a malformed hidden field doesn't blow
+    /// up the whole resolve handler.
+    #[test]
+    fn parse_collision_decisions_drops_malformed_lines() {
+        let decisions = "\n  \nnot_a_number:skip\nmissing_colon\n3:overwrite";
+        let out = parse_collision_decisions(decisions, "");
+        assert_eq!(out.len(), 1);
+        assert!(matches!(out.get(&3), Some(CollisionDecision::Overwrite)));
+    }
+
+    /// If the user picks `rename` but the renames block is missing
+    /// the corresponding entry, the resolved `Rename` value should
+    /// carry an empty string — the apply loop then records an
+    /// actionable error and the user can fix it.
+    #[test]
+    fn parse_collision_decisions_rename_without_entry_has_empty_name() {
+        let out = parse_collision_decisions("5:rename", "");
+        match out.get(&5) {
+            Some(CollisionDecision::Rename(name)) => assert!(name.is_empty()),
+            other => panic!("expected Rename with empty name, got {other:?}"),
+        }
+    }
+
+    /// Summary line shape for the common counter combinations. Keeping
+    /// these in tests because the summary is user-visible flash text
+    /// and regressions here show up as confusing UI.
+    #[test]
+    fn import_summary_shapes_by_counter_combinations() {
+        assert_eq!(import_summary(0, 0, 0, None), "Nothing to import.");
+        assert_eq!(import_summary(3, 0, 0, None), "Imported 3 Custom Format(s).");
+        assert_eq!(
+            import_summary(2, 1, 0, None),
+            "Imported 2, skipped 1 on collision."
+        );
+        assert_eq!(
+            import_summary(0, 0, 2, Some("oops".to_string())),
+            "Import failed (2 rejected). First error: oops"
+        );
+        assert_eq!(
+            import_summary(1, 1, 1, Some("bad".to_string())),
+            "Imported 1, skipped 1, failed 1. First error: bad"
+        );
+    }
 }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -248,6 +248,12 @@ pub async fn settings_submit(
         } else {
             existing_cfg.as_ref().map(|c| c.upgrade_search_enabled).unwrap_or(false)
         },
+        // Carried forward from the existing row — edited through the
+        // dedicated Custom Formats settings page (Phase 7), not this form.
+        custom_format_minimum_score: existing_cfg
+            .as_ref()
+            .map(|c| c.custom_format_minimum_score)
+            .unwrap_or(i32::MIN),
     };
 
     let active_tab = normalize_settings_tab(form.tab.clone());

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -254,6 +254,10 @@ pub async fn settings_submit(
             .as_ref()
             .map(|c| c.custom_format_minimum_score)
             .unwrap_or(i32::MIN),
+        seadex_enabled: existing_cfg
+            .as_ref()
+            .map(|c| c.seadex_enabled)
+            .unwrap_or(false),
     };
 
     let active_tab = normalize_settings_tab(form.tab.clone());

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -992,12 +992,22 @@ fn import_summary(
     failed: usize,
     first_error: Option<String>,
 ) -> String {
+    // Arm order matters: the (0, 0, f) "all-rejected" arm must come
+    // BEFORE the general (n, s, f) arm, and it must *not* swallow the
+    // skipped count — an earlier version had a `(0, _, f)` arm that
+    // silently dropped `skipped` when imported=0 and both skipped and
+    // failed were non-zero. The arms below break that case out so
+    // every counter combination shows every non-zero counter.
     match (imported, skipped, failed) {
         (0, 0, 0) => "Nothing to import.".to_string(),
         (n, 0, 0) => format!("Imported {n} Custom Format(s)."),
         (n, s, 0) => format!("Imported {n}, skipped {s} on collision."),
-        (0, _, f) => format!(
+        (0, 0, f) => format!(
             "Import failed ({f} rejected). First error: {}",
+            first_error.unwrap_or_default()
+        ),
+        (n, 0, f) => format!(
+            "Imported {n}, failed {f}. First error: {}",
             first_error.unwrap_or_default()
         ),
         (n, s, f) => format!(
@@ -1303,43 +1313,41 @@ struct InstallDefaultsReport {
     first_error: Option<String>,
 }
 
-/// Do the heavy lifting of loading the bundled defaults file, looping
-/// over entries, and inserting each one with `ORIGIN_DEFAULTS`. Returns
-/// either counts (even when `installed == 0` — e.g. the user clicked
-/// install-defaults a second time) or a fatal error string that the
-/// caller should surface as a flash message. The caller is responsible
-/// for rebuilding the compiled-CF cache if `installed > 0`.
-async fn install_default_cfs_core(state: &AppState) -> Result<InstallDefaultsReport, String> {
-    // Baked into the binary at compile time via `include_str!` so the
-    // handler can't ever fail to find the file at runtime. Parsing is
-    // still done once per click rather than at startup — the defaults
-    // payload is a few KB, the user rarely clicks this, and
-    // compile-time validation doesn't catch field-level typos anyway.
-    const DEFAULTS_JSON: &str = include_str!("../../static/default_custom_formats.json");
+/// The raw bundled-defaults JSON baked into the binary at compile time
+/// via `include_str!`. Parsed once per install/reset click rather than
+/// at startup — the payload is a few KB, the user rarely clicks this,
+/// and compile-time validation doesn't catch field-level typos anyway.
+const DEFAULTS_JSON: &str = include_str!("../../static/default_custom_formats.json");
 
+/// Parse the bundled `static/default_custom_formats.json` into a Vec of
+/// CF entry values. Shared by install-defaults and reset-defaults so
+/// they fail the same way on a malformed defaults file.
+fn parse_default_cf_entries() -> Result<Vec<serde_json::Value>, String> {
     let value: serde_json::Value = serde_json::from_str(DEFAULTS_JSON)
         .map_err(|e| format!("Defaults file is malformed: {e}"))?;
-    let entries = match value {
-        serde_json::Value::Array(items) => items,
-        _ => return Err("Defaults file is not a JSON array.".to_string()),
-    };
+    match value {
+        serde_json::Value::Array(items) => Ok(items),
+        _ => Err("Defaults file is not a JSON array.".to_string()),
+    }
+}
 
-    // Collect existing names so we can skip conflicts without a
-    // per-entry SELECT round-trip.
-    let existing: std::collections::HashSet<String> = cf_model::list_with_scores(&state.db)
-        .await
-        .map_err(|e| format!("Failed to read existing CFs: {e}"))?
-        .into_iter()
-        .map(|r| r.name)
-        .collect();
-
-    let mut report = InstallDefaultsReport {
-        installed: 0,
-        skipped: 0,
-        failed: 0,
-        first_error: None,
-    };
-
+/// Loop over parsed defaults entries and insert each one with
+/// `ORIGIN_DEFAULTS` within the caller's transaction. A compile error
+/// on one entry bumps `report.failed` and continues — individual
+/// entries are independent. A propagated `sqlx::Error` (connection
+/// lost, constraint violation, etc.) short-circuits via `?` so the
+/// caller can roll back by dropping the transaction without commit.
+///
+/// `existing_names` pre-seeds the collision-skip set. Reset Defaults
+/// passes an empty set because it already dropped the defaults rows;
+/// Install Defaults passes whatever `list_with_scores` returned before
+/// the transaction started.
+async fn install_defaults_entries_tx(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    entries: Vec<serde_json::Value>,
+    existing_names: &std::collections::HashSet<String>,
+    report: &mut InstallDefaultsReport,
+) -> Result<(), sqlx::Error> {
     for entry in entries {
         let name = entry
             .get("name")
@@ -1354,7 +1362,7 @@ async fn install_default_cfs_core(state: &AppState) -> Result<InstallDefaultsRep
             }
             continue;
         }
-        if existing.contains(&name) {
+        if existing_names.contains(&name) {
             report.skipped += 1;
             continue;
         }
@@ -1377,27 +1385,113 @@ async fn install_default_cfs_core(state: &AppState) -> Result<InstallDefaultsRep
             continue;
         }
 
-        match cf_model::insert(
-            &state.db,
+        cf_model::insert_with_tx(
+            tx,
             &name,
             trash_id.as_deref(),
             &raw_json,
             score,
             cf_model::ORIGIN_DEFAULTS,
         )
-        .await
-        {
-            Ok(_) => report.installed += 1,
-            Err(e) => {
-                report.failed += 1;
-                if report.first_error.is_none() {
-                    report.first_error = Some(format!("'{name}': {e}"));
-                }
-            }
-        }
+        .await?;
+        report.installed += 1;
     }
+    Ok(())
+}
+
+/// Do the heavy lifting of loading the bundled defaults file, looping
+/// over entries, and inserting each one with `ORIGIN_DEFAULTS`. Returns
+/// either counts (even when `installed == 0` — e.g. the user clicked
+/// install-defaults a second time) or a fatal error string that the
+/// caller should surface as a flash message. The caller is responsible
+/// for rebuilding the compiled-CF cache if `installed > 0`.
+///
+/// Wraps the whole insert loop in a single transaction so a propagated
+/// sqlx error mid-loop rolls back whatever was inserted rather than
+/// leaving a half-populated default set.
+async fn install_default_cfs_core(state: &AppState) -> Result<InstallDefaultsReport, String> {
+    let entries = parse_default_cf_entries()?;
+
+    // Collect existing names so we can skip conflicts without a
+    // per-entry SELECT round-trip. Read outside the transaction —
+    // there's no UI for concurrent CF edits, and INSERT will fail
+    // loudly on an unexpected collision anyway.
+    let existing: std::collections::HashSet<String> = cf_model::list_with_scores(&state.db)
+        .await
+        .map_err(|e| format!("Failed to read existing CFs: {e}"))?
+        .into_iter()
+        .map(|r| r.name)
+        .collect();
+
+    let mut report = InstallDefaultsReport {
+        installed: 0,
+        skipped: 0,
+        failed: 0,
+        first_error: None,
+    };
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|e| format!("Failed to open transaction: {e}"))?;
+    install_defaults_entries_tx(&mut tx, entries, &existing, &mut report)
+        .await
+        .map_err(|e| format!("Install failed mid-loop: {e}"))?;
+    tx.commit()
+        .await
+        .map_err(|e| format!("Failed to commit install transaction: {e}"))?;
 
     Ok(report)
+}
+
+/// Drop every `defaults`-origin row and reinstall the bundled set in
+/// the SAME transaction, so a mid-loop sqlx error rolls the delete
+/// back too — Reset leaves either the old defaults or the fresh
+/// defaults, never nothing. Returns (deleted_count, report). Rebuild
+/// of the compiled-CF cache is the caller's responsibility.
+async fn reset_defaults_core(
+    state: &AppState,
+) -> Result<(u64, InstallDefaultsReport), String> {
+    let entries = parse_default_cf_entries()?;
+
+    let mut report = InstallDefaultsReport {
+        installed: 0,
+        skipped: 0,
+        failed: 0,
+        first_error: None,
+    };
+
+    let mut tx = state
+        .db
+        .begin()
+        .await
+        .map_err(|e| format!("Failed to open transaction: {e}"))?;
+
+    let deleted = cf_model::delete_defaults_with_tx(&mut tx)
+        .await
+        .map_err(|e| format!("Reset failed (delete step): {e}"))?;
+
+    // After the delete, every remaining CF is manual/import — those
+    // names are still honored so the reinstall doesn't clobber a
+    // user-authored CF that happens to share a name with a default.
+    let existing: std::collections::HashSet<String> =
+        sqlx::query_scalar::<_, String>("SELECT name FROM custom_formats")
+            .fetch_all(&mut *tx)
+            .await
+            .map_err(|e| format!("Failed to read existing CFs: {e}"))?
+            .into_iter()
+            .collect();
+
+    install_defaults_entries_tx(&mut tx, entries, &existing, &mut report)
+        .await
+        .map_err(|e| format!("Reset failed (install step): {e}"))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| format!("Failed to commit reset transaction: {e}"))?;
+
+    Ok((deleted, report))
 }
 
 /// Install the bundled default Custom Format set (plan §7.2). The JSON
@@ -1479,19 +1573,11 @@ pub async fn settings_custom_formats_install_defaults(
 pub async fn settings_custom_formats_reset_defaults(
     State(state): State<AppState>,
 ) -> Redirect {
-    let deleted = match cf_model::delete_defaults(&state.db).await {
-        Ok(n) => n,
-        Err(e) => {
-            return Redirect::to(&cf_redirect(
-                None,
-                None,
-                Some(&format!("Reset failed (delete step): {e}")),
-            ));
-        }
-    };
-
-    let report = match install_default_cfs_core(&state).await {
-        Ok(r) => r,
+    // Delete + reinstall run inside a single transaction so a mid-loop
+    // failure rolls the whole thing back — the user is never left with
+    // a partially-nuked default set.
+    let (deleted, report) = match reset_defaults_core(&state).await {
+        Ok(pair) => pair,
         Err(msg) => return Redirect::to(&cf_redirect(None, None, Some(&msg))),
     };
 
@@ -2130,6 +2216,27 @@ mod tests {
         assert_eq!(
             import_summary(1, 1, 1, Some("bad".to_string())),
             "Imported 1, skipped 1, failed 1. First error: bad"
+        );
+    }
+
+    // Regression for PR #9 review: an earlier version of `import_summary`
+    // had a `(0, _, f)` catch-all arm that silently dropped `skipped`
+    // when imported=0, skipped>0, and failed>0. All three counters must
+    // appear in the flash message so the user knows what happened.
+    #[test]
+    fn import_summary_preserves_skipped_count_when_imported_is_zero() {
+        let msg = import_summary(0, 1, 1, Some("regex".to_string()));
+        assert!(msg.contains("skipped 1"), "missing skipped count: {msg}");
+        assert!(msg.contains("failed 1"), "missing failed count: {msg}");
+        assert!(msg.contains("regex"), "missing error context: {msg}");
+    }
+
+    #[test]
+    fn import_summary_shapes_imports_with_failures_only() {
+        // (n>0, s=0, f>0) — distinct from both (n, s, 0) and (n, s>0, f).
+        assert_eq!(
+            import_summary(2, 0, 1, Some("oops".to_string())),
+            "Imported 2, failed 1. First error: oops"
         );
     }
 }

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -134,6 +134,7 @@ rss::recent_decisions(&state.db, 500).await.unwrap_or_default()
         ("auth", LogCategory::Auth.label()),
         ("system", LogCategory::System.label()),
         ("post_process", LogCategory::PostProcess.label()),
+        ("scoring", LogCategory::Scoring.label()),
     ];
 
     let template = SystemTemplate {
@@ -220,6 +221,7 @@ pub async fn debug_settings_submit(
             ("auth", LogCategory::Auth.label()),
             ("system", LogCategory::System.label()),
             ("post_process", LogCategory::PostProcess.label()),
+            ("scoring", LogCategory::Scoring.label()),
         ],
         rss_enabled: cfg.rss_enabled,
         rss_interval_minutes: cfg.rss_interval_minutes,

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,9 @@ use services::{
         handlers::settings::settings_custom_formats_delete,
         handlers::settings::settings_custom_formats_minimum_score,
         handlers::settings::settings_custom_formats_import,
+        handlers::settings::settings_custom_formats_import_resolve,
+        handlers::settings::settings_custom_formats_install_defaults,
+        handlers::settings::settings_custom_formats_reset_defaults,
         handlers::settings::settings_custom_formats_export,
         handlers::system::api_logs_poll,
         handlers::system::api_logs_clear,
@@ -313,6 +316,9 @@ async fn main() {
         .route("/settings/custom-formats/delete", post(handlers::settings::settings_custom_formats_delete))
         .route("/settings/custom-formats/minimum-score", post(handlers::settings::settings_custom_formats_minimum_score))
         .route("/settings/custom-formats/import", post(handlers::settings::settings_custom_formats_import))
+        .route("/settings/custom-formats/import-resolve", post(handlers::settings::settings_custom_formats_import_resolve))
+        .route("/settings/custom-formats/install-defaults", post(handlers::settings::settings_custom_formats_install_defaults))
+        .route("/settings/custom-formats/reset-defaults", post(handlers::settings::settings_custom_formats_reset_defaults))
         .route("/settings/custom-formats/export", get(handlers::settings::settings_custom_formats_export))
         .route("/api/qbit/test", post(handlers::settings::qbit_test))
         .route("/api/jellyfin/test", post(handlers::settings::jellyfin_test))

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,12 @@ use services::{
         handlers::settings::qbit_test,
         handlers::settings::jellyfin_test,
         handlers::settings::jellyfin_refresh,
+        // Settings — Custom Formats
+        handlers::settings::settings_custom_formats_upsert,
+        handlers::settings::settings_custom_formats_delete,
+        handlers::settings::settings_custom_formats_minimum_score,
+        handlers::settings::settings_custom_formats_import,
+        handlers::settings::settings_custom_formats_export,
         handlers::system::api_logs_poll,
         handlers::system::api_logs_clear,
         handlers::system::api_rss_sync,
@@ -108,12 +114,17 @@ use services::{
         handlers::downloads::BlocklistRemoveForm,
         handlers::settings::QbitTestForm,
         handlers::settings::JellyfinTestForm,
+        handlers::settings::CustomFormatUpsertForm,
+        handlers::settings::CustomFormatDeleteForm,
+        handlers::settings::CustomFormatMinScoreForm,
+        handlers::settings::CustomFormatImportForm,
     )),
     tags(
         (name = "Library", description = "Anime library management — add, remove, search, and monitor series"),
         (name = "Search", description = "Nyaa torrent search and grabbing"),
         (name = "Downloads", description = "qBittorrent download management"),
         (name = "System", description = "Health checks, logs, RSS sync, and background tasks"),
+        (name = "Settings", description = "Settings management — Custom Formats CRUD, import/export, and scoring thresholds"),
     ),
 )]
 struct ApiDoc;
@@ -298,6 +309,11 @@ async fn main() {
         .route("/settings", get(handlers::settings::settings_page).post(handlers::settings::settings_submit))
         .route("/settings/groups", post(handlers::settings::settings_groups_upsert))
         .route("/settings/groups/delete", post(handlers::settings::settings_groups_delete))
+        .route("/settings/custom-formats/upsert", post(handlers::settings::settings_custom_formats_upsert))
+        .route("/settings/custom-formats/delete", post(handlers::settings::settings_custom_formats_delete))
+        .route("/settings/custom-formats/minimum-score", post(handlers::settings::settings_custom_formats_minimum_score))
+        .route("/settings/custom-formats/import", post(handlers::settings::settings_custom_formats_import))
+        .route("/settings/custom-formats/export", get(handlers::settings::settings_custom_formats_export))
         .route("/api/qbit/test", post(handlers::settings::qbit_test))
         .route("/api/jellyfin/test", post(handlers::settings::jellyfin_test))
         .route("/api/health", get(handlers::settings::api_health))

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,11 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
 
-use services::{jellyfin::JellyfinClient, qbit::QbitClient};
+use services::{
+    custom_formats::{self, CompiledCfCache},
+    jellyfin::JellyfinClient,
+    qbit::QbitClient,
+};
 
 #[derive(OpenApi)]
 #[openapi(
@@ -120,6 +124,12 @@ pub struct AppState {
     pub db: SqlitePool,
     pub qbit: Arc<RwLock<Option<QbitClient>>>,
     pub jellyfin: Arc<RwLock<Option<JellyfinClient>>>,
+    /// Compiled Custom Formats, loaded once at startup and rebuilt on
+    /// CF create/update/delete via `custom_formats::rebuild_cf_cache`.
+    /// Outer `RwLock` owns swap; the inner `Arc<Vec<_>>` is cheap-cloned
+    /// out on the scoring hot path so the read lock releases before the
+    /// per-candidate evaluation loop begins.
+    pub custom_formats: CompiledCfCache,
 }
 
 // Allow handlers to extract SqlitePool directly from AppState.
@@ -204,11 +214,18 @@ async fn main() {
     // runtime worker during startup.
     let _ = tokio::task::spawn_blocking(models::user::warm_timing_equalizer).await;
 
+    // Warm the Custom Formats cache from disk. Parse failures are logged
+    // inside `load_compiled_cfs` and skipped — startup never aborts over
+    // a bad CF row, so a corrupted import can't take the server down.
+    let cf_cache: CompiledCfCache =
+        Arc::new(RwLock::new(Arc::new(custom_formats::load_compiled_cfs(&db).await)));
+
     // Build shared state.
     let state = AppState {
         db: db.clone(),
         qbit: Arc::new(RwLock::new(None)),
         jellyfin: Arc::new(RwLock::new(None)),
+        custom_formats: cf_cache,
     };
 
     // Initialize qBittorrent client from saved config if available.

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -39,6 +39,11 @@ pub struct Config {
     pub radarr_enabled: bool,
     pub radarr_api_key: String,
     pub upgrade_search_enabled: bool,
+    /// Floor applied to `total_cf_score` after Custom Formats evaluation.
+    /// `i32::MIN` (the default) means no floor. Raised by the user via
+    /// the Custom Formats settings page to reject candidates whose
+    /// summed CF score falls below the threshold.
+    pub custom_format_minimum_score: i32,
 }
 
 impl Default for Config {
@@ -76,6 +81,7 @@ impl Default for Config {
             radarr_enabled: false,
             radarr_api_key: String::new(),
             upgrade_search_enabled: false,
+            custom_format_minimum_score: i32::MIN,
         }
     }
 }
@@ -114,12 +120,13 @@ struct ConfigRow {
     radarr_enabled: i64,
     radarr_api_key: String,
     upgrade_search_enabled: i64,
+    custom_format_minimum_score: i64,
 }
 
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled FROM config WHERE id = 1",
+        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -157,6 +164,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         radarr_enabled: r.radarr_enabled != 0,
         radarr_api_key: r.radarr_api_key,
         upgrade_search_enabled: r.upgrade_search_enabled != 0,
+        custom_format_minimum_score: r.custom_format_minimum_score as i32,
     }))
 }
 
@@ -164,8 +172,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             qbit_url = excluded.qbit_url,
             qbit_user = excluded.qbit_user,
@@ -198,7 +206,8 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             sonarr_api_key = excluded.sonarr_api_key,
             radarr_enabled = excluded.radarr_enabled,
             radarr_api_key = excluded.radarr_api_key,
-            upgrade_search_enabled = excluded.upgrade_search_enabled
+            upgrade_search_enabled = excluded.upgrade_search_enabled,
+            custom_format_minimum_score = excluded.custom_format_minimum_score
         "#,
     )
     .bind(&config.qbit_url)
@@ -233,6 +242,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(if config.radarr_enabled { 1_i64 } else { 0_i64 })
     .bind(&config.radarr_api_key)
     .bind(if config.upgrade_search_enabled { 1_i64 } else { 0_i64 })
+    .bind(config.custom_format_minimum_score as i64)
     .execute(db)
     .await?;
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -44,6 +44,12 @@ pub struct Config {
     /// the Custom Formats settings page to reject candidates whose
     /// summed CF score falls below the threshold.
     pub custom_format_minimum_score: i32,
+    /// Apply the hardcoded SeaDex "best release" score boost
+    /// (`SEADEX_SCORE_BOOST = 10_000`) at scoring time. Off by default.
+    /// Suppressed automatically when the user has any
+    /// `Ryokan.SeaDexBestSpecification` Custom Format installed — that
+    /// CF replaces the hardcoded boost with a user-controlled score.
+    pub seadex_enabled: bool,
 }
 
 impl Default for Config {
@@ -82,6 +88,7 @@ impl Default for Config {
             radarr_api_key: String::new(),
             upgrade_search_enabled: false,
             custom_format_minimum_score: i32::MIN,
+            seadex_enabled: false,
         }
     }
 }
@@ -121,12 +128,13 @@ struct ConfigRow {
     radarr_api_key: String,
     upgrade_search_enabled: i64,
     custom_format_minimum_score: i64,
+    seadex_enabled: i64,
 }
 
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score FROM config WHERE id = 1",
+        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -165,6 +173,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         radarr_api_key: r.radarr_api_key,
         upgrade_search_enabled: r.upgrade_search_enabled != 0,
         custom_format_minimum_score: r.custom_format_minimum_score as i32,
+        seadex_enabled: r.seadex_enabled != 0,
     }))
 }
 
@@ -172,8 +181,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             qbit_url = excluded.qbit_url,
             qbit_user = excluded.qbit_user,
@@ -207,7 +216,8 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             radarr_enabled = excluded.radarr_enabled,
             radarr_api_key = excluded.radarr_api_key,
             upgrade_search_enabled = excluded.upgrade_search_enabled,
-            custom_format_minimum_score = excluded.custom_format_minimum_score
+            custom_format_minimum_score = excluded.custom_format_minimum_score,
+            seadex_enabled = excluded.seadex_enabled
         "#,
     )
     .bind(&config.qbit_url)
@@ -243,6 +253,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(&config.radarr_api_key)
     .bind(if config.upgrade_search_enabled { 1_i64 } else { 0_i64 })
     .bind(config.custom_format_minimum_score as i64)
+    .bind(if config.seadex_enabled { 1_i64 } else { 0_i64 })
     .execute(db)
     .await?;
 

--- a/src/models/custom_formats.rs
+++ b/src/models/custom_formats.rs
@@ -19,7 +19,27 @@
 //! `ALTER TABLE ... ADD COLUMN` — not here — because Ryokan's config is
 //! a single typed row, not a key/value store.
 
-use sqlx::SqlitePool;
+use sqlx::{FromRow, SqlitePool};
+
+/// Single row in the `custom_formats` table joined with its V1-profile
+/// score from `custom_format_scores`. A row with no score entry yet
+/// returns `0` (via `COALESCE`) rather than `NULL`, so the settings UI
+/// never has to handle a missing-score case.
+#[derive(Debug, Clone, FromRow)]
+pub struct CustomFormatRow {
+    pub id: i64,
+    pub name: String,
+    pub trash_id: Option<String>,
+    pub json: String,
+    pub score: i64,
+    // Persisted timestamps. Not shown in the current UI but kept on the
+    // struct so a future "sort by recently edited" view has the data
+    // without a schema migration.
+    #[allow(dead_code)]
+    pub created_at: i64,
+    #[allow(dead_code)]
+    pub updated_at: i64,
+}
 
 pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query(
@@ -51,5 +71,149 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await?;
 
+    Ok(())
+}
+
+fn now_unix() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// Return every CF row joined with its V1-profile score, ordered by
+/// name for a stable settings-page layout.
+pub async fn list_with_scores(db: &SqlitePool) -> Result<Vec<CustomFormatRow>, sqlx::Error> {
+    sqlx::query_as::<_, CustomFormatRow>(
+        r#"
+        SELECT cf.id, cf.name, cf.trash_id, cf.json,
+               COALESCE(cfs.score, 0) AS score,
+               cf.created_at, cf.updated_at
+        FROM custom_formats cf
+        LEFT JOIN custom_format_scores cfs
+               ON cfs.custom_format_id = cf.id
+              AND cfs.profile_id = 1
+        ORDER BY cf.name COLLATE NOCASE
+        "#,
+    )
+    .fetch_all(db)
+    .await
+}
+
+/// Fetch a single CF by id, joined with its V1-profile score. Used to
+/// prefill the settings-page edit form when `?edit_id=N` is present.
+pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<CustomFormatRow>, sqlx::Error> {
+    sqlx::query_as::<_, CustomFormatRow>(
+        r#"
+        SELECT cf.id, cf.name, cf.trash_id, cf.json,
+               COALESCE(cfs.score, 0) AS score,
+               cf.created_at, cf.updated_at
+        FROM custom_formats cf
+        LEFT JOIN custom_format_scores cfs
+               ON cfs.custom_format_id = cf.id
+              AND cfs.profile_id = 1
+        WHERE cf.id = ?
+        "#,
+    )
+    .bind(id)
+    .fetch_optional(db)
+    .await
+}
+
+/// Insert a new CF row and its V1-profile score in a single transaction.
+/// Returns the newly-assigned row id so the caller can redirect straight
+/// to the edit view.
+pub async fn insert(
+    db: &SqlitePool,
+    name: &str,
+    trash_id: Option<&str>,
+    json: &str,
+    score: i32,
+) -> Result<i64, sqlx::Error> {
+    let now = now_unix();
+    let mut tx = db.begin().await?;
+    let res = sqlx::query(
+        r#"
+        INSERT INTO custom_formats (name, trash_id, json, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+        "#,
+    )
+    .bind(name)
+    .bind(trash_id)
+    .bind(json)
+    .bind(now)
+    .bind(now)
+    .execute(&mut *tx)
+    .await?;
+
+    let id = res.last_insert_rowid();
+
+    sqlx::query(
+        r#"
+        INSERT INTO custom_format_scores (custom_format_id, profile_id, score)
+        VALUES (?, 1, ?)
+        "#,
+    )
+    .bind(id)
+    .bind(score as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+    Ok(id)
+}
+
+/// Update an existing CF row and its V1-profile score. The score row
+/// uses `INSERT ... ON CONFLICT` rather than a plain `UPDATE` so an old
+/// row without a score entry still gets one on first edit.
+pub async fn update(
+    db: &SqlitePool,
+    id: i64,
+    name: &str,
+    trash_id: Option<&str>,
+    json: &str,
+    score: i32,
+) -> Result<(), sqlx::Error> {
+    let now = now_unix();
+    let mut tx = db.begin().await?;
+
+    sqlx::query(
+        r#"
+        UPDATE custom_formats
+        SET name = ?, trash_id = ?, json = ?, updated_at = ?
+        WHERE id = ?
+        "#,
+    )
+    .bind(name)
+    .bind(trash_id)
+    .bind(json)
+    .bind(now)
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO custom_format_scores (custom_format_id, profile_id, score)
+        VALUES (?, 1, ?)
+        ON CONFLICT(custom_format_id, profile_id) DO UPDATE SET score = excluded.score
+        "#,
+    )
+    .bind(id)
+    .bind(score as i64)
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Delete a CF row. The `ON DELETE CASCADE` on `custom_format_scores`
+/// drops the score row automatically.
+pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM custom_formats WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
     Ok(())
 }

--- a/src/models/custom_formats.rs
+++ b/src/models/custom_formats.rs
@@ -19,7 +19,7 @@
 //! `ALTER TABLE ... ADD COLUMN` — not here — because Ryokan's config is
 //! a single typed row, not a key/value store.
 
-use sqlx::{FromRow, SqlitePool};
+use sqlx::{FromRow, Sqlite, SqlitePool, Transaction};
 
 /// Single row in the `custom_formats` table joined with its V1-profile
 /// score from `custom_format_scores`. A row with no score entry yet
@@ -56,6 +56,12 @@ pub const ORIGIN_IMPORT: &str = "import";
 pub const ORIGIN_DEFAULTS: &str = "defaults";
 
 pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    // Fresh installs land the full schema in one shot — including the
+    // `origin` column that records provenance (`manual`/`import`/
+    // `defaults`). `models/mod.rs::migrate` still runs a best-effort
+    // `ALTER TABLE ADD COLUMN origin` after this for databases that
+    // were created before the column shipped; that ALTER is idempotent
+    // via `.ok()` and a no-op here.
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS custom_formats (
@@ -63,6 +69,7 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
             name       TEXT NOT NULL UNIQUE,
             trash_id   TEXT,
             json       TEXT NOT NULL,
+            origin     TEXT NOT NULL DEFAULT 'manual',
             created_at INTEGER NOT NULL,
             updated_at INTEGER NOT NULL
         )
@@ -148,8 +155,25 @@ pub async fn insert(
     score: i32,
     origin: &str,
 ) -> Result<i64, sqlx::Error> {
-    let now = now_unix();
     let mut tx = db.begin().await?;
+    let id = insert_with_tx(&mut tx, name, trash_id, json, score, origin).await?;
+    tx.commit().await?;
+    Ok(id)
+}
+
+/// Transaction-scoped variant of [`insert`] for callers that need to
+/// bundle multiple CF operations (e.g. the Reset Defaults handler's
+/// `DELETE defaults` + re-`INSERT` loop) into a single atomic unit.
+/// Does NOT commit — the caller owns transaction lifecycle.
+pub async fn insert_with_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+    name: &str,
+    trash_id: Option<&str>,
+    json: &str,
+    score: i32,
+    origin: &str,
+) -> Result<i64, sqlx::Error> {
+    let now = now_unix();
     let res = sqlx::query(
         r#"
         INSERT INTO custom_formats (name, trash_id, json, origin, created_at, updated_at)
@@ -162,7 +186,7 @@ pub async fn insert(
     .bind(origin)
     .bind(now)
     .bind(now)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await?;
 
     let id = res.last_insert_rowid();
@@ -175,10 +199,9 @@ pub async fn insert(
     )
     .bind(id)
     .bind(score as i64)
-    .execute(&mut *tx)
+    .execute(&mut **tx)
     .await?;
 
-    tx.commit().await?;
     Ok(id)
 }
 
@@ -237,15 +260,20 @@ pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
-/// Delete every CF row whose origin is `defaults`. Used by the Reset
-/// to Defaults button to wipe just the bundled set before reinstalling
-/// from disk. User-authored (`manual`) and imported (`import`) rows
-/// are left untouched — that's the whole point of the origin column.
-/// Returns the number of rows that were dropped.
-pub async fn delete_defaults(db: &SqlitePool) -> Result<u64, sqlx::Error> {
+/// Delete every CF row whose origin is `defaults`, within a
+/// caller-supplied transaction. Used by the Reset to Defaults handler
+/// to wipe just the bundled set before reinstalling from disk, inside
+/// the same transaction as the reinstall so a mid-loop install failure
+/// rolls the whole operation back. User-authored (`manual`) and
+/// imported (`import`) rows are left untouched — that's the whole
+/// point of the origin column. Does NOT commit — the caller owns
+/// transaction lifecycle. Returns the number of rows that were dropped.
+pub async fn delete_defaults_with_tx(
+    tx: &mut Transaction<'_, Sqlite>,
+) -> Result<u64, sqlx::Error> {
     let res = sqlx::query("DELETE FROM custom_formats WHERE origin = ?")
         .bind(ORIGIN_DEFAULTS)
-        .execute(db)
+        .execute(&mut **tx)
         .await?;
     Ok(res.rows_affected())
 }

--- a/src/models/custom_formats.rs
+++ b/src/models/custom_formats.rs
@@ -1,0 +1,55 @@
+//! Storage for user-defined Sonarr-v4-compatible Custom Formats.
+//!
+//! Two tables:
+//!
+//! - `custom_formats` — one row per CF, keyed by a stable auto-increment
+//!   ID. Stores the full original Sonarr JSON (`json` column) so
+//!   re-export round-trips byte-perfect into another Sonarr instance,
+//!   plus the display name and the optional trash-guides ID for
+//!   updates-from-upstream flows.
+//!
+//! - `custom_format_scores` — (custom_format_id, profile_id) → score.
+//!   V1 hardcodes `profile_id = 1` everywhere; the column is only in
+//!   place so V2 profile support is pure additive schema work (no data
+//!   migration). `ON DELETE CASCADE` so a CF delete cleans up its own
+//!   score row without a second query.
+//!
+//! The `custom_format_minimum_score` config row is added to the existing
+//! typed `config` table in `models/mod.rs::migrate()` via a regular
+//! `ALTER TABLE ... ADD COLUMN` — not here — because Ryokan's config is
+//! a single typed row, not a key/value store.
+
+use sqlx::SqlitePool;
+
+pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS custom_formats (
+            id         INTEGER PRIMARY KEY AUTOINCREMENT,
+            name       TEXT NOT NULL UNIQUE,
+            trash_id   TEXT,
+            json       TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            updated_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS custom_format_scores (
+            id               INTEGER PRIMARY KEY AUTOINCREMENT,
+            custom_format_id INTEGER NOT NULL REFERENCES custom_formats(id) ON DELETE CASCADE,
+            profile_id       INTEGER NOT NULL DEFAULT 1,
+            score            INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(custom_format_id, profile_id)
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    Ok(())
+}

--- a/src/models/custom_formats.rs
+++ b/src/models/custom_formats.rs
@@ -32,6 +32,12 @@ pub struct CustomFormatRow {
     pub trash_id: Option<String>,
     pub json: String,
     pub score: i64,
+    /// Provenance of this row. One of `manual` (created via the upsert
+    /// form), `import` (pasted into the Sonarr-export import box), or
+    /// `defaults` (installed via the "Install Defaults" button). Used
+    /// by the settings table to show a Source badge and by Reset to
+    /// Defaults to target just the `defaults`-origin rows.
+    pub origin: String,
     // Persisted timestamps. Not shown in the current UI but kept on the
     // struct so a future "sort by recently edited" view has the data
     // without a schema migration.
@@ -40,6 +46,14 @@ pub struct CustomFormatRow {
     #[allow(dead_code)]
     pub updated_at: i64,
 }
+
+/// Legal values for the `origin` column. Kept as bare &str rather
+/// than an enum because the three values are only meaningful at the
+/// handler boundary — the model layer just echoes the string into the
+/// database.
+pub const ORIGIN_MANUAL: &str = "manual";
+pub const ORIGIN_IMPORT: &str = "import";
+pub const ORIGIN_DEFAULTS: &str = "defaults";
 
 pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query(
@@ -88,6 +102,7 @@ pub async fn list_with_scores(db: &SqlitePool) -> Result<Vec<CustomFormatRow>, s
         r#"
         SELECT cf.id, cf.name, cf.trash_id, cf.json,
                COALESCE(cfs.score, 0) AS score,
+               cf.origin,
                cf.created_at, cf.updated_at
         FROM custom_formats cf
         LEFT JOIN custom_format_scores cfs
@@ -107,6 +122,7 @@ pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<CustomFormatRo
         r#"
         SELECT cf.id, cf.name, cf.trash_id, cf.json,
                COALESCE(cfs.score, 0) AS score,
+               cf.origin,
                cf.created_at, cf.updated_at
         FROM custom_formats cf
         LEFT JOIN custom_format_scores cfs
@@ -122,25 +138,28 @@ pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<CustomFormatRo
 
 /// Insert a new CF row and its V1-profile score in a single transaction.
 /// Returns the newly-assigned row id so the caller can redirect straight
-/// to the edit view.
+/// to the edit view. `origin` records provenance — callers should pass
+/// one of the `ORIGIN_*` constants.
 pub async fn insert(
     db: &SqlitePool,
     name: &str,
     trash_id: Option<&str>,
     json: &str,
     score: i32,
+    origin: &str,
 ) -> Result<i64, sqlx::Error> {
     let now = now_unix();
     let mut tx = db.begin().await?;
     let res = sqlx::query(
         r#"
-        INSERT INTO custom_formats (name, trash_id, json, created_at, updated_at)
-        VALUES (?, ?, ?, ?, ?)
+        INSERT INTO custom_formats (name, trash_id, json, origin, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
         "#,
     )
     .bind(name)
     .bind(trash_id)
     .bind(json)
+    .bind(origin)
     .bind(now)
     .bind(now)
     .execute(&mut *tx)
@@ -216,4 +235,17 @@ pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
     Ok(())
+}
+
+/// Delete every CF row whose origin is `defaults`. Used by the Reset
+/// to Defaults button to wipe just the bundled set before reinstalling
+/// from disk. User-authored (`manual`) and imported (`import`) rows
+/// are left untouched — that's the whole point of the origin column.
+/// Returns the number of rows that were dropped.
+pub async fn delete_defaults(db: &SqlitePool) -> Result<u64, sqlx::Error> {
+    let res = sqlx::query("DELETE FROM custom_formats WHERE origin = ?")
+        .bind(ORIGIN_DEFAULTS)
+        .execute(db)
+        .await?;
+    Ok(res.rows_affected())
 }

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -18,12 +18,17 @@ pub struct GrabbedTorrent {
     pub is_batch: bool,
 }
 
-/// Record a torrent grab for post-processing. Skips silently if we already
-/// have a pending or imported record with the same (non-empty) hash.
+/// Record a torrent grab for post-processing. Skips silently if we
+/// already have a pending or imported record with the same (non-empty)
+/// hash, in which case `Ok(None)` is returned. On a fresh insert,
+/// returns `Ok(Some(id))` so the Phase 2 multi-series routing path can
+/// attach `grabbed_torrent_series` rows via
+/// [`record_grab_series_routes`] without re-querying.
 ///
-/// `is_batch` is the caller's view (from the Nyaa listing or search hit)
-/// of whether the release is a batch/season pack. Persisted so the
-/// post-download classifier can feed the same flag back into Layer 4.
+/// `is_batch` is the caller's view (from the Nyaa listing or search
+/// hit) of whether the release is a batch/season pack. Persisted so
+/// the post-download classifier can feed the same flag back into
+/// Layer 4.
 pub async fn record_grab(
     db: &SqlitePool,
     hash: &str,
@@ -31,7 +36,7 @@ pub async fn record_grab(
     series_id: i64,
     episode_numbers: &[i32],
     is_batch: bool,
-) -> Result<(), sqlx::Error> {
+) -> Result<Option<i64>, sqlx::Error> {
     let eps_json = serde_json::to_string(episode_numbers).unwrap_or_else(|_| "[]".to_string());
 
     if !hash.is_empty() {
@@ -42,12 +47,12 @@ pub async fn record_grab(
         .fetch_optional(db)
         .await?;
         if existing.is_some() {
-            return Ok(());
+            return Ok(None);
         }
     }
 
     let is_batch_i = if is_batch { 1_i64 } else { 0_i64 };
-    sqlx::query(
+    let result = sqlx::query(
         "INSERT INTO grabbed_torrents (hash, torrent_name, series_id, episode_numbers, state, is_batch) VALUES (?, ?, ?, ?, 'pending', ?)",
     )
     .bind(hash)
@@ -58,7 +63,100 @@ pub async fn record_grab(
     .execute(db)
     .await?;
 
+    Ok(Some(result.last_insert_rowid()))
+}
+
+/// Per-file routing row for a grabbed torrent. Used to drive
+/// post-processing for multi-series batch releases: when a Phase 2
+/// grab detects sibling series in a megapack, one of these gets
+/// written per sibling (plus one for the parent, covering unclaimed
+/// files). Post-processing iterates the torrent's video files and
+/// consults the routes to decide which series' media folder each file
+/// belongs to.
+///
+/// `file_indices` are zero-based indices into the torrent's canonical
+/// file list as returned by qBit's `torrents/files` endpoint — the
+/// same ordering the detection function saw at grab time.
+///
+/// `episode_numbers` is pre-parsed at grab time so post-processing
+/// doesn't have to re-derive episode numbers from filenames (and so
+/// we can record them on the parent `grabbed_torrents` row for the
+/// existing `find_imported_for_episode` lookup to keep working).
+#[derive(Debug, Clone)]
+pub struct GrabSeriesRoute {
+    pub grab_id: i64,
+    pub series_id: i64,
+    pub file_indices: Vec<usize>,
+    pub episode_numbers: Vec<i32>,
+    pub matched_subtitle: String,
+}
+
+/// Write one or more `grabbed_torrent_series` rows for a freshly
+/// recorded grab. Used by the Phase 2 auto-expand path in
+/// `handlers::library` to persist per-sibling file routing. Single-
+/// series grabs don't need to call this — post-processing falls
+/// through to `grab.series_id` when no route rows exist.
+pub async fn record_grab_series_routes(
+    db: &SqlitePool,
+    routes: &[GrabSeriesRoute],
+) -> Result<(), sqlx::Error> {
+    for route in routes {
+        let file_idx_i64: Vec<i64> = route.file_indices.iter().map(|i| *i as i64).collect();
+        let file_indices_json =
+            serde_json::to_string(&file_idx_i64).unwrap_or_else(|_| "[]".to_string());
+        let eps_json = serde_json::to_string(&route.episode_numbers)
+            .unwrap_or_else(|_| "[]".to_string());
+        sqlx::query(
+            r#"INSERT OR REPLACE INTO grabbed_torrent_series
+               (grab_id, series_id, file_indices, episode_numbers, matched_subtitle)
+               VALUES (?, ?, ?, ?, ?)"#,
+        )
+        .bind(route.grab_id)
+        .bind(route.series_id)
+        .bind(&file_indices_json)
+        .bind(&eps_json)
+        .bind(&route.matched_subtitle)
+        .execute(db)
+        .await?;
+    }
     Ok(())
+}
+
+/// Fetch every route row for a grab. Returns an empty vec for legacy
+/// single-series grabs that predate Phase 2 — post-processing treats
+/// an empty result as "route all files to grab.series_id" in that
+/// case.
+pub async fn get_series_routes(
+    db: &SqlitePool,
+    grab_id: i64,
+) -> Result<Vec<GrabSeriesRoute>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"SELECT grab_id, series_id, file_indices, episode_numbers, matched_subtitle
+           FROM grabbed_torrent_series
+           WHERE grab_id = ?"#,
+    )
+    .bind(grab_id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let file_idx_json: String = row.get("file_indices");
+            let file_idx: Vec<i64> =
+                serde_json::from_str(&file_idx_json).unwrap_or_default();
+            let eps_json: String = row.get("episode_numbers");
+            let episode_numbers: Vec<i32> =
+                serde_json::from_str(&eps_json).unwrap_or_default();
+            GrabSeriesRoute {
+                grab_id: row.get("grab_id"),
+                series_id: row.get("series_id"),
+                file_indices: file_idx.into_iter().map(|i| i as usize).collect(),
+                episode_numbers,
+                matched_subtitle: row.get("matched_subtitle"),
+            }
+        })
+        .collect())
 }
 
 /// Look up the stored `is_batch` flag for a grab by its torrent name.
@@ -226,18 +324,44 @@ pub async fn mark_failed_by_name(db: &SqlitePool, series_id: i64, torrent_name: 
 
 /// Find previously imported grabs for a series that cover a given episode.
 /// Used by post-processing to identify old torrents to clean up during upgrades.
+///
+/// Unions two paths so Phase 2 sibling-routed imports get found
+/// correctly: (1) legacy path — grab rows where `series_id` is the
+/// primary and the episode appears in `grabbed_torrents.episode_numbers`;
+/// (2) routes path — grab rows where the series appears in
+/// `grabbed_torrent_series` (as a sibling of a batch torrent) and the
+/// episode appears in the route row's `episode_numbers`. Without the
+/// second path, upgrades for a sibling series would never find the
+/// batch import to clean up.
 pub async fn find_imported_for_episode(
     db: &SqlitePool,
     series_id: i64,
     episode_number: i32,
 ) -> Result<Vec<GrabbedTorrent>, sqlx::Error> {
-    // episode_numbers is stored as a JSON array, so we search with json_each.
+    // episode_numbers is stored as a JSON array, so we search with
+    // json_each on both the legacy column and the routes column.
+    // UNION dedups grabs where the same series matches through both
+    // paths (parent of a single-series grab).
     let rows = sqlx::query(
-        r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.grabbed_at
-           FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
-           WHERE g.series_id = ? AND je.value = ? AND g.state = 'imported'
-           ORDER BY g.grabbed_at DESC"#,
+        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at FROM (
+             SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
+                    g.series_id AS series_id, g.episode_numbers AS episode_numbers,
+                    g.grabbed_at AS grabbed_at
+             FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
+             WHERE g.series_id = ? AND je.value = ? AND g.state = 'imported'
+             UNION
+             SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
+                    g.series_id AS series_id, g.episode_numbers AS episode_numbers,
+                    g.grabbed_at AS grabbed_at
+             FROM grabbed_torrents g
+             JOIN grabbed_torrent_series r ON r.grab_id = g.id
+             , json_each(r.episode_numbers) AS je
+             WHERE r.series_id = ? AND je.value = ? AND g.state = 'imported'
+           )
+           ORDER BY grabbed_at DESC"#,
     )
+    .bind(series_id)
+    .bind(episode_number)
     .bind(series_id)
     .bind(episode_number)
     .fetch_all(db)

--- a/src/models/log.rs
+++ b/src/models/log.rs
@@ -56,6 +56,11 @@ pub enum LogCategory {
     /// debug records emit under this category so the logs page can be
     /// filtered to just classification trace output.
     Quality,
+    /// Per-candidate release scoring breakdown (`services/auto_search.rs`).
+    /// Emits one debug row per scored candidate with the CF breakdown so
+    /// users can introspect "why did release X win over release Y" — see
+    /// plan §6.3 of `ryokan-custom-formats.md`.
+    Scoring,
 }
 
 impl LogCategory {
@@ -75,6 +80,7 @@ impl LogCategory {
             LogCategory::System => "system",
             LogCategory::PostProcess => "post_process",
             LogCategory::Quality => "quality",
+            LogCategory::Scoring => "scoring",
         }
     }
 
@@ -95,6 +101,7 @@ impl LogCategory {
             "system" => Some(LogCategory::System),
             "post_process" => Some(LogCategory::PostProcess),
             "quality" => Some(LogCategory::Quality),
+            "scoring" => Some(LogCategory::Scoring),
             _ => None,
         }
     }
@@ -115,6 +122,7 @@ impl LogCategory {
             LogCategory::System => "System",
             LogCategory::PostProcess => "Post-Process",
             LogCategory::Quality => "Quality",
+            LogCategory::Scoring => "Scoring",
         }
     }
 }

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -849,6 +849,15 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // SeaDex "best release" boost toggle. Default OFF so upgrades don't
+    // kick in silently for existing installs on first run after the
+    // feature ships. Suppressed at scoring time when the user already
+    // has a SeaDexBestSpecification CF (avoids double-counting).
+    sqlx::query("ALTER TABLE config ADD COLUMN seadex_enabled INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
     sqlx::query("ALTER TABLE config ADD COLUMN preferred_source TEXT NOT NULL DEFAULT ''")
         .execute(db)
         .await

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -764,13 +764,13 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // profile_id = 1 everywhere.
     custom_formats::migrate(db).await?;
 
-    // Origin column on custom_formats: records where the row came from
-    // so the settings table can surface a "Source" badge and the Reset
-    // to Defaults button can target just the `defaults`-origin rows
-    // without clobbering user-authored CFs. Legal values: `manual`,
-    // `import`, `defaults`. Pre-existing rows default to `manual` on
-    // first migration — anyone who already installed defaults before
-    // this column shipped can use the Reset button to relabel them.
+    // Upgrade path for databases that were created before the `origin`
+    // column shipped. Fresh installs already got this column from the
+    // CREATE TABLE in `custom_formats::migrate`; the ALTER here is a
+    // no-op on those and adds the column on legacy databases. Legal
+    // values: `manual`, `import`, `defaults`. Pre-existing rows default
+    // to `manual` — anyone who already installed defaults before this
+    // column shipped can use the Reset button to relabel them.
     sqlx::query("ALTER TABLE custom_formats ADD COLUMN origin TEXT NOT NULL DEFAULT 'manual'")
         .execute(db)
         .await

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -764,6 +764,18 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // profile_id = 1 everywhere.
     custom_formats::migrate(db).await?;
 
+    // Origin column on custom_formats: records where the row came from
+    // so the settings table can surface a "Source" badge and the Reset
+    // to Defaults button can target just the `defaults`-origin rows
+    // without clobbering user-authored CFs. Legal values: `manual`,
+    // `import`, `defaults`. Pre-existing rows default to `manual` on
+    // first migration — anyone who already installed defaults before
+    // this column shipped can use the Reset button to relabel them.
+    sqlx::query("ALTER TABLE custom_formats ADD COLUMN origin TEXT NOT NULL DEFAULT 'manual'")
+        .execute(db)
+        .await
+        .ok();
+
     // ── Phase 1b: classification columns on episode_quality_tags ─────────
     // These record the ClassificationResult at grab time so later scoring,
     // upgrade detection, and UI review workflows can read structured source

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -546,6 +546,37 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
 
+    // Per-file series routing for multi-series batch releases. A
+    // megapack that covers e.g. JoJo S1-S5 gets one row per sibling
+    // in this table, each carrying the file indices (into the
+    // torrent's canonical file list) that belong to that sibling and
+    // the episode numbers those files represent. The parent series
+    // (the one the user actually searched for) also gets a row here
+    // covering unclaimed files. Legacy single-series grabs that
+    // predate Phase 2 have no row here and are handled by a
+    // fall-through path in post_processing that treats the
+    // grabbed_torrents.series_id as the sole route.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS grabbed_torrent_series (
+            grab_id INTEGER NOT NULL,
+            series_id INTEGER NOT NULL,
+            file_indices TEXT NOT NULL DEFAULT '[]',
+            episode_numbers TEXT NOT NULL DEFAULT '[]',
+            matched_subtitle TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (grab_id, series_id),
+            FOREIGN KEY (grab_id) REFERENCES grabbed_torrents(id) ON DELETE CASCADE,
+            FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_grabbed_torrent_series_series ON grabbed_torrent_series (series_id)")
+        .execute(db)
+        .await?;
+
     // tmdb_id on series is a leftover from before the Kitsu migration;
     // the column is harmless to keep for existing databases.
     sqlx::query("ALTER TABLE series ADD COLUMN tmdb_id INTEGER")

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -14,6 +14,7 @@ pub mod episode_tags;
 pub mod group_source_map;
 pub mod nyaa_description_cache;
 pub mod media_probe_cache;
+pub mod custom_formats;
 
 use sqlx::SqlitePool;
 
@@ -757,6 +758,12 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // upgrade checks) don't re-shell out to ffprobe for the same file.
     media_probe_cache::migrate(db).await?;
 
+    // Sonarr-v4-compatible Custom Formats. Two tables: one for CF
+    // definitions (raw JSON preserved for byte-perfect re-export) and
+    // one for (custom_format_id, profile_id) → score. V1 hardcodes
+    // profile_id = 1 everywhere.
+    custom_formats::migrate(db).await?;
+
     // ── Phase 1b: classification columns on episode_quality_tags ─────────
     // These record the ClassificationResult at grab time so later scoring,
     // upgrade detection, and UI review workflows can read structured source
@@ -832,6 +839,16 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // authoritative preferred-resolution field. The three new columns cover
     // the bits that didn't exist before. Legacy quality_profile and
     // quality_cutoff are kept for one release as a rollback hatch.
+    // Floor for total_cf_score after the CF pipeline sums a candidate's
+    // matching formats. Default `-2147483648` (= i32::MIN) means "no
+    // floor" — the user opts in by raising it via the Custom Formats
+    // settings page. Read paths fall back to this sentinel when the
+    // column is present but the row predates it.
+    sqlx::query("ALTER TABLE config ADD COLUMN custom_format_minimum_score INTEGER NOT NULL DEFAULT -2147483648")
+        .execute(db)
+        .await
+        .ok();
+
     sqlx::query("ALTER TABLE config ADD COLUMN preferred_source TEXT NOT NULL DEFAULT ''")
         .execute(db)
         .await

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -11,7 +11,7 @@ use crate::services::custom_formats::{
 };
 use crate::services::source::{self, ClassificationResult, Resolution, Source};
 use crate::services::{
-    anilist::AnimeDetail, logger, media, nyaa::{self, SearchOptions, SearchResult}, quality, seadex,
+    anilist::{AnimeDetail, RelatedEntry}, logger, media, nyaa::{self, SearchOptions, SearchResult}, quality, seadex,
 };
 
 // ── Pre-compiled regexes for parse_release_numbers ─────────────────────────
@@ -145,11 +145,36 @@ pub async fn find_all_for_target(
     // it's suppressed automatically when the user has a
     // `SeaDexBestSpecification` CF to avoid double counting.
     let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
-    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
+    let seadex_payload = fetch_seadex_payload(
+        db,
+        seadex_needs_lookup,
+        detail.id,
+        display_title(detail),
+        &preferred_groups,
+        &preferred_res,
+        true,
+    )
+    .await;
+    let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
+
+    // Seed the candidate pool with SeaDex-curated releases so they're
+    // guaranteed to show up in the interactive search UI even when
+    // Nyaa's text search would miss them entirely (smol-style
+    // megapacks titled by season rather than entry).
+    for result in seadex_payload.candidates {
+        let dedupe_key = if !result.info_hash.is_empty() {
+            result.info_hash.clone()
+        } else {
+            result.title.to_lowercase()
+        };
+        if seen.insert(dedupe_key) {
+            candidates.push(result);
+        }
+    }
 
     let ctx = InteractiveQueryCtx {
         aliases: &aliases,
@@ -157,6 +182,7 @@ pub async fn find_all_for_target(
         preferred_resolution: &preferred_res,
         target,
         expected_season,
+        seadex_hashes: &seadex_hashes,
     };
 
     // Interactive search: allow batch results so user can see & pick them,
@@ -307,11 +333,36 @@ pub async fn collect_scored_batches_for_target(
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
 
     let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
-    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
+    let seadex_payload = fetch_seadex_payload(
+        db,
+        seadex_needs_lookup,
+        detail.id,
+        display_title(detail),
+        &preferred_groups,
+        &preferred_res,
+        true,
+    )
+    .await;
+    let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
+
+    // Seed with SeaDex-curated candidates fetched directly from their
+    // view URLs. See `find_all_for_target` for the rationale — the
+    // text-query sweep can't find batches whose titles don't carry
+    // the target's alias tokens.
+    for result in seadex_payload.candidates {
+        let dedupe_key = if !result.info_hash.is_empty() {
+            result.info_hash.clone()
+        } else {
+            result.title.to_lowercase()
+        };
+        if seen.insert(dedupe_key) {
+            candidates.push(result);
+        }
+    }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
 
@@ -324,6 +375,7 @@ pub async fn collect_scored_batches_for_target(
         expected_season,
         categories: &categories,
         batch_episode_match: false,
+        seadex_hashes: &seadex_hashes,
     };
 
     // Standard query sweep — picks up any batches that happen to surface
@@ -446,11 +498,39 @@ async fn collect_scored_for_target(
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
 
     let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
-    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
+    let seadex_payload = fetch_seadex_payload(
+        db,
+        seadex_needs_lookup,
+        detail.id,
+        display_title(detail),
+        &preferred_groups,
+        &preferred_res,
+        true,
+    )
+    .await;
+    let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
+
+    // Seed with SeaDex-curated candidates fetched directly from their
+    // view URLs — this is how the smol Kizumonogatari pack (titled
+    // `[smol] Monogatari (Season 9) ...`) gets into the pool for a
+    // Kizumonogatari Part 2 target whose text queries would never
+    // match the smol filename. The batch filter at `run_queries`
+    // already has a SeaDex-match bypass so `allow_batch=false` targets
+    // still see SeaDex-curated megapacks.
+    for result in seadex_payload.candidates {
+        let dedupe_key = if !result.info_hash.is_empty() {
+            result.info_hash.clone()
+        } else {
+            result.title.to_lowercase()
+        };
+        if seen.insert(dedupe_key) {
+            candidates.push(result);
+        }
+    }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
 
@@ -463,6 +543,7 @@ async fn collect_scored_for_target(
         expected_season,
         categories: &categories,
         batch_episode_match,
+        seadex_hashes: &seadex_hashes,
     };
 
     // Phase 1: standard queries (primary aliases + episode variants).
@@ -589,6 +670,16 @@ struct AutoQueryCtx<'a> {
     expected_season: i32,
     categories: &'a [String],
     batch_episode_match: bool,
+    /// Lowercase info hashes SeaDex has flagged as "best" for this
+    /// target's AniList ID. A candidate whose hash is in this set
+    /// bypasses the title/season/episode heuristic filters — SeaDex
+    /// has already confirmed the release by AniList ID, so any
+    /// title-based check is strictly inferior. Without this bypass,
+    /// a smol/neoDESU-style release titled `Monogatari (Season 9)`
+    /// would be rejected for a Kizumonogatari Part 2 target because
+    /// `parse_release_season` would see "Season 9" and disagree
+    /// with the Part-2 expected season.
+    seadex_hashes: &'a HashSet<String>,
 }
 
 /// Same idea, but for the interactive-search helper which has a
@@ -600,6 +691,15 @@ struct InteractiveQueryCtx<'a> {
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
     expected_season: i32,
+    /// See the note on `AutoQueryCtx::seadex_hashes`. The interactive
+    /// path's consequences for failing the bypass are more severe
+    /// than the auto path: `run_queries_interactive` applies
+    /// `season_mismatch` *unconditionally*, including for Single
+    /// (movie) targets, where the auto path's `matches_target`
+    /// skips it. That's why the smol Kizumonogatari II release
+    /// vanished from interactive search even though auto search
+    /// surfaced it.
+    seadex_hashes: &'a HashSet<String>,
 }
 
 /// Run a set of queries against Nyaa page 1, collecting valid candidates.
@@ -635,11 +735,27 @@ async fn run_queries(
                 if !seen.insert(dedupe_key) {
                     continue;
                 }
-                if !ctx.allow_batch && result.is_batch {
-                    continue;
-                }
-                if !matches_target(&result.title, ctx.aliases, ctx.target, ctx.expected_season, ctx.batch_episode_match && result.is_batch) {
-                    continue;
+                // SeaDex trusts its AniList-ID-based curation over any
+                // title heuristic. A hash match here means the release
+                // is the community-curated best for this series, even
+                // if its Nyaa title carries a season marker that would
+                // otherwise fail `matches_target` (e.g. smol's
+                // `Monogatari (Season 9)` release for a Kizumonogatari
+                // Part 2 target).
+                let is_seadex_best = is_seadex_match(&result.info_hash, ctx.seadex_hashes);
+                if !is_seadex_best {
+                    if !ctx.allow_batch && result.is_batch {
+                        continue;
+                    }
+                    if !matches_target(&result.title, ctx.aliases, ctx.target, ctx.expected_season, ctx.batch_episode_match && result.is_batch) {
+                        continue;
+                    }
+                } else {
+                    tracing::debug!(
+                        "seadex: bypassing heuristic filters for SeaDex-best release title={:?} hash={}",
+                        result.title,
+                        result.info_hash
+                    );
                 }
                 candidates.push(result);
             }
@@ -680,6 +796,22 @@ async fn run_queries_interactive(
                 result.title.to_lowercase()
             };
             if !seen.insert(dedupe_key) {
+                continue;
+            }
+            // SeaDex trusts its AniList-ID-based curation over any
+            // title heuristic. If this hash is in the set, skip all
+            // alias / season / episode checks below — the unconditional
+            // `season_mismatch` in particular drops releases like
+            // smol's `Monogatari (Season 9)` for a Kizumonogatari Part
+            // 2 target, even though SeaDex has already confirmed the
+            // AniList ID match.
+            if is_seadex_match(&result.info_hash, ctx.seadex_hashes) {
+                tracing::debug!(
+                    "seadex: bypassing heuristic filters for SeaDex-best release title={:?} hash={}",
+                    result.title,
+                    result.info_hash
+                );
+                candidates.push(result);
                 continue;
             }
             // Relaxed alias matching: lower threshold than auto search
@@ -1039,13 +1171,158 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
 /// usable "best" info hashes. Disabled (or lookup-failed) returns an
 /// empty set, which causes the scoring-time SeaDex bonus and any
 /// `SeaDexBest` Custom Format spec to harmlessly contribute zero.
-async fn fetch_seadex_hashes(seadex_enabled: bool, anilist_id: i64) -> HashSet<String> {
-    if !seadex_enabled || anilist_id <= 0 {
-        return HashSet::new();
+///
+/// Emits both `tracing::debug!` lines (for `RUST_LOG=ryokan=debug`
+/// console readers) and `LogCategory::AutoSearch` rows (for the
+/// in-app Log Viewer) for every call — skip, hit, miss, and error.
+/// The previous version silently swallowed errors into
+/// `HashSet::new()`, which made a dead releases.moe indistinguishable
+/// from "SeaDex not configured" or "this title isn't on SeaDex."
+/// Everything the auto-search pipeline needs from one SeaDex lookup:
+/// the set of "best" info hashes (for the filter bypass and score
+/// overlay) and fully-populated `SearchResult` candidates built
+/// directly from each curated torrent's Nyaa view page.
+///
+/// The pre-fetched candidates are the key to surfacing SeaDex releases
+/// whose Nyaa titles don't overlap with the target's AniList aliases
+/// (smol's `Monogatari (Season 9)` megapack for Kizumonogatari Part 2
+/// is the canonical example). The text-query sweep can't find them;
+/// we go direct to `/view/<id>` and inject the result ourselves.
+#[derive(Default)]
+struct SeaDexPayload {
+    hashes: HashSet<String>,
+    /// Synthetic candidates fetched directly from each SeaDex-curated
+    /// torrent's Nyaa view URL. Empty when the lookup is skipped or
+    /// fails, or when every fetch fails. Merged into the candidate
+    /// pool by the caller before the text-query sweep runs.
+    candidates: Vec<SearchResult>,
+}
+
+async fn fetch_seadex_payload(
+    db: &SqlitePool,
+    seadex_enabled: bool,
+    anilist_id: i64,
+    series_title: &str,
+    preferred_groups: &[String],
+    preferred_resolution: &str,
+    prefer_subs: bool,
+) -> SeaDexPayload {
+    if !seadex_enabled {
+        tracing::debug!(
+            "seadex: skipping lookup — gate off (seadex_enabled=false and no SeaDex CF installed)"
+        );
+        // Intentionally no DB log row for the "gate off" path — this
+        // would spam the Log Viewer with one line per search for every
+        // user who hasn't turned SeaDex on.
+        return SeaDexPayload::default();
     }
+    if anilist_id <= 0 {
+        tracing::debug!(
+            "seadex: skipping lookup — no AniList ID on target (anilist_id={anilist_id})"
+        );
+        logger::debug(
+            db,
+            LogCategory::AutoSearch,
+            &format!("SeaDex lookup skipped for {series_title}"),
+            &format!("no AniList ID (anilist_id={anilist_id})"),
+        )
+        .await;
+        return SeaDexPayload::default();
+    }
+    tracing::debug!("seadex: fetching releases.moe entry for anilist_id={anilist_id}");
     match seadex::lookup(anilist_id).await {
-        Ok(Some(entry)) => seadex::best_hashes(&entry),
-        _ => HashSet::new(),
+        Ok(Some(entry)) => {
+            let hashes = seadex::best_hashes(&entry);
+            tracing::debug!(
+                "seadex: releases.moe returned {} usable hash(es) for anilist_id={}",
+                hashes.len(),
+                anilist_id
+            );
+            logger::debug(
+                db,
+                LogCategory::AutoSearch,
+                &format!(
+                    "SeaDex lookup: {} usable hash(es) for {series_title}",
+                    hashes.len()
+                ),
+                &format!("anilist_id={anilist_id}"),
+            )
+            .await;
+
+            // Fetch each usable torrent's view page so we have a real
+            // SearchResult to inject into the candidate list. This is
+            // what keeps SeaDex-curated releases discoverable even when
+            // the text-query sweep can't find them by title. Failures
+            // are non-fatal: we log and move on to the next torrent.
+            let opts_for_score = nyaa::SearchOptions {
+                query: series_title.to_string(),
+                category: "1_0".to_string(),
+                filter: "0".to_string(),
+                user: String::new(),
+                preferred_groups: preferred_groups.to_vec(),
+                preferred_resolution: preferred_resolution.to_string(),
+                prefer_subs,
+            };
+            let mut candidates = Vec::new();
+            for torrent in entry.torrents.iter() {
+                if !seadex::is_usable(torrent, &entry.notes) {
+                    continue;
+                }
+                let view_url = seadex::to_nyaa_view_url(torrent);
+                match nyaa::fetch_view_result(view_url, &opts_for_score).await {
+                    Ok(result) => {
+                        tracing::debug!(
+                            "seadex: injected curated candidate from view url={} title={:?} hash={}",
+                            view_url,
+                            result.title,
+                            result.info_hash
+                        );
+                        candidates.push(result);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "seadex: failed to fetch view page for {}: {}",
+                            view_url,
+                            e
+                        );
+                        logger::warn(
+                            db,
+                            LogCategory::AutoSearch,
+                            &format!("SeaDex view-page fetch failed for {series_title}"),
+                            &format!("url={view_url}, error={e}"),
+                        )
+                        .await;
+                    }
+                }
+            }
+            SeaDexPayload { hashes, candidates }
+        }
+        Ok(None) => {
+            tracing::debug!(
+                "seadex: releases.moe has no entry for anilist_id={anilist_id}"
+            );
+            logger::debug(
+                db,
+                LogCategory::AutoSearch,
+                &format!("SeaDex has no entry for {series_title}"),
+                &format!("anilist_id={anilist_id}"),
+            )
+            .await;
+            SeaDexPayload::default()
+        }
+        Err(e) => {
+            tracing::warn!(
+                "seadex: releases.moe lookup failed for anilist_id={anilist_id}: {e}"
+            );
+            logger::warn(
+                db,
+                LogCategory::AutoSearch,
+                &format!("SeaDex lookup failed for {series_title}"),
+                &format!("anilist_id={anilist_id}, error={e}"),
+            )
+            .await;
+            SeaDexPayload::default()
+        }
     }
 }
 
@@ -1064,6 +1341,31 @@ fn seadex_gates(
     let needs_lookup = config.seadex_enabled || has_cf;
     let boost_enabled = config.seadex_enabled && !has_cf;
     (needs_lookup, boost_enabled)
+}
+
+/// True if `info_hash` (non-empty) is in the SeaDex best-hashes set.
+/// Comparison is case-insensitive via lowercase normalization — the
+/// hash set is populated with lowercase hashes by `seadex::best_hashes`,
+/// and Nyaa-scraped hashes come through `extract_hash` already
+/// lowercased, but the explicit `to_ascii_lowercase` here keeps the
+/// contract obvious at the call sites.
+fn is_seadex_match(info_hash: &str, seadex_hashes: &HashSet<String>) -> bool {
+    if info_hash.is_empty() || seadex_hashes.is_empty() {
+        return false;
+    }
+    seadex_hashes.contains(&info_hash.to_ascii_lowercase())
+}
+
+/// Human-readable short label for a series, used in SeaDex lookup log
+/// rows. Prefers the English title and falls back to romaji so users
+/// browsing the Log Viewer see the same title the Auto Search banner
+/// uses.
+fn display_title(detail: &AnimeDetail) -> &str {
+    if !detail.title_english.is_empty() {
+        &detail.title_english
+    } else {
+        &detail.title_romaji
+    }
 }
 
 /// Apply the Custom Format + SeaDex overlay to a base score.
@@ -1418,6 +1720,550 @@ pub fn parse_release_season(title: &str) -> i32 {
     0
 }
 
+// ── Pre-compiled regexes for extract_part_number ───────────────────────────
+//
+// `extract_part_number` recovers the "which entry in a multi-part release"
+// number from an AniList title so the selective-download path can match
+// it against per-file episode numbers inside a megapack. This is distinct
+// from `infer_season_from_detail`, which is about season/cour indexing
+// for the *query* sweep. A movie trilogy like Kizumonogatari I/II/III
+// has no season at all, just parts.
+static RE_PART_N: LazyLock<Regex> = LazyLock::new(||
+    Regex::new(r"(?i)\b(?:part|chapter|movie|film)\s*(\d{1,2})\b").unwrap()
+);
+
+/// Bare Roman numeral at a word boundary. Covers the I–X range, which
+/// spans every multi-part anime film series we care about. Matches at
+/// end of string or before common separators (`:` for subtitle, space,
+/// `-`) so titles like "Kizumonogatari II: Nekketsu-hen" and
+/// "Rebuild of Evangelion III" both resolve cleanly.
+static RE_ROMAN_PART: LazyLock<Regex> = LazyLock::new(||
+    Regex::new(r"(?i)\b(i{1,3}|iv|v|vi{1,3}|ix|x)\b(?:\s*[:\-]|$|\s)").unwrap()
+);
+
+/// Extract the "part number" from an AniList detail's titles. Returns
+/// `None` when the title carries no such marker — the common case for
+/// single-film works and standalone TV seasons.
+///
+/// This is used by the selective-file download path: when the user
+/// grabs a megapack (e.g. the smol Monogatari pack containing Kizumo
+/// I, II, III as separate files), we need to know "the target is part
+/// 2" so `pick_wanted_file_indices` can match it against the E02 file.
+///
+/// Matching order (first hit wins):
+///   1. Explicit `Part N` / `Chapter N` / `Movie N` / `Film N`
+///   2. Roman numeral I–X at a word boundary
+///
+/// We check all three alias titles (romaji, english, native). Native
+/// is unlikely to fire the English regexes but it's cheap to include.
+pub fn extract_part_number(detail: &AnimeDetail) -> Option<i32> {
+    let titles = [
+        detail.title_english.as_str(),
+        detail.title_romaji.as_str(),
+        detail.title_native.as_str(),
+    ];
+    for title in titles.iter().filter(|t| !t.is_empty()) {
+        if let Some(caps) = RE_PART_N.captures(title) {
+            if let Some(n) = caps.get(1).and_then(|m| m.as_str().parse::<i32>().ok()) {
+                if (1..=20).contains(&n) {
+                    return Some(n);
+                }
+            }
+        }
+        if let Some(caps) = RE_ROMAN_PART.captures(title) {
+            if let Some(m) = caps.get(1) {
+                let n = roman_to_int(m.as_str());
+                if (1..=10).contains(&n) {
+                    return Some(n);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Convert a Roman numeral in the I–X range to its integer value.
+/// Returns 0 on anything outside that range so the caller's bounds
+/// check can cleanly reject it.
+fn roman_to_int(s: &str) -> i32 {
+    match s.to_ascii_uppercase().as_str() {
+        "I" => 1,
+        "II" => 2,
+        "III" => 3,
+        "IV" => 4,
+        "V" => 5,
+        "VI" => 6,
+        "VII" => 7,
+        "VIII" => 8,
+        "IX" => 9,
+        "X" => 10,
+        _ => 0,
+    }
+}
+
+/// Given the file list of a multi-entry pack torrent and the AniList
+/// detail of the user's target, return the indices of the files that
+/// correspond to the target. Returns `None` when we can't narrow the
+/// selection — the safe default is "keep everything" rather than
+/// guessing wrong and skipping the one file the user wanted.
+///
+/// Two narrowing strategies are tried in order:
+///
+/// 1. **Part number** via [`extract_part_number`]. Handles trilogies
+///    and multi-part OVAs where AniList titles end in "II", "III",
+///    "Part 2", etc. File selection is done by parsing episode-like
+///    numbers from each filename (via [`parse_release_numbers`]) and
+///    keeping files whose numbers contain the target part.
+///
+/// 2. **Positive subtitle match** via [`extract_season_subtitle`].
+///    Handles franchise megapacks where the target itself carries a
+///    distinguishing suffix after `:` or ` - ` — e.g. "JoJo's Bizarre
+///    Adventure: Stardust Crusaders" inside a JoJo S1–S5 pack. The
+///    filename must contain the normalized subtitle.
+///
+/// Non-media files (NFO, TXT, subtitles) are ignored so they don't
+/// dilute the selection. In both strategies, the result must fall
+/// within the target's expected episode count (×1.5 + 2 for slack)
+/// or we return `None` — guards against positive matches that
+/// accidentally sweep in bonus features or siblings that share a
+/// subtitle substring.
+///
+/// Note: **franchise roots without their own subtitle** (e.g. JoJo S1
+/// = "JoJo's Bizarre Adventure") are intentionally NOT narrowed here.
+/// They're handled by the higher-level multi-series pack detection
+/// path which downloads the full pack and auto-adds detected sibling
+/// entries to the library instead — a cleaner answer than
+/// filename-based negative matching, which is prone to partial
+/// coverage when AniList relations don't include every sibling.
+pub fn pick_wanted_file_indices(
+    filenames: &[String],
+    detail: &AnimeDetail,
+) -> Option<Vec<usize>> {
+    if let Some(part) = extract_part_number(detail) {
+        if let Some(ids) = pick_by_part_number(filenames, part, detail) {
+            return Some(ids);
+        }
+    }
+    if let Some(subtitle) = extract_season_subtitle(detail) {
+        if let Some(ids) = pick_by_subtitle_include(filenames, &subtitle, detail) {
+            return Some(ids);
+        }
+    }
+    None
+}
+
+fn pick_by_part_number(
+    filenames: &[String],
+    part: i32,
+    detail: &AnimeDetail,
+) -> Option<Vec<usize>> {
+    let mut matches: Vec<usize> = Vec::new();
+    let mut media_count = 0usize;
+    for (idx, name) in filenames.iter().enumerate() {
+        if !is_media_filename(name) {
+            continue;
+        }
+        media_count += 1;
+        if parse_release_numbers(name).contains(&part) {
+            matches.push(idx);
+        }
+    }
+    if matches.is_empty() || matches.len() >= media_count {
+        return None;
+    }
+    if !within_expected_episode_count(matches.len(), detail) {
+        return None;
+    }
+    Some(matches)
+}
+
+fn pick_by_subtitle_include(
+    filenames: &[String],
+    subtitle: &str,
+    detail: &AnimeDetail,
+) -> Option<Vec<usize>> {
+    let needle = normalize_subtitle(subtitle);
+    if needle.is_empty() {
+        return None;
+    }
+    let mut matches: Vec<usize> = Vec::new();
+    let mut media_count = 0usize;
+    for (idx, name) in filenames.iter().enumerate() {
+        if !is_media_filename(name) {
+            continue;
+        }
+        media_count += 1;
+        if normalize_subtitle(name).contains(&needle) {
+            matches.push(idx);
+        }
+    }
+    if matches.is_empty() || matches.len() >= media_count {
+        return None;
+    }
+    if !within_expected_episode_count(matches.len(), detail) {
+        return None;
+    }
+    Some(matches)
+}
+
+/// Sanity-cap the narrowed selection against the target's expected
+/// episode count. Rejects selections that are implausibly larger than
+/// the target's own season (×1.5 slack plus 2 for rounding / bonus
+/// features / BD extras). Without this guard, a positive subtitle
+/// match could accidentally sweep in files for a longer sibling that
+/// shares a subtitle substring, and the selective log line would
+/// mask the overshoot as a successful narrowing.
+///
+/// Shows that are still airing report `episodes: None` from AniList;
+/// in that case `effective_episode_count()` falls back to
+/// `nextAiringEpisode - 1`, which is 0 during the week-0 pre-airing
+/// window. Returning `true` unconditionally for 0-count targets keeps
+/// the cap disabled for airing shows and lets the strategy's own
+/// `matches.len() < media_count` guard carry the safety load.
+fn within_expected_episode_count(matches_len: usize, detail: &AnimeDetail) -> bool {
+    within_episode_slack(matches_len, detail.effective_episode_count())
+}
+
+/// Raw-count version of [`within_expected_episode_count`]. Shared with
+/// [`detect_sibling_entries_in_pack`], where the "expected" value comes
+/// from a `RelatedEntry` card that doesn't carry `next_airing_episode`
+/// and therefore can't use `effective_episode_count`.
+fn within_episode_slack(matches_len: usize, expected: i32) -> bool {
+    if expected <= 0 {
+        return true;
+    }
+    let slack = (expected as f32 * 1.5).ceil() as usize + 2;
+    matches_len <= slack
+}
+
+/// Extract a season "subtitle" — the trailing portion of the target's
+/// title after a delimiter like `: ` or ` - `. For example:
+/// * "JoJo no Kimyou na Bouken: Stardust Crusaders" → `Some("Stardust Crusaders")`
+/// * "Fate/stay night: Unlimited Blade Works" → `Some("Unlimited Blade Works")`
+/// * "Fullmetal Alchemist: Brotherhood" → `None` (single-token subtitle)
+/// * "JoJo's Bizarre Adventure" → `None` (no delimiter)
+/// * "Monogatari Series: Second Season" → `None` (generic ordinal)
+///
+/// Prefers the English title, falls back to romaji. Rejects single-token
+/// subtitles because they substring-match too aggressively, and rejects
+/// pure ordinal "Nth Season" phrasings because release filenames almost
+/// always carry "S02" / "2nd" rather than the English rendering, so
+/// matching on them yields zero hits and forces the full-pack fallback
+/// anyway.
+pub fn extract_season_subtitle(detail: &AnimeDetail) -> Option<String> {
+    let titles = [
+        detail.title_english.as_str(),
+        detail.title_romaji.as_str(),
+    ];
+    for title in titles.iter().filter(|t| !t.is_empty()) {
+        if let Some(sub) = trailing_subtitle_of(title) {
+            return Some(sub);
+        }
+    }
+    None
+}
+
+fn trailing_subtitle_of(title: &str) -> Option<String> {
+    // Normalize CJK/en/em dashes and colon-space to a common delimiter.
+    // Preserving "Re:" / "Fate/" (no space after) means "Re:Zero kara..."
+    // and "Fate/stay night" stay intact and only the trailing "`: Sub`"
+    // portion gets split off.
+    let normalized = title
+        .replace(['–', '—'], "|")
+        .replace(": ", "|")
+        .replace('：', "|")
+        .replace(" - ", "|");
+    // Take the LAST segment so "A: B: C" resolves to the innermost "C".
+    let last = normalized.rsplit('|').next()?.trim();
+    if last.is_empty() || last.eq_ignore_ascii_case(title.trim()) {
+        return None;
+    }
+    // Require ≥ 2 whitespace tokens. Single-word subtitles like
+    // "Brotherhood" are too generic to reliably narrow a filename list
+    // without false positives on unrelated entries in the same pack.
+    if last.split_whitespace().count() < 2 {
+        return None;
+    }
+    let lower = last.to_ascii_lowercase();
+    if is_generic_season_subtitle(&lower) {
+        return None;
+    }
+    Some(last.to_string())
+}
+
+/// Returns true for subtitle phrases that are pure ordinal/numeric
+/// season markers (e.g. "Second Season", "2nd Season", "Part 3"). These
+/// are rejected by [`extract_season_subtitle`] because release filenames
+/// overwhelmingly carry "S02" / "2nd" rather than the English rendering,
+/// so substring-matching them produces zero hits and falls back to a
+/// full-pack download anyway. Better to skip the selective path.
+fn is_generic_season_subtitle(lower: &str) -> bool {
+    matches!(
+        lower,
+        "first season"
+            | "second season"
+            | "third season"
+            | "fourth season"
+            | "fifth season"
+            | "sixth season"
+            | "seventh season"
+            | "eighth season"
+            | "ninth season"
+            | "tenth season"
+            | "1st season"
+            | "2nd season"
+            | "3rd season"
+            | "4th season"
+            | "5th season"
+            | "6th season"
+            | "7th season"
+            | "8th season"
+            | "9th season"
+            | "10th season"
+    ) || lower.starts_with("part ")
+        || lower.starts_with("chapter ")
+}
+
+/// True when the target has a discriminator that [`pick_wanted_file_indices`]
+/// can use to narrow a megapack — part number or own subtitle. Gate at
+/// the call sites so the expensive metadata-wait path is only entered
+/// when it has a chance of actually narrowing the file list.
+///
+/// Franchise roots without their own subtitle (JoJo S1 = "JoJo's
+/// Bizarre Adventure") deliberately return `false` here — they're
+/// handled by the higher-level multi-series pack auto-expansion path,
+/// not by filename-based negative matching, which produces silent
+/// wrong-selections when AniList relations only list direct siblings.
+pub fn has_selective_discriminator(detail: &AnimeDetail) -> bool {
+    extract_part_number(detail).is_some() || extract_season_subtitle(detail).is_some()
+}
+
+/// A sibling anime entry detected in the filename list of a megapack
+/// torrent — i.e. a related series (sequel, prequel, side story, …)
+/// of the parent target whose own files are also present in the pack.
+///
+/// Produced by [`detect_sibling_entries_in_pack`] and consumed by the
+/// library auto-expand path in `handlers::library`, which upserts each
+/// sibling into the tracked series table and records per-file routing
+/// so post-processing can move each file into the correct media
+/// folder.
+///
+/// All title / cover / format fields come straight from the parent
+/// detail's `relations` card so `series::upsert` has enough to
+/// populate a complete row without a second metadata fetch.
+#[derive(Debug, Clone)]
+pub struct SiblingMatch {
+    pub anilist_id: i64,
+    pub mal_id: Option<i64>,
+    pub title_romaji: String,
+    pub title_english: String,
+    pub title_native: String,
+    pub cover_url: String,
+    pub format: String,
+    pub status: String,
+    pub episodes: Option<i32>,
+    pub season_year: Option<i32>,
+    /// The subtitle that produced the match (e.g. "Stardust
+    /// Crusaders"). Logged at grab time so the operator can see *why*
+    /// a sibling was picked up.
+    pub matched_subtitle: String,
+    /// Indices into the torrent's file list of files that belong to
+    /// this sibling. Each file index is unique across the full return
+    /// value — [`detect_sibling_entries_in_pack`] resolves overlaps by
+    /// longest-subtitle-wins.
+    pub file_indices: Vec<usize>,
+}
+
+/// Relation types we'll consider in-pack candidates when scanning an
+/// AniList relation graph for siblings. Excludes source material
+/// (`ADAPTATION`, `SOURCE`, `COMPILATION`, `CONTAINS`) because those
+/// point at manga / LN / book entries that will never appear in an
+/// anime torrent. Everything else — `SEQUEL`, `PREQUEL`, `SIDE_STORY`,
+/// `PARENT`, `ALTERNATIVE`, `SPIN_OFF`, `CHARACTER`, `SUMMARY`,
+/// `OTHER` — passes through because the downstream subtitle-match +
+/// episode-count cap are already doing the real false-positive
+/// filtering. This gate is just a performance filter that avoids
+/// normalizing obvious non-anime titles against every filename.
+fn is_pack_candidate_relation(relation_type: &str) -> bool {
+    !matches!(
+        relation_type,
+        "ADAPTATION" | "SOURCE" | "COMPILATION" | "CONTAINS"
+    )
+}
+
+/// Detect sibling anime entries (sequel / prequel / side story /
+/// etc. of the parent) whose own episodes are present in a megapack
+/// release's file list.
+///
+/// **Provenance gate:** returns an empty `Vec` when
+/// `parent_detail.id <= 0`. Negative IDs are the Jikan fallback
+/// sentinel (`-mal_id`) and non-positive IDs are not AniList entries.
+/// Jikan's relations scrape reflects MAL's graph, and MAL splits
+/// sagas that AniList merges (Stone Ocean is 3 MAL entries vs 1 AL
+/// entry), so auto-adding MAL siblings against an AL-sourced parent
+/// would duplicate library rows. When AL is down, the grab still
+/// proceeds — it just skips sibling expansion — and the background
+/// 12h metadata refresh will retroactively run detection the next
+/// time AL returns the relation list.
+///
+/// **Overlap resolution:** when a filename matches more than one
+/// sibling subtitle (e.g. "Stardust" ⊂ "Stardust Crusaders", or a
+/// freak collision between two unrelated sibling titles), the longer
+/// normalized subtitle wins. Each file index appears in exactly one
+/// `SiblingMatch::file_indices` across the return value.
+///
+/// **Episode-count cap:** each sibling's match set is rejected if it
+/// overshoots the sibling's own AniList `episodes` count by ×1.5 + 2.
+/// Matches with `episodes: None` bypass the cap (airing series, which
+/// the downstream grab path handles anyway).
+///
+/// Callers get a best-effort list — siblings whose title has no
+/// trailing subtitle (e.g. a franchise root like "Naruto Shippuden")
+/// are silently skipped, matching the conservative behavior of
+/// `pick_wanted_file_indices`.
+pub fn detect_sibling_entries_in_pack(
+    filenames: &[String],
+    parent_detail: &AnimeDetail,
+) -> Vec<SiblingMatch> {
+    if parent_detail.id <= 0 {
+        return Vec::new();
+    }
+
+    // Candidates: one entry per relation that produced a usable
+    // subtitle. Stored by index into `parent_detail.relations` to
+    // avoid borrowing complications during the materialize pass.
+    let mut candidates: Vec<(usize, String, String)> = Vec::new(); // (rel_idx, raw subtitle, normalized needle)
+    for (rel_idx, rel) in parent_detail.relations.iter().enumerate() {
+        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        if !is_pack_candidate_relation(&rel.relation_type) {
+            continue;
+        }
+        let sibling_title = if !rel.title_english.is_empty() {
+            rel.title_english.as_str()
+        } else if !rel.title_romaji.is_empty() {
+            rel.title_romaji.as_str()
+        } else {
+            continue;
+        };
+        let Some(subtitle) = trailing_subtitle_of(sibling_title) else {
+            continue;
+        };
+        let needle = normalize_subtitle(&subtitle);
+        if needle.is_empty() {
+            continue;
+        }
+        candidates.push((rel_idx, subtitle, needle));
+    }
+
+    if candidates.is_empty() {
+        return Vec::new();
+    }
+
+    // First pass: for each media file, pick the candidate with the
+    // LONGEST normalized needle that substring-matches the filename.
+    // Longest-wins handles the Stardust ⊂ Stardust Crusaders case
+    // without ever double-counting a file.
+    let mut winner_by_file: std::collections::HashMap<usize, (usize, usize)> =
+        std::collections::HashMap::new(); // file_idx → (candidate_idx, needle_len)
+    for (file_idx, name) in filenames.iter().enumerate() {
+        if !is_media_filename(name) {
+            continue;
+        }
+        let normalized = normalize_subtitle(name);
+        let mut best: Option<(usize, usize)> = None; // (candidate_idx, needle_len)
+        for (cand_idx, (_, _, needle)) in candidates.iter().enumerate() {
+            if !normalized.contains(needle) {
+                continue;
+            }
+            match best {
+                Some((_, cur_len)) if cur_len >= needle.len() => {}
+                _ => best = Some((cand_idx, needle.len())),
+            }
+        }
+        if let Some(pick) = best {
+            winner_by_file.insert(file_idx, pick);
+        }
+    }
+
+    // Bucket files by winning candidate.
+    let mut per_candidate: Vec<Vec<usize>> = vec![Vec::new(); candidates.len()];
+    for (file_idx, (cand_idx, _)) in winner_by_file {
+        per_candidate[cand_idx].push(file_idx);
+    }
+    for list in per_candidate.iter_mut() {
+        list.sort_unstable();
+    }
+
+    // Materialize results. Drop candidates with no files and enforce
+    // the per-sibling episode-count sanity cap.
+    let mut out: Vec<SiblingMatch> = Vec::new();
+    for (cand_idx, (rel_idx, subtitle, _)) in candidates.into_iter().enumerate() {
+        let file_indices = std::mem::take(&mut per_candidate[cand_idx]);
+        if file_indices.is_empty() {
+            continue;
+        }
+        let rel: &RelatedEntry = &parent_detail.relations[rel_idx];
+        if !within_episode_slack(file_indices.len(), rel.episodes.unwrap_or(0)) {
+            continue;
+        }
+        out.push(SiblingMatch {
+            anilist_id: rel.id,
+            mal_id: rel.id_mal,
+            title_romaji: rel.title_romaji.clone(),
+            title_english: rel.title_english.clone(),
+            title_native: rel.title_native.clone(),
+            cover_url: rel.cover_url.clone(),
+            format: rel.format.clone(),
+            status: rel.status.clone(),
+            episodes: rel.episodes,
+            season_year: rel.season_year,
+            matched_subtitle: subtitle,
+            file_indices,
+        });
+    }
+
+    out
+}
+
+/// Lowercase ASCII-alphanumeric chars and collapse non-alphanumeric
+/// runs to single spaces. Used to make subtitle-vs-filename comparisons
+/// robust to punctuation differences like "JoJo's" vs "JoJos",
+/// "Stardust-Crusaders" vs "Stardust Crusaders", or brackets.
+fn normalize_subtitle(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = true;
+    for ch in s.chars() {
+        if ch.is_ascii_alphanumeric() {
+            out.push(ch.to_ascii_lowercase());
+            prev_space = false;
+        } else if !prev_space {
+            out.push(' ');
+            prev_space = true;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Is this filename likely a media file that `parse_release_numbers`
+/// should even be run against? Used by [`pick_wanted_file_indices`] to
+/// stop non-media files (NFOs, subtitles, samples) from inflating the
+/// media count or being accidentally kept/skipped.
+pub(crate) fn is_media_filename(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    matches!(
+        lower.rsplit('.').next(),
+        Some("mkv")
+            | Some("mp4")
+            | Some("avi")
+            | Some("m2ts")
+            | Some("ts")
+            | Some("mov")
+            | Some("wmv")
+    )
+}
+
 /// Check if a release's season conflicts with the expected season.
 /// Returns true if there is a definite mismatch.
 fn season_mismatch(release_title: &str, expected_season: i32) -> bool {
@@ -1719,6 +2565,145 @@ mod tests {
         );
     }
 
+    // ── extract_part_number / pick_wanted_file_indices ────────────────────
+    //
+    // These cover the selective-file download path that lets Ryokan grab
+    // just one entry out of a multi-part megapack (Kizumonogatari I/II/III
+    // in a single smol release, Rebuild of Evangelion 1.0/2.0/3.0, etc.).
+
+    fn detail_with_titles(english: &str, romaji: &str) -> AnimeDetail {
+        AnimeDetail {
+            id: 1,
+            id_mal: None,
+            title_romaji: romaji.to_string(),
+            title_english: english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            banner_url: String::new(),
+            format: "MOVIE".to_string(),
+            status: String::new(),
+            status_display: String::new(),
+            episodes: Some(1),
+            duration: None,
+            season: String::new(),
+            season_year: None,
+            end_year: None,
+            description: String::new(),
+            genres: Vec::new(),
+            average_score: None,
+            average_score_display: None,
+            score_is_ten_point: false,
+            score_class: String::new(),
+            next_airing_episode: None,
+            next_airing_at: None,
+            synonyms: Vec::new(),
+            streaming_episodes: Vec::new(),
+            relations: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn extract_part_number_parses_roman_ii() {
+        let d = detail_with_titles("Kizumonogatari II: Nekketsu-hen", "Kizumonogatari II: Nekketsu-hen");
+        assert_eq!(extract_part_number(&d), Some(2));
+    }
+
+    #[test]
+    fn extract_part_number_parses_roman_iii() {
+        let d = detail_with_titles("Kizumonogatari III: Reiketsu-hen", "Kizumonogatari III: Reiketsu-hen");
+        assert_eq!(extract_part_number(&d), Some(3));
+    }
+
+    #[test]
+    fn extract_part_number_parses_explicit_part_n() {
+        let d = detail_with_titles("Some Show Part 2", "Some Show Part 2");
+        assert_eq!(extract_part_number(&d), Some(2));
+    }
+
+    #[test]
+    fn extract_part_number_returns_none_for_single_entry() {
+        // A standalone film with no part marker at all.
+        let d = detail_with_titles("A Silent Voice", "Koe no Katachi");
+        assert_eq!(extract_part_number(&d), None);
+    }
+
+    #[test]
+    fn extract_part_number_ignores_roman_i_alone() {
+        // "Part I" is a part marker, but ambiguous bare Roman numeral
+        // "I" at the end of a title still resolves to 1 — the Roman
+        // regex accepts it. That's intentional: a trilogy's first
+        // entry is titled "Kizumonogatari I: Tekketsu-hen", and the
+        // user may want to grab that part specifically.
+        let d = detail_with_titles("Kizumonogatari I: Tekketsu-hen", "Kizumonogatari I: Tekketsu-hen");
+        assert_eq!(extract_part_number(&d), Some(1));
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_narrows_smol_monogatari_pack() {
+        // Simulates the smol Monogatari megapack. The filenames carry
+        // standard S09EXX numbering that `parse_release_numbers` picks
+        // up, and the target's part number (from the AniList title's
+        // Roman numeral) selects the right file.
+        let files = vec![
+            "[smol] Monogatari - S09E01 - Kizumonogatari Tekketsu-hen.mkv".to_string(),
+            "[smol] Monogatari - S09E02 - Kizumonogatari Nekketsu-hen.mkv".to_string(),
+            "[smol] Monogatari - S09E03 - Kizumonogatari Reiketsu-hen.mkv".to_string(),
+        ];
+        let d = detail_with_titles("Kizumonogatari II: Nekketsu-hen", "Kizumonogatari II");
+        let picked = pick_wanted_file_indices(&files, &d).expect("should narrow");
+        assert_eq!(picked, vec![1]);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_returns_none_when_target_has_no_part() {
+        // Standalone single-file release — nothing to narrow against.
+        let files = vec!["[Group] Some Film (BD 1080p).mkv".to_string()];
+        let d = detail_with_titles("A Silent Voice", "Koe no Katachi");
+        assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_returns_none_when_no_match() {
+        // Target is part 2 but the pack doesn't contain an E02 file.
+        // Safer to keep everything than to skip every file.
+        let files = vec![
+            "[Group] Show - 01.mkv".to_string(),
+            "[Group] Show - 03.mkv".to_string(),
+        ];
+        let d = detail_with_titles("Show II", "Show II");
+        assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_ignores_non_media_files() {
+        let files = vec![
+            "[Group] Pack - 01.mkv".to_string(),
+            "[Group] Pack - 02.mkv".to_string(),
+            "[Group] Pack - 02.nfo".to_string(),
+            "[Group] Pack - 02.txt".to_string(),
+        ];
+        let d = detail_with_titles("Show II", "Show II");
+        let picked = pick_wanted_file_indices(&files, &d).expect("should narrow");
+        // Only the E02 .mkv survives — the .nfo and .txt with "02"
+        // in their names are discarded before matching.
+        assert_eq!(picked, vec![1]);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_returns_none_when_every_media_file_matches() {
+        // Not actually a megapack — every media file carries the target
+        // number (e.g. a single-movie torrent with sample + main file).
+        // Don't mess with priorities.
+        let files = vec![
+            "[Group] Show II (BD 1080p).mkv".to_string(),
+            "[Group] Show II (BD 1080p) - sample.mkv".to_string(),
+        ];
+        let d = detail_with_titles("Show II", "Show II");
+        // Neither file carries an episode number, so parse_release_numbers
+        // returns an empty set — no matches, None returned.
+        assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
     #[test]
     fn format_scoring_detail_surfaces_seadex_bonus() {
         // SeaDex bonus is the only non-CF overlay; make sure it shows
@@ -1730,5 +2715,395 @@ mod tests {
             s,
             "base=60, cf=+300 [x265 +300], seadex=10000, final=10360"
         );
+    }
+
+    // ── extract_season_subtitle / positive subtitle match ────────────────
+    //
+    // Covers the second narrowing strategy in `pick_wanted_file_indices` —
+    // positive subtitle match for titles with a distinguishing suffix.
+    // Franchise roots without their own subtitle (JoJo S1) are NOT
+    // narrowed here; they flow through to the multi-series pack
+    // auto-expansion path instead.
+
+    #[test]
+    fn extract_season_subtitle_pulls_named_season() {
+        // Positive case: the English title ends in `: Stardust Crusaders`,
+        // which is a distinctive multi-token phrase.
+        let d = detail_with_titles(
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            "JoJo no Kimyou na Bouken: Stardust Crusaders",
+        );
+        assert_eq!(extract_season_subtitle(&d).as_deref(), Some("Stardust Crusaders"));
+    }
+
+    #[test]
+    fn extract_season_subtitle_pulls_from_dash_delimited_title() {
+        // En-dash / hyphen-space delimiter also produces a subtitle.
+        let d = detail_with_titles("Fate/stay night - Unlimited Blade Works", "");
+        assert_eq!(extract_season_subtitle(&d).as_deref(), Some("Unlimited Blade Works"));
+    }
+
+    #[test]
+    fn extract_season_subtitle_rejects_single_token_suffix() {
+        // "Brotherhood" alone is too generic — it could substring-match
+        // an unrelated filename fragment. The 2-token minimum blocks it.
+        let d = detail_with_titles("Fullmetal Alchemist: Brotherhood", "");
+        assert_eq!(extract_season_subtitle(&d), None);
+    }
+
+    #[test]
+    fn extract_season_subtitle_rejects_generic_ordinal_season() {
+        // "Second Season" is a pure ordinal marker — release filenames
+        // carry "S02" / "2nd" rather than the English spelling, so
+        // matching on this would yield zero hits and fall back to the
+        // full pack anyway. Skip it upfront.
+        let d = detail_with_titles("Monogatari Series: Second Season", "");
+        assert_eq!(extract_season_subtitle(&d), None);
+    }
+
+    #[test]
+    fn extract_season_subtitle_returns_none_without_delimiter() {
+        // Franchise root with no subtitle — handled by the
+        // multi-series pack auto-expansion path, not here.
+        let d = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
+        assert_eq!(extract_season_subtitle(&d), None);
+    }
+
+    #[test]
+    fn extract_season_subtitle_preserves_re_zero_style_colon() {
+        // "Re:Zero kara Hajimeru Isekai Seikatsu" — the `:` has no
+        // following space, so it should NOT be split. The trailing
+        // segment rule returns the whole title, which equals the
+        // original → None.
+        let d = detail_with_titles("Re:Zero kara Hajimeru Isekai Seikatsu", "");
+        assert_eq!(extract_season_subtitle(&d), None);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_narrows_by_subtitle_positive_match() {
+        // Simulates a JoJo franchise megapack. The target carries its
+        // own distinguishing subtitle ("Stardust Crusaders") that
+        // appears in the S2 filenames but not in the S1 / S3 / S4 ones.
+        let files = vec![
+            "[Group] JoJo's Bizarre Adventure - 01.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - 26.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - Stardust Crusaders - 01.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - Stardust Crusaders - 48.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - Diamond is Unbreakable - 01.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - Golden Wind - 01.mkv".to_string(),
+        ];
+        let mut d = detail_with_titles(
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            "JoJo no Kimyou na Bouken: Stardust Crusaders",
+        );
+        // JoJo S2 is 48 episodes — sanity cap (×1.5 + 2 = 74) passes.
+        d.episodes = Some(48);
+        let picked = pick_wanted_file_indices(&files, &d).expect("should narrow");
+        assert_eq!(picked, vec![2, 3]);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_returns_none_for_subtitleless_franchise_root() {
+        // JoJo S1 — no subtitle, no part number. The selective path is
+        // intentionally not used here. The grab handler's multi-series
+        // auto-expansion (Phase 2) is what handles this case.
+        let files = vec![
+            "[Group] JoJo's Bizarre Adventure - 01.mkv".to_string(),
+            "[Group] JoJo's Bizarre Adventure - Stardust Crusaders - 01.mkv".to_string(),
+        ];
+        let d = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
+        assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_rejects_overshoot_via_episode_cap() {
+        // Contrived pathological case: the target's subtitle is a
+        // prefix of every file in a much larger pack. Episode count
+        // says 12 but the match set is 50 — the cap fires and we
+        // return None rather than producing a wildly-wrong narrowing.
+        let files: Vec<String> = (1..=50)
+            .map(|i| format!("[Group] Show - Alpha Beta Ep{:02}.mkv", i))
+            .collect();
+        let mut d = detail_with_titles("Show: Alpha Beta", "");
+        d.episodes = Some(12);
+        assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
+    #[test]
+    fn has_selective_discriminator_true_for_part_number_title() {
+        let d = detail_with_titles("Kizumonogatari II: Nekketsu-hen", "");
+        assert!(has_selective_discriminator(&d));
+    }
+
+    #[test]
+    fn has_selective_discriminator_true_for_subtitle_title() {
+        let d = detail_with_titles("JoJo's Bizarre Adventure: Stardust Crusaders", "");
+        assert!(has_selective_discriminator(&d));
+    }
+
+    #[test]
+    fn has_selective_discriminator_false_for_standalone_single() {
+        // No part number, no subtitle — selective path skipped.
+        let d = detail_with_titles("A Silent Voice", "Koe no Katachi");
+        assert!(!has_selective_discriminator(&d));
+    }
+
+    #[test]
+    fn has_selective_discriminator_false_for_franchise_root() {
+        // Franchise root without its own subtitle — selective path
+        // skipped on purpose. Multi-series auto-expansion handles it.
+        let d = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
+        assert!(!has_selective_discriminator(&d));
+    }
+
+    // ── detect_sibling_entries_in_pack ──────────────────────────────
+
+    fn related(
+        id: i64,
+        english: &str,
+        romaji: &str,
+        relation_type: &str,
+        episodes: Option<i32>,
+    ) -> RelatedEntry {
+        RelatedEntry {
+            id,
+            id_mal: None,
+            title_romaji: romaji.to_string(),
+            title_english: english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes,
+            relation_type: relation_type.to_string(),
+            season_year: None,
+            media_type: "ANIME".to_string(),
+        }
+    }
+
+    #[test]
+    fn detect_siblings_finds_named_seasons_in_jojo_pack() {
+        // Parent: JoJo S1 (franchise root, no subtitle of its own).
+        // Pack contains files for S1 (no subtitle), S3 Stardust
+        // Crusaders, and S4 Diamond is Unbreakable. Detection should
+        // return two sibling matches (Stardust + Diamond) with only
+        // their own files; S1 files stay unclaimed.
+        let mut parent = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
+        parent.id = 14719; // AL id
+        parent.episodes = Some(26);
+        parent.relations = vec![
+            related(
+                20800,
+                "JoJo's Bizarre Adventure: Stardust Crusaders",
+                "JoJo no Kimyou na Bouken: Stardust Crusaders",
+                "SEQUEL",
+                Some(24),
+            ),
+            related(
+                31292,
+                "JoJo's Bizarre Adventure: Diamond is Unbreakable",
+                "JoJo no Kimyou na Bouken: Diamond wa Kudakenai",
+                "SEQUEL",
+                Some(39),
+            ),
+        ];
+
+        let files: Vec<String> = vec![
+            // S1 files (unclaimed)
+            "[Group] JoJo no Kimyou na Bouken - 01.mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - 02.mkv".to_string(),
+            // Stardust Crusaders (24 eps, we include just 3 for brevity)
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 01.mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 02.mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 03.mkv".to_string(),
+            // Diamond is Unbreakable
+            "[Group] JoJo no Kimyou na Bouken - Diamond is Unbreakable - 01.mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - Diamond is Unbreakable - 02.mkv".to_string(),
+        ];
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 2, "expected Stardust + Diamond matches");
+
+        let stardust = siblings
+            .iter()
+            .find(|s| s.anilist_id == 20800)
+            .expect("stardust sibling present");
+        assert_eq!(stardust.file_indices, vec![2, 3, 4]);
+        assert!(
+            stardust.matched_subtitle.to_lowercase().contains("stardust"),
+            "matched_subtitle should reference Stardust, got {:?}",
+            stardust.matched_subtitle
+        );
+
+        let diamond = siblings
+            .iter()
+            .find(|s| s.anilist_id == 31292)
+            .expect("diamond sibling present");
+        assert_eq!(diamond.file_indices, vec![5, 6]);
+    }
+
+    #[test]
+    fn detect_siblings_returns_empty_for_jikan_sourced_detail() {
+        // Provenance gate: Jikan-sourced details have id < 0. Even
+        // if relations look plausible, we must not run sibling
+        // detection against them — MAL splits sagas AL merges, which
+        // would duplicate library rows.
+        let mut parent = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
+        parent.id = -1; // Jikan sentinel
+        parent.relations = vec![related(
+            -20800,
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            "",
+            "SEQUEL",
+            Some(24),
+        )];
+        let files: Vec<String> = vec![
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 01.mkv".to_string(),
+        ];
+        assert!(detect_sibling_entries_in_pack(&files, &parent).is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_resolves_overlap_by_longest_subtitle() {
+        // Two siblings whose subtitles form a prefix relationship. A
+        // filename containing the longer subtitle matches both
+        // normalized needles, but the longer one must win — otherwise
+        // we'd double-count the file.
+        let mut parent = detail_with_titles("Franchise", "Franchise");
+        parent.id = 100;
+        parent.relations = vec![
+            related(201, "Franchise: Alpha", "", "SEQUEL", Some(12)),
+            related(202, "Franchise: Alpha Prime", "", "SEQUEL", Some(12)),
+        ];
+        let files: Vec<String> = vec![
+            "[Group] Franchise - Alpha Prime - 01.mkv".to_string(),
+            "[Group] Franchise - Alpha Prime - 02.mkv".to_string(),
+        ];
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].anilist_id, 202);
+        assert_eq!(siblings[0].file_indices, vec![0, 1]);
+    }
+
+    #[test]
+    fn detect_siblings_skips_relations_without_own_subtitle() {
+        // "Naruto Shippuden" has no trailing delimiter so
+        // trailing_subtitle_of returns None and the sibling gets
+        // silently dropped. This is intentional — without a
+        // subtitle we can't safely narrow a filename list, so
+        // conservative over-skipping is the right call.
+        let mut parent = detail_with_titles("Naruto", "Naruto");
+        parent.id = 20;
+        parent.relations = vec![related(1735, "Naruto Shippuden", "", "SEQUEL", Some(500))];
+        let files: Vec<String> = vec!["[Group] Naruto Shippuden - 01.mkv".to_string()];
+        assert!(detect_sibling_entries_in_pack(&files, &parent).is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_rejects_episode_count_overshoot() {
+        // A sibling with episodes=12 whose subtitle accidentally
+        // matches 50 files in the pack. The episode-count cap
+        // (×1.5 + 2 = 20) fires and drops the sibling entirely
+        // rather than emitting a wildly-wrong routing.
+        let mut parent = detail_with_titles("Franchise", "Franchise");
+        parent.id = 100;
+        parent.relations = vec![related(201, "Franchise: Alpha Beta", "", "SEQUEL", Some(12))];
+        let files: Vec<String> = (1..=50)
+            .map(|i| format!("[Group] Franchise - Alpha Beta - {:02}.mkv", i))
+            .collect();
+        assert!(detect_sibling_entries_in_pack(&files, &parent).is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_filters_out_source_material_relations() {
+        // ADAPTATION / SOURCE / COMPILATION / CONTAINS relations
+        // point at manga / LN / book entries that will never appear
+        // in an anime torrent. Even if one happened to share a
+        // substring with a filename, the relation-type gate must
+        // drop it before we waste cycles on string matching.
+        let mut parent = detail_with_titles("JoJo's Bizarre Adventure", "");
+        parent.id = 14719;
+        parent.relations = vec![related(
+            2,
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            "",
+            "SOURCE",
+            Some(1),
+        )];
+        let files: Vec<String> = vec![
+            "[Group] JoJo - Stardust Crusaders - 01.mkv".to_string(),
+        ];
+        assert!(detect_sibling_entries_in_pack(&files, &parent).is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_ignores_non_anime_media_types() {
+        // AL returns the parent manga via a relation edge with
+        // media_type="MANGA". Never an anime torrent candidate.
+        let mut parent = detail_with_titles("Show", "");
+        parent.id = 10;
+        let mut manga_rel = related(
+            5,
+            "Show: Spinoff Arc",
+            "",
+            "SIDE_STORY",
+            Some(10),
+        );
+        manga_rel.media_type = "MANGA".to_string();
+        parent.relations = vec![manga_rel];
+        let files: Vec<String> = vec!["[Group] Show - Spinoff Arc - 01.mkv".to_string()];
+        assert!(detect_sibling_entries_in_pack(&files, &parent).is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_passes_through_spin_off_and_summary_relations() {
+        // Niche relation types (SPIN_OFF, SUMMARY, CHARACTER,
+        // ALTERNATIVE) are included in the filter — the subtitle
+        // match and episode-count cap do the downstream filtering.
+        let mut parent = detail_with_titles("Show", "");
+        parent.id = 10;
+        parent.relations = vec![
+            related(11, "Show: Recap Arc", "", "SUMMARY", Some(4)),
+            related(12, "Show: Extra Chapter", "", "SPIN_OFF", Some(6)),
+        ];
+        let files: Vec<String> = vec![
+            "[Group] Show - Recap Arc - 01.mkv".to_string(),
+            "[Group] Show - Recap Arc - 02.mkv".to_string(),
+            "[Group] Show - Extra Chapter - 01.mkv".to_string(),
+        ];
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 2);
+        let recap = siblings
+            .iter()
+            .find(|s| s.anilist_id == 11)
+            .expect("recap sibling present");
+        assert_eq!(recap.file_indices, vec![0, 1]);
+        let extra = siblings
+            .iter()
+            .find(|s| s.anilist_id == 12)
+            .expect("extra sibling present");
+        assert_eq!(extra.file_indices, vec![2]);
+    }
+
+    #[test]
+    fn detect_siblings_ignores_non_media_files_in_match_set() {
+        // Subtitles, NFOs, samples etc. must not count toward the
+        // episode cap or get routed. Only .mkv/.mp4/... files pass
+        // through is_media_filename.
+        let mut parent = detail_with_titles("Show", "");
+        parent.id = 10;
+        parent.relations = vec![related(11, "Show: Alpha Beta", "", "SEQUEL", Some(12))];
+        let files: Vec<String> = vec![
+            "[Group] Show - Alpha Beta - 01.mkv".to_string(),
+            "[Group] Show - Alpha Beta - 01.srt".to_string(),
+            "[Group] Show - Alpha Beta - readme.nfo".to_string(),
+        ];
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1);
+        // Only the .mkv file routes — the .srt and .nfo are filtered
+        // out by is_media_filename before they can inflate the match
+        // set.
+        assert_eq!(siblings[0].file_indices, vec![0]);
     }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -5,8 +5,11 @@ use regex_lite::Regex;
 use sqlx::SqlitePool;
 
 use crate::models::config::Config;
+use crate::services::custom_formats::{
+    self, CompiledCustomFormat, EvalContext,
+};
 use crate::services::source::{self, ClassificationResult, Resolution, Source};
-use crate::services::{anilist::AnimeDetail, media, nyaa::{self, SearchOptions, SearchResult}, quality};
+use crate::services::{anilist::AnimeDetail, media, nyaa::{self, SearchOptions, SearchResult}, quality, seadex};
 
 // ── Pre-compiled regexes for parse_release_numbers ─────────────────────────
 static RE_EPISODE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| vec![
@@ -119,6 +122,7 @@ pub async fn find_all_for_target(
     config: &Config,
     target: &SearchTarget,
     _allow_batch: bool,
+    cfs: &[CompiledCustomFormat],
 ) -> Vec<SearchResult> {
     let queries = build_queries(detail, target);
     let aliases = collect_aliases(detail);
@@ -131,6 +135,16 @@ pub async fn find_all_for_target(
     // Scoring only looks at Source rank, so drop the BluRay sub-tier.
     let (cutoff_source_enum, _, _) = source::parse_cutoff_source(&config.cutoff_source);
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
+
+    // Single SeaDex lookup per entry-point call, reused across every
+    // candidate in the loop below. The `has_seadex_cf` check suppresses
+    // the hardcoded boost when the user has a SeaDexBestSpecification CF.
+    let seadex_boost_enabled = config.seadex_enabled && !custom_formats::has_seadex_cf(cfs);
+    let seadex_hashes = fetch_seadex_hashes(
+        config.seadex_enabled || custom_formats::has_seadex_cf(cfs),
+        detail.id,
+    )
+    .await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -164,7 +178,13 @@ pub async fn find_all_for_target(
         run_queries_interactive(&group_queries, ctx, &mut seen, &mut candidates).await;
     }
 
-    for c in &mut candidates {
+    // Interactive search is user-driven — we want to *show* the
+    // CF-filtered candidates even when they'd be dropped by an
+    // auto-search path, so the minimum_score floor is suppressed here
+    // (passed as `i32::MIN`). The CF score still contributes to ranking
+    // so the user sees the same ordering the auto-picker would have used.
+    let mut scored: Vec<SearchResult> = Vec::with_capacity(candidates.len());
+    for mut c in candidates.drain(..) {
         let classification = source::classify_release(
             db,
             &c.title,
@@ -181,8 +201,8 @@ pub async fn find_all_for_target(
             }),
         )
         .await;
-        c.score = rescore_for_auto_search(
-            c,
+        let base = rescore_for_auto_search(
+            &c,
             &classification,
             config,
             &aliases,
@@ -195,10 +215,23 @@ pub async fn find_all_for_target(
             cutoff_source_enum,
             cutoff_resolution_enum,
         );
+        // No CF floor on the interactive path — see comment above.
+        if let Some(final_score) = apply_cf_seadex_overlay(
+            base,
+            &c,
+            &classification,
+            cfs,
+            &seadex_hashes,
+            seadex_boost_enabled,
+            i32::MIN,
+        ) {
+            c.score = final_score;
+            scored.push(c);
+        }
     }
 
-    candidates.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
-    candidates
+    scored.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
+    scored
 }
 
 pub async fn find_best_for_target(
@@ -208,8 +241,9 @@ pub async fn find_best_for_target(
     target: &SearchTarget,
     allow_batch: bool,
     batch_episode_match: bool,
+    cfs: &[CompiledCustomFormat],
 ) -> Option<SearchResult> {
-    collect_scored_for_target(db, detail, config, target, allow_batch, batch_episode_match)
+    collect_scored_for_target(db, detail, config, target, allow_batch, batch_episode_match, cfs)
         .await
         .into_iter()
         .next()
@@ -236,8 +270,9 @@ pub async fn find_best_batch_for_target(
     detail: &AnimeDetail,
     config: &Config,
     target: &SearchTarget,
+    cfs: &[CompiledCustomFormat],
 ) -> Option<SearchResult> {
-    collect_scored_batches_for_target(db, detail, config, target)
+    collect_scored_batches_for_target(db, detail, config, target, cfs)
         .await
         .into_iter()
         .next()
@@ -255,6 +290,7 @@ pub async fn collect_scored_batches_for_target(
     detail: &AnimeDetail,
     config: &Config,
     target: &SearchTarget,
+    cfs: &[CompiledCustomFormat],
 ) -> Vec<SearchResult> {
     let aliases = collect_aliases(detail);
     let preferred_groups = quality::parse_group_list(&config.preferred_groups);
@@ -265,6 +301,14 @@ pub async fn collect_scored_batches_for_target(
     let preferred_resolution_enum = Resolution::from_str(&config.preferred_resolution);
     let (cutoff_source_enum, _, _) = source::parse_cutoff_source(&config.cutoff_source);
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
+
+    let has_seadex_cf_flag = custom_formats::has_seadex_cf(cfs);
+    let seadex_boost_enabled = config.seadex_enabled && !has_seadex_cf_flag;
+    let seadex_hashes = fetch_seadex_hashes(
+        config.seadex_enabled || has_seadex_cf_flag,
+        detail.id,
+    )
+    .await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -336,7 +380,7 @@ pub async fn collect_scored_batches_for_target(
             continue;
         }
 
-        c.score = rescore_for_auto_search(
+        let base = rescore_for_auto_search(
             &c,
             &classification,
             config,
@@ -350,7 +394,18 @@ pub async fn collect_scored_batches_for_target(
             cutoff_source_enum,
             cutoff_resolution_enum,
         );
-        scored.push(c);
+        if let Some(final_score) = apply_cf_seadex_overlay(
+            base,
+            &c,
+            &classification,
+            cfs,
+            &seadex_hashes,
+            seadex_boost_enabled,
+            config.custom_format_minimum_score,
+        ) {
+            c.score = final_score;
+            scored.push(c);
+        }
     }
 
     scored.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
@@ -374,6 +429,7 @@ async fn collect_scored_for_target(
     target: &SearchTarget,
     allow_batch: bool,
     batch_episode_match: bool,
+    cfs: &[CompiledCustomFormat],
 ) -> Vec<SearchResult> {
     let queries = build_queries(detail, target);
     let aliases = collect_aliases(detail);
@@ -386,6 +442,14 @@ async fn collect_scored_for_target(
     // Scoring only looks at Source rank, so drop the BluRay sub-tier.
     let (cutoff_source_enum, _, _) = source::parse_cutoff_source(&config.cutoff_source);
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
+
+    let has_seadex_cf_flag = custom_formats::has_seadex_cf(cfs);
+    let seadex_boost_enabled = config.seadex_enabled && !has_seadex_cf_flag;
+    let seadex_hashes = fetch_seadex_hashes(
+        config.seadex_enabled || has_seadex_cf_flag,
+        detail.id,
+    )
+    .await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -474,7 +538,7 @@ async fn collect_scored_for_target(
             continue;
         }
 
-        c.score = rescore_for_auto_search(
+        let base = rescore_for_auto_search(
             &c,
             &classification,
             config,
@@ -488,7 +552,18 @@ async fn collect_scored_for_target(
             cutoff_source_enum,
             cutoff_resolution_enum,
         );
-        scored.push(c);
+        if let Some(final_score) = apply_cf_seadex_overlay(
+            base,
+            &c,
+            &classification,
+            cfs,
+            &seadex_hashes,
+            seadex_boost_enabled,
+            config.custom_format_minimum_score,
+        ) {
+            c.score = final_score;
+            scored.push(c);
+        }
     }
 
     scored.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
@@ -958,6 +1033,56 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
             parsed.contains(target_ep)
         }
     }
+}
+
+/// Look up the SeaDex entry for `anilist_id` and return the set of
+/// usable "best" info hashes. Disabled (or lookup-failed) returns an
+/// empty set, which causes the scoring-time SeaDex bonus and any
+/// `SeaDexBest` Custom Format spec to harmlessly contribute zero.
+async fn fetch_seadex_hashes(seadex_enabled: bool, anilist_id: i64) -> HashSet<String> {
+    if !seadex_enabled || anilist_id <= 0 {
+        return HashSet::new();
+    }
+    match seadex::lookup(anilist_id).await {
+        Ok(Some(entry)) => seadex::best_hashes(&entry),
+        _ => HashSet::new(),
+    }
+}
+
+/// Apply the Custom Format + SeaDex overlay to a base score.
+///
+/// Returns `Some(final_score)` if the candidate survives the CF
+/// minimum-score floor, or `None` if it should be dropped. The SeaDex
+/// score bump is suppressed whenever the compiled CF set contains a
+/// `SeaDexBestSpecification` — the user has taken ownership of that
+/// number and double-counting would be a silent regression.
+fn apply_cf_seadex_overlay(
+    base: i32,
+    result: &SearchResult,
+    classification: &ClassificationResult,
+    cfs: &[CompiledCustomFormat],
+    seadex_hashes: &HashSet<String>,
+    seadex_boost_enabled: bool,
+    minimum_score: i32,
+) -> Option<i32> {
+    let ctx = EvalContext {
+        result,
+        classification,
+        seadex_hashes,
+    };
+    let cf = custom_formats::total_cf_score(cfs, &ctx);
+    if cf < minimum_score {
+        return None;
+    }
+    let seadex_bonus = if seadex_boost_enabled
+        && !result.info_hash.is_empty()
+        && seadex_hashes.contains(&result.info_hash.to_ascii_lowercase())
+    {
+        seadex::SEADEX_SCORE_BOOST
+    } else {
+        0
+    };
+    Some(base + cf + seadex_bonus)
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -5,11 +5,14 @@ use regex_lite::Regex;
 use sqlx::SqlitePool;
 
 use crate::models::config::Config;
+use crate::models::log::LogCategory;
 use crate::services::custom_formats::{
     self, CompiledCustomFormat, EvalContext,
 };
 use crate::services::source::{self, ClassificationResult, Resolution, Source};
-use crate::services::{anilist::AnimeDetail, media, nyaa::{self, SearchOptions, SearchResult}, quality, seadex};
+use crate::services::{
+    anilist::AnimeDetail, logger, media, nyaa::{self, SearchOptions, SearchResult}, quality, seadex,
+};
 
 // ── Pre-compiled regexes for parse_release_numbers ─────────────────────────
 static RE_EPISODE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| vec![
@@ -217,6 +220,7 @@ pub async fn find_all_for_target(
         );
         // No CF floor on the interactive path — see comment above.
         if let Some(final_score) = apply_cf_seadex_overlay(
+            db,
             base,
             &c,
             &classification,
@@ -224,7 +228,9 @@ pub async fn find_all_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             i32::MIN,
-        ) {
+        )
+        .await
+        {
             c.score = final_score;
             scored.push(c);
         }
@@ -395,6 +401,7 @@ pub async fn collect_scored_batches_for_target(
             cutoff_resolution_enum,
         );
         if let Some(final_score) = apply_cf_seadex_overlay(
+            db,
             base,
             &c,
             &classification,
@@ -402,7 +409,9 @@ pub async fn collect_scored_batches_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             config.custom_format_minimum_score,
-        ) {
+        )
+        .await
+        {
             c.score = final_score;
             scored.push(c);
         }
@@ -553,6 +562,7 @@ async fn collect_scored_for_target(
             cutoff_resolution_enum,
         );
         if let Some(final_score) = apply_cf_seadex_overlay(
+            db,
             base,
             &c,
             &classification,
@@ -560,7 +570,9 @@ async fn collect_scored_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             config.custom_format_minimum_score,
-        ) {
+        )
+        .await
+        {
             c.score = final_score;
             scored.push(c);
         }
@@ -1056,7 +1068,14 @@ async fn fetch_seadex_hashes(seadex_enabled: bool, anilist_id: i64) -> HashSet<S
 /// score bump is suppressed whenever the compiled CF set contains a
 /// `SeaDexBestSpecification` — the user has taken ownership of that
 /// number and double-counting would be a silent regression.
-fn apply_cf_seadex_overlay(
+///
+/// On the way through, emits one `LogCategory::Scoring` debug row per
+/// candidate with a CF-aware breakdown line (plan §6.3). Dropped
+/// candidates are logged too so the user can introspect "why did this
+/// candidate get cut from the results" in addition to "why did X win."
+#[allow(clippy::too_many_arguments)]
+async fn apply_cf_seadex_overlay(
+    db: &SqlitePool,
     base: i32,
     result: &SearchResult,
     classification: &ClassificationResult,
@@ -1070,10 +1089,11 @@ fn apply_cf_seadex_overlay(
         classification,
         seadex_hashes,
     };
-    let cf = custom_formats::total_cf_score(cfs, &ctx);
-    if cf < minimum_score {
-        return None;
-    }
+    // Use the breakdown variant so the log line can name which CFs
+    // contributed. Per plan §6.3, production scoring normally uses the
+    // scalar `total_cf_score`; the cost of the `Vec<(String, i32)>`
+    // allocation is absorbed here because we're about to log anyway.
+    let (cf, breakdown) = custom_formats::total_cf_score_with_breakdown(cfs, &ctx);
     let seadex_bonus = if seadex_boost_enabled
         && !result.info_hash.is_empty()
         && seadex_hashes.contains(&result.info_hash.to_ascii_lowercase())
@@ -1082,7 +1102,56 @@ fn apply_cf_seadex_overlay(
     } else {
         0
     };
-    Some(base + cf + seadex_bonus)
+
+    let below_floor = cf < minimum_score;
+    let final_score = base + cf + seadex_bonus;
+
+    let detail = format_scoring_detail(base, cf, &breakdown, seadex_bonus, final_score, below_floor);
+    logger::debug(db, LogCategory::Scoring, &result.title, &detail).await;
+
+    if below_floor {
+        None
+    } else {
+        Some(final_score)
+    }
+}
+
+/// Build the structured scoring detail string that lands in the
+/// `logs.detail` column. Factored out of `apply_cf_seadex_overlay` so
+/// the format is in one place and unit-testable. Matches the shape
+/// documented in plan §6.3:
+///
+/// `base=85, cf=+420 [10bit x265 +200, FLAC audio +120, Preferred Groups: MTBB +100], seadex=0, final=505`
+///
+/// Negative contributions include the sign. An empty breakdown drops
+/// the bracket section entirely ("cf=+0" with nothing inside would be
+/// noisy). Candidates dropped by the CF minimum-score floor get a
+/// trailing ` DROPPED(floor=N)` marker so log readers can tell filtered
+/// candidates apart from surviving ones.
+fn format_scoring_detail(
+    base: i32,
+    cf: i32,
+    breakdown: &[(String, i32)],
+    seadex_bonus: i32,
+    final_score: i32,
+    below_floor: bool,
+) -> String {
+    let cf_section = if breakdown.is_empty() {
+        format!("cf={cf:+}")
+    } else {
+        let parts: Vec<String> = breakdown
+            .iter()
+            .map(|(name, score)| format!("{name} {score:+}"))
+            .collect();
+        format!("cf={:+} [{}]", cf, parts.join(", "))
+    };
+    let mut out = format!(
+        "base={base}, {cf_section}, seadex={seadex_bonus}, final={final_score}"
+    );
+    if below_floor {
+        out.push_str(" DROPPED(below minimum_score floor)");
+    }
+    out
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -1604,5 +1673,57 @@ mod tests {
             0,
             false,
         ));
+    }
+
+    #[test]
+    fn format_scoring_detail_matches_plan_docs_example() {
+        // Shape documented in plan §6.3 — the scoring log entry should
+        // read like this exact format so users grepping the logs can
+        // rely on a stable column layout. The CF names below ("10bit
+        // x265", "FLAC audio", "Preferred Groups: MTBB") are reproduced
+        // verbatim from the plan doc example; they're opaque label
+        // strings passed through by the formatter, not claims about
+        // any release group's actual naming scheme.
+        let breakdown = vec![
+            ("10bit x265".to_string(), 200),
+            ("FLAC audio".to_string(), 120),
+            ("Preferred Groups: MTBB".to_string(), 100),
+        ];
+        let s = format_scoring_detail(85, 420, &breakdown, 0, 505, false);
+        assert_eq!(
+            s,
+            "base=85, cf=+420 [10bit x265 +200, FLAC audio +120, Preferred Groups: MTBB +100], seadex=0, final=505"
+        );
+    }
+
+    #[test]
+    fn format_scoring_detail_empty_breakdown_drops_bracket_section() {
+        // No CFs matched → the bracket section is noise. Just show the
+        // scalar cf= total.
+        let s = format_scoring_detail(50, 0, &[], 0, 50, false);
+        assert_eq!(s, "base=50, cf=+0, seadex=0, final=50");
+    }
+
+    #[test]
+    fn format_scoring_detail_negative_cf_has_sign_and_marks_drop() {
+        let breakdown = vec![("Casual group penalty".to_string(), -1000)];
+        let s = format_scoring_detail(20, -1000, &breakdown, 0, -980, true);
+        assert_eq!(
+            s,
+            "base=20, cf=-1000 [Casual group penalty -1000], seadex=0, final=-980 DROPPED(below minimum_score floor)"
+        );
+    }
+
+    #[test]
+    fn format_scoring_detail_surfaces_seadex_bonus() {
+        // SeaDex bonus is the only non-CF overlay; make sure it shows
+        // up in the final line so the log reader can tell "SeaDex hit"
+        // apart from "CF scoring pushed this above everything else."
+        let breakdown = vec![("x265".to_string(), 300)];
+        let s = format_scoring_detail(60, 300, &breakdown, 10000, 10360, false);
+        assert_eq!(
+            s,
+            "base=60, cf=+300 [x265 +300], seadex=10000, final=10360"
+        );
     }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -140,14 +140,12 @@ pub async fn find_all_for_target(
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
 
     // Single SeaDex lookup per entry-point call, reused across every
-    // candidate in the loop below. The `has_seadex_cf` check suppresses
-    // the hardcoded boost when the user has a SeaDexBestSpecification CF.
-    let seadex_boost_enabled = config.seadex_enabled && !custom_formats::has_seadex_cf(cfs);
-    let seadex_hashes = fetch_seadex_hashes(
-        config.seadex_enabled || custom_formats::has_seadex_cf(cfs),
-        detail.id,
-    )
-    .await;
+    // candidate in the loop below. `seadex_gates` decides whether a
+    // lookup is needed and whether the hardcoded boost is active —
+    // it's suppressed automatically when the user has a
+    // `SeaDexBestSpecification` CF to avoid double counting.
+    let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
+    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -308,13 +306,8 @@ pub async fn collect_scored_batches_for_target(
     let (cutoff_source_enum, _, _) = source::parse_cutoff_source(&config.cutoff_source);
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
 
-    let has_seadex_cf_flag = custom_formats::has_seadex_cf(cfs);
-    let seadex_boost_enabled = config.seadex_enabled && !has_seadex_cf_flag;
-    let seadex_hashes = fetch_seadex_hashes(
-        config.seadex_enabled || has_seadex_cf_flag,
-        detail.id,
-    )
-    .await;
+    let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
+    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -452,13 +445,8 @@ async fn collect_scored_for_target(
     let (cutoff_source_enum, _, _) = source::parse_cutoff_source(&config.cutoff_source);
     let cutoff_resolution_enum = Resolution::from_str(&config.cutoff_resolution);
 
-    let has_seadex_cf_flag = custom_formats::has_seadex_cf(cfs);
-    let seadex_boost_enabled = config.seadex_enabled && !has_seadex_cf_flag;
-    let seadex_hashes = fetch_seadex_hashes(
-        config.seadex_enabled || has_seadex_cf_flag,
-        detail.id,
-    )
-    .await;
+    let (seadex_needs_lookup, seadex_boost_enabled) = seadex_gates(config, cfs);
+    let seadex_hashes = fetch_seadex_hashes(seadex_needs_lookup, detail.id).await;
 
     let expected_season = infer_season_from_detail(detail);
     let mut seen = HashSet::new();
@@ -1059,6 +1047,23 @@ async fn fetch_seadex_hashes(seadex_enabled: bool, anilist_id: i64) -> HashSet<S
         Ok(Some(entry)) => seadex::best_hashes(&entry),
         _ => HashSet::new(),
     }
+}
+
+/// Decide whether the current search call needs to make a SeaDex
+/// network round-trip. Hashes are required if *either* the config has
+/// SeaDex enabled (hardcoded boost) or the compiled CF set contains a
+/// `SeaDexBestSpecification` (Custom-Format-driven boost) — so one call
+/// serves both paths. Returns the gate flag plus the "hardcoded boost
+/// active" flag (suppressed whenever the user has a SeaDex CF, to
+/// avoid double-counting).
+fn seadex_gates(
+    config: &Config,
+    cfs: &[CompiledCustomFormat],
+) -> (bool /* needs_lookup */, bool /* boost_enabled */) {
+    let has_cf = custom_formats::has_seadex_cf(cfs);
+    let needs_lookup = config.seadex_enabled || has_cf;
+    let boost_enabled = config.seadex_enabled && !has_cf;
+    (needs_lookup, boost_enabled)
 }
 
 /// Apply the Custom Format + SeaDex overlay to a base score.

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -18,12 +18,11 @@
 //! with a subtle required-hard-fail rule. See [`evaluate`] and the
 //! worked examples in its unit tests for the exact semantics.
 
-// Phase 4 lands the module in isolation; Phases 5–6 wire the caller
-// (AppState, startup load, auto_search integration). Until those
-// phases land, `load_compiled_cfs` and `total_cf_score` are referenced
-// only by unit tests, which trips `-D warnings` dead-code errors in
-// clippy. Scope the allow to this file so the warnings come back the
-// moment a caller goes missing later.
+// A handful of spec fields (negate, required, source's raw Sonarr int)
+// are parsed but not read by the current evaluator path — they're
+// preserved so round-trip export matches Sonarr byte-for-byte and the
+// semantics stay visible in the debugger. Scope the allow narrowly to
+// this file rather than annotating each struct field.
 #![allow(dead_code)]
 
 use std::collections::{BTreeMap, HashSet};
@@ -434,6 +433,27 @@ pub async fn load_compiled_cfs(db: &SqlitePool) -> Vec<CompiledCustomFormat> {
             }
         })
         .collect()
+}
+
+/// Re-run `load_compiled_cfs` and atomically swap the compiled set into
+/// the shared `CompiledCfCache`. Callers take the write lock only long
+/// enough to replace the inner `Arc`; readers on the scoring hot path
+/// clone the `Arc` out under the read lock and never contend with the
+/// swap after that. Used by the Custom Formats settings page after any
+/// create / update / delete / import.
+pub async fn rebuild_cf_cache(cache: &CompiledCfCache, db: &SqlitePool) {
+    let fresh = Arc::new(load_compiled_cfs(db).await);
+    *cache.write().await = fresh;
+}
+
+/// `true` if any compiled CF contains a `SeaDexBest` spec. Used to
+/// suppress the hardcoded SeaDex score boost when the user has opted
+/// into controlling that boost themselves through a Custom Format —
+/// otherwise a candidate on SeaDex would earn both the CF score and
+/// the hardcoded `SEADEX_SCORE_BOOST` bump, which is double counting.
+pub fn has_seadex_cf(cfs: &[CompiledCustomFormat]) -> bool {
+    cfs.iter()
+        .any(|cf| cf.specs.iter().any(|s| matches!(s.kind, SpecKind::SeaDexBest)))
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -553,9 +553,11 @@ pub async fn load_compiled_cfs(db: &SqlitePool) -> Vec<CompiledCustomFormat> {
 /// Re-run `load_compiled_cfs` and atomically swap the compiled set into
 /// the shared `CompiledCfCache`. Callers take the write lock only long
 /// enough to replace the inner `Arc`; readers on the scoring hot path
-/// clone the `Arc` out under the read lock and never contend with the
-/// swap after that. Used by the Custom Formats settings page after any
-/// create / update / delete / import.
+/// clone the `Arc` out under the read lock and then release it — so a
+/// reader arriving mid-swap blocks for at most the duration of the Arc
+/// replacement (microseconds) before returning a consistent snapshot.
+/// Used by the Custom Formats settings page after any create / update /
+/// delete / import.
 pub async fn rebuild_cf_cache(cache: &CompiledCfCache, db: &SqlitePool) {
     let fresh = Arc::new(load_compiled_cfs(db).await);
     *cache.write().await = fresh;

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -1,0 +1,1161 @@
+//! Sonarr-v4-compatible Custom Formats.
+//!
+//! A Custom Format is a user-authored bundle of specifications that
+//! either matches a release (CF score adds to the candidate's total)
+//! or doesn't. Ryokan's CF model is a strict subset of Sonarr v4's —
+//! same JSON shape, same match semantics — with a single Ryokan-only
+//! addition (`Ryokan.SeaDexBestSpecification`) surfaced via the
+//! `Ryokan.` namespace so Sonarr-safe exports can detect and skip it.
+//!
+//! This module owns the parser, the per-candidate evaluator, and the
+//! DB-backed startup loader. It does **not** own cache invalidation or
+//! the `AppState` plumbing — Phase 5 wires the compiled-CF cache onto
+//! `AppState` and adds `rebuild_cf_cache`, and Phase 6 plugs
+//! `total_cf_score` into the three `auto_search.rs` call sites.
+//!
+//! The critical piece of correctness here is §5.7 of the plan: the
+//! match rule is NOT "all specs true" — it's group-by-type DidMatch
+//! with a subtle required-hard-fail rule. See [`evaluate`] and the
+//! worked examples in its unit tests for the exact semantics.
+
+// Phase 4 lands the module in isolation; Phases 5–6 wire the caller
+// (AppState, startup load, auto_search integration). Until those
+// phases land, `load_compiled_cfs` and `total_cf_score` are referenced
+// only by unit tests, which trips `-D warnings` dead-code errors in
+// clippy. Scope the allow to this file so the warnings come back the
+// moment a caller goes missing later.
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, HashSet};
+use std::sync::Arc;
+
+use sqlx::SqlitePool;
+use tokio::sync::RwLock;
+
+use super::nyaa::SearchResult;
+use super::source::{ClassificationResult, Resolution, Source, WebKind};
+
+// ───────────────────────────────────────────────────────────────────────────
+// Types
+// ───────────────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub struct CompiledCustomFormat {
+    pub id: i64,
+    pub name: String,
+    pub score: i32,
+    pub specs: Vec<CompiledSpec>,
+}
+
+/// Every spec variant carries both `negate` and `required`, matching
+/// Sonarr's `ICustomFormatSpecification` interface. `required` is
+/// consumed by the group-by-type DidMatch rule in [`evaluate`] (§5.7),
+/// not inside [`evaluate_spec`].
+#[derive(Debug, Clone)]
+pub struct CompiledSpec {
+    pub kind: SpecKind,
+    pub negate: bool,
+    pub required: bool,
+}
+
+#[derive(Debug, Clone)]
+pub enum SpecKind {
+    ReleaseTitle { regex: regex_lite::Regex },
+    ReleaseGroup { regex: regex_lite::Regex },
+    Size { min_bytes: i64, max_bytes: i64 },
+    Resolution { value: Resolution },
+    /// Stores Sonarr's raw `QualitySource` integer (see plan §4.5).
+    /// Dispatch happens inside `evaluate_spec_kernel` — one branch per
+    /// supported Sonarr int, with `2` (TelevisionRaw) rejected at parse
+    /// time.
+    Source { sonarr_value: u8 },
+    /// Ryokan-only: matches when the candidate's info_hash is in the
+    /// SeaDex "best" hash set for the current anilist_id. Namespaced
+    /// as `Ryokan.SeaDexBestSpecification` in exported JSON.
+    SeaDexBest,
+}
+
+impl SpecKind {
+    /// Group-by-type discriminator used by [`evaluate`]. Two specs
+    /// belong to the same group iff this returns the same value.
+    /// Mirrors Sonarr's `.GroupBy(t => t.GetType())`.
+    pub fn type_tag(&self) -> u8 {
+        match self {
+            SpecKind::ReleaseTitle { .. } => 1,
+            SpecKind::ReleaseGroup { .. } => 2,
+            SpecKind::Size { .. } => 3,
+            SpecKind::Resolution { .. } => 4,
+            SpecKind::Source { .. } => 5,
+            SpecKind::SeaDexBest => 6,
+        }
+    }
+}
+
+/// Evaluation context threaded through [`evaluate`] / [`total_cf_score`].
+///
+/// Holds borrowed references to the candidate, its classification, and
+/// the (possibly empty) set of SeaDex best hashes for the current
+/// anilist_id. Lifetimes keep everything non-allocating on the per-
+/// candidate path.
+pub struct EvalContext<'a> {
+    pub result: &'a SearchResult,
+    pub classification: &'a ClassificationResult,
+    /// Lowercased info hashes that SeaDex has flagged as `isBest` for
+    /// the current anilist_id. Empty when SeaDex is disabled, the entry
+    /// is missing, or `pick_best` rejected every candidate.
+    pub seadex_hashes: &'a HashSet<String>,
+}
+
+/// Shared cache container — an `RwLock` around an `Arc<Vec<...>>` so
+/// evaluation code can cheap-clone the inner `Arc` and release the read
+/// lock before iterating over candidates. Phase 5 adds a field of this
+/// type to `AppState`; this alias is declared here so both sides agree
+/// on the shape.
+pub type CompiledCfCache = Arc<RwLock<Arc<Vec<CompiledCustomFormat>>>>;
+
+// ───────────────────────────────────────────────────────────────────────────
+// Parser
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Compile a single Sonarr-shape CF JSON blob into an evaluator-ready
+/// [`CompiledCustomFormat`].
+///
+/// Rejects, with an explanatory error, any CF whose intent cannot be
+/// faithfully represented in Ryokan:
+/// - All of the original specs were of unsupported types (e.g. a
+///   TRaSH `BR-DISK` CF with only a `QualityModifierSpecification`).
+///   Silently collapsing would leave `specs=[]`, which under the §5.7.2
+///   vacuous-truth rule would match every release.
+/// - A `required=true` spec was dropped for being unsupported. Dropping
+///   a required spec would change the DidMatch gate for its group.
+///
+/// All regex compilation happens here once, not per-candidate: a 1000-
+/// candidate search over 10 CFs with one regex each would otherwise
+/// compile 10k regexes.
+pub fn compile_from_json(raw: &str, score: i32, id: i64) -> Result<CompiledCustomFormat, String> {
+    let v: serde_json::Value =
+        serde_json::from_str(raw).map_err(|e| format!("CF JSON parse: {e}"))?;
+
+    let name = v
+        .get("name")
+        .and_then(|n| n.as_str())
+        .ok_or_else(|| "CF missing name".to_string())?
+        .to_string();
+
+    let specs_json = v
+        .get("specifications")
+        .and_then(|s| s.as_array())
+        .ok_or_else(|| "CF missing specifications".to_string())?;
+
+    let original_spec_count = specs_json.len();
+    let mut specs: Vec<CompiledSpec> = Vec::new();
+    let mut dropped_required: Option<String> = None;
+
+    for spec_v in specs_json {
+        let implementation = spec_v
+            .get("implementation")
+            .and_then(|i| i.as_str())
+            .unwrap_or("");
+        let negate = spec_v.get("negate").and_then(|b| b.as_bool()).unwrap_or(false);
+        let required = spec_v.get("required").and_then(|b| b.as_bool()).unwrap_or(false);
+        let empty_fields: Vec<serde_json::Value> = Vec::new();
+        let fields = spec_v
+            .get("fields")
+            .and_then(|f| f.as_array())
+            .unwrap_or(&empty_fields);
+
+        let kind: SpecKind = match implementation {
+            "ReleaseTitleSpecification" => {
+                let value = field_str(fields, "value")?;
+                // Sonarr regexes are case-insensitive by convention;
+                // prepend `(?i)` so every imported CF matches regardless
+                // of how the user authored it.
+                let re = regex_lite::Regex::new(&format!("(?i){value}"))
+                    .map_err(|e| format!("ReleaseTitle regex: {e}"))?;
+                SpecKind::ReleaseTitle { regex: re }
+            }
+            "ReleaseGroupSpecification" => {
+                let value = field_str(fields, "value")?;
+                let re = regex_lite::Regex::new(&format!("(?i){value}"))
+                    .map_err(|e| format!("ReleaseGroup regex: {e}"))?;
+                SpecKind::ReleaseGroup { regex: re }
+            }
+            "SizeSpecification" => {
+                // Sonarr ships size bounds as GB floats. Field names
+                // are literally `min` and `max` (verified against
+                // Sonarr's SizeSpecification.cs).
+                let min = field_f64(fields, "min").unwrap_or(0.0);
+                let max = field_f64(fields, "max").unwrap_or(f64::INFINITY);
+                const GB: f64 = 1024.0 * 1024.0 * 1024.0;
+                SpecKind::Size {
+                    min_bytes: (min * GB) as i64,
+                    max_bytes: if max.is_finite() {
+                        (max * GB) as i64
+                    } else {
+                        i64::MAX
+                    },
+                }
+            }
+            "ResolutionSpecification" => {
+                let value = field_i64(fields, "value")? as i32;
+                SpecKind::Resolution {
+                    value: Resolution::from_int(value),
+                }
+            }
+            "SourceSpecification" => {
+                let value = field_i64(fields, "value")?;
+                // Reject TelevisionRaw (2) — no anime mapping. Also
+                // reject anything out of range. Treat like an unknown
+                // implementation so the drop/required logic below fires.
+                if value == 2 || !(0..=7).contains(&value) {
+                    tracing::warn!(
+                        "custom_formats: skipping SourceSpecification(value={value}) on CF `{name}`"
+                    );
+                    if required && dropped_required.is_none() {
+                        dropped_required = Some(format!("SourceSpecification(value={value})"));
+                    }
+                    continue;
+                }
+                SpecKind::Source {
+                    sonarr_value: value as u8,
+                }
+            }
+            // Ryokan-only spec: accept both the namespaced form (new
+            // default, see plan §5.7.5) and the bare form for backwards
+            // compatibility with older Ryokan exports.
+            "Ryokan.SeaDexBestSpecification" | "SeaDexBestSpecification" => SpecKind::SeaDexBest,
+            other => {
+                tracing::warn!(
+                    "custom_formats: skipping unsupported spec `{other}` on CF `{name}`"
+                );
+                if required && dropped_required.is_none() {
+                    dropped_required = Some(other.to_string());
+                }
+                continue;
+            }
+        };
+
+        specs.push(CompiledSpec { kind, negate, required });
+    }
+
+    // Cross-compat safety: a CF whose intent cannot be preserved must
+    // not silently become a match-everything vacuous-truth CF. See
+    // plan §5.7.2 for why.
+    if original_spec_count > 0 && specs.is_empty() {
+        return Err(format!(
+            "all {original_spec_count} specifications unsupported — CF `{name}` cannot be \
+             represented in Ryokan and was rejected to avoid a vacuous-match CF"
+        ));
+    }
+    if let Some(label) = dropped_required {
+        return Err(format!(
+            "required=true specification `{label}` was dropped — CF `{name}` semantics \
+             cannot be preserved and the CF was rejected"
+        ));
+    }
+
+    Ok(CompiledCustomFormat { id, name, score, specs })
+}
+
+fn field_str(fields: &[serde_json::Value], name: &str) -> Result<String, String> {
+    for f in fields {
+        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
+            return Ok(f
+                .get("value")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string());
+        }
+    }
+    Err(format!("field `{name}` missing"))
+}
+
+fn field_i64(fields: &[serde_json::Value], name: &str) -> Result<i64, String> {
+    for f in fields {
+        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
+            return f
+                .get("value")
+                .and_then(|v| v.as_i64())
+                .ok_or_else(|| format!("field `{name}` not an integer"));
+        }
+    }
+    Err(format!("field `{name}` missing"))
+}
+
+fn field_f64(fields: &[serde_json::Value], name: &str) -> Option<f64> {
+    for f in fields {
+        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
+            // Sonarr ships these as JSON numbers; accept either f64 or
+            // i64 encodings for robustness (`"min": 5` vs `"min": 5.0`).
+            return f
+                .get("value")
+                .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|n| n as f64)));
+        }
+    }
+    None
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Per-spec kernel + negate wrapper
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Raw per-spec match, pre-negate. Mirrors Sonarr's
+/// `IsSatisfiedByWithoutNegate`.
+fn evaluate_spec_kernel(spec: &CompiledSpec, ctx: &EvalContext) -> bool {
+    match &spec.kind {
+        SpecKind::ReleaseTitle { regex } => regex.is_match(&ctx.result.title),
+        // `SearchResult::group` is a bare String. Empty means the Nyaa
+        // scraper didn't find a `[Group]` prefix; an empty-string regex
+        // still matches it, which is consistent with Sonarr's behavior.
+        SpecKind::ReleaseGroup { regex } => regex.is_match(&ctx.result.group),
+        SpecKind::Size { min_bytes, max_bytes } => {
+            // Sonarr's SizeSpecification.cs uses strict-greater on the
+            // lower bound and ≤ on the upper bound: `size > Min &&
+            // size <= Max`. Mirror exactly.
+            let s = ctx.result.size_bytes;
+            s > *min_bytes && s <= *max_bytes
+        }
+        SpecKind::Resolution { value } => ctx.classification.resolution == *value,
+        SpecKind::Source { sonarr_value } => {
+            let c = ctx.classification;
+            match sonarr_value {
+                0 => c.source == Source::Unknown,
+                1 => matches!(c.source, Source::Hdtv | Source::Tv),
+                3 => c.source == Source::Web && c.web_kind == WebKind::WebDl,
+                4 => c.source == Source::Web && c.web_kind == WebKind::WebRip,
+                5 => c.source == Source::Dvd,
+                6 => c.source == Source::BluRay && !c.is_bdmv,
+                7 => c.source == Source::BluRay && c.is_bdmv,
+                // 2 (TelevisionRaw) and out-of-range are filtered at
+                // parse time, so they never reach here.
+                _ => false,
+            }
+        }
+        SpecKind::SeaDexBest => {
+            !ctx.result.info_hash.is_empty()
+                && ctx
+                    .seadex_hashes
+                    .contains(&ctx.result.info_hash.to_ascii_lowercase())
+        }
+    }
+}
+
+/// Per-spec match with Sonarr's `Negate` applied. This is the input to
+/// the group-by-type DidMatch rule in [`evaluate`] — never call the
+/// kernel directly from there.
+fn evaluate_spec(spec: &CompiledSpec, ctx: &EvalContext) -> bool {
+    let raw = evaluate_spec_kernel(spec, ctx);
+    if spec.negate {
+        !raw
+    } else {
+        raw
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// CF-level match + score summation
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Does this CF match the candidate?
+///
+/// Implements Sonarr v4's group-by-type DidMatch rule verbatim. See
+/// plan §5.7.1 for the Sonarr source snippet this mirrors, and §5.7.3
+/// for worked examples.
+///
+/// The rule is NOT "all specs true" and NOT "any spec true". It's:
+/// 1. Group specs by `type_tag()`.
+/// 2. Within each group: match iff no `required=true` spec returned
+///    false AND at least one spec returned true.
+/// 3. CF matches iff every group matches.
+pub fn evaluate(cf: &CompiledCustomFormat, ctx: &EvalContext) -> bool {
+    // Vacuous-truth parity with Sonarr: a CF with zero specs produces
+    // an empty groups list, and `empty.All(x => x.DidMatch)` is `true`
+    // in LINQ (same as `.all()` in Rust). Real imports can't reach this
+    // branch — `compile_from_json` rejects all-unsupported CFs — but
+    // strict parity means we mirror Sonarr rather than second-guessing.
+    if cf.specs.is_empty() {
+        return true;
+    }
+
+    let mut groups: BTreeMap<u8, Vec<(&CompiledSpec, bool)>> = BTreeMap::new();
+    for spec in &cf.specs {
+        let matched = evaluate_spec(spec, ctx);
+        groups.entry(spec.kind.type_tag()).or_default().push((spec, matched));
+    }
+
+    groups.values().all(|group| {
+        let any_required_failed = group.iter().any(|(s, m)| s.required && !m);
+        let all_failed = group.iter().all(|(_, m)| !m);
+        !(any_required_failed || all_failed)
+    })
+}
+
+/// Sum the scores of every CF that matches the candidate. Non-matching
+/// CFs contribute 0 regardless of their score sign. Used by the Phase 6
+/// auto_search integration as a single-call overlay on `base_score`.
+pub fn total_cf_score(cfs: &[CompiledCustomFormat], ctx: &EvalContext) -> i32 {
+    cfs.iter()
+        .filter(|cf| evaluate(cf, ctx))
+        .map(|cf| cf.score)
+        .sum()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// DB-backed startup loader
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Load every CF row, join its V1-profile score, and compile each one.
+/// A CF that fails to parse is logged at WARN and skipped; the rest of
+/// the set still loads. Phase 5 wraps the returned Vec in an `Arc` and
+/// stashes it on `AppState` at startup.
+pub async fn load_compiled_cfs(db: &SqlitePool) -> Vec<CompiledCustomFormat> {
+    let rows: Vec<(i64, String, String, i64)> = sqlx::query_as(
+        r#"
+        SELECT cf.id, cf.name, cf.json, COALESCE(cfs.score, 0) AS score
+        FROM custom_formats cf
+        LEFT JOIN custom_format_scores cfs
+               ON cfs.custom_format_id = cf.id
+              AND cfs.profile_id = 1
+        ORDER BY cf.id
+        "#,
+    )
+    .fetch_all(db)
+    .await
+    .unwrap_or_default();
+
+    rows.into_iter()
+        .filter_map(|(id, name, raw_json, score)| {
+            match compile_from_json(&raw_json, score as i32, id) {
+                Ok(cf) => Some(cf),
+                Err(e) => {
+                    tracing::warn!("custom_formats: skipping {name} (id={id}): {e}");
+                    None
+                }
+            }
+        })
+        .collect()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::source::{DecisionRule, Source};
+
+    // ── Helpers ──────────────────────────────────────────────────────────
+
+    fn candidate(title: &str, group: &str, size_bytes: i64, info_hash: &str) -> SearchResult {
+        SearchResult {
+            title: title.to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            torrent: String::new(),
+            size: String::new(),
+            size_bytes,
+            seeders: 0,
+            leechers: 0,
+            downloads: 0,
+            group: group.to_string(),
+            resolution: String::new(),
+            is_batch: false,
+            is_trusted: false,
+            score: 0,
+            info_hash: info_hash.to_string(),
+        }
+    }
+
+    fn classification(source: Source, resolution: Resolution) -> ClassificationResult {
+        ClassificationResult {
+            source,
+            resolution,
+            is_remux: false,
+            web_kind: WebKind::Unknown,
+            is_bdmv: false,
+            confidence: 1.0,
+            needs_review: false,
+            evidence: vec![],
+            decision_rule: DecisionRule::Empty,
+        }
+    }
+
+    fn ctx<'a>(
+        result: &'a SearchResult,
+        classification: &'a ClassificationResult,
+        seadex: &'a HashSet<String>,
+    ) -> EvalContext<'a> {
+        EvalContext {
+            result,
+            classification,
+            seadex_hashes: seadex,
+        }
+    }
+
+    fn compile(raw: &str) -> CompiledCustomFormat {
+        compile_from_json(raw, 100, 1).expect("fixture CF should compile")
+    }
+
+    // ── Parser: basic shapes and field extraction ────────────────────────
+
+    #[test]
+    fn parse_release_title_spec() {
+        let json = r#"{
+            "name": "x265 preference",
+            "specifications": [
+                {
+                    "name": "x265",
+                    "implementation": "ReleaseTitleSpecification",
+                    "implementationName": "Release Title",
+                    "negate": false,
+                    "required": false,
+                    "fields": [{"name": "value", "value": "x265"}]
+                }
+            ]
+        }"#;
+        let cf = compile(json);
+        assert_eq!(cf.name, "x265 preference");
+        assert_eq!(cf.specs.len(), 1);
+        assert!(matches!(cf.specs[0].kind, SpecKind::ReleaseTitle { .. }));
+    }
+
+    #[test]
+    fn parse_size_spec_converts_gb_to_bytes() {
+        let json = r#"{
+            "name": "5-20 GB",
+            "specifications": [
+                {
+                    "implementation": "SizeSpecification",
+                    "fields": [
+                        {"name": "min", "value": 5},
+                        {"name": "max", "value": 20}
+                    ]
+                }
+            ]
+        }"#;
+        let cf = compile(json);
+        if let SpecKind::Size { min_bytes, max_bytes } = cf.specs[0].kind {
+            const GB: i64 = 1024 * 1024 * 1024;
+            assert_eq!(min_bytes, 5 * GB);
+            assert_eq!(max_bytes, 20 * GB);
+        } else {
+            panic!("expected Size spec");
+        }
+    }
+
+    #[test]
+    fn parse_resolution_spec_uses_from_int() {
+        let json = r#"{
+            "name": "1080p",
+            "specifications": [
+                {
+                    "implementation": "ResolutionSpecification",
+                    "fields": [{"name": "value", "value": 1080}]
+                }
+            ]
+        }"#;
+        let cf = compile(json);
+        assert!(matches!(
+            cf.specs[0].kind,
+            SpecKind::Resolution { value: Resolution::R1080p }
+        ));
+    }
+
+    #[test]
+    fn parse_source_spec_webdl() {
+        let json = r#"{
+            "name": "WEB-DL",
+            "specifications": [
+                {
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 3}]
+                }
+            ]
+        }"#;
+        let cf = compile(json);
+        assert!(matches!(
+            cf.specs[0].kind,
+            SpecKind::Source { sonarr_value: 3 }
+        ));
+    }
+
+    #[test]
+    fn parse_source_spec_rejects_television_raw() {
+        // Sonarr's TelevisionRaw (2) has no anime mapping, so the
+        // parser drops it. In this case it's the only spec and its
+        // removal would leave a vacuous-match CF, so compilation fails.
+        let json = r#"{
+            "name": "tv raw only",
+            "specifications": [
+                {
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 2}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, 0, 1).unwrap_err();
+        assert!(err.contains("all 1 specifications unsupported"));
+    }
+
+    #[test]
+    fn parse_source_spec_rejects_out_of_range() {
+        let json = r#"{
+            "name": "bogus",
+            "specifications": [
+                {
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 42}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, 0, 1).unwrap_err();
+        assert!(err.contains("all 1 specifications unsupported"));
+    }
+
+    #[test]
+    fn parse_seadex_best_namespaced_and_bare() {
+        let namespaced = r#"{
+            "name": "seadex new",
+            "specifications": [
+                {
+                    "implementation": "Ryokan.SeaDexBestSpecification",
+                    "fields": []
+                }
+            ]
+        }"#;
+        let bare = r#"{
+            "name": "seadex old",
+            "specifications": [
+                {
+                    "implementation": "SeaDexBestSpecification",
+                    "fields": []
+                }
+            ]
+        }"#;
+        assert!(matches!(compile(namespaced).specs[0].kind, SpecKind::SeaDexBest));
+        assert!(matches!(compile(bare).specs[0].kind, SpecKind::SeaDexBest));
+    }
+
+    #[test]
+    fn parse_rejects_all_unsupported() {
+        // Simulates TRaSH's `BR-DISK` CF: only a spec type Ryokan
+        // doesn't implement. Must NOT collapse to an empty specs vec.
+        let json = r#"{
+            "name": "BR-DISK",
+            "specifications": [
+                {
+                    "implementation": "QualityModifierSpecification",
+                    "fields": [{"name": "value", "value": 6}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, -10000, 1).unwrap_err();
+        assert!(
+            err.contains("all 1 specifications unsupported"),
+            "error should mention vacuous-match guard: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_rejects_dropped_required_spec() {
+        // A CF with a surviving ReleaseTitle spec but a required=true
+        // LanguageSpecification (unsupported) must be rejected, because
+        // dropping the required spec would change the DidMatch gate.
+        let json = r#"{
+            "name": "english x265",
+            "specifications": [
+                {
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "x265"}]
+                },
+                {
+                    "implementation": "LanguageSpecification",
+                    "required": true,
+                    "fields": [{"name": "value", "value": 1}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, 0, 1).unwrap_err();
+        assert!(err.contains("LanguageSpecification"), "got: {err}");
+        assert!(err.contains("required=true"), "got: {err}");
+    }
+
+    #[test]
+    fn parse_rejects_invalid_regex() {
+        let json = r#"{
+            "name": "bad regex",
+            "specifications": [
+                {
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "[unclosed"}]
+                }
+            ]
+        }"#;
+        assert!(compile_from_json(json, 0, 1).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_missing_name() {
+        let json = r#"{"specifications": []}"#;
+        assert!(compile_from_json(json, 0, 1).is_err());
+    }
+
+    #[test]
+    fn parse_rejects_missing_specifications_key() {
+        let json = r#"{"name": "lonely"}"#;
+        assert!(compile_from_json(json, 0, 1).is_err());
+    }
+
+    // ── evaluate_spec_kernel / evaluate_spec ─────────────────────────────
+
+    #[test]
+    fn release_title_kernel_matches_case_insensitive() {
+        let cf = compile(
+            r#"{
+                "name": "x265",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "x265"}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+
+        let hit = candidate("[MTBB] Show - 01 [BD 1080p X265]", "MTBB", 0, "");
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+        assert!(evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+
+        let miss = candidate("[Judas] Show - 01 [1080p]", "Judas", 0, "");
+        assert!(!evaluate(&cf, &ctx(&miss, &cls, &hashes)));
+    }
+
+    #[test]
+    fn release_group_spec_matches_parsed_group_not_title() {
+        // The plan's "win over Sonarr": `^MTBB$` anchored against the
+        // parsed group field, not the whole title. Sonarr's older
+        // behavior would fail to match because the title carries
+        // surrounding characters.
+        let cf = compile(
+            r#"{
+                "name": "MTBB only",
+                "specifications": [{
+                    "implementation": "ReleaseGroupSpecification",
+                    "fields": [{"name": "value", "value": "^MTBB$"}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+
+        let hit = candidate("[MTBB] Kizumonogatari - 01 (BD 1080p)", "MTBB", 0, "");
+        assert!(evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+
+        let miss = candidate("[NoobSubs] Kizumonogatari - 01", "NoobSubs", 0, "");
+        assert!(!evaluate(&cf, &ctx(&miss, &cls, &hashes)));
+    }
+
+    #[test]
+    fn size_spec_strict_lower_inclusive_upper() {
+        // Match Sonarr: `size > min && size <= max`.
+        let cf = compile(
+            r#"{
+                "name": "5 to 20 GB",
+                "specifications": [{
+                    "implementation": "SizeSpecification",
+                    "fields": [
+                        {"name": "min", "value": 5},
+                        {"name": "max", "value": 20}
+                    ]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+        const GB: i64 = 1024 * 1024 * 1024;
+
+        // Exactly at the lower bound: strict-greater means NO match.
+        let at_min = candidate("x", "", 5 * GB, "");
+        assert!(!evaluate(&cf, &ctx(&at_min, &cls, &hashes)));
+
+        // Just above the lower bound: match.
+        let just_above = candidate("x", "", 5 * GB + 1, "");
+        assert!(evaluate(&cf, &ctx(&just_above, &cls, &hashes)));
+
+        // Exactly at the upper bound: inclusive means match.
+        let at_max = candidate("x", "", 20 * GB, "");
+        assert!(evaluate(&cf, &ctx(&at_max, &cls, &hashes)));
+
+        // Above the upper bound: no match.
+        let above = candidate("x", "", 20 * GB + 1, "");
+        assert!(!evaluate(&cf, &ctx(&above, &cls, &hashes)));
+    }
+
+    #[test]
+    fn resolution_spec_uses_classification_not_filename() {
+        // The whole point: filename-parsed `SearchResult::resolution`
+        // string is ignored; we compare against the pipeline's
+        // structured `ClassificationResult::resolution`.
+        let cf = compile(
+            r#"{
+                "name": "1080p only",
+                "specifications": [{
+                    "implementation": "ResolutionSpecification",
+                    "fields": [{"name": "value", "value": 1080}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+
+        let cand = candidate("cosmetic 720p in filename", "", 0, "");
+        // The candidate's filename says 720p but the classifier decided
+        // R1080p — the CF trusts the classifier.
+        let cls = classification(Source::Web, Resolution::R1080p);
+        assert!(evaluate(&cf, &ctx(&cand, &cls, &hashes)));
+
+        let cls_720 = classification(Source::Web, Resolution::R720p);
+        assert!(!evaluate(&cf, &ctx(&cand, &cls_720, &hashes)));
+    }
+
+    #[test]
+    fn source_spec_webdl_vs_webrip_vs_bare_web() {
+        let webdl_cf = compile(
+            r#"{
+                "name": "WEB-DL",
+                "specifications": [{
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 3}]
+                }]
+            }"#,
+        );
+        let webrip_cf = compile(
+            r#"{
+                "name": "WEBRip",
+                "specifications": [{
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 4}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cand = candidate("x", "", 0, "");
+
+        let mut webdl = classification(Source::Web, Resolution::R1080p);
+        webdl.web_kind = WebKind::WebDl;
+        let mut webrip = classification(Source::Web, Resolution::R1080p);
+        webrip.web_kind = WebKind::WebRip;
+        let bare = classification(Source::Web, Resolution::R1080p); // Unknown
+
+        assert!(evaluate(&webdl_cf, &ctx(&cand, &webdl, &hashes)));
+        assert!(!evaluate(&webdl_cf, &ctx(&cand, &webrip, &hashes)));
+        assert!(!evaluate(&webdl_cf, &ctx(&cand, &bare, &hashes)));
+
+        assert!(evaluate(&webrip_cf, &ctx(&cand, &webrip, &hashes)));
+        assert!(!evaluate(&webrip_cf, &ctx(&cand, &webdl, &hashes)));
+        // Bare-WEB deliberately matches neither (plan §4.5).
+        assert!(!evaluate(&webrip_cf, &ctx(&cand, &bare, &hashes)));
+    }
+
+    #[test]
+    fn source_spec_bluray_vs_bluray_raw() {
+        let bluray_cf = compile(
+            r#"{
+                "name": "BluRay",
+                "specifications": [{
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 6}]
+                }]
+            }"#,
+        );
+        let bluray_raw_cf = compile(
+            r#"{
+                "name": "BluRay RAW",
+                "specifications": [{
+                    "implementation": "SourceSpecification",
+                    "fields": [{"name": "value", "value": 7}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cand = candidate("x", "", 0, "");
+
+        let encode = classification(Source::BluRay, Resolution::R1080p);
+        let mut bdmv = classification(Source::BluRay, Resolution::R1080p);
+        bdmv.is_bdmv = true;
+
+        assert!(evaluate(&bluray_cf, &ctx(&cand, &encode, &hashes)));
+        assert!(!evaluate(&bluray_cf, &ctx(&cand, &bdmv, &hashes))); // BDMV excluded by !is_bdmv
+
+        assert!(evaluate(&bluray_raw_cf, &ctx(&cand, &bdmv, &hashes)));
+        assert!(!evaluate(&bluray_raw_cf, &ctx(&cand, &encode, &hashes)));
+    }
+
+    #[test]
+    fn seadex_best_matches_lowercased_hash_set() {
+        let cf = compile(
+            r#"{
+                "name": "SeaDex",
+                "specifications": [{
+                    "implementation": "Ryokan.SeaDexBestSpecification",
+                    "fields": []
+                }]
+            }"#,
+        );
+        let mut hashes = HashSet::new();
+        hashes.insert("abc123".to_string());
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+
+        // Exact match.
+        let in_set = candidate("x", "", 0, "abc123");
+        assert!(evaluate(&cf, &ctx(&in_set, &cls, &hashes)));
+
+        // Uppercase match via lowercasing on compare.
+        let in_set_upper = candidate("x", "", 0, "ABC123");
+        assert!(evaluate(&cf, &ctx(&in_set_upper, &cls, &hashes)));
+
+        // Miss.
+        let not_in_set = candidate("x", "", 0, "def456");
+        assert!(!evaluate(&cf, &ctx(&not_in_set, &cls, &hashes)));
+
+        // Empty hash never matches.
+        let no_hash = candidate("x", "", 0, "");
+        assert!(!evaluate(&cf, &ctx(&no_hash, &cls, &hashes)));
+
+        // Empty set never matches.
+        let empty = HashSet::new();
+        assert!(!evaluate(&cf, &ctx(&in_set, &cls, &empty)));
+    }
+
+    // ── Group-by-type DidMatch rule (§5.7.3 worked examples) ─────────────
+
+    #[test]
+    fn example_a_single_spec_match() {
+        let cf = compile(
+            r#"{
+                "name": "A",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "x265"}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+        let hit = candidate("[MTBB] Show - 01 [BD 1080p x265]", "MTBB", 0, "");
+        assert!(evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+    }
+
+    #[test]
+    fn example_b_or_within_same_type() {
+        // Two ReleaseTitle specs in the same group — OR within type.
+        let cf = compile(
+            r#"{
+                "name": "B",
+                "specifications": [
+                    {
+                        "implementation": "ReleaseTitleSpecification",
+                        "fields": [{"name": "value", "value": "x265"}]
+                    },
+                    {
+                        "implementation": "ReleaseTitleSpecification",
+                        "fields": [{"name": "value", "value": "HEVC"}]
+                    }
+                ]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::Web, Resolution::R1080p);
+        // Only HEVC hits — the other spec in the same group is false,
+        // but OR within group means the whole group still matches.
+        let hit = candidate("[Judas] Show - 01 [HEVC]", "Judas", 0, "");
+        assert!(evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+    }
+
+    #[test]
+    fn example_c_and_across_groups() {
+        // ReleaseTitle ∧ Size — different type_tags, groups must all
+        // match.
+        let cf = compile(
+            r#"{
+                "name": "C",
+                "specifications": [
+                    {
+                        "implementation": "ReleaseTitleSpecification",
+                        "fields": [{"name": "value", "value": "x265"}]
+                    },
+                    {
+                        "implementation": "SizeSpecification",
+                        "fields": [
+                            {"name": "min", "value": 5},
+                            {"name": "max", "value": 20}
+                        ]
+                    }
+                ]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::BluRay, Resolution::R1080p);
+        const GB: i64 = 1024 * 1024 * 1024;
+
+        // Both groups match.
+        let hit = candidate("[MTBB] Show - 01 [BD 1080p x265]", "MTBB", 12 * GB, "");
+        assert!(evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+
+        // Title group fails — CF fails even though size is in range.
+        let title_miss = candidate("[SubsPlease] Show - 01 (1080p)", "SubsPlease", 6 * GB, "");
+        assert!(!evaluate(&cf, &ctx(&title_miss, &cls, &hashes)));
+
+        // Size group fails — CF fails even though title matches.
+        let size_miss = candidate("[MTBB] Show - 01 [BD 1080p x265]", "MTBB", 1_200_000_000, "");
+        assert!(!evaluate(&cf, &ctx(&size_miss, &cls, &hashes)));
+    }
+
+    #[test]
+    fn example_d_required_hard_gate_within_group() {
+        // Two ReleaseTitle specs in the same group, one with required=true.
+        // When the required spec fails, the whole group fails even though
+        // the OR partner matched — required=true is a hard gate.
+        let cf = compile(
+            r#"{
+                "name": "D",
+                "specifications": [
+                    {
+                        "implementation": "ReleaseTitleSpecification",
+                        "required": true,
+                        "fields": [{"name": "value", "value": "x265"}]
+                    },
+                    {
+                        "implementation": "ReleaseTitleSpecification",
+                        "fields": [{"name": "value", "value": "HEVC"}]
+                    }
+                ]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::Web, Resolution::R1080p);
+        let hit = candidate("[Judas] Show - 01 [HEVC]", "Judas", 0, "");
+        // Without required=true this matches (Example B); with it, no.
+        assert!(!evaluate(&cf, &ctx(&hit, &cls, &hashes)));
+    }
+
+    #[test]
+    fn example_e_negate_inverts_kernel() {
+        let cf = compile(
+            r#"{
+                "name": "E",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "negate": true,
+                    "fields": [{"name": "value", "value": "NoobSubs"}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::Web, Resolution::R1080p);
+
+        // Kernel matches "NoobSubs", negate flips to false, CF fails.
+        let noob = candidate("[NoobSubs] Show - 01 [8bit].mp4", "NoobSubs", 0, "");
+        assert!(!evaluate(&cf, &ctx(&noob, &cls, &hashes)));
+
+        // Kernel miss, negate flips to true, CF matches.
+        let clean = candidate("[MTBB] Show - 01", "MTBB", 0, "");
+        assert!(evaluate(&cf, &ctx(&clean, &cls, &hashes)));
+    }
+
+    #[test]
+    fn example_f_negate_plus_required_blacklist_pattern() {
+        // The standard TRaSH blacklist shape.
+        let cf = compile(
+            r#"{
+                "name": "F",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "negate": true,
+                    "required": true,
+                    "fields": [{"name": "value", "value": "NoobSubs"}]
+                }]
+            }"#,
+        );
+        let hashes = HashSet::new();
+        let cls = classification(Source::Web, Resolution::R1080p);
+
+        let clean = candidate("[MTBB] Show - 01", "MTBB", 0, "");
+        assert!(evaluate(&cf, &ctx(&clean, &cls, &hashes)));
+
+        let noob = candidate("[NoobSubs] Show - 01", "NoobSubs", 0, "");
+        assert!(!evaluate(&cf, &ctx(&noob, &cls, &hashes)));
+    }
+
+    // ── Score summation ──────────────────────────────────────────────────
+
+    #[test]
+    fn total_cf_score_sums_only_matching_cfs() {
+        let cf_x265 = compile(
+            r#"{
+                "name": "x265",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "x265"}]
+                }]
+            }"#,
+        );
+        let mut cf_x265 = cf_x265;
+        cf_x265.score = 500;
+
+        let cf_anti_noob = compile(
+            r#"{
+                "name": "anti noob",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "negate": true,
+                    "required": true,
+                    "fields": [{"name": "value", "value": "NoobSubs"}]
+                }]
+            }"#,
+        );
+        let mut cf_anti_noob = cf_anti_noob;
+        cf_anti_noob.score = -1000;
+
+        let hashes = HashSet::new();
+        let cls = classification(Source::Web, Resolution::R1080p);
+
+        // MTBB x265: matches x265 (+500), matches anti-noob (-0? no,
+        // anti-noob matches → its score -1000 also adds).
+        let mtbb = candidate("[MTBB] Show - 01 [x265]", "MTBB", 0, "");
+        let score = total_cf_score(&[cf_x265.clone(), cf_anti_noob.clone()], &ctx(&mtbb, &cls, &hashes));
+        assert_eq!(score, 500 + (-1000));
+
+        // NoobSubs (no x265): anti-noob fires negatively → CF doesn't
+        // match → no -1000 contribution. x265 also doesn't match.
+        let noob = candidate("[NoobSubs] Show - 01", "NoobSubs", 0, "");
+        let score = total_cf_score(&[cf_x265, cf_anti_noob], &ctx(&noob, &cls, &hashes));
+        assert_eq!(score, 0);
+    }
+
+    #[test]
+    fn total_cf_score_empty_list_is_zero() {
+        let hashes = HashSet::new();
+        let cand = candidate("x", "", 0, "");
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+        assert_eq!(total_cf_score(&[], &ctx(&cand, &cls, &hashes)), 0);
+    }
+
+    // ── Vacuous-truth parity ─────────────────────────────────────────────
+
+    #[test]
+    fn empty_specs_cf_matches_every_release_strict_sonarr_parity() {
+        // compile_from_json rejects this shape, but the evaluator still
+        // has to handle it for strict Sonarr parity (pathologically
+        // hand-edited state). Construct one manually.
+        let cf = CompiledCustomFormat {
+            id: 1,
+            name: "empty".to_string(),
+            score: 42,
+            specs: vec![],
+        };
+        let hashes = HashSet::new();
+        let cand = candidate("anything", "anyone", 0, "");
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+        assert!(evaluate(&cf, &ctx(&cand, &cls, &hashes)));
+    }
+}

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -59,8 +59,8 @@ pub struct CompiledSpec {
 
 #[derive(Debug, Clone)]
 pub enum SpecKind {
-    ReleaseTitle { regex: regex_lite::Regex },
-    ReleaseGroup { regex: regex_lite::Regex },
+    ReleaseTitle { regex: fancy_regex::Regex },
+    ReleaseGroup { regex: fancy_regex::Regex },
     Size { min_bytes: i64, max_bytes: i64 },
     Resolution { value: Resolution },
     /// Stores Sonarr's raw `QualitySource` integer (see plan §4.5).
@@ -157,25 +157,35 @@ pub fn compile_from_json(raw: &str, score: i32, id: i64) -> Result<CompiledCusto
             .unwrap_or("");
         let negate = spec_v.get("negate").and_then(|b| b.as_bool()).unwrap_or(false);
         let required = spec_v.get("required").and_then(|b| b.as_bool()).unwrap_or(false);
-        let empty_fields: Vec<serde_json::Value> = Vec::new();
-        let fields = spec_v
-            .get("fields")
-            .and_then(|f| f.as_array())
-            .unwrap_or(&empty_fields);
+        // Sonarr's CF JSON ships `fields` in two shapes depending on
+        // where the dump came from:
+        //   - Sonarr UI / API export: array of `{"name": …, "value": …}`
+        //   - trash-guides repo JSON: object map like `{"value": …}`
+        // `field_str` / `field_i64` / `field_f64` accept either shape via
+        // `field_value`; we hand them the raw `fields` node and let them
+        // do the work. An absent `fields` becomes `Value::Null`, which
+        // both lookups treat as "no such field".
+        let null_fields = serde_json::Value::Null;
+        let fields: &serde_json::Value = spec_v.get("fields").unwrap_or(&null_fields);
 
         let kind: SpecKind = match implementation {
             "ReleaseTitleSpecification" => {
                 let value = field_str(fields, "value")?;
                 // Sonarr regexes are case-insensitive by convention;
                 // prepend `(?i)` so every imported CF matches regardless
-                // of how the user authored it.
-                let re = regex_lite::Regex::new(&format!("(?i){value}"))
+                // of how the user authored it. `sonarr_to_rust_regex`
+                // rewrites .NET-isms (literal `[` inside a char class)
+                // into forms fancy-regex accepts. See that function's
+                // docs for the exact transforms.
+                let rewritten = sonarr_to_rust_regex(&value);
+                let re = fancy_regex::Regex::new(&format!("(?i){rewritten}"))
                     .map_err(|e| format!("ReleaseTitle regex: {e}"))?;
                 SpecKind::ReleaseTitle { regex: re }
             }
             "ReleaseGroupSpecification" => {
                 let value = field_str(fields, "value")?;
-                let re = regex_lite::Regex::new(&format!("(?i){value}"))
+                let rewritten = sonarr_to_rust_regex(&value);
+                let re = fancy_regex::Regex::new(&format!("(?i){rewritten}"))
                     .map_err(|e| format!("ReleaseGroup regex: {e}"))?;
                 SpecKind::ReleaseGroup { regex: re }
             }
@@ -256,42 +266,113 @@ pub fn compile_from_json(raw: &str, score: i32, id: i64) -> Result<CompiledCusto
     Ok(CompiledCustomFormat { id, name, score, specs })
 }
 
-fn field_str(fields: &[serde_json::Value], name: &str) -> Result<String, String> {
-    for f in fields {
-        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
-            return Ok(f
-                .get("value")
-                .and_then(|v| v.as_str())
-                .unwrap_or("")
-                .to_string());
+/// Rewrite a .NET/Sonarr-flavored regex into something fancy-regex
+/// accepts, preserving match semantics. The transforms performed:
+///
+/// 1. **Literal `[` inside a character class is escaped.** .NET regex
+///    treats `[` as a literal when it appears inside `[...]`, so
+///    trash-guides patterns like `[([]dual[])]` are valid .NET but
+///    reject in regex-syntax (the parser errors on a "nested" class).
+///    We walk the pattern tracking char-class state and emit `\[`
+///    whenever a bare `[` appears inside a class.
+///
+/// The char-class-leading-`]` rule (`[])]` = class containing `]`, `)`)
+/// is already handled by regex-syntax natively, so this pass leaves it
+/// alone.
+///
+/// Backslash escapes are copied through without interpretation — this
+/// is a syntactic fixup, not a semantic one.
+fn sonarr_to_rust_regex(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len() + 4);
+    let mut chars = pattern.chars().peekable();
+    let mut in_class = false;
+    // `just_opened` is true immediately after `[` (and after an
+    // optional leading `^`), so a `]` in that position is treated as
+    // a literal rather than closing the class.
+    let mut just_opened = false;
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            // Escape sequence: copy both the backslash and the next
+            // char verbatim regardless of class state.
+            out.push(c);
+            if let Some(n) = chars.next() {
+                out.push(n);
+            }
+            just_opened = false;
+            continue;
+        }
+
+        if !in_class {
+            out.push(c);
+            if c == '[' {
+                in_class = true;
+                just_opened = true;
+            }
+        } else if c == '^' && just_opened {
+            // Negated class marker; still at the "leading position"
+            // after the `^`.
+            out.push(c);
+        } else if c == ']' && !just_opened {
+            out.push(c);
+            in_class = false;
+        } else if c == '[' {
+            // Literal `[` inside a class — escape for regex-syntax.
+            out.push('\\');
+            out.push('[');
+            just_opened = false;
+        } else {
+            out.push(c);
+            just_opened = false;
         }
     }
-    Err(format!("field `{name}` missing"))
+
+    out
 }
 
-fn field_i64(fields: &[serde_json::Value], name: &str) -> Result<i64, String> {
-    for f in fields {
-        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
-            return f
-                .get("value")
-                .and_then(|v| v.as_i64())
-                .ok_or_else(|| format!("field `{name}` not an integer"));
+/// Look up a named field in a Sonarr CF spec regardless of which of
+/// the two `fields` shapes the exporter used:
+///
+/// - **Array form** (Sonarr UI / API): `[{"name": "value", "value": X}, …]`
+///   — the canonical shape Sonarr returns from `/api/v3/customformat`.
+/// - **Object form** (trash-guides repo JSON): `{"value": X, "min": Y}`
+///   — the shape trash-guides ships in `docs/json/sonarr/cf/*.json`.
+///
+/// Both shapes are valid round-trip Sonarr imports, so Ryokan accepts
+/// both. Returns `None` if `fields` is neither shape or the name is
+/// absent. Callers coerce the returned `Value` to the expected type.
+fn field_value<'a>(fields: &'a serde_json::Value, name: &str) -> Option<&'a serde_json::Value> {
+    if let Some(arr) = fields.as_array() {
+        for f in arr {
+            if f.get("name").and_then(|n| n.as_str()) == Some(name) {
+                return f.get("value");
+            }
         }
+        None
+    } else if let Some(obj) = fields.as_object() {
+        obj.get(name)
+    } else {
+        None
     }
-    Err(format!("field `{name}` missing"))
 }
 
-fn field_f64(fields: &[serde_json::Value], name: &str) -> Option<f64> {
-    for f in fields {
-        if f.get("name").and_then(|n| n.as_str()) == Some(name) {
-            // Sonarr ships these as JSON numbers; accept either f64 or
-            // i64 encodings for robustness (`"min": 5` vs `"min": 5.0`).
-            return f
-                .get("value")
-                .and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|n| n as f64)));
-        }
-    }
-    None
+fn field_str(fields: &serde_json::Value, name: &str) -> Result<String, String> {
+    field_value(fields, name)
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+        .ok_or_else(|| format!("field `{name}` missing"))
+}
+
+fn field_i64(fields: &serde_json::Value, name: &str) -> Result<i64, String> {
+    field_value(fields, name)
+        .and_then(|v| v.as_i64())
+        .ok_or_else(|| format!("field `{name}` missing"))
+}
+
+fn field_f64(fields: &serde_json::Value, name: &str) -> Option<f64> {
+    // Sonarr ships these as JSON numbers; accept either f64 or i64
+    // encodings for robustness (`"min": 5` vs `"min": 5.0`).
+    field_value(fields, name).and_then(|v| v.as_f64().or_else(|| v.as_i64().map(|n| n as f64)))
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -302,11 +383,16 @@ fn field_f64(fields: &[serde_json::Value], name: &str) -> Option<f64> {
 /// `IsSatisfiedByWithoutNegate`.
 fn evaluate_spec_kernel(spec: &CompiledSpec, ctx: &EvalContext) -> bool {
     match &spec.kind {
-        SpecKind::ReleaseTitle { regex } => regex.is_match(&ctx.result.title),
+        // fancy-regex returns `Result<bool, Error>` because backtracking
+        // can hit a step limit on pathological inputs. On error (step
+        // limit exceeded, runtime failure) treat as non-match — a
+        // Sonarr-compat CF should not be able to brick scoring for an
+        // entire search just because one spec timed out.
+        SpecKind::ReleaseTitle { regex } => regex.is_match(&ctx.result.title).unwrap_or(false),
         // `SearchResult::group` is a bare String. Empty means the Nyaa
         // scraper didn't find a `[Group]` prefix; an empty-string regex
         // still matches it, which is consistent with Sonarr's behavior.
-        SpecKind::ReleaseGroup { regex } => regex.is_match(&ctx.result.group),
+        SpecKind::ReleaseGroup { regex } => regex.is_match(&ctx.result.group).unwrap_or(false),
         SpecKind::Size { min_bytes, max_bytes } => {
             // Sonarr's SizeSpecification.cs uses strict-greater on the
             // lower bound and ≤ on the upper bound: `size > Min &&
@@ -397,6 +483,35 @@ pub fn total_cf_score(cfs: &[CompiledCustomFormat], ctx: &EvalContext) -> i32 {
         .filter(|cf| evaluate(cf, ctx))
         .map(|cf| cf.score)
         .sum()
+}
+
+/// Same total as [`total_cf_score`], but also returns the per-CF
+/// breakdown of every matching CF with a non-zero score contribution,
+/// in `custom_formats.id` order (the natural iteration order of the
+/// compiled cache). Used by the scoring debug-log path in
+/// `auto_search.rs` so the user-facing log row can list exactly which
+/// CFs fired on each candidate (§6.3 of the plan). Production scoring
+/// stays on the scalar [`total_cf_score`] variant for speed — only the
+/// debug-log path pays the allocation.
+pub fn total_cf_score_with_breakdown(
+    cfs: &[CompiledCustomFormat],
+    ctx: &EvalContext,
+) -> (i32, Vec<(String, i32)>) {
+    let mut total: i32 = 0;
+    let mut breakdown: Vec<(String, i32)> = Vec::new();
+    for cf in cfs {
+        if !evaluate(cf, ctx) {
+            continue;
+        }
+        total += cf.score;
+        // Zero-score matches are meaningful for CF authoring but add
+        // noise to the debug line — skip them per the plan §6.3 wording
+        // "every CF that matched with a nonzero score contribution."
+        if cf.score != 0 {
+            breakdown.push((cf.name.clone(), cf.score));
+        }
+    }
+    (total, breakdown)
 }
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -1177,5 +1292,867 @@ mod tests {
         let cand = candidate("anything", "anyone", 0, "");
         let cls = classification(Source::Unknown, Resolution::Unknown);
         assert!(evaluate(&cf, &ctx(&cand, &cls, &hashes)));
+    }
+
+    // ── Breakdown variant ────────────────────────────────────────────────
+
+    #[test]
+    fn total_cf_score_with_breakdown_returns_matching_contributions() {
+        // Three CFs: two that match the candidate with non-zero scores,
+        // one that doesn't match. Expect both matches in the breakdown
+        // in CF order, and the total == sum of the matching scores.
+        let cfs = vec![
+            compile_from_json(
+                r#"{"name":"x265","specifications":[{"implementation":"ReleaseTitleSpecification","fields":[{"name":"value","value":"x265"}]}]}"#,
+                300,
+                1,
+            )
+            .unwrap(),
+            compile_from_json(
+                r#"{"name":"flac","specifications":[{"implementation":"ReleaseTitleSpecification","fields":[{"name":"value","value":"flac"}]}]}"#,
+                150,
+                2,
+            )
+            .unwrap(),
+            compile_from_json(
+                r#"{"name":"noob","specifications":[{"implementation":"ReleaseGroupSpecification","fields":[{"name":"value","value":"^NoobSubs$"}]}]}"#,
+                -1000,
+                3,
+            )
+            .unwrap(),
+        ];
+        let cand = candidate("[MTBB] Show - 01 (BD x265 FLAC)", "MTBB", 0, "");
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+        let hashes = HashSet::new();
+        let (total, breakdown) = total_cf_score_with_breakdown(&cfs, &ctx(&cand, &cls, &hashes));
+        assert_eq!(total, 300 + 150);
+        assert_eq!(breakdown.len(), 2);
+        assert_eq!(breakdown[0].0, "x265");
+        assert_eq!(breakdown[0].1, 300);
+        assert_eq!(breakdown[1].0, "flac");
+        assert_eq!(breakdown[1].1, 150);
+    }
+
+    #[test]
+    fn total_cf_score_with_breakdown_skips_zero_score_matches() {
+        // A CF that matches but has score=0 contributes to the total
+        // correctly (trivially) but is omitted from the breakdown per
+        // plan §6.3's "nonzero score contribution" wording.
+        let cf = compile_from_json(
+            r#"{"name":"zero","specifications":[{"implementation":"ReleaseTitleSpecification","fields":[{"name":"value","value":"x265"}]}]}"#,
+            0,
+            1,
+        )
+        .unwrap();
+        let cand = candidate("Show x265", "", 0, "");
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+        let hashes = HashSet::new();
+        let (total, breakdown) = total_cf_score_with_breakdown(&[cf], &ctx(&cand, &cls, &hashes));
+        assert_eq!(total, 0);
+        assert!(breakdown.is_empty());
+    }
+
+    // ── Default CF library ───────────────────────────────────────────────
+
+    #[test]
+    fn default_custom_formats_json_compiles_every_cf() {
+        // Plan §7.2: the bundled default CF set at
+        // `static/default_custom_formats.json` must compile through the
+        // production CF compiler. This test is the regression guard for
+        // a typo (wrong field name, bad regex, unsupported spec type)
+        // silently breaking the Install Defaults button.
+        const DEFAULTS: &str = include_str!("../../static/default_custom_formats.json");
+        let value: serde_json::Value =
+            serde_json::from_str(DEFAULTS).expect("defaults file is valid JSON");
+        let entries = value
+            .as_array()
+            .expect("defaults file top-level must be an array");
+        assert_eq!(
+            entries.len(),
+            8,
+            "plan §7.2 specifies exactly 8 default CFs"
+        );
+        for (i, entry) in entries.iter().enumerate() {
+            let name = entry
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("(missing)");
+            let score = entry.get("score").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+            let raw = entry.to_string();
+            compile_from_json(&raw, score, (i + 1) as i64)
+                .unwrap_or_else(|e| panic!("default CF `{name}` failed to compile: {e}"));
+        }
+    }
+
+    #[test]
+    fn default_seadex_cf_fires_on_seadex_hash_match() {
+        // The first default CF is the SeaDex boost. Compiling it and
+        // feeding it a candidate whose info_hash is in the SeaDex set
+        // should trigger the match with a +10000 contribution — that's
+        // the score that dominates every other CF in the stacked
+        // hierarchy from plan §7.1.
+        const DEFAULTS: &str = include_str!("../../static/default_custom_formats.json");
+        let value: serde_json::Value = serde_json::from_str(DEFAULTS).unwrap();
+        let first = &value.as_array().unwrap()[0];
+        let score = first.get("score").unwrap().as_i64().unwrap() as i32;
+        assert_eq!(score, 10000, "SeaDex CF score must be +10000");
+        let cf = compile_from_json(&first.to_string(), score, 1).unwrap();
+
+        let mut hashes = HashSet::new();
+        hashes.insert("deadbeef".to_string());
+        let cand = candidate("[MTBB] Show - 01 (BD x265 FLAC)", "MTBB", 0, "deadbeef");
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+        assert!(evaluate(&cf, &ctx(&cand, &cls, &hashes)));
+        assert!(has_seadex_cf(&[cf]));
+    }
+
+    #[test]
+    fn default_penalize_8bit_mp4_spares_subsplease_mkv() {
+        // Regression guard for plan §7.3 CF #7: the two-spec
+        // `required=true` AND pattern must NOT fire on SubsPlease mkvs
+        // even though they're 8-bit (no 10-bit marker). The `.mp4`
+        // extension check is what protects them.
+        const DEFAULTS: &str = include_str!("../../static/default_custom_formats.json");
+        let value: serde_json::Value = serde_json::from_str(DEFAULTS).unwrap();
+        // Find the penalize-8bit-mp4 entry by name rather than index so
+        // a future reordering doesn't turn this into a silent false.
+        let entry = value
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|e| {
+                e.get("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.contains("8-bit mp4"))
+                    .unwrap_or(false)
+            })
+            .expect("default set must include the 8-bit mp4 penalty CF");
+        let cf = compile_from_json(
+            &entry.to_string(),
+            entry.get("score").unwrap().as_i64().unwrap() as i32,
+            1,
+        )
+        .unwrap();
+
+        let hashes = HashSet::new();
+        let cls = classification(Source::Unknown, Resolution::Unknown);
+
+        // SubsPlease weekly, .mkv container: should NOT match.
+        let sp = candidate(
+            "[SubsPlease] ShowX - 01 (1080p).mkv",
+            "SubsPlease",
+            0,
+            "",
+        );
+        assert!(
+            !evaluate(&cf, &ctx(&sp, &cls, &hashes)),
+            "SubsPlease mkv must be spared by the 8-bit mp4 penalty"
+        );
+
+        // NoobSubs-style 8-bit mp4: SHOULD match (hits both specs).
+        let noob = candidate(
+            "[NoobSubs] ShowX - 01 (1080p 8bit).mp4",
+            "NoobSubs",
+            0,
+            "",
+        );
+        assert!(
+            evaluate(&cf, &ctx(&noob, &cls, &hashes)),
+            "NoobSubs 8-bit mp4 must be caught by the penalty"
+        );
+
+        // A 10-bit mp4 (rare but possible): the required=true negate-10bit
+        // spec fails post-negate, so the penalty should NOT fire.
+        let tenbit_mp4 = candidate(
+            "[SomeGroup] ShowX - 01 (1080p 10bit).mp4",
+            "SomeGroup",
+            0,
+            "",
+        );
+        assert!(
+            !evaluate(&cf, &ctx(&tenbit_mp4, &cls, &hashes)),
+            "10-bit mp4 must survive the penalty"
+        );
+    }
+
+    // ── Phase 9 integration: Kizumonogatari regression ──────────────────
+
+    /// Load every CF from `static/default_custom_formats.json` into the
+    /// compiled form the runtime actually uses. Factored into a helper so
+    /// the Kizumonogatari regression test and the benchmark smoke test
+    /// build the same CF set.
+    fn load_default_cfs() -> Vec<CompiledCustomFormat> {
+        const DEFAULTS: &str = include_str!("../../static/default_custom_formats.json");
+        let value: serde_json::Value = serde_json::from_str(DEFAULTS).unwrap();
+        value
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+            .map(|(i, entry)| {
+                let score = entry.get("score").and_then(|v| v.as_i64()).unwrap_or(0) as i32;
+                compile_from_json(&entry.to_string(), score, (i + 1) as i64).unwrap()
+            })
+            .collect()
+    }
+
+    /// Helper that bundles the (title, group, classification) triple
+    /// most integration-test candidates need. Mirrors the real-world
+    /// pipeline: a Nyaa `SearchResult` plus a `ClassificationResult`
+    /// from the source module. Keeping both in a tuple keeps each
+    /// candidate row on one grep-able line in the test body.
+    fn make_fixture(
+        title: &str,
+        group: &str,
+        source: Source,
+        resolution: Resolution,
+        info_hash: &str,
+    ) -> (SearchResult, ClassificationResult) {
+        let cand = candidate(title, group, 8 * 1024 * 1024 * 1024, info_hash);
+        let cls = classification(source, resolution);
+        (cand, cls)
+    }
+
+    /// Sum the matching CF scores for a candidate against the default
+    /// set, with an empty SeaDex set. Mirrors the exact code path the
+    /// auto-search scorer uses in production, minus the `base_score`
+    /// layer (which is classification-driven and orthogonal to CF
+    /// ordering for this regression test).
+    fn score_against_defaults(
+        cfs: &[CompiledCustomFormat],
+        cand: &SearchResult,
+        cls: &ClassificationResult,
+    ) -> i32 {
+        let hashes = HashSet::new();
+        total_cf_score(cfs, &ctx(cand, cls, &hashes))
+    }
+
+    /// The core regression test for the bug where an 8-bit NoobSubs
+    /// mp4 with high seeders could tie or beat a 10-bit BD release
+    /// because the hardcoded `+5` quality-marker bonus was identical
+    /// for both. With the default CF set installed, the BD release
+    /// must win by a wide margin and the 8-bit mp4 release must sit
+    /// at the bottom of the score ordering.
+    ///
+    /// We assert strict ordering of the whole fixture, not just the
+    /// head-to-head — any future regression (a mis-applied negation,
+    /// a dropped required spec, a bad regex) flips the sort order and
+    /// fails the test with a message that names the regressed pair.
+    ///
+    /// **Fixture titles are deliberately synthetic.** `ReleaseGroup`
+    /// CFs evaluate against `SearchResult.group` (see
+    /// `SpecKind::ReleaseGroup` at ~L309), not the title, so the
+    /// group identity comes from the `group` argument to
+    /// `make_fixture`. The title string only needs to carry the
+    /// tokens that `ReleaseTitleSpecification` CFs match on
+    /// (`10bit`, `x265`, `hevc`, `flac`, `.mp4`). Nothing here
+    /// claims to be any specific group's real-world filename format.
+    #[test]
+    fn kizumonogatari_regression_cf_ordering() {
+        let cfs = load_default_cfs();
+        assert_eq!(cfs.len(), 8, "default CF set must be 8 CFs");
+
+        // Expected totals are computed from plan §7.2's score values:
+        //   Tier-S BD   = 1200 (Tier S) + 600 (BD source)
+        //               + 300 (10-bit/x265) + 150 (FLAC) = 2250
+        //   WEB HEVC    = 400 (WEB groups) + 300 (hevc/10-bit) = 700
+        //   WEB plain   = 400 (WEB groups) = 400
+        //   WEB neutral = 0 (matches no CF)
+        //   Casual WEB  = -1000 (casual groups)
+        //   Casual 8bit = -1000 (casual) + -500 (8-bit mp4) = -1500
+        //
+        // Groups are attached via the SearchResult.group field (the
+        // 2nd argument to make_fixture), not the title. Titles are
+        // opaque synthetic token blobs.
+        let tier_s_bd = make_fixture(
+            "fixture-bd-1080p-10bit-x265-flac.mkv",
+            "MTBB",
+            Source::BluRay,
+            Resolution::R1080p,
+            "aaaa",
+        );
+        let web_hevc = make_fixture(
+            "fixture-web-1080p-hevc-10bit.mkv",
+            "Judas",
+            Source::Web,
+            Resolution::R1080p,
+            "bbbb",
+        );
+        let web_plain = make_fixture(
+            "fixture-web-1080p.mkv",
+            "SubsPlease",
+            Source::Web,
+            Resolution::R1080p,
+            "cccc",
+        );
+        let web_neutral = make_fixture(
+            "fixture-web-1080p.mkv",
+            "Erai-raws",
+            Source::Web,
+            Resolution::R1080p,
+            "dddd",
+        );
+        let casual_web = make_fixture(
+            "fixture-web-1080p.mkv",
+            "HorribleSubs",
+            Source::Web,
+            Resolution::R1080p,
+            "eeee",
+        );
+        let casual_8bit_mp4 = make_fixture(
+            "fixture-web-1080p-8bit.mp4",
+            "NoobSubs",
+            Source::Web,
+            Resolution::R1080p,
+            "ffff",
+        );
+        // Build the flat list of (label, candidate, classification,
+        // expected) tuples used for both scoring and ordering checks.
+        let fixture: Vec<(&str, &SearchResult, &ClassificationResult, i32)> = vec![
+            ("Tier-S BD",      &tier_s_bd.0,       &tier_s_bd.1,       2250),
+            ("WEB HEVC",       &web_hevc.0,        &web_hevc.1,        700),
+            ("WEB plain",      &web_plain.0,       &web_plain.1,       400),
+            ("WEB neutral",    &web_neutral.0,     &web_neutral.1,     0),
+            ("Casual WEB",     &casual_web.0,      &casual_web.1,      -1000),
+            ("Casual 8bit mp4", &casual_8bit_mp4.0, &casual_8bit_mp4.1, -1500),
+        ];
+
+        // Per-candidate score assertion — each row's total must match
+        // plan §7.2's score values. If any of these fails, the
+        // failing row's label appears in the assertion message.
+        for (label, cand, cls, expected) in &fixture {
+            let got = score_against_defaults(&cfs, cand, cls);
+            assert_eq!(
+                got, *expected,
+                "candidate `{label}` scored {got}, expected {expected}"
+            );
+        }
+
+        // Strict ordering assertion — the fixture is already in
+        // expected descending order, so the sort result should equal
+        // the fixture order.
+        let mut sorted: Vec<(&&str, i32)> = fixture
+            .iter()
+            .map(|(label, cand, cls, _)| (label, score_against_defaults(&cfs, cand, cls)))
+            .collect();
+        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        let labels_in_score_order: Vec<&str> =
+            sorted.iter().map(|(label, _)| **label).collect();
+        assert_eq!(
+            labels_in_score_order,
+            vec![
+                "Tier-S BD",
+                "WEB HEVC",
+                "WEB plain",
+                "WEB neutral",
+                "Casual WEB",
+                "Casual 8bit mp4",
+            ],
+            "default CF set must produce the expected regression ordering"
+        );
+
+        // Finally, the single most important pairwise check — the
+        // literal regression from plan §1: Tier-S BluRay > Casual
+        // 8-bit mp4 by a strictly dominating margin.
+        let bd_score = score_against_defaults(&cfs, &tier_s_bd.0, &tier_s_bd.1);
+        let mp4_score = score_against_defaults(&cfs, &casual_8bit_mp4.0, &casual_8bit_mp4.1);
+        assert!(
+            bd_score > mp4_score + 3000,
+            "Tier-S BD ({bd_score}) must dominate Casual 8bit mp4 ({mp4_score}) by > 3000 points"
+        );
+    }
+
+    // ── Phase 9 cross-compat §5.7.7 — reject-on-all-unsupported ───────
+
+    #[test]
+    fn compile_rejects_cf_with_only_unsupported_spec() {
+        // TRaSH's real-world `BR-DISK` CF uses only a
+        // `QualityModifierSpecification`, which Ryokan doesn't
+        // implement. Per plan §5.7.7 #6, the compiler must reject
+        // this rather than silently letting it through as an empty
+        // (vacuous-match) CF.
+        let json = r#"{
+            "name": "BR-DISK",
+            "specifications": [
+                {
+                    "name": "BR-DISK modifier",
+                    "implementation": "QualityModifierSpecification",
+                    "negate": false,
+                    "required": false,
+                    "fields": [{"name":"value","value":1}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, 100, 1).unwrap_err();
+        assert!(
+            err.contains("all 1 specifications unsupported"),
+            "error must mention the all-unsupported rejection, got: {err}"
+        );
+    }
+
+    #[test]
+    fn compile_rejects_cf_with_dropped_required_spec() {
+        // Plan §5.7.7 #6: a CF with one supported spec plus a
+        // required=true unsupported spec must be rejected — dropping
+        // the required spec would change the CF's semantics silently.
+        let json = r#"{
+            "name": "Multi-Audio",
+            "specifications": [
+                {
+                    "name": "Title",
+                    "implementation": "ReleaseTitleSpecification",
+                    "negate": false,
+                    "required": false,
+                    "fields": [{"name":"value","value":"x265"}]
+                },
+                {
+                    "name": "Language",
+                    "implementation": "LanguageSpecification",
+                    "negate": false,
+                    "required": true,
+                    "fields": [{"name":"value","value":10}]
+                }
+            ]
+        }"#;
+        let err = compile_from_json(json, 100, 1).unwrap_err();
+        assert!(
+            err.contains("required=true") && err.contains("dropped"),
+            "error must mention the dropped-required rejection, got: {err}"
+        );
+    }
+
+    // ── Phase 9 round-trip (§5.7.7 #4) ────────────────────────────────
+
+    #[test]
+    fn round_trip_preserves_trash_metadata() {
+        // A representative trash-guides-shaped CF with all the
+        // extension fields plan §5.7.6 wants preserved: `trash_id`,
+        // `trash_scores`, `trash_description`, plus `includeCustomFormatWhenRenaming`.
+        // The test proves that compiling the CF, re-serializing the
+        // stored JSON (which is just the verbatim input because §5.1
+        // stores raw JSON), and re-parsing gives back the same `Value`
+        // tree. This is the "round-trip faithfully" assertion from §9.
+        let json = r#"{
+            "trash_id": "ed38b0b3-1e57-47bc-b0e1-abcdef012345",
+            "trash_scores": {"default": 500},
+            "trash_description": "Prefer x265 encodes over x264",
+            "name": "x265 preference",
+            "includeCustomFormatWhenRenaming": false,
+            "specifications": [
+                {
+                    "name": "x265",
+                    "implementation": "ReleaseTitleSpecification",
+                    "implementationName": "Release Title",
+                    "negate": false,
+                    "required": false,
+                    "fields": [{"name": "value", "value": "x265"}]
+                }
+            ]
+        }"#;
+
+        // Compile once to prove it's a valid CF from the production
+        // compiler's perspective.
+        let cf = compile_from_json(json, 500, 42).expect("fixture CF must compile");
+        assert_eq!(cf.name, "x265 preference");
+
+        // Round-trip path 1: raw JSON → Value → back to string →
+        // Value. Mirrors what `settings_custom_formats_export` does
+        // to every row in the database. The two Values must be equal
+        // because `serde_json::Value` is order-sensitive for arrays
+        // and order-insensitive for objects, which is exactly the
+        // "byte-level equivalence modulo whitespace/field order"
+        // semantic from plan §9.
+        let parsed_in: serde_json::Value = serde_json::from_str(json).unwrap();
+        let reserialized = serde_json::to_string(&parsed_in).unwrap();
+        let parsed_out: serde_json::Value = serde_json::from_str(&reserialized).unwrap();
+        assert_eq!(
+            parsed_in, parsed_out,
+            "raw JSON must round-trip as equal Value trees"
+        );
+
+        // Check every trash-guides extension field survived the round
+        // trip — plan §5.7.6 flags these as the ones Ryokan must NOT
+        // drop, even though the evaluator ignores them.
+        assert_eq!(
+            parsed_out.get("trash_id").and_then(|v| v.as_str()),
+            Some("ed38b0b3-1e57-47bc-b0e1-abcdef012345")
+        );
+        assert_eq!(
+            parsed_out
+                .get("trash_scores")
+                .and_then(|v| v.get("default"))
+                .and_then(|v| v.as_i64()),
+            Some(500)
+        );
+        assert_eq!(
+            parsed_out.get("trash_description").and_then(|v| v.as_str()),
+            Some("Prefer x265 encodes over x264")
+        );
+        assert_eq!(
+            parsed_out
+                .get("includeCustomFormatWhenRenaming")
+                .and_then(|v| v.as_bool()),
+            Some(false)
+        );
+    }
+
+    // ── Phase 9 benchmark smoke (§9) ──────────────────────────────────
+
+    #[test]
+    fn benchmark_100_candidates_8_cfs_under_15ms() {
+        // Plan §9: compile the 8-CF default set once, score 100
+        // candidates, hard threshold 15 ms wall-clock (three-sigma
+        // headroom over the < 5 ms target). If this blows past 15 ms
+        // something has regressed — allocation in the hot path, a
+        // regex re-compile per candidate, quadratic behavior in
+        // `evaluate`, etc.
+        //
+        // Debug builds are ~3-5x slower than release, so we only run
+        // the hard assertion under release. In debug we just run the
+        // loop to catch outright panics and print the timing.
+        let cfs = load_default_cfs();
+
+        // Five synthetic-token candidates reused round-robin to hit
+        // 100 iterations. The mix exercises every branch of every
+        // default CF, including the §5.7.3 Example D AND-across-specs
+        // path for the 8-bit mp4 penalty. Titles carry only the CF
+        // regex tokens — they do not mimic any specific group's real
+        // filename format.
+        let base_candidates: Vec<(SearchResult, ClassificationResult)> = vec![
+            make_fixture(
+                "fixture-bd-1080p-10bit-x265-flac.mkv",
+                "MTBB",
+                Source::BluRay,
+                Resolution::R1080p,
+                "hash0",
+            ),
+            make_fixture(
+                "fixture-web-1080p-hevc-10bit.mkv",
+                "Judas",
+                Source::Web,
+                Resolution::R1080p,
+                "hash1",
+            ),
+            make_fixture(
+                "fixture-web-1080p.mkv",
+                "SubsPlease",
+                Source::Web,
+                Resolution::R1080p,
+                "hash2",
+            ),
+            make_fixture(
+                "fixture-web-1080p.mkv",
+                "Erai-raws",
+                Source::Web,
+                Resolution::R1080p,
+                "hash3",
+            ),
+            make_fixture(
+                "fixture-web-1080p-8bit.mp4",
+                "NoobSubs",
+                Source::Unknown,
+                Resolution::R1080p,
+                "hash4",
+            ),
+        ];
+
+        let hashes = HashSet::new();
+        let iterations = 100usize;
+        let start = std::time::Instant::now();
+        let mut checksum: i32 = 0;
+        for i in 0..iterations {
+            let (cand, cls) = &base_candidates[i % base_candidates.len()];
+            checksum = checksum.wrapping_add(total_cf_score(&cfs, &ctx(cand, cls, &hashes)));
+        }
+        let elapsed = start.elapsed();
+        // Force the optimizer to keep the loop body.
+        std::hint::black_box(checksum);
+
+        let ms = elapsed.as_secs_f64() * 1000.0;
+        eprintln!("cf-benchmark: {iterations} candidates × 8 CFs in {ms:.3} ms");
+
+        // Hard threshold only in release. Debug timing is informational.
+        if !cfg!(debug_assertions) {
+            assert!(
+                elapsed < std::time::Duration::from_millis(15),
+                "CF evaluation over {iterations} candidates took {ms:.3} ms, \
+                 exceeding the 15 ms regression threshold from plan §9"
+            );
+        }
+    }
+
+    // ── sonarr_to_rust_regex ────────────────────────────────────────────
+
+    #[test]
+    fn sonarr_rewrite_escapes_literal_lbracket_in_class() {
+        // The trash-guides `anime-dual-audio` regex's critical fragment.
+        let rewritten = sonarr_to_rust_regex(r"[([]dual[])]");
+        assert_eq!(rewritten, r"[(\[]dual[])]");
+        assert!(fancy_regex::Regex::new(&rewritten).is_ok());
+    }
+
+    #[test]
+    fn sonarr_rewrite_passes_through_class_leading_rbracket() {
+        // Sonarr's convention: `]` immediately after `[` is literal.
+        // regex-syntax handles this natively, so the rewrite should
+        // leave it alone and the result should still compile.
+        let rewritten = sonarr_to_rust_regex(r"[])]");
+        assert_eq!(rewritten, r"[])]");
+        assert!(fancy_regex::Regex::new(&rewritten).is_ok());
+    }
+
+    #[test]
+    fn sonarr_rewrite_preserves_escapes_and_negation() {
+        // Negated class `[^...]` with escaped dot inside — should
+        // pass through unchanged.
+        let src = r"[^\.ab]";
+        assert_eq!(sonarr_to_rust_regex(src), src);
+        assert!(fancy_regex::Regex::new(src).is_ok());
+    }
+
+    #[test]
+    fn sonarr_rewrite_leaves_non_class_lbracket_alone() {
+        // A `[` outside a class (impossible per strict regex grammar
+        // but harmless here) is not rewritten — `sonarr_to_rust_regex`
+        // only touches `[` inside an already-open class.
+        let src = r"\[text\]";
+        assert_eq!(sonarr_to_rust_regex(src), src);
+    }
+
+    #[test]
+    fn sonarr_rewrite_handles_multiple_classes_in_same_pattern() {
+        // Two separate classes in one pattern, both with literal `[`.
+        let rewritten = sonarr_to_rust_regex(r"[[a][[b]");
+        assert_eq!(rewritten, r"[\[a][\[b]");
+        assert!(fancy_regex::Regex::new(&rewritten).is_ok());
+    }
+
+    // ── trash-guides anime fixture set (plan §9, Gap E) ──────────────────
+    //
+    // Twenty-eight real trash-guides anime CF JSON files are vendored at
+    // `fixtures/trash-guides-anime/`. Each fixture is pulled into the
+    // binary via `include_str!` so the test needs no filesystem access
+    // and no network at build time. These are the **actual** JSON shapes
+    // trash-guides ships (object-form `fields`, `trash_id`, `trash_scores`,
+    // `trash_description`, `LanguageSpecification` used as a soft hint),
+    // so the test doubles as a round-trip regression for the object/array
+    // `fields` bug that Gap E was created to catch — if either exporter
+    // shape stops parsing, every entry in this array breaks at once.
+    //
+    // Extending the set: add a new file under `fixtures/trash-guides-anime/`
+    // and a new `include_str!` line below. Any CF with a `required=true`
+    // LanguageSpecification will fail the parse guard on purpose — that is
+    // not a bug, that is Ryokan refusing to silently drop a gating spec.
+    const TRASH_ANIME_FIXTURES: &[(&str, &str)] = &[
+        ("10bit", include_str!("../../fixtures/trash-guides-anime/10bit.json")),
+        ("anime-bd-tier-01", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-01.json")),
+        ("anime-bd-tier-02", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-02.json")),
+        ("anime-bd-tier-03", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-03.json")),
+        ("anime-bd-tier-04", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-04.json")),
+        ("anime-bd-tier-05", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-05.json")),
+        ("anime-bd-tier-06", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-06.json")),
+        ("anime-bd-tier-07", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-07.json")),
+        ("anime-bd-tier-08", include_str!("../../fixtures/trash-guides-anime/anime-bd-tier-08.json")),
+        ("anime-dual-audio", include_str!("../../fixtures/trash-guides-anime/anime-dual-audio.json")),
+        ("anime-lq-groups", include_str!("../../fixtures/trash-guides-anime/anime-lq-groups.json")),
+        ("anime-raws", include_str!("../../fixtures/trash-guides-anime/anime-raws.json")),
+        ("anime-web-tier-01", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-01.json")),
+        ("anime-web-tier-02", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-02.json")),
+        ("anime-web-tier-03", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-03.json")),
+        ("anime-web-tier-04", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-04.json")),
+        ("anime-web-tier-05", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-05.json")),
+        ("anime-web-tier-06", include_str!("../../fixtures/trash-guides-anime/anime-web-tier-06.json")),
+        ("bad-dual-groups", include_str!("../../fixtures/trash-guides-anime/bad-dual-groups.json")),
+        ("dubs-only", include_str!("../../fixtures/trash-guides-anime/dubs-only.json")),
+        ("fansub", include_str!("../../fixtures/trash-guides-anime/fansub.json")),
+        ("fastsub", include_str!("../../fixtures/trash-guides-anime/fastsub.json")),
+        ("uncensored", include_str!("../../fixtures/trash-guides-anime/uncensored.json")),
+        ("v0", include_str!("../../fixtures/trash-guides-anime/v0.json")),
+        ("v1", include_str!("../../fixtures/trash-guides-anime/v1.json")),
+        ("v2", include_str!("../../fixtures/trash-guides-anime/v2.json")),
+        ("v3", include_str!("../../fixtures/trash-guides-anime/v3.json")),
+        ("v4", include_str!("../../fixtures/trash-guides-anime/v4.json")),
+    ];
+
+    /// Every vendored trash-guides anime CF must compile cleanly. A
+    /// failure here means one of three things is broken:
+    ///
+    /// 1. The object-form `fields` accessor regressed — every fixture
+    ///    would fail at once.
+    /// 2. trash-guides shipped a new spec implementation string Ryokan
+    ///    doesn't recognize, and it's `required=true` (and therefore
+    ///    correctly rejected instead of silently dropped).
+    /// 3. A regex in a vendored file became invalid against `fancy-regex`
+    ///    (unlikely but possible since Sonarr uses .NET's regex engine
+    ///    and we use `fancy-regex`, which supports look-around but not
+    ///    every PCRE feature).
+    #[test]
+    fn trash_anime_fixtures_all_parse() {
+        assert_eq!(
+            TRASH_ANIME_FIXTURES.len(),
+            28,
+            "fixture count drift: update the set and this assertion together"
+        );
+
+        let mut failures: Vec<(String, String)> = Vec::new();
+        for (label, raw) in TRASH_ANIME_FIXTURES {
+            match compile_from_json(raw, 0, 1) {
+                Ok(cf) => {
+                    // Sanity: every fixture has at least one surviving
+                    // spec (otherwise it's either vacuous or the parser
+                    // silently dropped something we didn't expect).
+                    assert!(
+                        !cf.specs.is_empty(),
+                        "fixture `{label}` compiled to zero specs — vacuous CF"
+                    );
+                }
+                Err(e) => failures.push(((*label).to_string(), e)),
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "trash-guides anime fixtures failed to parse:\n{}",
+            failures
+                .iter()
+                .map(|(name, err)| format!("  - {name}: {err}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    /// Every `specifications[].implementation` string in the fixture set
+    /// must be one Ryokan knows about (supported + handled, or
+    /// explicitly-tolerated-as-soft-hint). If trash-guides ships a new
+    /// implementation type (e.g. they add `EditionSpecification` to an
+    /// anime CF), this test fails with the exact file + unknown string
+    /// so a human can decide whether to add support or reject the CF.
+    #[test]
+    fn trash_anime_fixtures_use_only_known_implementations() {
+        // Strict subset of Ryokan's supported spec list. Kept in sync
+        // with the match arm in `compile_from_json`.
+        //
+        // `LanguageSpecification` is **not supported** but is soft-
+        // tolerated by the parser when `required=false` — it is silently
+        // dropped. Including it here is a claim that "we intentionally
+        // let this appear in vendored fixtures"; a `required=true`
+        // Language spec would still fail the first fixture test above.
+        const KNOWN: &[&str] = &[
+            "ReleaseTitleSpecification",
+            "ReleaseGroupSpecification",
+            "SourceSpecification",
+            "ResolutionSpecification",
+            "SizeSpecification",
+            "LanguageSpecification",
+            "SeaDexBestSpecification",
+            "Ryokan.SeaDexBestSpecification",
+        ];
+
+        let mut unknowns: Vec<(String, String)> = Vec::new();
+        for (label, raw) in TRASH_ANIME_FIXTURES {
+            let v: serde_json::Value = serde_json::from_str(raw)
+                .unwrap_or_else(|e| panic!("fixture `{label}` is not valid JSON: {e}"));
+            let specs = v
+                .get("specifications")
+                .and_then(|s| s.as_array())
+                .unwrap_or_else(|| panic!("fixture `{label}` has no specifications array"));
+            for s in specs {
+                let impl_name = s
+                    .get("implementation")
+                    .and_then(|i| i.as_str())
+                    .unwrap_or("<missing>");
+                if !KNOWN.contains(&impl_name) {
+                    unknowns.push(((*label).to_string(), impl_name.to_string()));
+                }
+            }
+        }
+
+        assert!(
+            unknowns.is_empty(),
+            "trash-guides anime fixtures reference unknown implementations — \
+             either add parser support or update the KNOWN list with a rationale:\n{}",
+            unknowns
+                .iter()
+                .map(|(name, imp)| format!("  - {name}: {imp}"))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    /// Round-trip guard: parse → serialize → re-parse must produce the
+    /// same compiled CF (same spec count, same match against a known
+    /// release title). This catches upstream schema drift that would
+    /// break Ryokan-compatible re-export of a trash-guides CF.
+    #[test]
+    fn trash_anime_fixtures_roundtrip_json() {
+        for (label, raw) in TRASH_ANIME_FIXTURES {
+            let first = compile_from_json(raw, 0, 1)
+                .unwrap_or_else(|e| panic!("fixture `{label}` failed first parse: {e}"));
+
+            // Re-serialize the raw JSON Value (not the compiled form —
+            // the compiled form is lossy by design). This mirrors what
+            // the export handler does: it hands back the stored `json`
+            // column, which for a CF imported from trash-guides is the
+            // raw trash-guides bytes.
+            let value: serde_json::Value = serde_json::from_str(raw)
+                .unwrap_or_else(|e| panic!("fixture `{label}` not valid JSON on re-read: {e}"));
+            let reserialized = serde_json::to_string(&value)
+                .unwrap_or_else(|e| panic!("fixture `{label}` failed to re-serialize: {e}"));
+
+            let second = compile_from_json(&reserialized, 0, 1).unwrap_or_else(|e| {
+                panic!("fixture `{label}` failed round-trip parse: {e}")
+            });
+
+            assert_eq!(
+                first.specs.len(),
+                second.specs.len(),
+                "fixture `{label}`: spec count drifted across round-trip \
+                 ({} → {})",
+                first.specs.len(),
+                second.specs.len()
+            );
+            assert_eq!(
+                first.name, second.name,
+                "fixture `{label}`: name drifted across round-trip"
+            );
+        }
+    }
+
+    /// Surviving-spec diff: catches "we silently started dropping more
+    /// specs than before" across the whole fixture set, which would
+    /// indicate either a parser regression or a new unsupported spec
+    /// type appearing in trash-guides. The numbers below are the
+    /// surviving (post-drop) spec counts as of 2026-04-13 and should
+    /// be updated in lockstep with intentional parser changes.
+    #[test]
+    fn trash_anime_fixtures_surviving_spec_counts_are_stable() {
+        // Every fixture compiles to >=1 spec (otherwise Gap E's fixture
+        // set includes a vacuous-match CF, which is meaningless). This
+        // is a weaker assertion than a hard expected-count map, but it
+        // survives trash-guides upstream edits without needing a lockstep
+        // update while still catching mass regressions. If you want to
+        // tighten this further, snapshot the `(label, spec_count)` map
+        // here.
+        let mut total_surviving = 0usize;
+        for (label, raw) in TRASH_ANIME_FIXTURES {
+            let cf = compile_from_json(raw, 0, 1)
+                .unwrap_or_else(|e| panic!("fixture `{label}` failed to parse: {e}"));
+            assert!(
+                !cf.specs.is_empty(),
+                "fixture `{label}` compiled to zero surviving specs"
+            );
+            total_surviving += cf.specs.len();
+        }
+        // Sanity floor: 28 CFs × at least 1 surviving spec each = 28.
+        // Realistic floor is far higher (hundreds of ReleaseTitle/Group
+        // specs across the set) — we saw 504 at vendoring time. Use a
+        // conservative floor that allows trash-guides some churn without
+        // triggering a spurious test failure.
+        assert!(
+            total_surviving >= 200,
+            "surviving-spec count dropped to {total_surviving} — expected \
+             at least 200 across the 28-file fixture set (saw 504 at vendor \
+             time). Investigate before updating this floor."
+        );
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -30,6 +30,7 @@ pub mod anibridge;
 pub mod upgrade;
 
 pub mod seadex;
+pub mod custom_formats;
 
 // Classification pipeline (Phase 1a foundations).
 pub mod source;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -29,6 +29,8 @@ pub mod post_processing;
 pub mod anibridge;
 pub mod upgrade;
 
+pub mod seadex;
+
 // Classification pipeline (Phase 1a foundations).
 pub mod source;
 pub mod source_description;

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -30,6 +30,25 @@ static SEL_NEXT: LazyLock<Selector> = LazyLock::new(|| {
     Selector::parse("ul.pagination li.next:not(.disabled)").expect("SEL_NEXT parses")
 });
 
+/// Pre-compiled selectors for the single-torrent view page
+/// (`/view/<id>`). Used by [`fetch_view_result`] for the SeaDex-bypass
+/// path that ingests curated torrents directly from their view URLs
+/// instead of going through the text search.
+static SEL_VIEW_TITLE: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("div.panel h3.panel-title").expect("SEL_VIEW_TITLE parses")
+});
+static SEL_VIEW_ROW: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("div.panel-body div.row").expect("SEL_VIEW_ROW parses"));
+static SEL_VIEW_COL: LazyLock<Selector> =
+    LazyLock::new(|| Selector::parse("div").expect("SEL_VIEW_COL parses"));
+static SEL_VIEW_MAGNET: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("a.card-footer-item[href^='magnet:']").expect("SEL_VIEW_MAGNET parses")
+});
+static SEL_VIEW_TORRENT: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("a.card-footer-item[href$='.torrent']")
+        .expect("SEL_VIEW_TORRENT parses")
+});
+
 /// Episode range like "01-12", "01~24", "1 - 24". Broader than the old
 /// `01[-~]\d{2,3}` hard-coded form so releases that start at a non-01
 /// episode (sequels, cour splits) still register as batches.
@@ -333,4 +352,238 @@ fn parse_size(s: &str) -> i64 {
 
 fn parse_int(s: &str) -> i32 {
     s.trim().parse().unwrap_or(0)
+}
+
+/// Fetch a single Nyaa view page by URL and return a populated
+/// [`SearchResult`]. Used by the SeaDex bypass path in auto-search:
+/// SeaDex tells us the curated torrent's info hash and view URL for a
+/// given AniList ID, but the torrent's title may not contain any of
+/// the query tokens (smol's Kizumonogatari pack is titled
+/// `[smol] Monogatari (Season 9) ...` so searches for "Kizumonogatari
+/// II: Nekketsu-hen" never surface it). Going direct to the view page
+/// sidesteps the whole text-match problem.
+///
+/// The parser extracts the same fields `parse_results` extracts from a
+/// search-listing row: title, seeders/leechers/completed, size,
+/// magnet, torrent file URL, info hash. `group`, `resolution`, and
+/// `is_batch` are derived from the title exactly the same way as in
+/// `parse_results`. `score` is computed with the passed options so the
+/// caller can merge these into the normal candidate pool seamlessly.
+pub async fn fetch_view_result(
+    view_url: &str,
+    opts: &SearchOptions,
+) -> Result<SearchResult, String> {
+    let html = HTTP_CLIENT
+        .get(view_url)
+        .send()
+        .await
+        .map_err(|e| format!("Nyaa view fetch failed: {}", e))?
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read view body: {}", e))?;
+
+    parse_view_page(&html, view_url, opts)
+        .ok_or_else(|| "Nyaa view page parse failed".to_string())
+}
+
+fn parse_view_page(
+    html: &str,
+    view_url: &str,
+    opts: &SearchOptions,
+) -> Option<SearchResult> {
+    let document = Html::parse_document(html);
+
+    // Title is the first `<h3 class="panel-title">` under the first
+    // `.panel` — the second instance is the "File list" header.
+    let title = document
+        .select(&SEL_VIEW_TITLE)
+        .next()?
+        .text()
+        .collect::<String>()
+        .trim()
+        .to_string();
+    if title.is_empty() {
+        return None;
+    }
+
+    // Scrape the labelled key/value rows in the header panel. Nyaa lays
+    // them out as `<div class="row"><div class="col-md-1">Label:</div>
+    // <div class="col-md-5">value</div> …</div>`, with a second
+    // (label, value) pair on the same row for Leechers/Completed/etc.
+    let mut seeders = 0i32;
+    let mut leechers = 0i32;
+    let mut downloads = 0i32;
+    let mut size = String::new();
+    for row in document.select(&SEL_VIEW_ROW) {
+        let cols: Vec<_> = row
+            .select(&SEL_VIEW_COL)
+            .map(|el| el.text().collect::<String>().trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        // We want pairs: each "Label:" should be followed by its value.
+        let mut i = 0;
+        while i + 1 < cols.len() {
+            let label = cols[i].trim_end_matches(':').trim().to_ascii_lowercase();
+            let value = cols[i + 1].trim().to_string();
+            match label.as_str() {
+                "seeders" => seeders = parse_int(&value),
+                "leechers" => leechers = parse_int(&value),
+                "completed" => downloads = parse_int(&value),
+                "file size" => size = value,
+                _ => {}
+            }
+            i += 2;
+        }
+    }
+
+    let size_bytes = parse_size(&size);
+
+    // Magnet: first `a.card-footer-item` with a `magnet:` href. Info
+    // hash comes from the same magnet via `extract_hash`.
+    let magnet = document
+        .select(&SEL_VIEW_MAGNET)
+        .next()
+        .and_then(|a| a.value().attr("href"))
+        .unwrap_or("")
+        .to_string();
+    let info_hash = extract_hash(&magnet);
+
+    // Torrent file URL: sibling `.card-footer-item` ending in .torrent.
+    // Paths on nyaa.si are relative, so prefix NYAA_BASE when needed.
+    let torrent = document
+        .select(&SEL_VIEW_TORRENT)
+        .next()
+        .and_then(|a| a.value().attr("href"))
+        .map(|href| {
+            if href.starts_with("http") {
+                href.to_string()
+            } else {
+                format!("{}{}", NYAA_BASE, href)
+            }
+        })
+        .unwrap_or_default();
+
+    let group = extract_group(&title);
+    let resolution = extract_resolution(&title);
+    let is_batch = detect_batch(&title);
+
+    let mut result = SearchResult {
+        title,
+        link: view_url.to_string(),
+        magnet,
+        torrent,
+        size,
+        size_bytes,
+        seeders,
+        leechers,
+        downloads,
+        group,
+        resolution,
+        is_batch,
+        // We don't get the row-class `success` tag from a view page, so
+        // the trusted flag stays false. Not a problem for the SeaDex
+        // path because the SeaDex boost dominates any trusted bonus.
+        is_trusted: false,
+        score: 0,
+        info_hash,
+    };
+
+    result.score = crate::services::scoring::score_result_with_sub_pref(
+        &result,
+        opts,
+        opts.prefer_subs,
+    );
+
+    Some(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Minimal fixture mirroring the real Nyaa view page structure we
+    /// saw for the smol Kizumonogatari megapack (`/view/1713886`). This
+    /// keeps `parse_view_page` tied to the actual DOM shape rather than
+    /// the assumptions the parser makes in isolation. If Nyaa ever
+    /// renumbers the column layout, this test fails loudly.
+    const SMOL_VIEW_FIXTURE: &str = r#"
+<html><body>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">
+      [smol] Monogatari (Season 9) (BD 1080p 1920x816 HEVC Opus) | Kizumonogatari | Monogatari Series | Kizumonogatari: Tekketsu-hen | Kizumonogatari: Nekketsu-hen | Kizumonogatari: Reiketsu-hen
+    </h3>
+  </div>
+  <div class="panel-body">
+    <div class="row">
+      <div class="col-md-1">Category:</div>
+      <div class="col-md-5"><a href="/?c=1_0">Anime</a> - <a href="/?c=1_2">English-translated</a></div>
+      <div class="col-md-1">Date:</div>
+      <div class="col-md-5" data-timestamp="1694025140">2023-09-06 18:32 UTC</div>
+    </div>
+    <div class="row">
+      <div class="col-md-1">Submitter:</div>
+      <div class="col-md-5"><a class="text-default" href="/user/smol">smol</a></div>
+      <div class="col-md-1">Seeders:</div>
+      <div class="col-md-5"><span style="color: green;">51</span></div>
+    </div>
+    <div class="row">
+      <div class="col-md-1">Information:</div>
+      <div class="col-md-5"><a href="https://anidb.net/anime/8357">https://anidb.net/anime/8357</a></div>
+      <div class="col-md-1">Leechers:</div>
+      <div class="col-md-5"><span style="color: red;">0</span></div>
+    </div>
+    <div class="row">
+      <div class="col-md-1">File size:</div>
+      <div class="col-md-5">23.8 GiB</div>
+      <div class="col-md-1">Completed:</div>
+      <div class="col-md-5">2286</div>
+    </div>
+    <div class="row">
+      <div class="col-md-offset-6 col-md-1">Info hash:</div>
+      <div class="col-md-5"><kbd>0f8ee3286d768fb53ae593f10155a5077e38e893</kbd></div>
+    </div>
+  </div>
+  <div class="panel-footer clearfix">
+    <a href="/download/1713886.torrent" class="card-footer-item">Download Torrent</a>
+    or
+    <a href="magnet:?xt=urn:btih:0f8ee3286d768fb53ae593f10155a5077e38e893&amp;dn=smol+pack" class="card-footer-item">Magnet</a>
+  </div>
+</div>
+</body></html>
+"#;
+
+    #[test]
+    fn parse_view_page_extracts_smol_pack_metadata() {
+        let opts = SearchOptions::default();
+        let result = parse_view_page(SMOL_VIEW_FIXTURE, "https://nyaa.si/view/1713886", &opts)
+            .expect("parser should succeed on a well-formed view page");
+
+        assert!(
+            result.title.contains("smol") && result.title.contains("Kizumonogatari"),
+            "title should be scraped from the header panel, got {:?}",
+            result.title
+        );
+        assert_eq!(result.seeders, 51);
+        assert_eq!(result.leechers, 0);
+        assert_eq!(result.downloads, 2286);
+        assert_eq!(result.size, "23.8 GiB");
+        assert!(result.size_bytes > 20 * 1024 * 1024 * 1024, "size_bytes should parse to GiB range");
+        assert_eq!(
+            result.info_hash,
+            "0f8ee3286d768fb53ae593f10155a5077e38e893",
+            "info_hash should be extracted from the magnet link"
+        );
+        assert!(
+            result.magnet.starts_with("magnet:?"),
+            "magnet link should be captured, got {:?}",
+            result.magnet
+        );
+        assert_eq!(result.torrent, "https://nyaa.si/download/1713886.torrent");
+        assert_eq!(result.link, "https://nyaa.si/view/1713886");
+        // `detect_batch` fires on the season marker in the title.
+        assert!(result.is_batch, "smol pack titled with Season N should be flagged as batch");
+        assert_eq!(result.resolution, "1080");
+        assert_eq!(result.group, "smol");
+    }
 }

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -138,19 +138,39 @@ async fn copy_poster(db: &sqlx::SqlitePool, series_id: i64, dest: &Path) {
     }
 }
 
-/// Process a single completed torrent. Returns `true` if at least one file was
-/// imported, `false` if there was nothing to do yet.
-async fn import_torrent(
+/// Per-series derived state used during an import. Built once per target
+/// series_id on demand inside [`import_torrent`] so a multi-series batch
+/// grab doesn't re-fetch the same rows or re-create the same directories
+/// for every file. The single-series case fills exactly one entry; a
+/// Phase 2 auto-expanded batch fills one entry per sibling touched.
+struct SeriesImportCtx {
+    series: series::Series,
+    folder_name: String,
+    series_title: String,
+    season_dir: PathBuf,
+    ep_meta: HashMap<i32, local_metadata::CachedEpisodeMetadata>,
+    /// Cached AniList detail used to enrich episode + series NFOs with
+    /// plot, genres, runtime, etc. `None` when the per-series metadata
+    /// cache is empty — the NFO writers fall back to the minimal
+    /// series-row-only shape.
+    cached_detail: Option<crate::services::anilist::AnimeDetail>,
+    runtime_minutes: Option<i32>,
+}
+
+/// Resolve the [`SeriesImportCtx`] for `series_id`: loads the series
+/// row, materializes its folder name + season directory, and warms up
+/// the episode metadata and AniList detail caches. Split out of
+/// [`import_torrent`] so a multi-series routed batch can reuse the same
+/// context across files without re-running the expensive preamble.
+async fn load_series_import_ctx(
     state: &AppState,
     cfg: &config::Config,
-    grab: &grabbed_torrents::GrabbedTorrent,
-    torrent_hash: &str,
-    torrent_save_path: &str,
-) -> Result<bool, String> {
-    let series = series::get_by_id(&state.db, grab.series_id)
+    series_id: i64,
+) -> Result<SeriesImportCtx, String> {
+    let series = series::get_by_id(&state.db, series_id)
         .await
         .map_err(|e| e.to_string())?
-        .ok_or_else(|| format!("series {} not found", grab.series_id))?;
+        .ok_or_else(|| format!("series {} not found", series_id))?;
 
     // Auto-generate folder_name from the best title if it was never set.
     let folder_name = if series.folder_name.is_empty() {
@@ -168,25 +188,17 @@ async fn import_torrent(
         series.folder_name.clone()
     };
 
-    let qbit = state
-        .qbit
-        .read()
-        .await
-        .clone()
-        .ok_or("qBittorrent not configured")?;
+    let series_title = nfo::best_title(&series);
+    let season_dir = Path::new(&cfg.media_root)
+        .join(&folder_name)
+        .join(format!("Season {:02}", 1_i32));
 
-    let files = qbit
-        .get_torrent_files(torrent_hash)
-        .await
-        .map_err(|e| format!("get torrent files: {}", e))?;
-
-    let video_files: Vec<_> = files
-        .iter()
-        .filter(|f| f.progress >= 1.0 && is_video_file(&f.name))
-        .collect();
-
-    if video_files.is_empty() {
-        return Ok(false);
+    {
+        let season_dir = season_dir.clone();
+        tokio::task::spawn_blocking(move || std::fs::create_dir_all(&season_dir))
+            .await
+            .map_err(|e| format!("create season dir join: {}", e))?
+            .map_err(|e| format!("create season dir: {}", e))?;
     }
 
     let ep_meta = local_metadata::get_episode_map_for_series(&state.db, series.id)
@@ -204,22 +216,76 @@ async fn import_torrent(
         .map(|c| c.detail);
     let runtime_minutes = cached_detail.as_ref().and_then(|d| d.duration);
 
-    let series_title = nfo::best_title(&series);
-    let season = 1_i32;
+    Ok(SeriesImportCtx {
+        series,
+        folder_name,
+        series_title,
+        season_dir,
+        ep_meta,
+        cached_detail,
+        runtime_minutes,
+    })
+}
 
-    let season_dir = Path::new(&cfg.media_root)
-        .join(&folder_name)
-        .join(format!("Season {:02}", season));
+/// Process a single completed torrent. Returns `true` if at least one file was
+/// imported, `false` if there was nothing to do yet.
+///
+/// Phase 2: if the grab has routing rows in `grabbed_torrent_series`
+/// (written by the auto-expand path when a megapack contained sibling
+/// entries), each file is routed to the sibling's own library folder
+/// instead of the parent's. Grabs without routes fall through to the
+/// legacy single-series behavior where every file targets
+/// `grab.series_id`.
+async fn import_torrent(
+    state: &AppState,
+    cfg: &config::Config,
+    grab: &grabbed_torrents::GrabbedTorrent,
+    torrent_hash: &str,
+    torrent_save_path: &str,
+) -> Result<bool, String> {
+    // Phase 2: look up per-file routing rows written by the auto-expand
+    // path. A non-empty result means this grab was an auto-expanded
+    // batch and each file is tagged with the sibling series_id it
+    // belongs to; an empty result is the legacy path where every file
+    // routes to `grab.series_id` (pre-Phase-2 grabs, or Phase-2 grabs
+    // where sibling detection returned nothing).
+    let routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
+        .await
+        .unwrap_or_default();
 
-    {
-        let season_dir = season_dir.clone();
-        tokio::task::spawn_blocking(move || std::fs::create_dir_all(&season_dir))
-            .await
-            .map_err(|e| format!("create season dir join: {}", e))?
-            .map_err(|e| format!("create season dir: {}", e))?;
+    // file_idx → target series_id, flattened from the routes table.
+    let routes_by_file: HashMap<usize, i64> = routes
+        .iter()
+        .flat_map(|r| r.file_indices.iter().map(move |i| (*i, r.series_id)))
+        .collect();
+
+    let qbit = state
+        .qbit
+        .read()
+        .await
+        .clone()
+        .ok_or("qBittorrent not configured")?;
+
+    let files = qbit
+        .get_torrent_files(torrent_hash)
+        .await
+        .map_err(|e| format!("get torrent files: {}", e))?;
+
+    // Preserve the canonical qBit file index alongside each entry so
+    // completed files can be correlated back to their route row. qBit
+    // returns files in a deterministic order keyed by file index, so
+    // `enumerate()` applied to the untouched `files` vec yields the
+    // same indices that `detect_sibling_entries_in_pack` recorded at
+    // grab time.
+    let video_files: Vec<(usize, &crate::services::qbit::TorrentFile)> = files
+        .iter()
+        .enumerate()
+        .filter(|(_, f)| f.progress >= 1.0 && is_video_file(&f.name))
+        .collect();
+
+    if video_files.is_empty() {
+        return Ok(false);
     }
-
-    let mut imported_count = 0_usize;
 
     // Determine the source base path. If qbit_download_path is configured, use
     // that instead of qBit's internal save_path — this handles Docker path
@@ -230,7 +296,50 @@ async fn import_torrent(
         torrent_save_path.to_string()
     };
 
-    for file in &video_files {
+    // Lazily-loaded per-series context cache. The single-series case
+    // fills exactly one entry; a multi-series routed batch fills one
+    // entry per sibling touched.
+    let mut series_ctx_cache: HashMap<i64, SeriesImportCtx> = HashMap::new();
+    // Unique series_ids that had at least one file successfully
+    // imported — drives the per-series NFO/poster write after the loop.
+    let mut touched_series: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    let mut imported_count = 0_usize;
+
+    for (file_idx, file) in &video_files {
+        // Route this file: prefer the routes table (Phase 2 batch
+        // auto-expansion), fall back to `grab.series_id` for legacy
+        // grabs and for any completed video file whose index wasn't
+        // covered by a route (e.g. extension mismatch between
+        // `auto_search::is_media_filename` and [`is_video_file`]).
+        let target_series_id = routes_by_file
+            .get(file_idx)
+            .copied()
+            .unwrap_or(grab.series_id);
+
+        if !series_ctx_cache.contains_key(&target_series_id) {
+            match load_series_import_ctx(state, cfg, target_series_id).await {
+                Ok(ctx) => {
+                    series_ctx_cache.insert(target_series_id, ctx);
+                }
+                Err(e) => {
+                    logger::error(
+                        &state.db,
+                        LogCategory::PostProcess,
+                        &format!(
+                            "Failed to load series context for id={}",
+                            target_series_id
+                        ),
+                        &e,
+                    )
+                    .await;
+                    continue;
+                }
+            }
+        }
+        let ctx = series_ctx_cache
+            .get(&target_series_id)
+            .expect("ctx just inserted");
+
         let src: PathBuf = Path::new(&source_base).join(&file.name);
 
         let filename_only = Path::new(&file.name)
@@ -238,12 +347,19 @@ async fn import_torrent(
             .and_then(|n| n.to_str())
             .unwrap_or(&file.name);
 
-        // Parse episode number from the filename.
+        // Parse episode number from the filename. The `grab.episode_numbers`
+        // fallback only makes sense for the legacy single-series path —
+        // in a routed batch the routes rows already carry per-sibling
+        // episode numbers and the parent grab's list doesn't apply to
+        // sibling files.
         let ep_num = media::parse_episode_number(&filename_only.to_lowercase())
             .map(|(_, ep)| ep)
             .or_else(|| {
-                // Fall back to the first episode number recorded at grab time.
-                grab.episode_numbers.first().copied()
+                if routes_by_file.is_empty() {
+                    grab.episode_numbers.first().copied()
+                } else {
+                    None
+                }
             });
 
         let Some(ep_num) = ep_num else {
@@ -251,13 +367,14 @@ async fn import_torrent(
                 &state.db,
                 LogCategory::PostProcess,
                 &format!("Could not parse episode number from '{}'", filename_only),
-                &format!("series={}", series.title),
+                &format!("series={}", ctx.series.title),
             )
             .await;
             continue;
         };
 
-        let ep_title = ep_meta
+        let ep_title = ctx
+            .ep_meta
             .get(&ep_num)
             .map(|m| {
                 if !m.title_english.is_empty() {
@@ -270,7 +387,8 @@ async fn import_torrent(
             })
             .unwrap_or_default();
 
-        let aired = ep_meta
+        let aired = ctx
+            .ep_meta
             .get(&ep_num)
             .map(|m| m.aired.clone())
             .unwrap_or_default();
@@ -280,25 +398,26 @@ async fn import_torrent(
             .and_then(|e| e.to_str())
             .unwrap_or("mkv");
 
+        let season = 1_i32;
         let dest_stem = if ep_title.is_empty() {
             format!(
                 "{} - S{:02}E{:02}",
-                sanitize_filename(&series_title),
+                sanitize_filename(&ctx.series_title),
                 season,
                 ep_num
             )
         } else {
             format!(
                 "{} - S{:02}E{:02} - {}",
-                sanitize_filename(&series_title),
+                sanitize_filename(&ctx.series_title),
                 season,
                 ep_num,
                 sanitize_filename(&ep_title)
             )
         };
 
-        let dest_video = season_dir.join(format!("{}.{}", dest_stem, ext));
-        let dest_nfo = season_dir.join(format!("{}.nfo", dest_stem));
+        let dest_video = ctx.season_dir.join(format!("{}.{}", dest_stem, ext));
+        let dest_nfo = ctx.season_dir.join(format!("{}.nfo", dest_stem));
 
         // Check for existing files with the same SxxExx tag (any extension).
         // Matching by episode tag instead of full stem handles cases where the
@@ -310,7 +429,7 @@ async fn import_torrent(
         // hundreds of ms. The filter logic is cheap CPU, so we also move
         // it into the spawned task.
         let existing_for_ep: Vec<PathBuf> = {
-            let season_dir = season_dir.clone();
+            let season_dir = ctx.season_dir.clone();
             let ep_tag = ep_tag.clone();
             tokio::task::spawn_blocking(move || -> Vec<PathBuf> {
                 std::fs::read_dir(&season_dir)
@@ -338,9 +457,16 @@ async fn import_torrent(
             // Check if this is an upgrade replacing a previously imported file.
             // If an older imported grab exists for this episode, this is an
             // upgrade — remove the old file and old torrent, then import the new one.
+            //
+            // Using `target_series_id` (the routed sibling) rather than
+            // `grab.series_id` (the parent) is what makes per-sibling
+            // upgrade detection work: `find_imported_for_episode`
+            // unions across the legacy grabbed_torrents column and the
+            // routes table, so a prior sibling-routed import still
+            // surfaces here.
             let old_grabs = grabbed_torrents::find_imported_for_episode(
                 &state.db,
-                grab.series_id,
+                target_series_id,
                 ep_num,
             )
             .await
@@ -367,14 +493,17 @@ async fn import_torrent(
                 // Remove corresponding NFO (old stem may differ from new dest_stem
                 // if the episode title changed between grabs).
                 if let Some(stem) = old_file.file_stem().and_then(|s| s.to_str()) {
-                    let _ = tokio::fs::remove_file(season_dir.join(format!("{}.nfo", stem))).await;
+                    let _ = tokio::fs::remove_file(ctx.season_dir.join(format!("{}.nfo", stem))).await;
                 }
             }
 
             logger::info(
                 &state.db,
                 LogCategory::PostProcess,
-                &format!("Replacing S{:02}E{:02} of '{}' with upgraded release", season, ep_num, series.title),
+                &format!(
+                    "Replacing S{:02}E{:02} of '{}' with upgraded release",
+                    season, ep_num, ctx.series.title
+                ),
                 &format!("old_grabs={}", old_grabs.len()),
             )
             .await;
@@ -397,19 +526,27 @@ async fn import_torrent(
             Ok(()) => {
                 let _ = nfo::write_episode_nfo(
                     &dest_nfo,
-                    &series_title,
+                    &ctx.series_title,
                     season,
                     ep_num,
                     &ep_title,
                     &aired,
-                    runtime_minutes,
+                    ctx.runtime_minutes,
                 );
                 imported_count += 1;
+                touched_series.insert(target_series_id);
                 logger::info(
                     &state.db,
                     LogCategory::PostProcess,
-                    &format!("Imported S{:02}E{:02} of '{}'", season, ep_num, series.title),
-                    &format!("mode={} dest={}", cfg.post_processing_mode, dest_video.display()),
+                    &format!(
+                        "Imported S{:02}E{:02} of '{}'",
+                        season, ep_num, ctx.series.title
+                    ),
+                    &format!(
+                        "mode={} dest={}",
+                        cfg.post_processing_mode,
+                        dest_video.display()
+                    ),
                 )
                 .await;
 
@@ -418,8 +555,8 @@ async fn import_torrent(
                 // artifacts, then updates episode_quality_tags in place.
                 // Rows with manual_override = 1 are left alone by the DB
                 // helper so user tags stick.
-                let series_root = Path::new(&cfg.media_root).join(&folder_name);
-                let pre_source = episode_tags::get_for_series(&state.db, series.id)
+                let series_root = Path::new(&cfg.media_root).join(&ctx.folder_name);
+                let pre_source = episode_tags::get_for_series(&state.db, ctx.series.id)
                     .await
                     .ok()
                     .and_then(|m| m.get(&ep_num).map(|t| t.source.clone()))
@@ -430,16 +567,16 @@ async fn import_torrent(
                     Some(&series_root),
                     &grab.torrent_name,
                     Some(SeriesContext {
-                        status: &series.status,
-                        season_year: series.season_year,
-                        end_year: series.end_year,
+                        status: &ctx.series.status,
+                        season_year: ctx.series.season_year,
+                        end_year: ctx.series.end_year,
                     }),
                     grab.is_batch,
                 )
                 .await;
                 if let Err(e) = episode_tags::update_classification(
                     &state.db,
-                    series.id,
+                    ctx.series.id,
                     ep_num,
                     &post,
                 )
@@ -477,7 +614,7 @@ async fn import_torrent(
                             LogCategory::PostProcess,
                             &format!(
                                 "Needs review: {} S{:02}E{:02}",
-                                series.title, season, ep_num
+                                ctx.series.title, season, ep_num
                             ),
                             &format!(
                                 "post-download classification {} flagged for review",
@@ -504,23 +641,55 @@ async fn import_torrent(
         return Ok(false);
     }
 
-    // Always (re)write series-level NFO so Jellyfin picks up refreshed
+    // Series-level artifacts (tvshow.nfo + poster) run once per unique
+    // series actually touched, not once total. A multi-series routed
+    // batch now maintains the correct per-sibling artifacts instead of
+    // dumping everything into the parent's folder.
+    //
+    // Always (re)write tvshow.nfo so Jellyfin picks up refreshed
     // metadata (status flips from RELEASING to FINISHED, plot updates,
-    // newly indexed genres). The previous "write once if missing" behavior
-    // meant any NFO written before metadata enrichment shipped never got
-    // upgraded. The file is small and the write is local; rewriting on
-    // every import run is cheap.
-    let series_nfo = Path::new(&cfg.media_root)
-        .join(&folder_name)
-        .join("tvshow.nfo");
-    let _ = nfo::write_series_nfo(&series_nfo, &series, cached_detail.as_ref());
+    // newly indexed genres). The previous "write once if missing"
+    // behavior meant any NFO written before metadata enrichment shipped
+    // never got upgraded. The file is small and the write is local;
+    // rewriting on every import run is cheap.
+    for series_id in &touched_series {
+        let Some(ctx) = series_ctx_cache.get(series_id) else {
+            continue;
+        };
+        let series_root = Path::new(&cfg.media_root).join(&ctx.folder_name);
+        let series_nfo = series_root.join("tvshow.nfo");
+        let _ = nfo::write_series_nfo(&series_nfo, &ctx.series, ctx.cached_detail.as_ref());
 
-    // Copy poster once.
-    let poster_dest = Path::new(&cfg.media_root)
-        .join(&folder_name)
-        .join("poster.jpg");
-    if !poster_dest.exists() {
-        copy_poster(&state.db, series.id, &poster_dest).await;
+        let poster_dest = series_root.join("poster.jpg");
+        if !poster_dest.exists() {
+            copy_poster(&state.db, ctx.series.id, &poster_dest).await;
+        }
+    }
+
+    // Flip episode tag rows from "grabbed" to "completed" per target
+    // series. For a routed batch each sibling route gets its own
+    // `mark_completed` call with the per-sibling episode numbers the
+    // auto-expand path wrote into the routes table; the legacy path
+    // falls through to the grab's parent series and episode list.
+    if routes.is_empty() {
+        let _ = episode_tags::mark_completed(
+            &state.db,
+            grab.series_id,
+            &grab.episode_numbers,
+        )
+        .await;
+    } else {
+        for route in &routes {
+            if route.episode_numbers.is_empty() {
+                continue;
+            }
+            let _ = episode_tags::mark_completed(
+                &state.db,
+                route.series_id,
+                &route.episode_numbers,
+            )
+            .await;
+        }
     }
 
     Ok(true)
@@ -643,13 +812,12 @@ pub async fn run_once(state: &AppState) {
             Ok(true) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
-                // Update episode quality tags from "grabbed" to "completed" so the UI
-                // shows the quality label instead of a stale progress bar on revisit.
-                let _ = episode_tags::mark_completed(
-                    &state.db,
-                    grab.series_id,
-                    &grab.episode_numbers,
-                ).await;
+                // Episode tag "grabbed → completed" flips happen inside
+                // `import_torrent` itself so a Phase 2 routed batch can
+                // mark each sibling's tags under the sibling's own
+                // series_id + per-route episode numbers. Legacy grabs
+                // still get the same flip as before via the
+                // `routes.is_empty()` fallback there.
             }
             Ok(false) => {
                 // Torrent complete but no video files yet — leave as pending.

--- a/src/services/qbit.rs
+++ b/src/services/qbit.rs
@@ -34,6 +34,31 @@ pub struct TorrentFile {
     pub name: String,
     pub size: i64,
     pub progress: f64,
+    /// qBit file priority: 0 = skip, 1 = normal, 6 = high, 7 = max.
+    /// Defaulted to `1` (normal) on the off chance qBit omits the
+    /// field — safer than defaulting to 0 "skip", which our
+    /// additive-merge logic interprets as "this torrent has been
+    /// narrowed before".
+    #[serde(default = "default_file_priority")]
+    pub priority: i32,
+}
+
+fn default_file_priority() -> i32 {
+    1
+}
+
+/// Outcome of an `add_torrent_with_file_filter` call.
+#[derive(Debug)]
+pub enum SelectiveOutcome {
+    /// Filter narrowed the torrent to specific files. Contains the
+    /// kept file indices (always a strict subset of the file list).
+    Filtered(Vec<usize>),
+    /// No filter applied — the torrent is downloading all files.
+    /// Used when the caller's `pick` returned `None`, when the pick
+    /// matched every file (not a megapack after all), or when qBit
+    /// metadata fetch timed out and we resumed the already-added
+    /// torrent unchanged instead of leaving it stuck paused.
+    FullDownload,
 }
 
 impl QbitClient {
@@ -146,6 +171,182 @@ impl QbitClient {
         Ok(())
     }
 
+    /// Set the download priority for a list of file indices inside a
+    /// single torrent. `priority` meanings:
+    ///   0 = do not download (skip)
+    ///   1 = normal
+    ///   6 = high
+    ///   7 = maximum
+    ///
+    /// qBit expects the file ids joined with `|`.
+    pub async fn set_file_priority(
+        &self,
+        hash: &str,
+        file_ids: &[usize],
+        priority: i32,
+    ) -> Result<(), String> {
+        if file_ids.is_empty() {
+            return Ok(());
+        }
+        let id_str = file_ids
+            .iter()
+            .map(|i| i.to_string())
+            .collect::<Vec<_>>()
+            .join("|");
+        let prio_str = priority.to_string();
+        let form = [
+            ("hash", hash),
+            ("id", id_str.as_str()),
+            ("priority", prio_str.as_str()),
+        ];
+        let resp = self.do_post_form("/api/v2/torrents/filePrio", &form).await?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("qbit filePrio failed: {} {}", status, body.trim()));
+        }
+        Ok(())
+    }
+
+    /// Poll the torrent's file list until qBit has fetched metadata and
+    /// knows the contents, or `timeout` elapses. For magnet links added
+    /// paused, the file list is not immediately available — qBit has to
+    /// hit trackers and pull the metadata first. Returns the final file
+    /// list on success.
+    pub async fn wait_for_metadata(
+        &self,
+        hash: &str,
+        timeout: std::time::Duration,
+    ) -> Result<Vec<TorrentFile>, String> {
+        let start = std::time::Instant::now();
+        let mut delay = std::time::Duration::from_millis(500);
+        loop {
+            match self.get_torrent_files(hash).await {
+                Ok(files) if !files.is_empty() => return Ok(files),
+                Ok(_) => {}
+                Err(e) => {
+                    // 404 while qBit is still discovering the torrent —
+                    // treat as "not ready yet" until the timeout expires.
+                    if start.elapsed() >= timeout {
+                        return Err(format!(
+                            "qbit metadata fetch error after {:?}: {}",
+                            timeout, e
+                        ));
+                    }
+                }
+            }
+            if start.elapsed() >= timeout {
+                return Err(format!(
+                    "qbit metadata fetch timed out after {:?}",
+                    timeout
+                ));
+            }
+            tokio::time::sleep(delay).await;
+            // Gentle backoff, capped at 2s per poll.
+            delay = (delay * 2).min(std::time::Duration::from_secs(2));
+        }
+    }
+
+    /// Add a torrent, wait for qBit to know its file list, invoke `pick`
+    /// to select which files to keep, and mark the rest as skip. On
+    /// metadata-fetch timeout, or when `pick` returns `None` / an empty
+    /// list / a set that covers every file, the torrent is left
+    /// downloading unfiltered so the user still gets a full grab.
+    ///
+    /// Notably: we do **not** add paused. qBit 5.x renamed pause/resume
+    /// to stop/start and — more importantly — a torrent added in
+    /// stopped state doesn't publish its file list through
+    /// `/torrents/files`, so the old "add paused → wait metadata → set
+    /// priorities → resume" flow hangs forever on 5.x. Instead we add
+    /// unpaused and race `filePrio` against qBit's peer-discovery
+    /// startup. For a `.torrent` URL add, qBit parses the file list
+    /// within a couple of seconds — well before any real data transfer
+    /// begins — so the window where unwanted pieces might be requested
+    /// is small and bounded. An explicit `resume_torrent` call after
+    /// the add handles the dedup case where qBit already has the same
+    /// info hash sitting in stopped state from an earlier failed grab.
+    ///
+    /// **Additive merge**: when a second selective grab lands on a
+    /// torrent that's already been narrowed by an earlier grab (e.g.
+    /// the user grabbed Kizu 2 from a Monogatari megapack, then grabs
+    /// Kizu 1 from the same pack), we only bump the *new* wanted
+    /// files from skip → normal. We do **not** re-skip everything
+    /// outside the new keep set, because that would silently clobber
+    /// files that earlier grabs deliberately enabled. Detection is by
+    /// looking at current file priorities in the qBit file list: if
+    /// any file is currently at priority 0, the torrent has been
+    /// narrowed before and we take the merge branch.
+    pub async fn add_torrent_with_file_filter<F>(
+        &self,
+        url: &str,
+        info_hash: &str,
+        pick: F,
+    ) -> Result<SelectiveOutcome, String>
+    where
+        F: FnOnce(&[String]) -> Option<Vec<usize>>,
+    {
+        if info_hash.is_empty() {
+            return Err("selective download requires a known info hash".into());
+        }
+        let hash_lc = info_hash.to_ascii_lowercase();
+
+        self.add_torrent(url).await?;
+
+        // If qBit already had this hash sitting in stopped state from
+        // a prior failed attempt, the add above is a dedupe no-op and
+        // the torrent is still stopped. Explicitly start it so
+        // metadata starts flowing and the file list becomes visible.
+        // Fresh adds are already running, so this is a no-op for them.
+        self.resume_torrent(&hash_lc).await?;
+
+        // With a `.torrent` URL qBit has the file list within 1-3
+        // seconds; 60s is a generous ceiling. On timeout we give up
+        // on narrowing and let the full download proceed — the
+        // torrent is running, not stuck.
+        let files = match self
+            .wait_for_metadata(&hash_lc, std::time::Duration::from_secs(60))
+            .await
+        {
+            Ok(files) => files,
+            Err(_) => return Ok(SelectiveOutcome::FullDownload),
+        };
+
+        let names: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
+        let keep = pick(&names);
+
+        let new_keep_ids = match keep {
+            Some(ids) if !ids.is_empty() && ids.len() < files.len() => ids,
+            _ => return Ok(SelectiveOutcome::FullDownload),
+        };
+
+        // Has an earlier grab already narrowed this torrent? Any file
+        // currently at priority 0 proves yes — qBit only sets 0 when
+        // something explicitly skipped it, not as a default.
+        let already_narrowed = files.iter().any(|f| f.priority == 0);
+
+        if already_narrowed {
+            // Merge branch: only bump new keeps that are currently at
+            // skip. Files already > 0 stay untouched so previous
+            // grabs on this megapack keep downloading.
+            let to_bump: Vec<usize> = new_keep_ids
+                .iter()
+                .copied()
+                .filter(|&i| files.get(i).map(|f| f.priority == 0).unwrap_or(false))
+                .collect();
+            if !to_bump.is_empty() {
+                self.set_file_priority(&hash_lc, &to_bump, 1).await?;
+            }
+        } else {
+            // Fresh branch: apply the full skip/keep split.
+            let skip_ids: Vec<usize> = (0..files.len())
+                .filter(|i| !new_keep_ids.contains(i))
+                .collect();
+            self.set_file_priority(&hash_lc, &skip_ids, 0).await?;
+            self.set_file_priority(&hash_lc, &new_keep_ids, 1).await?;
+        }
+        Ok(SelectiveOutcome::Filtered(new_keep_ids))
+    }
+
     /// Get all torrents, optionally filtered by category.
     pub async fn get_torrents(&self) -> Result<Vec<Torrent>, String> {
         let endpoint = if self.category.is_empty() {
@@ -174,24 +375,42 @@ impl QbitClient {
         Ok(files)
     }
 
-    /// Pause a torrent by hash.
+    /// Pause a torrent by hash. qBit 5.x renamed `/torrents/pause` to
+    /// `/torrents/stop`; we try the new name first and fall back to the
+    /// old one so both generations work without a version probe.
     pub async fn pause_torrent(&self, hash: &str) -> Result<(), String> {
         let form = [("hashes", hash)];
-        let resp = self.do_post_form("/api/v2/torrents/pause", &form).await?;
-        if !resp.status().is_success() {
-            return Err("Failed to pause torrent".into());
+        let resp = self.do_post_form("/api/v2/torrents/stop", &form).await?;
+        if resp.status().is_success() {
+            return Ok(());
         }
-        Ok(())
+        // Fallback for qBit ≤ 4.x.
+        let resp = self.do_post_form("/api/v2/torrents/pause", &form).await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        Err(format!("qbit pause failed: {} {}", status, body.trim()))
     }
 
-    /// Resume a torrent by hash.
+    /// Resume a torrent by hash. qBit 5.x renamed `/torrents/resume` to
+    /// `/torrents/start`; we try the new name first and fall back to
+    /// the old one so the 4.x → 5.x transition is transparent.
     pub async fn resume_torrent(&self, hash: &str) -> Result<(), String> {
         let form = [("hashes", hash)];
-        let resp = self.do_post_form("/api/v2/torrents/resume", &form).await?;
-        if !resp.status().is_success() {
-            return Err("Failed to resume torrent".into());
+        let resp = self.do_post_form("/api/v2/torrents/start", &form).await?;
+        if resp.status().is_success() {
+            return Ok(());
         }
-        Ok(())
+        // Fallback for qBit ≤ 4.x.
+        let resp = self.do_post_form("/api/v2/torrents/resume", &form).await?;
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        Err(format!("qbit resume failed: {} {}", status, body.trim()))
     }
 
     /// Delete a torrent by hash (optionally delete files).

--- a/src/services/seadex.rs
+++ b/src/services/seadex.rs
@@ -1,0 +1,919 @@
+//! SeaDex (releases.moe) lookup client.
+//!
+//! SeaDex is a community-curated "best anime releases" database keyed by
+//! AniList ID. This module handles the API round-trip, the usability
+//! filter (Nyaa-hosted, muxed, curation-best), and the dual-audio /
+//! file-count tiebreak that picks a single winner per entry.
+//!
+//! The output of [`pick_best`] is a single torrent record whose
+//! `info_hash` can be fed to [`to_magnet_uri`] to synthesize a magnet
+//! URI without any further HTTP round-trip — SeaDex already ships the
+//! hash in the API response, so we skip scraping the Nyaa view page.
+//!
+//! Scope limits (per the integration plan, V1):
+//! - AnimeBytes (private tracker) entries are filtered out — we have no
+//!   credentials.
+//! - AnimeTosho / RuTracker entries are filtered out — we don't support
+//!   those hosts yet (six entries total, see plan §4.5).
+//! - Unmuxed best releases are filtered out — the user would have to
+//!   hand-mux sidecars in MPV. We'd rather fall through to Nyaa search
+//!   than hand the user a broken download.
+//! - Umbrella / franchise resolution (walking AniList relations) is V2.
+
+// Phase 1+2 lands the module in isolation; later phases wire it into
+// `auto_search`, the scoring pipeline, and the settings UI. Until those
+// phases land, most of the public surface is referenced only by unit
+// tests, which trips `-D warnings` dead-code errors in clippy. Scope the
+// allow to this file so the warnings come back the moment a caller goes
+// missing later.
+#![allow(dead_code)]
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use serde::Deserialize;
+
+const SEADEX_API: &str = "https://releases.moe/api/collections/entries/records";
+
+/// Process-global reqwest client for SeaDex. Same reasoning as the
+/// nyaa.rs client: avoid re-doing the TLS handshake and keep-alive
+/// pool on every lookup.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .user_agent("Ryokan/0.1")
+        .timeout(Duration::from_secs(15))
+        .build()
+        .expect("building the SeaDex reqwest client should not fail")
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Public types
+// ───────────────────────────────────────────────────────────────────────────
+
+/// A SeaDex entry (one AniList ID → zero or more curated torrents).
+#[derive(Debug, Clone)]
+pub struct SeaDexEntry {
+    pub anilist_id: i64,
+    pub pocketbase_id: String,
+    pub notes: String,
+    pub incomplete: bool,
+    pub torrents: Vec<SeaDexTorrent>,
+}
+
+/// A single torrent record from SeaDex. Fields are preserved verbatim
+/// from the API — interpretation happens in [`is_usable`], [`pick_best`],
+/// and friends.
+#[derive(Debug, Clone)]
+pub struct SeaDexTorrent {
+    pub release_group: String,
+    /// Tracker enum: `"Nyaa"`, `"AB"`, `"AnimeTosho"`, `"RuTracker"`.
+    /// See plan §2. Ryokan V1 only acts on `"Nyaa"`.
+    pub tracker: String,
+    /// Full URL for public trackers. May be relative (`/torrents.php?...`)
+    /// for AnimeBytes, or even a literal non-URL string (`"Chihiro"` at
+    /// alID=151126). Defensive parsing in [`is_usable`].
+    pub url: String,
+    /// Lowercase 40-char hex hash for public trackers;
+    /// `"<redacted>"` for AnimeBytes.
+    pub info_hash: String,
+    pub is_best: bool,
+    pub dual_audio: bool,
+    pub files: Vec<SeaDexFile>,
+}
+
+/// A single file inside a SeaDex torrent. Used by the unmuxed heuristic
+/// in [`is_unmuxed`].
+#[derive(Debug, Clone)]
+pub struct SeaDexFile {
+    pub length: i64,
+    pub name: String,
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Internal JSON shape (PocketBase)
+// ───────────────────────────────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+struct PbListResponse {
+    #[serde(default)]
+    items: Vec<PbRecord>,
+}
+
+#[derive(Deserialize)]
+struct PbRecord {
+    #[serde(default, rename = "alID")]
+    al_id: i64,
+    #[serde(default)]
+    id: String,
+    #[serde(default)]
+    notes: String,
+    #[serde(default)]
+    incomplete: bool,
+    #[serde(default)]
+    expand: Option<PbExpand>,
+}
+
+#[derive(Deserialize)]
+struct PbExpand {
+    #[serde(default)]
+    trs: Vec<PbTorrent>,
+}
+
+#[derive(Deserialize)]
+struct PbTorrent {
+    #[serde(default, rename = "releaseGroup")]
+    release_group: String,
+    #[serde(default)]
+    tracker: String,
+    #[serde(default)]
+    url: String,
+    #[serde(default, rename = "infoHash")]
+    info_hash: String,
+    #[serde(default, rename = "isBest")]
+    is_best: bool,
+    #[serde(default, rename = "dualAudio")]
+    dual_audio: bool,
+    #[serde(default)]
+    files: Vec<PbFile>,
+}
+
+#[derive(Deserialize)]
+struct PbFile {
+    #[serde(default)]
+    length: i64,
+    #[serde(default)]
+    name: String,
+}
+
+impl From<PbRecord> for SeaDexEntry {
+    fn from(r: PbRecord) -> Self {
+        let torrents = r
+            .expand
+            .map(|e| e.trs.into_iter().map(Into::into).collect())
+            .unwrap_or_default();
+        SeaDexEntry {
+            anilist_id: r.al_id,
+            pocketbase_id: r.id,
+            notes: r.notes,
+            incomplete: r.incomplete,
+            torrents,
+        }
+    }
+}
+
+impl From<PbTorrent> for SeaDexTorrent {
+    fn from(t: PbTorrent) -> Self {
+        SeaDexTorrent {
+            release_group: t.release_group,
+            tracker: t.tracker,
+            url: t.url,
+            info_hash: t.info_hash,
+            is_best: t.is_best,
+            dual_audio: t.dual_audio,
+            files: t.files.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+impl From<PbFile> for SeaDexFile {
+    fn from(f: PbFile) -> Self {
+        SeaDexFile {
+            length: f.length,
+            name: f.name,
+        }
+    }
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Lookup
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Look up a SeaDex entry by AniList ID.
+///
+/// Returns:
+/// - `Ok(Some(entry))` if SeaDex has a record for this AniList ID
+/// - `Ok(None)` if SeaDex doesn't have a record (the PocketBase
+///   `items` array came back empty — not an error)
+/// - `Err(_)` on HTTP / parse failures
+///
+/// No caching in V1 — see plan §10. The caller (scoring integration)
+/// skips calling this entirely when `seadex_enabled=false`, which
+/// already gives us zero API round-trips for the default config.
+pub async fn lookup(anilist_id: i64) -> Result<Option<SeaDexEntry>, String> {
+    let url = format!(
+        "{}?filter=alID%3D{}&expand=trs",
+        SEADEX_API, anilist_id,
+    );
+
+    let response = HTTP_CLIENT
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("SeaDex request failed: {e}"))?;
+
+    // PocketBase returns 200 with an empty `items` array when the
+    // record doesn't exist, not 404 — so any non-200 is a real error.
+    if !response.status().is_success() {
+        return Err(format!(
+            "SeaDex API returned HTTP {}",
+            response.status().as_u16()
+        ));
+    }
+
+    let body = response
+        .text()
+        .await
+        .map_err(|e| format!("SeaDex read body failed: {e}"))?;
+
+    parse_list_response(&body)
+}
+
+/// Internal parser — split out so unit tests can feed it a fixture
+/// without touching the network.
+fn parse_list_response(body: &str) -> Result<Option<SeaDexEntry>, String> {
+    let parsed: PbListResponse = serde_json::from_str(body)
+        .map_err(|e| format!("SeaDex parse failed: {e}"))?;
+
+    Ok(parsed.items.into_iter().next().map(Into::into))
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Filters
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Classify a filename by extension into video / audio-sidecar / sub-sidecar
+/// buckets. Used by the file-structure heuristic in [`is_unmuxed`].
+fn file_kind(name: &str) -> FileKind {
+    let lower = name.to_ascii_lowercase();
+    let ext = lower.rsplit_once('.').map(|(_, e)| e).unwrap_or("");
+    match ext {
+        "mkv" | "mp4" | "m2ts" | "ts" | "avi" | "mov" | "webm" => FileKind::Video,
+        "mka" | "flac" | "opus" | "aac" | "ac3" | "dts" | "wav" => FileKind::AudioSidecar,
+        "ass" | "srt" | "ssa" | "sub" | "vtt" | "idx" | "pgs" | "sup" => FileKind::SubSidecar,
+        _ => FileKind::Other,
+    }
+}
+
+#[derive(PartialEq, Eq, Clone, Copy)]
+enum FileKind {
+    Video,
+    AudioSidecar,
+    SubSidecar,
+    Other,
+}
+
+/// True if the torrent looks "unmuxed" — either the editor notes say so,
+/// or the file listing has audio / sub sidecars stacked next to video
+/// files (audio count ≥ video count, or sub count ≥ video count with no
+/// audio at all).
+///
+/// Both signals are documented in plan §4.4 and are combined here.
+pub fn is_unmuxed(torrent: &SeaDexTorrent, notes: &str) -> bool {
+    // Signal 1: editor notes keyword. Case-insensitive substring is
+    // sufficient — the known corpus uses lowercase `unmuxed` / `unmux`
+    // / `needs mux` in running prose. Open question §10 of the plan
+    // allows upgrading to word-boundary regex if we see a false
+    // positive, but there isn't one today.
+    let notes_lower = notes.to_ascii_lowercase();
+    if notes_lower.contains("unmuxed")
+        || notes_lower.contains("unmux")
+        || notes_lower.contains("needs mux")
+    {
+        return true;
+    }
+
+    // Signal 2: file-structure heuristic. Count videos, audio
+    // sidecars, and sub sidecars. A muxed release embeds audio+subs
+    // inside the .mkv, so both sidecar counts should be zero.
+    let mut video_count = 0i32;
+    let mut audio_count = 0i32;
+    let mut sub_count = 0i32;
+    for f in &torrent.files {
+        match file_kind(&f.name) {
+            FileKind::Video => video_count += 1,
+            FileKind::AudioSidecar => audio_count += 1,
+            FileKind::SubSidecar => sub_count += 1,
+            FileKind::Other => {}
+        }
+    }
+
+    if video_count == 0 {
+        return false;
+    }
+
+    // Audio-sidecar pattern: one .mka per .mkv (or more).
+    if audio_count >= video_count {
+        return true;
+    }
+    // Sub-sidecar-only pattern: a .ass per .mp4 with no audio sidecars.
+    // (Muxed fansub releases have zero external subs.)
+    if sub_count >= video_count && audio_count == 0 {
+        return true;
+    }
+
+    false
+}
+
+/// True if the URL looks like a real nyaa.si view page. Guards against
+/// the documented `url="Chihiro"` data-quality case and any future
+/// weirdness where the tracker field says Nyaa but the URL doesn't
+/// actually point there.
+fn looks_like_nyaa_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.contains("nyaa.si/view/") || lower.contains("nyaa.si/torrent/")
+}
+
+/// Full usability gate. A torrent is usable by Ryokan iff:
+/// - `is_best == true` (SeaDex curation flag — non-best is NOT a fallback)
+/// - `tracker == "Nyaa"` (positive match, not `!= "AB"`, per plan §4.5)
+/// - URL looks like a real nyaa.si page (defensive against the
+///   `url="Chihiro"` case)
+/// - `info_hash` is a plausible hash (non-empty, not `"<redacted>"`)
+/// - [`is_unmuxed`] is false
+pub fn is_usable(torrent: &SeaDexTorrent, notes: &str) -> bool {
+    if !torrent.is_best {
+        return false;
+    }
+    if torrent.tracker != "Nyaa" {
+        return false;
+    }
+    if !looks_like_nyaa_url(&torrent.url) {
+        return false;
+    }
+    if torrent.info_hash.is_empty() || torrent.info_hash.eq_ignore_ascii_case("<redacted>") {
+        return false;
+    }
+    if is_unmuxed(torrent, notes) {
+        return false;
+    }
+    true
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Selection
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Pick the single best torrent from a SeaDex entry, applying the
+/// full V1 selection pipeline (plan §5.1):
+///
+/// 1. Keep only [`is_usable`] torrents.
+/// 2. If any have `dualAudio` diversity, filter by `prefer_subs`
+///    (`true` → keep `dualAudio=false`, else keep `dualAudio=true`).
+///    If the filter empties the pool, fall back to the pre-filter set
+///    so we still return *something* usable.
+/// 3. Tiebreak by file count descending (mega-packs win over patches /
+///    partial-series batches per plan §4.2).
+/// 4. Stable tiebreak by info_hash lexicographic so repeated lookups
+///    return the same pick.
+///
+/// Returns `None` if the entry has no usable torrent — caller should
+/// fall through to the regular Nyaa search.
+pub fn pick_best(entry: &SeaDexEntry, prefer_subs: bool) -> Option<&SeaDexTorrent> {
+    let usable: Vec<&SeaDexTorrent> = entry
+        .torrents
+        .iter()
+        .filter(|t| is_usable(t, &entry.notes))
+        .collect();
+    if usable.is_empty() {
+        return None;
+    }
+
+    // Dual-audio filter — only kicks in when the pool has diversity.
+    // If every usable torrent has the same dualAudio value, prefer_subs
+    // is a no-op.
+    let has_dub = usable.iter().any(|t| t.dual_audio);
+    let has_sub = usable.iter().any(|t| !t.dual_audio);
+    let filtered: Vec<&SeaDexTorrent> = if has_dub && has_sub {
+        let want_dual = !prefer_subs;
+        usable
+            .iter()
+            .copied()
+            .filter(|t| t.dual_audio == want_dual)
+            .collect()
+    } else {
+        usable.clone()
+    };
+
+    // Defensive fallback: if the dual-audio filter emptied the pool
+    // (can't actually happen given the `has_dub && has_sub` guard, but
+    // belt-and-suspenders for future refactors), use the un-filtered set.
+    let pool: Vec<&SeaDexTorrent> = if filtered.is_empty() {
+        usable
+    } else {
+        filtered
+    };
+
+    // File-count descending, then info_hash ascending for stability.
+    pool.into_iter().max_by(|a, b| {
+        a.files
+            .len()
+            .cmp(&b.files.len())
+            .then_with(|| b.info_hash.cmp(&a.info_hash))
+    })
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Magnet construction
+// ───────────────────────────────────────────────────────────────────────────
+
+/// Canonical Nyaa public-tracker set, hardcoded so we don't have to
+/// scrape a magnet link out of the view page. DHT bootstrap alone works
+/// but is slow (tens of seconds to first peer); these five trackers are
+/// stable and shave the cold-start delay.
+const NYAA_TRACKER_SET: &[&str] = &[
+    "http://nyaa.tracker.wf:7777/announce",
+    "udp://open.stealth.si:80/announce",
+    "udp://tracker.opentrackr.org:1337/announce",
+    "udp://exodus.desync.com:6969/announce",
+    "udp://tracker.torrent.eu.org:451/announce",
+];
+
+/// Synthesize a magnet URI from a SeaDex torrent record. All public
+/// `isBest=true` Nyaa entries in SeaDex carry a valid 40-char hex
+/// `infoHash` (verified in the plan's 2595-entry audit), so this never
+/// needs an HTTP round-trip.
+///
+/// The URI shape is:
+/// ```
+/// magnet:?xt=urn:btih:<hash>&dn=<group>&tr=<tracker1>&tr=<tracker2>...
+/// ```
+///
+/// `dn` is a display hint for qBit's UI while metadata is being
+/// fetched; `tr[]` are the Nyaa public tracker set. Callers that only
+/// care about the hash can pass the URI to qBit unchanged.
+pub fn to_magnet_uri(torrent: &SeaDexTorrent) -> String {
+    let mut uri = format!("magnet:?xt=urn:btih:{}", torrent.info_hash);
+    if !torrent.release_group.is_empty() {
+        uri.push_str("&dn=");
+        uri.push_str(&urlencoding::encode(&torrent.release_group));
+    }
+    for tracker in NYAA_TRACKER_SET {
+        uri.push_str("&tr=");
+        uri.push_str(&urlencoding::encode(tracker));
+    }
+    uri
+}
+
+/// Return the torrent's Nyaa view URL for display / linking. Thin
+/// accessor kept in the public API so callers don't reach into the
+/// struct field directly — keeps the option open to normalize URLs
+/// (strip trailing slashes, canonicalize, etc.) later.
+pub fn to_nyaa_view_url(torrent: &SeaDexTorrent) -> &str {
+    &torrent.url
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Tests
+// ───────────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn torrent(
+        group: &str,
+        tracker: &str,
+        url: &str,
+        info_hash: &str,
+        is_best: bool,
+        dual_audio: bool,
+        files: Vec<(&str, i64)>,
+    ) -> SeaDexTorrent {
+        SeaDexTorrent {
+            release_group: group.into(),
+            tracker: tracker.into(),
+            url: url.into(),
+            info_hash: info_hash.into(),
+            is_best,
+            dual_audio,
+            files: files
+                .into_iter()
+                .map(|(n, l)| SeaDexFile {
+                    name: n.into(),
+                    length: l,
+                })
+                .collect(),
+        }
+    }
+
+    fn nyaa_torrent(group: &str, hash: &str, dual_audio: bool, files: usize) -> SeaDexTorrent {
+        let files = (0..files)
+            .map(|i| (format!("episode_{i:02}.mkv"), 1_000_000_000_i64))
+            .collect::<Vec<_>>();
+        SeaDexTorrent {
+            release_group: group.into(),
+            tracker: "Nyaa".into(),
+            url: format!("https://nyaa.si/view/{}", 1_000_000 + files.len() as u32),
+            info_hash: hash.into(),
+            is_best: true,
+            dual_audio,
+            files: files
+                .into_iter()
+                .map(|(n, l)| SeaDexFile { name: n, length: l })
+                .collect(),
+        }
+    }
+
+    // ── parse_list_response ──────────────────────────────────────────
+
+    #[test]
+    fn parse_empty_response_returns_none() {
+        let body = r#"{"items":[],"page":1,"perPage":30,"totalItems":0}"#;
+        let out = parse_list_response(body).unwrap();
+        assert!(out.is_none());
+    }
+
+    #[test]
+    fn parse_minimal_response() {
+        let body = r#"{
+          "items": [{
+            "alID": 9260,
+            "id": "abc123",
+            "notes": "some notes",
+            "incomplete": false,
+            "expand": {
+              "trs": [{
+                "releaseGroup": "MTBB",
+                "tracker": "Nyaa",
+                "url": "https://nyaa.si/view/1446994",
+                "infoHash": "abcdef0123456789abcdef0123456789abcdef01",
+                "isBest": true,
+                "dualAudio": false,
+                "files": [{"name": "ep01.mkv", "length": 123}]
+              }]
+            }
+          }]
+        }"#;
+        let entry = parse_list_response(body).unwrap().expect("some entry");
+        assert_eq!(entry.anilist_id, 9260);
+        assert_eq!(entry.torrents.len(), 1);
+        assert_eq!(entry.torrents[0].release_group, "MTBB");
+        assert_eq!(entry.torrents[0].tracker, "Nyaa");
+        assert!(entry.torrents[0].is_best);
+        assert_eq!(entry.torrents[0].files.len(), 1);
+    }
+
+    #[test]
+    fn parse_entry_with_no_expand_is_empty_torrents() {
+        let body = r#"{
+          "items": [{"alID": 1, "id": "x", "notes": "", "incomplete": false}]
+        }"#;
+        let entry = parse_list_response(body).unwrap().expect("some entry");
+        assert!(entry.torrents.is_empty());
+    }
+
+    // ── is_unmuxed — signal 1: notes keyword ─────────────────────────
+
+    #[test]
+    fn unmuxed_notes_keyword() {
+        let t = nyaa_torrent("Headpatter", "a".repeat(40).as_str(), false, 12);
+        assert!(is_unmuxed(&t, "Headpatter is the unmuxed best but needs hand-muxing"));
+        assert!(is_unmuxed(&t, "notes mention UNMUXED in caps"));
+        assert!(is_unmuxed(&t, "unmux sidecars"));
+        assert!(is_unmuxed(&t, "needs mux per E.N.D notes"));
+        assert!(!is_unmuxed(&t, "Headpatter's normal BD encode, MTBB subs"));
+    }
+
+    // ── is_unmuxed — signal 2: file-structure heuristic ─────────────
+
+    #[test]
+    fn unmuxed_by_audio_sidecar_pattern() {
+        // JySzE Cowboy Bebop shape: 40 .mkv + 157 .mka.
+        let mut files: Vec<(&str, i64)> = Vec::new();
+        for i in 0..40 {
+            // Leak an owned name via Box::leak for the test helper.
+            let name = Box::leak(format!("ep_{i}.mkv").into_boxed_str());
+            files.push((name, 1));
+        }
+        for i in 0..157 {
+            let name = Box::leak(format!("ep_{i}.mka").into_boxed_str());
+            files.push((name, 1));
+        }
+        let t = torrent("JySzE", "Nyaa", "https://nyaa.si/view/1", "h", true, false, files);
+        assert!(is_unmuxed(&t, ""));
+    }
+
+    #[test]
+    fn unmuxed_by_sub_sidecar_pattern_with_no_audio() {
+        // Figmentos Kemonozume: .mp4 videos with .ass sidecars, no .mka.
+        let files = vec![
+            ("kemonozume_01.mp4", 1),
+            ("kemonozume_01.ass", 1),
+            ("kemonozume_02.mp4", 1),
+            ("kemonozume_02.ass", 1),
+        ];
+        let t = torrent(
+            "Figmentos",
+            "Nyaa",
+            "https://nyaa.si/view/2",
+            "h",
+            true,
+            false,
+            files,
+        );
+        assert!(is_unmuxed(&t, ""));
+    }
+
+    #[test]
+    fn muxed_release_has_no_sidecars() {
+        // MTBB Monogatari: pure .mkv, no sidecars. Not unmuxed.
+        let files = vec![
+            ("mono_01.mkv", 1),
+            ("mono_02.mkv", 1),
+            ("mono_03.mkv", 1),
+        ];
+        let t = torrent("MTBB", "Nyaa", "https://nyaa.si/view/3", "h", true, false, files);
+        assert!(!is_unmuxed(&t, ""));
+    }
+
+    #[test]
+    fn sub_sidecar_with_audio_present_is_muxed() {
+        // If a release has .ass AND .mka, the .ass is probably a font
+        // attachment or a bonus sub — not a forced sidecar. Don't flag.
+        // (Well, we flag on audio-count alone in this case.)
+        let files = vec![
+            ("ep01.mkv", 1),
+            ("ep01.mka", 1), // triggers audio sidecar rule
+            ("ep01.ass", 1),
+        ];
+        let t = torrent("X", "Nyaa", "https://nyaa.si/view/4", "h", true, false, files);
+        assert!(is_unmuxed(&t, ""));
+    }
+
+    #[test]
+    fn zero_video_files_is_not_unmuxed() {
+        let files = vec![("cover.jpg", 1), ("readme.txt", 1)];
+        let t = torrent("X", "Nyaa", "https://nyaa.si/view/5", "h", true, false, files);
+        assert!(!is_unmuxed(&t, ""));
+    }
+
+    // ── is_usable ──────────────────────────────────────────────────
+
+    #[test]
+    fn usable_rejects_non_best() {
+        let mut t = nyaa_torrent("X", &"a".repeat(40), false, 1);
+        t.is_best = false;
+        assert!(!is_usable(&t, ""));
+    }
+
+    #[test]
+    fn usable_rejects_ab_tracker() {
+        let mut t = nyaa_torrent("X", &"a".repeat(40), false, 1);
+        t.tracker = "AB".into();
+        assert!(!is_usable(&t, ""));
+    }
+
+    #[test]
+    fn usable_rejects_animetosho() {
+        let mut t = nyaa_torrent("FREEPALESTINE", &"a".repeat(40), false, 1);
+        t.tracker = "AnimeTosho".into();
+        t.url = "https://animetosho.org/view/freepalestine.12345".into();
+        assert!(!is_usable(&t, ""));
+    }
+
+    #[test]
+    fn usable_rejects_chihiro_literal_url() {
+        // alID=151126 data-quality case: tracker says something but URL
+        // is a literal non-URL string. Even if tracker were "Nyaa",
+        // looks_like_nyaa_url should kill it.
+        let t = torrent(
+            "Chihiro",
+            "Nyaa",
+            "Chihiro", // literally this string
+            "abcdef0123456789abcdef0123456789abcdef01",
+            true,
+            false,
+            vec![("ep01.mkv", 1)],
+        );
+        assert!(!is_usable(&t, ""));
+    }
+
+    #[test]
+    fn usable_rejects_redacted_infohash() {
+        let t = torrent(
+            "X",
+            "Nyaa",
+            "https://nyaa.si/view/9",
+            "<redacted>",
+            true,
+            false,
+            vec![("ep01.mkv", 1)],
+        );
+        assert!(!is_usable(&t, ""));
+    }
+
+    #[test]
+    fn usable_rejects_unmuxed() {
+        let t = nyaa_torrent("E.N.D", &"a".repeat(40), false, 1);
+        assert!(!is_usable(&t, "E.N.D is the unmuxed best release"));
+    }
+
+    #[test]
+    fn usable_accepts_clean_nyaa_muxed_best() {
+        let t = nyaa_torrent("MTBB", &"a".repeat(40), false, 1);
+        assert!(is_usable(&t, "standard notes"));
+    }
+
+    // ── pick_best ──────────────────────────────────────────────────
+
+    #[test]
+    fn pick_best_returns_none_on_empty() {
+        let entry = SeaDexEntry {
+            anilist_id: 1,
+            pocketbase_id: "x".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![],
+        };
+        assert!(pick_best(&entry, true).is_none());
+    }
+
+    #[test]
+    fn pick_best_returns_none_when_all_filtered() {
+        // All AB — no Nyaa candidates.
+        let mut a = nyaa_torrent("MTBB", &"a".repeat(40), false, 1);
+        a.tracker = "AB".into();
+        let entry = SeaDexEntry {
+            anilist_id: 1,
+            pocketbase_id: "x".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![a],
+        };
+        assert!(pick_best(&entry, true).is_none());
+    }
+
+    #[test]
+    fn pick_best_single_candidate() {
+        let a = nyaa_torrent("MTBB", &"a".repeat(40), false, 12);
+        let entry = SeaDexEntry {
+            anilist_id: 9260,
+            pocketbase_id: "x".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![a],
+        };
+        let pick = pick_best(&entry, true).unwrap();
+        assert_eq!(pick.release_group, "MTBB");
+    }
+
+    #[test]
+    fn pick_best_chainsaw_man_dual_audio_split() {
+        // alID=127230: Flugel dualAudio=true, Okay-Subs dualAudio=false.
+        // Both Nyaa, both muxed, both best. Filtering by prefer_subs
+        // picks exactly one.
+        let flugel = nyaa_torrent("Flugel", &"b".repeat(40), true, 12);
+        let okay = nyaa_torrent("Okay-Subs", &"a".repeat(40), false, 12);
+        let entry = SeaDexEntry {
+            anilist_id: 127230,
+            pocketbase_id: "csm".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![flugel, okay],
+        };
+        let subs = pick_best(&entry, true).unwrap();
+        assert_eq!(subs.release_group, "Okay-Subs");
+        let dubs = pick_best(&entry, false).unwrap();
+        assert_eq!(dubs.release_group, "Flugel");
+    }
+
+    #[test]
+    fn pick_best_file_count_tiebreak_favors_mega_pack() {
+        // Pattern C from plan §4.2: JySzE 554-file mega-pack vs two
+        // 1-file patches. Prefer_subs is unused (all same dual_audio).
+        let mega = nyaa_torrent("JySzE-mega", &"f".repeat(40), false, 554);
+        let patch1 = nyaa_torrent("JySzE-patch1", &"e".repeat(40), false, 1);
+        let patch2 = nyaa_torrent("JySzE-patch2", &"d".repeat(40), false, 1);
+        let entry = SeaDexEntry {
+            anilist_id: 1735,
+            pocketbase_id: "lotgh".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![patch1, mega, patch2],
+        };
+        let pick = pick_best(&entry, true).unwrap();
+        assert_eq!(pick.release_group, "JySzE-mega");
+    }
+
+    #[test]
+    fn pick_best_equivalent_remuxes_stable_tiebreak() {
+        // Pattern A: BiRJU vs PMR — same file count, no dual-audio split.
+        // Stable pick is whichever info_hash sorts smaller (we pick the
+        // larger one for determinism; the exact order doesn't matter,
+        // just that it's consistent across calls).
+        let a = nyaa_torrent("BiRJU", &"a".repeat(40), false, 12);
+        let b = nyaa_torrent("PMR", &"b".repeat(40), false, 12);
+        let entry = SeaDexEntry {
+            anilist_id: 103119,
+            pocketbase_id: "x".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![a.clone(), b.clone()],
+        };
+        // Whatever we pick, two back-to-back calls must agree.
+        let p1 = pick_best(&entry, true).map(|t| t.release_group.clone());
+        let p2 = pick_best(&entry, true).map(|t| t.release_group.clone());
+        assert_eq!(p1, p2);
+        assert!(p1.is_some());
+    }
+
+    #[test]
+    fn pick_best_skips_unmuxed_best_even_if_only_candidate() {
+        let mut t = nyaa_torrent("Headpatter", &"a".repeat(40), false, 12);
+        // Inject an audio sidecar to trigger the heuristic.
+        t.files.push(SeaDexFile {
+            name: "bonus.mka".into(),
+            length: 1,
+        });
+        // Need audio_count >= video_count, which is already not the
+        // case here (12 vs 1). Use notes instead.
+        let entry = SeaDexEntry {
+            anilist_id: 20910,
+            pocketbase_id: "x".into(),
+            notes: "Headpatter is the unmuxed best".into(),
+            incomplete: false,
+            torrents: vec![t],
+        };
+        assert!(pick_best(&entry, true).is_none());
+    }
+
+    #[test]
+    fn pick_best_skips_dual_audio_filter_if_pool_is_uniform() {
+        // Two subs-only releases — prefer_subs has nothing to filter.
+        let a = nyaa_torrent("Group1", &"a".repeat(40), false, 12);
+        let b = nyaa_torrent("Group2", &"b".repeat(40), false, 10);
+        let entry = SeaDexEntry {
+            anilist_id: 1,
+            pocketbase_id: "x".into(),
+            notes: String::new(),
+            incomplete: false,
+            torrents: vec![a, b],
+        };
+        // prefer_subs=false (wants dub) — but nothing has dub, so we
+        // fall back to file-count tiebreak on the whole set.
+        let pick = pick_best(&entry, false).unwrap();
+        assert_eq!(pick.release_group, "Group1"); // more files
+    }
+
+    // ── to_magnet_uri ──────────────────────────────────────────────
+
+    #[test]
+    fn magnet_contains_hash_and_trackers() {
+        let t = torrent(
+            "MTBB",
+            "Nyaa",
+            "https://nyaa.si/view/1",
+            "abcdef0123456789abcdef0123456789abcdef01",
+            true,
+            false,
+            vec![("ep01.mkv", 1)],
+        );
+        let uri = to_magnet_uri(&t);
+        assert!(uri.starts_with("magnet:?xt=urn:btih:abcdef0123456789abcdef0123456789abcdef01"));
+        assert!(uri.contains("&dn=MTBB"));
+        // Every tracker should be URL-encoded and present.
+        for tr in NYAA_TRACKER_SET {
+            assert!(uri.contains(&urlencoding::encode(tr).into_owned()));
+        }
+    }
+
+    #[test]
+    fn magnet_encodes_release_group_with_special_chars() {
+        let t = torrent(
+            "Yūrei",
+            "Nyaa",
+            "https://nyaa.si/view/1",
+            "aa",
+            true,
+            false,
+            vec![],
+        );
+        let uri = to_magnet_uri(&t);
+        // `ū` is percent-encoded in the `dn=` param.
+        assert!(uri.contains("&dn="));
+        assert!(!uri.contains("ū"));
+    }
+
+    #[test]
+    fn magnet_empty_group_is_omitted() {
+        let t = torrent("", "Nyaa", "https://nyaa.si/view/1", "aa", true, false, vec![]);
+        let uri = to_magnet_uri(&t);
+        assert!(!uri.contains("&dn="));
+    }
+
+    // ── to_nyaa_view_url ───────────────────────────────────────────
+
+    #[test]
+    fn view_url_is_passthrough() {
+        let t = torrent(
+            "MTBB",
+            "Nyaa",
+            "https://nyaa.si/view/1446994",
+            "aa",
+            true,
+            false,
+            vec![],
+        );
+        assert_eq!(to_nyaa_view_url(&t), "https://nyaa.si/view/1446994");
+    }
+}

--- a/src/services/seadex.rs
+++ b/src/services/seadex.rs
@@ -35,6 +35,14 @@ use serde::Deserialize;
 
 const SEADEX_API: &str = "https://releases.moe/api/collections/entries/records";
 
+/// Score bump applied at scoring time when a candidate's info hash
+/// matches a SeaDex "best" torrent for the series. Large enough to
+/// reliably outrank an otherwise-tied release, small enough that a
+/// preferred-group or resolution bonus can still move the needle.
+/// Suppressed entirely when the user has a `SeaDexBestSpecification`
+/// Custom Format installed (see `custom_formats::has_seadex_cf`).
+pub const SEADEX_SCORE_BOOST: i32 = 10_000;
+
 /// Process-global reqwest client for SeaDex. Same reasoning as the
 /// nyaa.rs client: avoid re-doing the TLS handshake and keep-alive
 /// pool on every lookup.
@@ -368,6 +376,20 @@ pub fn is_usable(torrent: &SeaDexTorrent, notes: &str) -> bool {
 ///
 /// Returns `None` if the entry has no usable torrent — caller should
 /// fall through to the regular Nyaa search.
+/// Return every usable "best" info hash for the entry as a lowercase
+/// set. Used by the auto-search scoring path to detect SeaDex candidates
+/// without having to re-run [`pick_best`] — multiple torrents can carry
+/// `isBest=true` (different group, different container, etc.), and the
+/// boost should apply to all of them.
+pub fn best_hashes(entry: &SeaDexEntry) -> std::collections::HashSet<String> {
+    entry
+        .torrents
+        .iter()
+        .filter(|t| is_usable(t, &entry.notes))
+        .map(|t| t.info_hash.to_ascii_lowercase())
+        .collect()
+}
+
 pub fn pick_best(entry: &SeaDexEntry, prefer_subs: bool) -> Option<&SeaDexTorrent> {
     let usable: Vec<&SeaDexTorrent> = entry
         .torrents

--- a/src/services/source.rs
+++ b/src/services/source.rs
@@ -208,6 +208,29 @@ impl Resolution {
         }
     }
 
+    /// Parse from Sonarr's `ResolutionSpecification` integer value. Sonarr
+    /// stores the raw pixel height (480, 576, 720, 1080, 2160), with `0 =
+    /// Unknown`. Sonarr also defines `360` and `540` variants; Ryokan
+    /// folds both to `Unknown` since we don't classify them as distinct
+    /// tiers and anime releases at those heights are rare.
+    ///
+    /// Used by the Custom Formats parser to compile a
+    /// `ResolutionSpecification` into a comparison against
+    /// `ClassificationResult::resolution`. Phase 3 lands the helper in
+    /// isolation; Phase 4 (`src/services/custom_formats.rs`) adds the
+    /// caller, at which point the `#[allow(dead_code)]` comes off.
+    #[allow(dead_code)]
+    pub fn from_int(value: i32) -> Self {
+        match value {
+            480 => Resolution::R480p,
+            576 => Resolution::R576p,
+            720 => Resolution::R720p,
+            1080 => Resolution::R1080p,
+            2160 => Resolution::R2160p,
+            _ => Resolution::Unknown,
+        }
+    }
+
     /// Derive resolution from explicit pixel dimensions. Used by ffprobe layer
     /// in Phase 2, and by Layer 1 for cross-referencing against mentioned
     /// dimensions like "1920x1080".
@@ -1452,6 +1475,23 @@ mod tests {
         // Resolution ordering.
         assert!(Resolution::R2160p.rank() > Resolution::R1080p.rank());
         assert!(Resolution::R1080p.rank() > Resolution::R720p.rank());
+    }
+
+    #[test]
+    fn resolution_from_int_maps_sonarr_values() {
+        assert_eq!(Resolution::from_int(480), Resolution::R480p);
+        assert_eq!(Resolution::from_int(576), Resolution::R576p);
+        assert_eq!(Resolution::from_int(720), Resolution::R720p);
+        assert_eq!(Resolution::from_int(1080), Resolution::R1080p);
+        assert_eq!(Resolution::from_int(2160), Resolution::R2160p);
+        // Sonarr's 360 and 540 variants fold to Unknown — Ryokan doesn't
+        // classify those tiers and anime rarely ships at either height.
+        assert_eq!(Resolution::from_int(360), Resolution::Unknown);
+        assert_eq!(Resolution::from_int(540), Resolution::Unknown);
+        // Nonsense input, including Sonarr's sentinel 0, also folds to Unknown.
+        assert_eq!(Resolution::from_int(0), Resolution::Unknown);
+        assert_eq!(Resolution::from_int(-1), Resolution::Unknown);
+        assert_eq!(Resolution::from_int(9999), Resolution::Unknown);
     }
 
     #[test]

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -56,6 +56,11 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
     let mut total_episodes_checked: usize = 0;
     let mut total_upgrades_grabbed: usize = 0;
 
+    // One compiled-CF snapshot for the whole upgrade pass. The background
+    // scheduler can't race a CF edit during this run — if the user edits
+    // a CF mid-sweep, the next scheduled run picks it up.
+    let cfs = state.custom_formats.read().await.clone();
+
     logger::info(
         &state.db,
         LogCategory::AutoSearch,
@@ -150,7 +155,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             let label = auto_search::target_label(&target);
             // batch_episode_match=true so BD season packs can match episode targets.
             let best =
-                auto_search::find_best_for_target(&state.db, &detail, &cfg, &target, true, true).await;
+                auto_search::find_best_for_target(&state.db, &detail, &cfg, &target, true, true, &cfs).await;
 
             let Some(result) = best else {
                 continue;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -139,7 +139,8 @@ body {
 }
 
 .form-group input,
-.form-group select {
+.form-group select,
+.form-group textarea {
     padding: 10px 12px;
     background: var(--bg);
     border: 1px solid var(--border);
@@ -151,9 +152,26 @@ body {
 }
 
 .form-group input:focus,
-.form-group select:focus {
+.form-group select:focus,
+.form-group textarea:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+.form-group textarea {
+    resize: vertical;
+    min-height: 120px;
+    line-height: 1.5;
+}
+
+/* JSON / Sonarr-export textareas land here via `spellcheck="false"` — the
+   monospace font plus tab-size makes pasted multi-line JSON readable
+   instead of wrapping into a blob. */
+.form-group textarea[spellcheck="false"] {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    tab-size: 2;
+    -moz-tab-size: 2;
 }
 
 .form-hint {
@@ -1941,6 +1959,182 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     .settings-tab-panel .settings-form.group-upsert-form {
         grid-template-columns: 1fr;
     }
+}
+
+/* --- Custom Formats settings tab --- */
+
+/* Top-level sections are each wrapped in a dark card so the CF page
+   reads as distinct actions (Current list / Add-Edit / Defaults / etc.)
+   instead of a single scrolling blob. */
+.cf-section {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    padding: 22px 24px;
+    margin-bottom: 20px;
+}
+
+.cf-section-header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 16px;
+    margin: 0 0 6px;
+}
+
+.cf-section-header h3 {
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--text-bright);
+    text-transform: none;
+    letter-spacing: normal;
+    margin: 0;
+}
+
+.cf-section-desc {
+    color: var(--text-dim);
+    font-size: 13px;
+    margin: 0 0 18px;
+    line-height: 1.55;
+    max-width: 820px;
+}
+
+/* When a list table lives inside a .cf-section card, strip its own
+   frame (the card already provides one) so it doesn't look like a
+   card-within-a-card. A subtle top divider visually separates the
+   section header from the rows. */
+.cf-section .group-source-table {
+    background: transparent;
+    border: none;
+    border-radius: 0;
+    margin: 14px 0 0;
+    border-top: 1px solid var(--border);
+}
+
+.cf-section .group-source-table thead {
+    background: transparent;
+}
+
+.cf-section .group-source-table th:first-child,
+.cf-section .group-source-table td:first-child {
+    padding-left: 0;
+}
+
+.cf-section .group-source-table th:last-child,
+.cf-section .group-source-table td:last-child {
+    padding-right: 0;
+}
+
+/* The last <form> or <div> in a card shouldn't leave a dangling bottom
+   margin on top of the card padding. */
+.cf-section > *:last-child { margin-bottom: 0; }
+.cf-section > form:last-child > :last-child { margin-bottom: 0; }
+
+.cf-count-pill {
+    display: inline-block;
+    background: var(--bg-elevated);
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 500;
+}
+
+/* Trash-Guides description callout shown above the edit form when the
+   CF carries a `trash_description` field. Replaces the inline-styled
+   white box that broke the dark theme. */
+.cf-trash-description {
+    margin: 0 0 16px;
+    padding: 12px 14px;
+    border-left: 3px solid var(--accent);
+    background: var(--bg-elevated);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.cf-trash-description strong {
+    display: block;
+    margin-bottom: 4px;
+    color: var(--accent);
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+/* Import collision review panel — shown after a Sonarr export import
+   hits one or more name collisions. Styled as a highlighted card so the
+   user can't miss that an action is required. */
+.cf-import-review {
+    margin: 16px 0;
+    padding: 16px 18px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--accent);
+    border-radius: var(--radius-lg);
+}
+
+.cf-import-review h4 {
+    margin: 0 0 6px;
+    color: var(--accent);
+    font-size: 14px;
+    font-weight: 600;
+}
+
+.cf-import-review .form-hint { margin-bottom: 12px; }
+
+/* Empty-state card shown when the user has zero Custom Formats. The
+   bundled-defaults CTA sits inside it so first-time users see a clear
+   next step instead of an empty table. */
+.cf-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 20px;
+    background: var(--bg-elevated);
+    border: 1px dashed var(--border-accent);
+    border-radius: var(--radius);
+}
+
+.cf-empty-state p {
+    color: var(--text-dim);
+    font-size: 13px;
+    margin: 0;
+}
+
+/* CF list table tweaks — the base `.group-source-table` layout is
+   reused, but CF rows have a badge column that needs a bit more room
+   and the actions column should align its buttons cleanly. */
+.cf-table .cf-name { font-weight: 600; color: var(--text-bright); }
+.cf-table .cf-score { font-variant-numeric: tabular-nums; }
+.cf-table .cf-score-positive { color: var(--green); }
+.cf-table .cf-score-negative { color: var(--red); }
+.cf-table .cf-score-zero { color: var(--text-dim); }
+
+.cf-origin-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.cf-origin-default  { background: var(--purple-bg); color: var(--accent); }
+.cf-origin-import   { background: var(--blue-bg);   color: var(--blue); }
+.cf-origin-manual   { background: var(--bg-elevated); color: var(--text-dim); border: 1px solid var(--border); }
+
+.cf-parse-error {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+    background: rgba(211, 125, 125, 0.12);
+    color: var(--red);
 }
 
 /* Logs Toolbar */

--- a/static/default_custom_formats.json
+++ b/static/default_custom_formats.json
@@ -8,7 +8,7 @@
         "name": "SeaDex best",
         "implementation": "Ryokan.SeaDexBestSpecification",
         "negate": false,
-        "required": true,
+        "required": false,
         "fields": []
       }
     ]

--- a/static/default_custom_formats.json
+++ b/static/default_custom_formats.json
@@ -1,0 +1,146 @@
+[
+  {
+    "name": "SeaDex best",
+    "trash_id": null,
+    "score": 10000,
+    "specifications": [
+      {
+        "name": "SeaDex best",
+        "implementation": "Ryokan.SeaDexBestSpecification",
+        "negate": false,
+        "required": true,
+        "fields": []
+      }
+    ]
+  },
+  {
+    "name": "Tier S BD groups (MTBB, Yūrei, Arukoru, Bakemono-Kami, Sephirotic)",
+    "trash_id": null,
+    "score": 1200,
+    "specifications": [
+      {
+        "name": "Tier S BD groups",
+        "implementation": "ReleaseGroupSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": "^(MTBB|Yūrei|Yurei|Arukoru|Bakemono-Kami|Sephirotic)$" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Prefer BluRay source",
+    "trash_id": null,
+    "score": 600,
+    "specifications": [
+      {
+        "name": "Bluray",
+        "implementation": "SourceSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": 6 }
+        ]
+      },
+      {
+        "name": "Bluray Raw",
+        "implementation": "SourceSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": 7 }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Prefer WEB release groups (SubsPlease, Judas)",
+    "trash_id": null,
+    "score": 400,
+    "specifications": [
+      {
+        "name": "Preferred WEB groups",
+        "implementation": "ReleaseGroupSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": "^(SubsPlease|Judas)$" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Prefer 10-bit / x265 / HEVC encoding",
+    "trash_id": null,
+    "score": 300,
+    "specifications": [
+      {
+        "name": "10-bit / x265 / HEVC",
+        "implementation": "ReleaseTitleSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": "(10[.\\-]?bit|hi10p?|x[.\\-]?265|hevc)" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Prefer FLAC / Opus audio",
+    "trash_id": null,
+    "score": 150,
+    "specifications": [
+      {
+        "name": "FLAC / Opus",
+        "implementation": "ReleaseTitleSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": "(flac|opus)" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Penalize 8-bit mp4 combo",
+    "trash_id": null,
+    "score": -500,
+    "specifications": [
+      {
+        "name": "No 10-bit marker",
+        "implementation": "ReleaseTitleSpecification",
+        "negate": true,
+        "required": true,
+        "fields": [
+          { "name": "value", "value": "10[.\\-]?bit|hi10p?" }
+        ]
+      },
+      {
+        "name": ".mp4 extension",
+        "implementation": "ReleaseTitleSpecification",
+        "negate": false,
+        "required": true,
+        "fields": [
+          { "name": "value", "value": "\\.mp4\\b" }
+        ]
+      }
+    ]
+  },
+  {
+    "name": "Penalize casual groups (NoobSubs, HorribleSubs)",
+    "trash_id": null,
+    "score": -1000,
+    "specifications": [
+      {
+        "name": "Casual groups",
+        "implementation": "ReleaseGroupSpecification",
+        "negate": false,
+        "required": false,
+        "fields": [
+          { "name": "value", "value": "^(NoobSubs|HorribleSubs)$" }
+        ]
+      }
+    ]
+  }
+]

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -387,75 +387,25 @@
 
 {% if tab == "custom_formats" %}
 <div class="settings-tab-panel active">
-    <fieldset>
-        <legend>Custom Formats</legend>
-        <p class="form-hint">
-            Sonarr v4-compatible Custom Formats. During auto-search, every matching spec contributes its score to the release total.
-            Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
-        </p>
+    <p class="cf-section-desc" style="max-width: 820px; margin-bottom: 20px;">
+        Sonarr v4-compatible Custom Formats. Every matching spec contributes its score to the release total during auto-search. Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
+    </p>
 
-        <h3 class="settings-subheading">Global Minimum Score</h3>
-        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form">
-            <div class="form-group">
-                <label for="cf_min_score">Custom Format Minimum Score</label>
-                <input type="number" name="minimum_score" id="cf_min_score"
-                    value="{{ custom_format_min_score_display }}" placeholder="(blank = no floor)">
-                <span class="form-hint">Auto-search drops releases whose summed CF score falls below this threshold. Interactive search still shows everything. Leave blank to disable the floor.</span>
-            </div>
-            <button type="submit" class="btn btn-primary">Save Minimum Score</button>
-        </form>
-
-        <h3 class="settings-subheading">
-            {% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}
-        </h3>
-        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
-            {% if let Some(edit) = custom_format_edit %}
-            <input type="hidden" name="id" value="{{ edit.row.id }}">
-            {% if let Some(desc) = edit.trash_description.as_ref() %}
-            <div class="cf-trash-description" style="margin-bottom: 12px; padding: 10px 12px; border-left: 3px solid var(--accent, #5b9bd5); background: var(--subtle-bg, #f5f7fa);">
-                <strong>Trash Guides description:</strong>
-                <div style="margin-top: 4px; white-space: pre-wrap;">{{ desc }}</div>
-            </div>
-            {% endif %}
-            {% endif %}
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="cf_name">Name</label>
-                    <input type="text" name="name" id="cf_name" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
-                </div>
-                <div class="form-group">
-                    <label for="cf_score">Score</label>
-                    <input type="number" name="score" id="cf_score" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
-                </div>
-                <div class="form-group">
-                    <label for="cf_trash_id">Trash ID (optional)</label>
-                    <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
-                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
-                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
-                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
-                <span class="form-hint">Full Sonarr v4 CF object. Supported spec implementations: <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>. The compiler runs before saving, so invalid JSON is rejected with an error message. A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
-            </div>
-            <div class="settings-inline-actions">
-                <button type="submit" class="btn btn-primary">
-                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
-                </button>
-                {% if custom_format_edit.is_some() %}
-                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
-                {% endif %}
-            </div>
-        </form>
-
-        <h3 class="settings-subheading">Current Custom Formats ({{ custom_formats.len() }})</h3>
+    {# ── Current Custom Formats ─────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Current Custom Formats</h3>
+            <span class="cf-count-pill">{{ custom_formats.len() }} total</span>
+        </div>
         {% if custom_formats.is_empty() %}
-        <p class="form-hint">No Custom Formats defined. Add one above or import from a Sonarr export below.</p>
+        <div class="cf-empty-state">
+            <p>You don't have any Custom Formats yet. Install the bundled anime-tuned defaults to get started with SeaDex, tier-S BD groups, 10-bit/x265, FLAC/Opus, and other curated rules.</p>
+            <form method="post" action="/settings/custom-formats/install-defaults" onsubmit="return confirm('Install the bundled default Custom Formats? CFs whose name already exists will be skipped.');">
+                <button type="submit" class="btn btn-primary">Install Bundled Defaults</button>
+            </form>
+        </div>
         {% else %}
-        <table class="group-source-table">
+        <table class="group-source-table cf-table">
             <thead>
                 <tr>
                     <th>Name</th>
@@ -469,22 +419,24 @@
             <tbody>
                 {% for cf in custom_formats %}
                 <tr>
-                    <td>{{ cf.row.name }}</td>
-                    <td>{{ cf.row.score }}</td>
+                    <td class="cf-name">{{ cf.row.name }}</td>
+                    <td class="cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                        {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
+                    </td>
                     <td>
                         {% if let Some(err) = cf.parse_error.as_ref() %}
-                        <span class="tag tag-res" title="{{ err }}">parse error</span>
+                        <span class="cf-parse-error" title="{{ err }}">parse error</span>
                         {% else %}
                         {{ cf.specs_count }}
                         {% endif %}
                     </td>
                     <td>
                         {% if cf.row.origin == "defaults" %}
-                        <span class="tag tag-source" title="Installed from the bundled default set">default</span>
+                        <span class="cf-origin-badge cf-origin-default" title="Installed from the bundled default set">default</span>
                         {% else if cf.row.origin == "import" %}
-                        <span class="tag tag-source" title="Imported from a Sonarr v4 JSON export">import</span>
+                        <span class="cf-origin-badge cf-origin-import" title="Imported from a Sonarr v4 JSON export">import</span>
                         {% else %}
-                        <span class="tag tag-res" title="Created via the Add Custom Format form">manual</span>
+                        <span class="cf-origin-badge cf-origin-manual" title="Created via the Add Custom Format form">manual</span>
                         {% endif %}
                     </td>
                     <td>
@@ -504,33 +456,116 @@
             </tbody>
         </table>
         {% endif %}
+    </div>
 
-        <h3 class="settings-subheading">Defaults</h3>
-        <div class="settings-inline-actions" style="margin-bottom: 12px;">
+    {# ── Add / Edit ─────────────────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
+        </div>
+        <p class="cf-section-desc">
+            Full Sonarr v4 CF object. Supported spec implementations:
+            <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
+            The compiler runs before saving, so invalid JSON is rejected with an error message.
+        </p>
+        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
+            {% if let Some(edit) = custom_format_edit %}
+            <input type="hidden" name="id" value="{{ edit.row.id }}">
+            {% if let Some(desc) = edit.trash_description.as_ref() %}
+            <div class="cf-trash-description">
+                <strong>Trash Guides description</strong>
+                <div style="white-space: pre-wrap;">{{ desc }}</div>
+            </div>
+            {% endif %}
+            {% endif %}
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="cf_name">Name</label>
+                    <input type="text" name="name" id="cf_name" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
+                </div>
+                <div class="form-group">
+                    <label for="cf_score">Score</label>
+                    <input type="number" name="score" id="cf_score" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
+                <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
+                    value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+            </div>
+            <div class="form-group">
+                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
+                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
+                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
+                <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
+            </div>
+            <div class="settings-inline-actions">
+                <button type="submit" class="btn btn-primary">
+                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+                </button>
+                {% if custom_format_edit.is_some() %}
+                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
+                {% endif %}
+            </div>
+        </form>
+    </div>
+
+    {# ── Global Minimum Score ───────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Global Minimum Score</h3>
+        </div>
+        <p class="cf-section-desc">
+            Auto-search drops releases whose summed CF score falls below this threshold. Interactive search still shows everything. Leave blank to disable the floor.
+        </p>
+        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form">
+            <div class="form-group">
+                <label for="cf_min_score">Minimum Score</label>
+                <input type="number" name="minimum_score" id="cf_min_score"
+                    value="{{ custom_format_min_score_display }}" placeholder="(blank = no floor)">
+            </div>
+            <button type="submit" class="btn btn-primary">Save Minimum Score</button>
+        </form>
+    </div>
+
+    {# ── Bundled Defaults ───────────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Bundled Defaults</h3>
+        </div>
+        <p class="cf-section-desc">
+            <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BluRay source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 and casual-group penalties) — existing names are skipped so repeat clicks are safe.
+            <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file — use this after you've edited a default CF and want the original back. Manual and imported CFs are untouched.
+        </p>
+        <div class="settings-inline-actions">
             <form method="post" action="/settings/custom-formats/install-defaults" onsubmit="return confirm('Install the bundled default Custom Formats? CFs whose name already exists will be skipped.');">
                 <button type="submit" class="btn btn-primary">Install Defaults</button>
             </form>
             <form method="post" action="/settings/custom-formats/reset-defaults" onsubmit="return confirm('Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched.');">
                 <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
             </form>
-            <span class="form-hint">
-                <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BluRay source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 and casual-group penalties) — CFs whose name already exists are skipped so repeat clicks are safe.
-                <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file — use this after you've edited a default CF and want the original back.
-            </span>
         </div>
+    </div>
 
-        <h3 class="settings-subheading">Import / Export</h3>
-        <div class="settings-inline-actions" style="margin-bottom: 12px;">
+    {# ── Import / Export ────────────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Import / Export</h3>
+        </div>
+        <p class="cf-section-desc">
+            <strong>Export All</strong> keeps every saved CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
+            <strong>Sonarr-safe</strong> drops whole CFs containing Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
+        </p>
+        <div class="settings-inline-actions" style="margin-bottom: 16px;">
             <a href="/settings/custom-formats/export" class="btn btn-secondary">Export All as JSON</a>
             <a href="/settings/custom-formats/export?mode=sonarr-safe" class="btn btn-secondary">Export (Sonarr-safe)</a>
-            <span class="form-hint">
-                <strong>Export All</strong> keeps every saved CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
-                <strong>Sonarr-safe</strong> drops whole CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
-            </span>
         </div>
+
         {% if let Some(review) = custom_format_import_review %}
-        <div class="cf-import-review" style="margin: 12px 0; padding: 14px; border: 1px solid var(--accent, #5b9bd5); background: var(--subtle-bg, #f5f7fa); border-radius: 6px;">
-            <h4 style="margin-top: 0;">Review Import Collisions</h4>
+        <div class="cf-import-review">
+            <h4>Review Import Collisions</h4>
             <p class="form-hint">
                 {{ review.collisions.len() }} Custom Format(s) in your import share a name with an existing row.
                 Pick an action per collision. Entries with no collision will import as new rows regardless of these choices.
@@ -540,7 +575,7 @@
                 <input type="hidden" name="payload" value="{{ review.payload }}">
                 <input type="hidden" name="decisions" id="cf_import_resolve_decisions" value="">
                 <input type="hidden" name="renames" id="cf_import_resolve_renames" value="">
-                <table class="group-source-table">
+                <table class="group-source-table cf-table">
                     <thead>
                         <tr>
                             <th>Existing name</th>
@@ -574,17 +609,18 @@
 
         <form method="post" action="/settings/custom-formats/import" class="settings-form">
             <div class="form-group">
-                <label for="cf_import_payload">Paste Sonarr v4 CF Export (single object, array, or <code>{"custom_formats":[…]}</code> wrapper)</label>
+                <label for="cf_import_payload">Paste Sonarr v4 CF Export</label>
                 <textarea name="payload" id="cf_import_payload" rows="10" spellcheck="false"
                     placeholder='[{"name": "...", "specifications": [...], "score": 100}, ...]'></textarea>
                 <span class="form-hint">
+                    Accepts a single object, an array, or <code>{"custom_formats":[…]}</code> wrapper.
                     Each entry is compiled via the same parser as the create form. Per-entry failures are counted and the first error is reported.
                     CFs whose name matches an existing row trigger a review page where you can pick <em>overwrite</em>, <em>rename</em>, or <em>skip</em> per conflict before anything is written.
                 </span>
             </div>
             <button type="submit" class="btn btn-primary">Import</button>
         </form>
-    </fieldset>
+    </div>
 </div>
 {% endif %}
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -406,34 +406,40 @@
         </form>
 
         <h3 class="settings-subheading">
-            {% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.id }}{% else %}Add Custom Format{% endif %}
+            {% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}
         </h3>
         <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
             {% if let Some(edit) = custom_format_edit %}
-            <input type="hidden" name="id" value="{{ edit.id }}">
+            <input type="hidden" name="id" value="{{ edit.row.id }}">
+            {% if let Some(desc) = edit.trash_description.as_ref() %}
+            <div class="cf-trash-description" style="margin-bottom: 12px; padding: 10px 12px; border-left: 3px solid var(--accent, #5b9bd5); background: var(--subtle-bg, #f5f7fa);">
+                <strong>Trash Guides description:</strong>
+                <div style="margin-top: 4px; white-space: pre-wrap;">{{ desc }}</div>
+            </div>
+            {% endif %}
             {% endif %}
             <div class="form-row">
                 <div class="form-group">
                     <label for="cf_name">Name</label>
                     <input type="text" name="name" id="cf_name" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.name }}{% endif %}">
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
                 </div>
                 <div class="form-group">
                     <label for="cf_score">Score</label>
                     <input type="number" name="score" id="cf_score" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.score }}{% else %}0{% endif %}">
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
                 </div>
                 <div class="form-group">
                     <label for="cf_trash_id">Trash ID (optional)</label>
                     <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
-                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
                 </div>
             </div>
             <div class="form-group">
                 <label for="cf_json">Sonarr v4 Custom Format JSON</label>
                 <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
-                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.json }}{% endif %}</textarea>
-                <span class="form-hint">Full Sonarr v4 CF object. Supported spec implementations: <code>ReleaseTitleSpecification</code>, <code>SourceSpecification</code>, <code>ResolutionSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>LanguageSpecification</code>, <code>SeaDexBestSpecification</code>. The compiler runs before saving, so invalid JSON is rejected with an error message.</span>
+                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
+                <span class="form-hint">Full Sonarr v4 CF object. Supported spec implementations: <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>. The compiler runs before saving, so invalid JSON is rejected with an error message. A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
             </div>
             <div class="settings-inline-actions">
                 <button type="submit" class="btn btn-primary">
@@ -455,6 +461,7 @@
                     <th>Name</th>
                     <th>Score</th>
                     <th>Specs</th>
+                    <th>Source</th>
                     <th>Trash ID</th>
                     <th></th>
                 </tr>
@@ -469,6 +476,15 @@
                         <span class="tag tag-res" title="{{ err }}">parse error</span>
                         {% else %}
                         {{ cf.specs_count }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if cf.row.origin == "defaults" %}
+                        <span class="tag tag-source" title="Installed from the bundled default set">default</span>
+                        {% else if cf.row.origin == "import" %}
+                        <span class="tag tag-source" title="Imported from a Sonarr v4 JSON export">import</span>
+                        {% else %}
+                        <span class="tag tag-res" title="Created via the Add Custom Format form">manual</span>
                         {% endif %}
                     </td>
                     <td>
@@ -489,17 +505,82 @@
         </table>
         {% endif %}
 
+        <h3 class="settings-subheading">Defaults</h3>
+        <div class="settings-inline-actions" style="margin-bottom: 12px;">
+            <form method="post" action="/settings/custom-formats/install-defaults" onsubmit="return confirm('Install the bundled default Custom Formats? CFs whose name already exists will be skipped.');">
+                <button type="submit" class="btn btn-primary">Install Defaults</button>
+            </form>
+            <form method="post" action="/settings/custom-formats/reset-defaults" onsubmit="return confirm('Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched.');">
+                <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
+            </form>
+            <span class="form-hint">
+                <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BluRay source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 and casual-group penalties) — CFs whose name already exists are skipped so repeat clicks are safe.
+                <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file — use this after you've edited a default CF and want the original back.
+            </span>
+        </div>
+
         <h3 class="settings-subheading">Import / Export</h3>
         <div class="settings-inline-actions" style="margin-bottom: 12px;">
             <a href="/settings/custom-formats/export" class="btn btn-secondary">Export All as JSON</a>
-            <span class="form-hint">Downloads every saved CF (with persisted scores) as a JSON array. Round-trips into Sonarr or another Ryokan instance.</span>
+            <a href="/settings/custom-formats/export?mode=sonarr-safe" class="btn btn-secondary">Export (Sonarr-safe)</a>
+            <span class="form-hint">
+                <strong>Export All</strong> keeps every saved CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
+                <strong>Sonarr-safe</strong> drops whole CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
+            </span>
         </div>
+        {% if let Some(review) = custom_format_import_review %}
+        <div class="cf-import-review" style="margin: 12px 0; padding: 14px; border: 1px solid var(--accent, #5b9bd5); background: var(--subtle-bg, #f5f7fa); border-radius: 6px;">
+            <h4 style="margin-top: 0;">Review Import Collisions</h4>
+            <p class="form-hint">
+                {{ review.collisions.len() }} Custom Format(s) in your import share a name with an existing row.
+                Pick an action per collision. Entries with no collision will import as new rows regardless of these choices.
+            </p>
+            <form method="post" action="/settings/custom-formats/import-resolve" class="settings-form"
+                  onsubmit="return buildCfImportResolvePayload(this);">
+                <input type="hidden" name="payload" value="{{ review.payload }}">
+                <input type="hidden" name="decisions" id="cf_import_resolve_decisions" value="">
+                <input type="hidden" name="renames" id="cf_import_resolve_renames" value="">
+                <table class="group-source-table">
+                    <thead>
+                        <tr>
+                            <th>Existing name</th>
+                            <th>Action</th>
+                            <th>New name (for rename)</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for c in review.collisions %}
+                        <tr data-cf-collision-idx="{{ c.index }}">
+                            <td><strong>{{ c.name }}</strong></td>
+                            <td>
+                                <label><input type="radio" name="cf_action_{{ c.index }}" value="skip" checked> Skip</label>
+                                <label style="margin-left: 8px;"><input type="radio" name="cf_action_{{ c.index }}" value="overwrite"> Overwrite</label>
+                                <label style="margin-left: 8px;"><input type="radio" name="cf_action_{{ c.index }}" value="rename"> Rename</label>
+                            </td>
+                            <td>
+                                <input type="text" name="cf_rename_{{ c.index }}" placeholder="New unique name">
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div class="settings-inline-actions" style="margin-top: 12px;">
+                    <button type="submit" class="btn btn-primary">Apply &amp; Import</button>
+                    <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
+                </div>
+            </form>
+        </div>
+        {% endif %}
+
         <form method="post" action="/settings/custom-formats/import" class="settings-form">
             <div class="form-group">
-                <label for="cf_import_payload">Paste Sonarr v4 CF Export (object or array)</label>
+                <label for="cf_import_payload">Paste Sonarr v4 CF Export (single object, array, or <code>{"custom_formats":[…]}</code> wrapper)</label>
                 <textarea name="payload" id="cf_import_payload" rows="10" spellcheck="false"
                     placeholder='[{"name": "...", "specifications": [...], "score": 100}, ...]'></textarea>
-                <span class="form-hint">Each entry is compiled via the same parser as the create form. Per-entry failures are counted and the first error is reported, but valid entries still import.</span>
+                <span class="form-hint">
+                    Each entry is compiled via the same parser as the create form. Per-entry failures are counted and the first error is reported.
+                    CFs whose name matches an existing row trigger a review page where you can pick <em>overwrite</em>, <em>rename</em>, or <em>skip</em> per conflict before anything is written.
+                </span>
             </div>
             <button type="submit" class="btn btn-primary">Import</button>
         </form>
@@ -528,6 +609,33 @@ function generateRadarrApiKey() {
 
 function syncTitleLanguagePreview(lang) {
     localStorage.setItem('titleLanguage', lang);
+}
+
+// Gather the per-collision radio selections and rename text fields
+// into the two newline-delimited hidden inputs that the import-resolve
+// handler expects. See plan §6.2 — each line is "<index>:<action>".
+function buildCfImportResolvePayload(form) {
+    const rows = form.querySelectorAll('tr[data-cf-collision-idx]');
+    const decisions = [];
+    const renames = [];
+    for (const row of rows) {
+        const idx = row.getAttribute('data-cf-collision-idx');
+        const chosen = row.querySelector('input[name="cf_action_' + idx + '"]:checked');
+        const action = chosen ? chosen.value : 'skip';
+        decisions.push(idx + ':' + action);
+        if (action === 'rename') {
+            const input = row.querySelector('input[name="cf_rename_' + idx + '"]');
+            const newName = input ? input.value.trim() : '';
+            if (!newName) {
+                alert('Collision ' + idx + ': pick a new name or choose a different action.');
+                return false;
+            }
+            renames.push(idx + ':' + newName);
+        }
+    }
+    form.querySelector('#cf_import_resolve_decisions').value = decisions.join('\n');
+    form.querySelector('#cf_import_resolve_renames').value = renames.join('\n');
+    return true;
 }
 
 function testQbit(btn) {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -17,11 +17,12 @@
 <div class="settings-tabs system-tabs">
     <a href="/settings?tab=integrations" class="system-tab {% if tab == "integrations" %}active{% endif %}">Connections</a>
     <a href="/settings?tab=quality" class="system-tab {% if tab == "quality" %}active{% endif %}">Preferred Quality &amp; Releases</a>
+    <a href="/settings?tab=custom_formats" class="system-tab {% if tab == "custom_formats" %}active{% endif %}">Custom Formats</a>
     <a href="/settings?tab=groups" class="system-tab {% if tab == "groups" %}active{% endif %}">Release Groups</a>
     <a href="/settings?tab=general" class="system-tab {% if tab == "general" %}active{% endif %}">General</a>
 </div>
 
-{% if tab != "groups" %}
+{% if tab != "groups" && tab != "custom_formats" %}
 <form method="post" action="/settings" class="settings-form">
     <input type="hidden" name="tab" value="{{ tab }}">
 
@@ -200,6 +201,13 @@
                 </label>
                 <span class="form-hint">Periodically search for higher-quality releases of downloaded episodes. Runs every 24 hours. Upgrades via RSS are always active regardless of this setting.</span>
             </div>
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="seadex_enabled" value="1" {% if config.seadex_enabled %}checked{% endif %}>
+                    Enable SeaDex release boost
+                </label>
+                <span class="form-hint">Query <a href="https://releases.moe" target="_blank" rel="noopener">releases.moe</a> during auto-search and boost releases the SeaDex community has flagged as best (or alt-best). Automatically suppressed when you have a <code>SeaDexBestSpecification</code> Custom Format, since the CF takes precedence.</span>
+            </div>
         </fieldset>
     </div>
 
@@ -373,6 +381,128 @@
                 {% endfor %}
             </tbody>
         </table>
+    </fieldset>
+</div>
+{% endif %}
+
+{% if tab == "custom_formats" %}
+<div class="settings-tab-panel active">
+    <fieldset>
+        <legend>Custom Formats</legend>
+        <p class="form-hint">
+            Sonarr v4-compatible Custom Formats. During auto-search, every matching spec contributes its score to the release total.
+            Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
+        </p>
+
+        <h3 class="settings-subheading">Global Minimum Score</h3>
+        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form">
+            <div class="form-group">
+                <label for="cf_min_score">Custom Format Minimum Score</label>
+                <input type="number" name="minimum_score" id="cf_min_score"
+                    value="{{ custom_format_min_score_display }}" placeholder="(blank = no floor)">
+                <span class="form-hint">Auto-search drops releases whose summed CF score falls below this threshold. Interactive search still shows everything. Leave blank to disable the floor.</span>
+            </div>
+            <button type="submit" class="btn btn-primary">Save Minimum Score</button>
+        </form>
+
+        <h3 class="settings-subheading">
+            {% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.id }}{% else %}Add Custom Format{% endif %}
+        </h3>
+        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
+            {% if let Some(edit) = custom_format_edit %}
+            <input type="hidden" name="id" value="{{ edit.id }}">
+            {% endif %}
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="cf_name">Name</label>
+                    <input type="text" name="name" id="cf_name" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.name }}{% endif %}">
+                </div>
+                <div class="form-group">
+                    <label for="cf_score">Score</label>
+                    <input type="number" name="score" id="cf_score" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.score }}{% else %}0{% endif %}">
+                </div>
+                <div class="form-group">
+                    <label for="cf_trash_id">Trash ID (optional)</label>
+                    <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
+                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
+                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
+                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.json }}{% endif %}</textarea>
+                <span class="form-hint">Full Sonarr v4 CF object. Supported spec implementations: <code>ReleaseTitleSpecification</code>, <code>SourceSpecification</code>, <code>ResolutionSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>LanguageSpecification</code>, <code>SeaDexBestSpecification</code>. The compiler runs before saving, so invalid JSON is rejected with an error message.</span>
+            </div>
+            <div class="settings-inline-actions">
+                <button type="submit" class="btn btn-primary">
+                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+                </button>
+                {% if custom_format_edit.is_some() %}
+                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
+                {% endif %}
+            </div>
+        </form>
+
+        <h3 class="settings-subheading">Current Custom Formats ({{ custom_formats.len() }})</h3>
+        {% if custom_formats.is_empty() %}
+        <p class="form-hint">No Custom Formats defined. Add one above or import from a Sonarr export below.</p>
+        {% else %}
+        <table class="group-source-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Score</th>
+                    <th>Specs</th>
+                    <th>Trash ID</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for cf in custom_formats %}
+                <tr>
+                    <td>{{ cf.row.name }}</td>
+                    <td>{{ cf.row.score }}</td>
+                    <td>
+                        {% if let Some(err) = cf.parse_error.as_ref() %}
+                        <span class="tag tag-res" title="{{ err }}">parse error</span>
+                        {% else %}
+                        {{ cf.specs_count }}
+                        {% endif %}
+                    </td>
+                    <td>
+                        {% if let Some(tid) = cf.row.trash_id.as_ref() %}<code>{{ tid }}</code>{% else %}<span class="form-hint">—</span>{% endif %}
+                    </td>
+                    <td>
+                        <div class="settings-inline-actions">
+                            <a href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}" class="btn btn-secondary">Edit</a>
+                            <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
+                                <input type="hidden" name="id" value="{{ cf.row.id }}">
+                                <button type="submit" class="btn btn-danger">Delete</button>
+                            </form>
+                        </div>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% endif %}
+
+        <h3 class="settings-subheading">Import / Export</h3>
+        <div class="settings-inline-actions" style="margin-bottom: 12px;">
+            <a href="/settings/custom-formats/export" class="btn btn-secondary">Export All as JSON</a>
+            <span class="form-hint">Downloads every saved CF (with persisted scores) as a JSON array. Round-trips into Sonarr or another Ryokan instance.</span>
+        </div>
+        <form method="post" action="/settings/custom-formats/import" class="settings-form">
+            <div class="form-group">
+                <label for="cf_import_payload">Paste Sonarr v4 CF Export (object or array)</label>
+                <textarea name="payload" id="cf_import_payload" rows="10" spellcheck="false"
+                    placeholder='[{"name": "...", "specifications": [...], "score": 100}, ...]'></textarea>
+                <span class="form-hint">Each entry is compiled via the same parser as the create form. Per-entry failures are counted and the first error is reported, but valid entries still import.</span>
+            </div>
+            <button type="submit" class="btn btn-primary">Import</button>
+        </form>
     </fieldset>
 </div>
 {% endif %}


### PR DESCRIPTION
## Summary

Full Custom Formats (Sonarr v4-compatible) + SeaDex integration, closing out the plan in `ryokan-custom-formats.md`. Spans Phases 1–9 plus all six post-Phase-9 gaps (A–F) identified during dogfooding.

- **Custom Formats**: parser, evaluator, and DB storage for Sonarr-v4-compatible CFs. Group-by-type DidMatch semantics with the required-hard-fail rule (plan §5.7). Per-candidate CF scoring plugged into `auto_search.rs` alongside the existing quality scoring.
- **SeaDex**: releases.moe PocketBase client with `pick_best` filters (muxed preference, group allowlist, unmuxed detection). Exposed as a Ryokan-only `Ryokan.SeaDexBestSpecification` so CFs can reference "this release is on SeaDex" as a boolean gate.
- **Settings UI**: full CF CRUD (create/edit/delete/duplicate), dual-mode export (Ryokan-compatible + Sonarr-safe with a System-category audit log for dropped CFs), import accepting bare object / bare array / `{custom_formats: …}` wrapper shapes, name-collision prompt with per-entry skip/overwrite/rename flow, `trash_description` rendering, Source badge (`manual` / `import` / `defaults`), and a Reset to Defaults button scoped to defaults-origin rows only.
- **trash-guides fixture set**: 28 real anime CFs vendored at `fixtures/trash-guides-anime/` and embedded via `include_str!`. Four fixture tests (parse, round-trip, known-implementation allowlist, surviving-spec floor). **The fixture pass caught three latent parser bugs** that the synthetic tests had missed — all fixed in the same commit:
  - `fields` accessor handled array form only; trash-guides ships object form
  - `regex-lite` doesn't support look-around or variable look-behind (neither does the main `regex` crate); swapped the CF-only backend to `fancy-regex`
  - .NET allows literal `[` inside a character class; added `sonarr_to_rust_regex` preprocessor that escapes those and routes results through fancy-regex

## Test plan

- [x] `cargo test` — **277 passing** (up from 268 before gap work, +9 tests for fixture set + regex rewrite helper)
- [x] `cargo clippy --all-targets` clean
- [x] Fixture tests validate every vendored trash-guides anime CF parses, round-trips, and uses only known spec implementations
- [ ] Manual smoke test: import `fixtures/trash-guides-anime/*.json` via the settings UI, verify CFs appear with Source: `import` and scores from `trash_scores.default`
- [ ] Manual smoke test: export in Sonarr-safe mode and re-import into a stock Sonarr instance to confirm the stripped file is accepted
- [ ] Manual smoke test: trigger a name-collision on import and exercise all three resolve actions (skip, overwrite, rename)
- [ ] Manual smoke test: Install Defaults → Reset to Defaults round-trip leaves manual/imported CFs untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)