### PR TITLE
fix: address PR #9 follow-up review + test plan for minimally tested merge

### DIFF
--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1855,6 +1855,39 @@ pub async fn list_folders(
 /// when auto-expand fails partway through. Any failures get logged
 /// at warn level.
 ///
+/// Resolve the list of episode numbers a batch release should be
+/// recorded against at grab time. Parses explicit episode ranges
+/// from the release title (e.g. "01-12", "E01-E24") via
+/// [`auto_search::parse_release_numbers`], and when the title carries
+/// no explicit numbers falls back to the series' known episode count
+/// so a title like "Jellyfish Can't Swim in the Night" still spawns
+/// a row per episode.
+///
+/// Used by the two batch grab handlers (`search_batch_releases` and
+/// `grab_batch_result`). Without this, batch grabs passed an empty
+/// episode list to `grabbed_torrents::record_grab` and skipped
+/// `episode_tags::record_grab` entirely, which meant the series page
+/// showed every episode as UNKNOWN until post-processing ran — and
+/// if the user had post-processing disabled, the rows never got
+/// created at all.
+///
+/// Capped at 1000 episodes as a safety rail against a garbage
+/// AniList record reporting an absurd episode count.
+fn batch_episode_numbers(title: &str, detail: &anilist::AnimeDetail) -> Vec<i32> {
+    let mut ep_nums: Vec<i32> = auto_search::parse_release_numbers(title)
+        .into_iter()
+        .collect();
+    if ep_nums.is_empty() {
+        if let Some(total) = detail.episodes {
+            if total > 0 && total <= 1000 {
+                ep_nums = (1..=total).collect();
+            }
+        }
+    }
+    ep_nums.sort_unstable();
+    ep_nums
+}
+
 /// Returns the number of siblings *newly added* to the library
 /// (upserts that hit an existing row don't count).
 #[allow(clippy::too_many_arguments)]
@@ -2299,6 +2332,7 @@ async fn run_auto_search_targets_with_upgrades(
                                     &incoming_classification,
                                     &result.title,
                                     &result.group,
+                                    result.size_bytes,
                                 ).await;
                             }
                             // Phase 2 sibling auto-expand: when the
@@ -2663,9 +2697,41 @@ pub async fn search_batch_releases(
                 &format!("group={}, score={}, tier={}", result.group, result.score, tier_label),
             ).await;
             if let Some(sid) = series_id_for_grab {
+                // Parse episode list from the batch title so every covered
+                // episode gets a per-episode `episode_quality_tags` row at
+                // grab time, not just at post-processing time. Without
+                // this the UI shows UNKNOWN for every episode of a
+                // freshly-grabbed batch — and if the user has
+                // post-processing disabled the rows never get created at
+                // all. Mirrors the auto-search-path logic at
+                // `run_auto_search_targets_with_upgrades` (look for
+                // `parse_release_numbers` above).
+                //
+                // Fallback when the title carries no explicit range
+                // (e.g. "Jellyfish Can't Swim in the Night" with no
+                // "01-12" suffix): use the series' known episode count.
+                // Capped at 1000 so a garbage AniList record can't
+                // spawn a million rows.
+                let ep_nums = batch_episode_numbers(&result.title, &detail);
                 let _ = crate::models::grabbed_torrents::record_grab(
-                    &state.db, &result.info_hash, &result.title, sid, &[], result.is_batch,
+                    &state.db,
+                    &result.info_hash,
+                    &result.title,
+                    sid,
+                    &ep_nums,
+                    result.is_batch,
                 ).await;
+                for ep_num in &ep_nums {
+                    let _ = episode_tags::record_grab(
+                        &state.db,
+                        sid,
+                        *ep_num,
+                        &classification,
+                        &result.title,
+                        &result.group,
+                        result.size_bytes,
+                    ).await;
+                }
             }
             Ok(Json(auto_search::AutoSearchReport {
                 grabbed: vec![auto_search::AutoSearchHit {
@@ -2777,9 +2843,11 @@ pub async fn interactive_search_batches(
 /// Grab a specific batch release chosen from interactive batch search.
 ///
 /// Mirrors `grab_interactive_result` but without an episode number —
-/// batches don't belong to a single episode, and the per-episode tag
-/// bookkeeping (`episode_tags::record_grab`) is skipped because the
-/// episodes will be tagged when the post-processing stage extracts them.
+/// batches cover a range of episodes — the episode list is resolved
+/// from the release title via [`batch_episode_numbers`] at grab time
+/// so per-episode `episode_tags::record_grab` writes land immediately
+/// and the UI shows the batch's quality tier without waiting on
+/// post-processing.
 #[utoipa::path(
     post,
     path = "/api/series/{anilist_id}/grab-batch",
@@ -2811,6 +2879,7 @@ pub async fn grab_batch_result(
     let group = body["group"].as_str().unwrap_or("").to_string();
     let resolution = body["resolution"].as_str().unwrap_or("").to_string();
     let info_hash = body["info_hash"].as_str().unwrap_or("").to_string();
+    let size_bytes = body["size_bytes"].as_i64().unwrap_or(0);
 
     if url.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "No URL provided".to_string()));
@@ -2893,9 +2962,27 @@ pub async fn grab_batch_result(
     ).await;
 
     if let Some(sid) = series_id {
+        // Parse episode list from the batch title so every covered
+        // episode gets a per-episode `episode_quality_tags` row at
+        // grab time. Same reasoning as in `search_batch_releases` —
+        // without this, batch grabs leave every episode showing
+        // UNKNOWN in the UI, and with post-processing disabled the
+        // rows never get created at all.
+        let ep_nums = batch_episode_numbers(&title, &detail);
         let grab_id = crate::models::grabbed_torrents::record_grab(
-            &state.db, &info_hash, &title, sid, &[], true,
+            &state.db, &info_hash, &title, sid, &ep_nums, true,
         ).await.ok().flatten();
+        for ep_num in &ep_nums {
+            let _ = episode_tags::record_grab(
+                &state.db,
+                sid,
+                *ep_num,
+                &classification,
+                &title,
+                &group,
+                size_bytes,
+            ).await;
+        }
         // Phase 2 sibling auto-expand. Skip when selective narrowing
         // successfully applied — the user picked a specific sibling
         // (e.g. Stardust Crusaders) out of a megapack and the other
@@ -2916,6 +3003,7 @@ pub async fn grab_batch_result(
                 let info_hash_task = info_hash.clone();
                 let detail_task = detail.clone();
                 let title_task = title.clone();
+                let ep_nums_task = ep_nums.clone();
                 tokio::spawn(async move {
                     auto_expand_library_from_pack(
                         &db_task,
@@ -2923,7 +3011,7 @@ pub async fn grab_batch_result(
                         &info_hash_task,
                         &detail_task,
                         sid,
-                        &[],
+                        &ep_nums_task,
                         grab_id,
                         &title_task,
                     ).await;
@@ -2973,6 +3061,7 @@ pub async fn grab_interactive_result(
     let group = body["group"].as_str().unwrap_or("").to_string();
     let resolution = body["resolution"].as_str().unwrap_or("").to_string();
     let info_hash = body["info_hash"].as_str().unwrap_or("").to_string();
+    let size_bytes = body["size_bytes"].as_i64().unwrap_or(0);
 
     if url.is_empty() {
         return Err((axum::http::StatusCode::BAD_REQUEST, "No URL provided".to_string()));
@@ -3065,7 +3154,7 @@ pub async fn grab_interactive_result(
             &state.db, &info_hash, &title, sid, &[episode_number], false,
         ).await;
         let _ = episode_tags::record_grab(
-            &state.db, sid, episode_number, &classification, &title, &group,
+            &state.db, sid, episode_number, &classification, &title, &group, size_bytes,
         ).await;
     }
 

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2024,12 +2024,16 @@ async fn auto_expand_library_from_pack_with_files(
     // goes through the AL detail cache so repeat grabs within the
     // TTL are free. Failures are soft — any neighbor we can't fetch
     // is silently skipped and detection falls back to the parent's
-    // direct relations.
+    // direct relations. Fetches are dispatched concurrently via a
+    // JoinSet so N neighbors take max(fetch_time), not sum — every
+    // hop previously blocked the grab path end-to-end.
     let mut neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> =
         std::collections::HashMap::new();
-    let mut fetched = 0_usize;
+    let mut walk_set: tokio::task::JoinSet<(i64, String, Result<anilist::AnimeDetail, String>)> =
+        tokio::task::JoinSet::new();
+    let mut dispatched = 0_usize;
     for rel in &parent_detail.relations {
-        if fetched >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
+        if dispatched >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
             break;
         }
         if !auto_search::is_transitive_walk_source(&rel.relation_type) {
@@ -2041,17 +2045,33 @@ async fn auto_expand_library_from_pack_with_files(
         if rel.id <= 0 {
             continue;
         }
-        match anilist::get_anime_detail(rel.id).await {
-            Ok(detail) => {
-                neighbor_details.insert(rel.id, detail);
-                fetched += 1;
+        let rel_id = rel.id;
+        let rel_type = rel.relation_type.clone();
+        walk_set.spawn(async move {
+            let res = anilist::get_anime_detail(rel_id)
+                .await
+                .map_err(|e| e.to_string());
+            (rel_id, rel_type, res)
+        });
+        dispatched += 1;
+    }
+    while let Some(joined) = walk_set.join_next().await {
+        match joined {
+            Ok((rel_id, _rel_type, Ok(detail))) => {
+                neighbor_details.insert(rel_id, detail);
             }
-            Err(e) => {
+            Ok((rel_id, rel_type, Err(e))) => {
                 tracing::debug!(
                     "auto-expand: transitive neighbor fetch failed rel_id={} rel_type={} err={}",
-                    rel.id,
-                    rel.relation_type,
+                    rel_id,
+                    rel_type,
                     e
+                );
+            }
+            Err(join_err) => {
+                tracing::debug!(
+                    "auto-expand: transitive neighbor task panicked: {}",
+                    join_err
                 );
             }
         }
@@ -2207,7 +2227,7 @@ async fn auto_expand_library_from_pack_with_files(
         // selectors only call in on `result.is_batch && !selective_narrowed`),
         // so `is_batch=true` is always correct here.
         for &local_ep in &ep_nums {
-            let _ = episode_tags::record_grab(
+            if let Err(e) = episode_tags::record_grab(
                 db,
                 sibling_id,
                 local_ep,
@@ -2217,7 +2237,19 @@ async fn auto_expand_library_from_pack_with_files(
                 grab_ctx.size_bytes,
                 true,
             )
-            .await;
+            .await
+            {
+                logger::warn(
+                    db,
+                    LogCategory::Library,
+                    &format!(
+                        "Auto-expand: failed to backfill grab history for sibling {} ep {}",
+                        sibling_id, local_ep,
+                    ),
+                    &format!("{}: {}", torrent_title, e),
+                )
+                .await;
+            }
         }
 
         routes.push(grabbed_torrents::GrabSeriesRoute {
@@ -3642,6 +3674,23 @@ pub async fn episode_download_progress(
         return Ok(Json(Vec::new()));
     }
 
+    // Phase 2: consult `grabbed_torrent_series` so sibling pages
+    // surface the parent torrent's progress. Auto-expand writes one
+    // route row per sibling + one for the parent; each row carries
+    // that series' own effective (post-offset) episode numbers.
+    // When routes exist we trust them exclusively (same rule post-
+    // processing uses), so the legacy parent-only match on
+    // `grab.series_id` is skipped for auto-expanded grabs.
+    //
+    // Bulk-fetched into a HashMap<grab_id, routes> so the poller (run
+    // every few seconds on every open series page) issues exactly one
+    // routes query per poll, not N.
+    let grab_ids: Vec<i64> = pending.iter().map(|g| g.id).collect();
+    let routes_by_grab =
+        crate::models::grabbed_torrents::get_series_routes_for_grabs(&state.db, &grab_ids)
+            .await
+            .unwrap_or_default();
+
     let qbit = {
         let guard = state.qbit.read().await;
         match guard.as_ref() {
@@ -3658,30 +3707,15 @@ pub async fn episode_download_progress(
 
     let mut results = Vec::new();
     for grab in &pending {
-        // Phase 2: consult `grabbed_torrent_series` so sibling pages
-        // surface the parent torrent's progress. Auto-expand writes
-        // one route row per sibling + one for the parent; each row
-        // carries that series' own effective (post-offset) episode
-        // numbers. When routes exist we trust them exclusively (same
-        // rule post-processing uses), so the legacy parent-only match
-        // on `grab.series_id` is skipped for auto-expanded grabs.
-        // Without this, the sibling's progress bar is stuck at 0.0%
-        // — its `episode_quality_tags` rows exist (so the DOM bar
-        // renders) but the poller can't find a matching grab row
-        // keyed to the sibling's series_id.
-        let routes = crate::models::grabbed_torrents::get_series_routes(&state.db, grab.id)
-            .await
-            .unwrap_or_default();
-        let ep_nums: Vec<i32> = if !routes.is_empty() {
-            routes
+        let routes = routes_by_grab.get(&grab.id);
+        let ep_nums: Vec<i32> = match routes {
+            Some(routes) if !routes.is_empty() => routes
                 .iter()
                 .filter(|r| r.series_id == tracked.id)
                 .flat_map(|r| r.episode_numbers.iter().copied())
-                .collect()
-        } else if grab.series_id == tracked.id {
-            grab.episode_numbers.clone()
-        } else {
-            continue;
+                .collect(),
+            _ if grab.series_id == tracked.id => grab.episode_numbers.clone(),
+            _ => continue,
         };
         if ep_nums.is_empty() {
             continue;

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2125,6 +2125,10 @@ async fn auto_expand_library_from_pack_with_files(
             file_indices: sibling.file_indices,
             episode_numbers: ep_nums,
             matched_subtitle: sibling.matched_subtitle,
+            // Wired through from sibling.episode_offset in Commit 5;
+            // for now the schema column exists and every row writes 0
+            // so legacy behavior is preserved.
+            episode_offset: 0,
         });
     }
 
@@ -2168,6 +2172,9 @@ async fn auto_expand_library_from_pack_with_files(
             file_indices: parent_file_indices,
             episode_numbers: parent_episode_numbers.to_vec(),
             matched_subtitle: String::new(),
+            // Parent-route files always use their own arc-local
+            // numbering — no offset ever needed here.
+            episode_offset: 0,
         });
     }
 

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1888,9 +1888,6 @@ fn batch_episode_numbers(title: &str, detail: &anilist::AnimeDetail) -> Vec<i32>
     ep_nums
 }
 
-/// Returns the number of siblings *newly added* to the library
-/// (upserts that hit an existing row don't count).
-#[allow(clippy::too_many_arguments)]
 /// Grab-time context threaded through the auto-expand path so each
 /// detected sibling series gets its own `episode_quality_tags` +
 /// `episode_grab_history` rows alongside its route record. Without
@@ -1907,6 +1904,8 @@ struct AutoExpandGrabContext {
     size_bytes: i64,
 }
 
+/// Returns the number of siblings *newly added* to the library
+/// (upserts that hit an existing row don't count).
 #[allow(clippy::too_many_arguments)]
 async fn auto_expand_library_from_pack(
     db: &SqlitePool,
@@ -3639,8 +3638,7 @@ pub async fn episode_download_progress(
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let series_pending: Vec<_> = pending.iter().filter(|g| g.series_id == tracked.id).collect();
-    if series_pending.is_empty() {
+    if pending.is_empty() {
         return Ok(Json(Vec::new()));
     }
 
@@ -3659,7 +3657,36 @@ pub async fn episode_download_progress(
         .collect();
 
     let mut results = Vec::new();
-    for grab in &series_pending {
+    for grab in &pending {
+        // Phase 2: consult `grabbed_torrent_series` so sibling pages
+        // surface the parent torrent's progress. Auto-expand writes
+        // one route row per sibling + one for the parent; each row
+        // carries that series' own effective (post-offset) episode
+        // numbers. When routes exist we trust them exclusively (same
+        // rule post-processing uses), so the legacy parent-only match
+        // on `grab.series_id` is skipped for auto-expanded grabs.
+        // Without this, the sibling's progress bar is stuck at 0.0%
+        // — its `episode_quality_tags` rows exist (so the DOM bar
+        // renders) but the poller can't find a matching grab row
+        // keyed to the sibling's series_id.
+        let routes = crate::models::grabbed_torrents::get_series_routes(&state.db, grab.id)
+            .await
+            .unwrap_or_default();
+        let ep_nums: Vec<i32> = if !routes.is_empty() {
+            routes
+                .iter()
+                .filter(|r| r.series_id == tracked.id)
+                .flat_map(|r| r.episode_numbers.iter().copied())
+                .collect()
+        } else if grab.series_id == tracked.id {
+            grab.episode_numbers.clone()
+        } else {
+            continue;
+        };
+        if ep_nums.is_empty() {
+            continue;
+        }
+
         let torrent = if !grab.hash.is_empty() {
             by_hash.get(&grab.hash.to_lowercase()).copied()
         } else {
@@ -3672,9 +3699,9 @@ pub async fn episode_download_progress(
             continue;
         };
 
-        for ep in &grab.episode_numbers {
+        for ep in ep_nums {
             results.push(EpisodeProgress {
-                episode: *ep,
+                episode: ep,
                 progress: t.progress,
                 speed: t.dlspeed,
                 state: t.state.clone(),

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1891,6 +1891,23 @@ fn batch_episode_numbers(title: &str, detail: &anilist::AnimeDetail) -> Vec<i32>
 /// Returns the number of siblings *newly added* to the library
 /// (upserts that hit an existing row don't count).
 #[allow(clippy::too_many_arguments)]
+/// Grab-time context threaded through the auto-expand path so each
+/// detected sibling series gets its own `episode_quality_tags` +
+/// `episode_grab_history` rows alongside its route record. Without
+/// this, the sibling series page shows UNKNOWN with no progress bar
+/// until post-processing runs — the parent series records the grab
+/// for its own episodes synchronously, but the siblings are detected
+/// asynchronously inside `auto_expand_library_from_pack` and were
+/// previously only getting route rows written. Owned-fields so the
+/// struct can be cloned into the spawned task.
+#[derive(Clone)]
+struct AutoExpandGrabContext {
+    classification: crate::services::source::ClassificationResult,
+    release_group: String,
+    size_bytes: i64,
+}
+
+#[allow(clippy::too_many_arguments)]
 async fn auto_expand_library_from_pack(
     db: &SqlitePool,
     qbit: &crate::services::qbit::QbitClient,
@@ -1900,6 +1917,7 @@ async fn auto_expand_library_from_pack(
     parent_episode_numbers: &[i32],
     grab_id: i64,
     torrent_title: &str,
+    grab_ctx: &AutoExpandGrabContext,
 ) -> usize {
     if parent_detail.id <= 0 || info_hash.is_empty() {
         return 0;
@@ -1941,6 +1959,7 @@ async fn auto_expand_library_from_pack(
         parent_episode_numbers,
         grab_id,
         torrent_title,
+        grab_ctx,
     )
     .await
 }
@@ -1959,6 +1978,7 @@ async fn auto_expand_library_from_pack_with_files(
     parent_episode_numbers: &[i32],
     grab_id: i64,
     torrent_title: &str,
+    grab_ctx: &AutoExpandGrabContext,
 ) -> usize {
     let parent_title = if !parent_detail.title_english.is_empty() {
         parent_detail.title_english.as_str()
@@ -2176,6 +2196,31 @@ async fn auto_expand_library_from_pack_with_files(
         for &i in &sibling.file_indices {
             claimed.insert(i);
         }
+
+        // Write per-episode grab history + quality tag rows for this
+        // sibling so its episode list shows `state=grabbed` in the UI
+        // (progress bar + "came from X GB batch" tooltip). The parent
+        // path records its own rows synchronously at grab time; siblings
+        // were previously only getting route rows written here, which
+        // meant their series pages rendered UNKNOWN with no progress bar
+        // until post-processing finished and backfilled the tags. Every
+        // auto-expand firing is a batch by definition (the outer
+        // selectors only call in on `result.is_batch && !selective_narrowed`),
+        // so `is_batch=true` is always correct here.
+        for &local_ep in &ep_nums {
+            let _ = episode_tags::record_grab(
+                db,
+                sibling_id,
+                local_ep,
+                &grab_ctx.classification,
+                torrent_title,
+                &grab_ctx.release_group,
+                grab_ctx.size_bytes,
+                true,
+            )
+            .await;
+        }
+
         routes.push(grabbed_torrents::GrabSeriesRoute {
             grab_id,
             series_id: sibling_id,
@@ -2496,6 +2541,11 @@ async fn run_auto_search_targets_with_upgrades(
                                     let detail_task = detail.clone();
                                     let ep_nums_task = ep_nums.clone();
                                     let title_task = result.title.clone();
+                                    let grab_ctx_task = AutoExpandGrabContext {
+                                        classification: incoming_classification.clone(),
+                                        release_group: result.group.clone(),
+                                        size_bytes: result.size_bytes,
+                                    };
                                     tokio::spawn(async move {
                                         auto_expand_library_from_pack(
                                             &db_task,
@@ -2506,6 +2556,7 @@ async fn run_auto_search_targets_with_upgrades(
                                             &ep_nums_task,
                                             grab_id,
                                             &title_task,
+                                            &grab_ctx_task,
                                         ).await;
                                     });
                                 }
@@ -3128,6 +3179,11 @@ pub async fn grab_batch_result(
                 let detail_task = detail.clone();
                 let title_task = title.clone();
                 let ep_nums_task = ep_nums.clone();
+                let grab_ctx_task = AutoExpandGrabContext {
+                    classification: classification.clone(),
+                    release_group: group.clone(),
+                    size_bytes,
+                };
                 tokio::spawn(async move {
                     auto_expand_library_from_pack(
                         &db_task,
@@ -3138,6 +3194,7 @@ pub async fn grab_batch_result(
                         &ep_nums_task,
                         grab_id,
                         &title_task,
+                        &grab_ctx_task,
                     ).await;
                 });
             }
@@ -3712,6 +3769,14 @@ mod tests {
         }
     }
 
+    fn test_grab_ctx() -> AutoExpandGrabContext {
+        AutoExpandGrabContext {
+            classification: crate::services::source::ClassificationResult::unknown(),
+            release_group: String::new(),
+            size_bytes: 0,
+        }
+    }
+
     fn related_entry(
         id: i64,
         title_english: &str,
@@ -3809,6 +3874,7 @@ mod tests {
             "[Group] JoJo no Kimyou na Bouken - 02 [BD 1080p].mkv".to_string(),
         ];
 
+        let grab_ctx = test_grab_ctx();
         let added = auto_expand_library_from_pack_with_files(
             &db,
             &filenames,
@@ -3817,6 +3883,7 @@ mod tests {
             &[1, 2],
             grab_id,
             "[Group] JoJo Megapack (BD 1080p)",
+            &grab_ctx,
         )
         .await;
 
@@ -3925,6 +3992,7 @@ mod tests {
         }
         let parent_episode_numbers: Vec<i32> = (1..=13).collect();
 
+        let grab_ctx = test_grab_ctx();
         let added = auto_expand_library_from_pack_with_files(
             &db,
             &filenames,
@@ -3933,6 +4001,7 @@ mod tests {
             &parent_episode_numbers,
             grab_id,
             "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            &grab_ctx,
         )
         .await;
 
@@ -3967,6 +4036,38 @@ mod tests {
             .expect("parent route present");
         assert_eq!(parent_route.file_indices, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
         assert_eq!(parent_route.episode_offset, 0);
+
+        // Regression guard: auto-expand must also write per-episode
+        // `episode_quality_tags` + `episode_grab_history` rows for the
+        // newly-upserted sibling. Without these the sibling's series
+        // page renders UNKNOWN with no progress bar until post-
+        // processing backfills them (which, if the user has PP
+        // disabled, never happens). Uses the effective (post-offset)
+        // local episode numbers the route already stores.
+        let sibling_id = sibling_route.series_id;
+        let sibling_tags = episode_tags::get_for_series(&db, sibling_id)
+            .await
+            .expect("sibling quality tags");
+        assert_eq!(
+            sibling_tags.len(),
+            7,
+            "sibling should have 7 quality-tag rows (one per local ep 1..=7)"
+        );
+        for local_ep in 1..=7 {
+            let tag = sibling_tags
+                .get(&local_ep)
+                .unwrap_or_else(|| panic!("sibling tag for local ep {} missing", local_ep));
+            assert_eq!(tag.state, "grabbed");
+            let history = episode_tags::get_grab_history(&db, sibling_id, local_ep)
+                .await
+                .expect("sibling grab history");
+            assert_eq!(
+                history.len(),
+                1,
+                "sibling local ep {} should have 1 grab-history row",
+                local_ep
+            );
+        }
     }
 
     /// When the file list has no sibling matches, the inner fn is a
@@ -4022,6 +4123,7 @@ mod tests {
             "[Group] My Dress-Up Darling - 02 [BD 1080p].mkv".to_string(),
         ];
 
+        let grab_ctx = test_grab_ctx();
         let added = auto_expand_library_from_pack_with_files(
             &db,
             &filenames,
@@ -4030,6 +4132,7 @@ mod tests {
             &[1, 2],
             grab_id,
             "[Group] My Dress-Up Darling S01 (BD 1080p)",
+            &grab_ctx,
         )
         .await;
 

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2105,11 +2105,21 @@ async fn auto_expand_library_from_pack_with_files(
         // Derive episode numbers per sibling so
         // find_imported_for_episode can locate this route when
         // an upgrade later targets one of the sibling's episodes.
+        //
+        // The stored ep_nums are *effective* (post-offset) numbers so
+        // an upgrade searching by episode 1 of Owari S2 finds a route
+        // whose files were originally numbered E14 on disk. Skip
+        // rows that would resolve to a non-positive effective number
+        // (shouldn't happen — detection sets offset conservatively —
+        // but guards against a bad route/file pairing).
         let mut ep_nums: Vec<i32> = Vec::new();
         for &file_idx in &sibling.file_indices {
             if let Some(name) = filenames.get(file_idx) {
-                if let Some((_, n)) = media::parse_episode_number(&name.to_lowercase()) {
-                    ep_nums.push(n);
+                if let Some((_, raw)) = media::parse_episode_number(&name.to_lowercase()) {
+                    let effective = raw - sibling.episode_offset;
+                    if effective > 0 {
+                        ep_nums.push(effective);
+                    }
                 }
             }
         }
@@ -2125,10 +2135,7 @@ async fn auto_expand_library_from_pack_with_files(
             file_indices: sibling.file_indices,
             episode_numbers: ep_nums,
             matched_subtitle: sibling.matched_subtitle,
-            // Wired through from sibling.episode_offset in Commit 5;
-            // for now the schema column exists and every row writes 0
-            // so legacy behavior is preserved.
-            episode_offset: 0,
+            episode_offset: sibling.episode_offset,
         });
     }
 
@@ -3782,6 +3789,11 @@ mod tests {
             .expect("sibling route present");
         assert_eq!(sibling_route.file_indices, vec![0, 1]);
         assert_eq!(sibling_route.matched_subtitle, "Stardust Crusaders");
+        // Arc-local numbering (files E01, E02) → min_ep=1 ≤
+        // parent_cap=26 → offset=0, and stored episode_numbers
+        // equal the raw parsed values.
+        assert_eq!(sibling_route.episode_offset, 0);
+        assert_eq!(sibling_route.episode_numbers, vec![1, 2]);
 
         // The parent route: claims the unclaimed media files (2 and 3)
         // and reuses the caller-supplied episode numbers verbatim.
@@ -3791,6 +3803,123 @@ mod tests {
             .expect("parent route present");
         assert_eq!(parent_route.file_indices, vec![2, 3]);
         assert_eq!(parent_route.episode_numbers, vec![1, 2]);
+        // Parent routes always carry offset 0.
+        assert_eq!(parent_route.episode_offset, 0);
+    }
+
+    /// Smol Monogatari-style batch: absolute episode numbering runs
+    /// across parent + sibling (E13 = last parent ep, E14 = first
+    /// sibling ep). The fallback path detects Owarimonogatari Second
+    /// Season via title-prefix matching AND the per-sibling offset
+    /// pass sets offset=13 so the route row's episode_numbers store
+    /// the effective (arc-local) 1..=7 instead of the raw 14..=20.
+    #[tokio::test]
+    async fn auto_expand_persists_episode_offset_for_absolute_numbered_batch() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21320,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(13),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "owarismolhash00000000000000000000000000",
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        // Parent AnimeDetail with a continuation relation. Use the
+        // real title "Owarimonogatari Second Season" — no delimiter,
+        // no 2-token trailing subtitle — so the subtitle path cannot
+        // match and the fallback path's title-prefix rule must fire.
+        let mut parent_detail = empty_anime_detail(21320, "Owarimonogatari");
+        parent_detail.episodes = Some(13);
+        parent_detail
+            .relations
+            .push(related_entry(21860, "Owarimonogatari Second Season", Some(7)));
+
+        // 13 parent files (S07E01..E13) + 7 sibling files (S07E14..E20).
+        let mut filenames: Vec<String> = Vec::new();
+        for n in 1..=13 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari (BD 1080p).mkv",
+                n
+            ));
+        }
+        for n in 14..=20 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari Second Season (Ge) (BD 1080p).mkv",
+                n
+            ));
+        }
+        let parent_episode_numbers: Vec<i32> = (1..=13).collect();
+
+        let added = auto_expand_library_from_pack_with_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &parent_episode_numbers,
+            grab_id,
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+        )
+        .await;
+
+        assert_eq!(added, 1, "one new sibling (Owari S2) expected");
+
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(routes.len(), 2, "sibling route + parent route expected");
+
+        let sibling_route = routes
+            .iter()
+            .find(|r| r.series_id != parent_id)
+            .expect("sibling route present");
+        // Files 13..=19 (0-based indices) correspond to S07E14..E20.
+        assert_eq!(sibling_route.file_indices, vec![13, 14, 15, 16, 17, 18, 19]);
+        // The matched subtitle records the detection method for
+        // operator inspection.
+        assert!(sibling_route
+            .matched_subtitle
+            .starts_with("episode-range fallback"));
+        // Absolute numbering → offset = parent_cap = 13.
+        assert_eq!(sibling_route.episode_offset, 13);
+        // Stored episode_numbers are effective (post-offset) values,
+        // so a later `find_imported_for_episode(sibling, 1)` upgrade
+        // query hits this route row correctly.
+        assert_eq!(sibling_route.episode_numbers, vec![1, 2, 3, 4, 5, 6, 7]);
+
+        let parent_route = routes
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route present");
+        assert_eq!(parent_route.file_indices, vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]);
+        assert_eq!(parent_route.episode_offset, 0);
     }
 
     /// When the file list has no sibling matches, the inner fn is a

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1875,7 +1875,10 @@ async fn auto_expand_library_from_pack(
     // Wait for qBit metadata before asking for the file list. Fresh
     // grabs via `add_torrent` don't block on metadata discovery, so
     // a naive `get_torrent_files` right after add returns empty.
-    // The 60s ceiling matches `add_torrent_with_file_filter`.
+    // We use a generous 60s ceiling here (rather than the 10s used
+    // by the interactive selective-narrowing path) because this runs
+    // inside a `tokio::spawn` — blocking up to a minute in the
+    // background is fine, the HTTP handler has already returned.
     let files = match qbit
         .wait_for_metadata(info_hash, std::time::Duration::from_secs(60))
         .await

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1960,15 +1960,59 @@ async fn auto_expand_library_from_pack_with_files(
     grab_id: i64,
     torrent_title: &str,
 ) -> usize {
+    let parent_title = if !parent_detail.title_english.is_empty() {
+        parent_detail.title_english.as_str()
+    } else {
+        parent_detail.title_romaji.as_str()
+    };
+
     if parent_detail.id <= 0 {
+        logger::debug(
+            db,
+            LogCategory::Library,
+            "Auto-expand: skipping sibling detection, parent has no AniList id",
+            &format!("parent_series_id={}, torrent='{}'", parent_series_id, torrent_title),
+        )
+        .await;
         return 0;
     }
+
+    logger::debug(
+        db,
+        LogCategory::Library,
+        &format!(
+            "Auto-expand: scanning {} file(s) for siblings of '{}'",
+            filenames.len(),
+            parent_title
+        ),
+        &format!(
+            "parent_anilist_id={}, torrent='{}'",
+            parent_detail.id, torrent_title
+        ),
+    )
+    .await;
 
     let siblings = auto_search::detect_sibling_entries_in_pack(filenames, parent_detail);
     if siblings.is_empty() {
+        logger::info(
+            db,
+            LogCategory::Library,
+            &format!(
+                "Auto-expand: no siblings detected in pack '{}'",
+                torrent_title
+            ),
+            &format!(
+                "parent='{}', parent_anilist_id={}, files={}",
+                parent_title,
+                parent_detail.id,
+                filenames.len()
+            ),
+        )
+        .await;
         return 0;
     }
 
+    let siblings_considered = siblings.len();
     let mut added = 0_usize;
     let mut claimed: std::collections::HashSet<usize> = std::collections::HashSet::new();
     let mut routes: Vec<grabbed_torrents::GrabSeriesRoute> = Vec::new();
@@ -2141,6 +2185,22 @@ async fn auto_expand_library_from_pack_with_files(
             .await;
         }
     }
+
+    logger::info(
+        db,
+        LogCategory::Library,
+        &format!(
+            "Auto-expand: finished batch '{}' — {} sibling(s) added",
+            torrent_title, added
+        ),
+        &format!(
+            "parent='{}', siblings_considered={}, routes_written={}",
+            parent_title,
+            siblings_considered,
+            routes.len()
+        ),
+    )
+    .await;
 
     added
 }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1886,8 +1886,8 @@ async fn auto_expand_library_from_pack(
                 db,
                 LogCategory::Library,
                 &format!(
-                    "auto-expand: metadata wait failed for '{}', skipping sibling detection",
-                    torrent_title
+                    "auto-expand: metadata wait failed for '{}', skipping sibling detection (fallback: all files will route to parent series_id={})",
+                    torrent_title, parent_series_id
                 ),
                 &e,
             )
@@ -1897,7 +1897,38 @@ async fn auto_expand_library_from_pack(
     };
     let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
 
-    let siblings = auto_search::detect_sibling_entries_in_pack(&filenames, parent_detail);
+    auto_expand_library_from_pack_with_files(
+        db,
+        &filenames,
+        parent_detail,
+        parent_series_id,
+        parent_episode_numbers,
+        grab_id,
+        torrent_title,
+    )
+    .await
+}
+
+/// Pure inner fn — takes a pre-fetched file list instead of a qBit
+/// client so the test suite can exercise the sibling detection, series
+/// upsert, and route-writing logic without spinning up qBittorrent.
+/// The outer [`auto_expand_library_from_pack`] handles the metadata-
+/// wait dance; everything else lives here.
+#[allow(clippy::too_many_arguments)]
+async fn auto_expand_library_from_pack_with_files(
+    db: &SqlitePool,
+    filenames: &[String],
+    parent_detail: &anilist::AnimeDetail,
+    parent_series_id: i64,
+    parent_episode_numbers: &[i32],
+    grab_id: i64,
+    torrent_title: &str,
+) -> usize {
+    if parent_detail.id <= 0 {
+        return 0;
+    }
+
+    let siblings = auto_search::detect_sibling_entries_in_pack(filenames, parent_detail);
     if siblings.is_empty() {
         return 0;
     }
@@ -2292,16 +2323,32 @@ async fn run_auto_search_targets_with_upgrades(
                             let selective_narrowed = wants_selective && kept.is_some();
                             if result.is_batch && !selective_narrowed {
                                 if let Some(grab_id) = grab_id {
-                                    let _ = auto_expand_library_from_pack(
-                                        &state.db,
-                                        &qbit,
-                                        &result.info_hash,
-                                        &detail,
-                                        sid,
-                                        &ep_nums,
-                                        grab_id,
-                                        &result.title,
-                                    ).await;
+                                    // Fire-and-forget so the HTTP handler
+                                    // doesn't block up to ~60s waiting on
+                                    // qBit to discover metadata (see the
+                                    // `wait_for_metadata` call inside
+                                    // `auto_expand_library_from_pack`).
+                                    // Failures here only affect post-
+                                    // processing routing, which already
+                                    // falls back to the parent series.
+                                    let db_task = state.db.clone();
+                                    let qbit_task = qbit.clone();
+                                    let info_hash_task = result.info_hash.clone();
+                                    let detail_task = detail.clone();
+                                    let ep_nums_task = ep_nums.clone();
+                                    let title_task = result.title.clone();
+                                    tokio::spawn(async move {
+                                        auto_expand_library_from_pack(
+                                            &db_task,
+                                            &qbit_task,
+                                            &info_hash_task,
+                                            &detail_task,
+                                            sid,
+                                            &ep_nums_task,
+                                            grab_id,
+                                            &title_task,
+                                        ).await;
+                                    });
                                 }
                             }
                         }
@@ -2858,16 +2905,26 @@ pub async fn grab_batch_result(
         let selective_narrowed = wants_selective && selective_outcome.is_some();
         if !selective_narrowed {
             if let Some(grab_id) = grab_id {
-                let _ = auto_expand_library_from_pack(
-                    &state.db,
-                    &qbit,
-                    &info_hash,
-                    &detail,
-                    sid,
-                    &[],
-                    grab_id,
-                    &title,
-                ).await;
+                // Fire-and-forget so the HTTP handler doesn't block
+                // up to ~60s on qBit metadata discovery. See the
+                // matching spawn in `run_auto_search_targets_with_upgrades`.
+                let db_task = state.db.clone();
+                let qbit_task = qbit.clone();
+                let info_hash_task = info_hash.clone();
+                let detail_task = detail.clone();
+                let title_task = title.clone();
+                tokio::spawn(async move {
+                    auto_expand_library_from_pack(
+                        &db_task,
+                        &qbit_task,
+                        &info_hash_task,
+                        &detail_task,
+                        sid,
+                        &[],
+                        grab_id,
+                        &title_task,
+                    ).await;
+                });
             }
         }
     }
@@ -3402,4 +3459,249 @@ pub async fn series_episodes_json(
         build_episodes(&state.db, &detail, db_id, &folder_name, &media_root).await;
 
     Ok(Json(episodes))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn empty_anime_detail(id: i64, title_english: &str) -> anilist::AnimeDetail {
+        anilist::AnimeDetail {
+            id,
+            id_mal: None,
+            title_romaji: title_english.to_string(),
+            title_english: title_english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            banner_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes: Some(26),
+            duration: Some(24),
+            season: String::new(),
+            season_year: Some(2012),
+            end_year: Some(2013),
+            description: String::new(),
+            genres: Vec::new(),
+            average_score: None,
+            average_score_display: None,
+            score_is_ten_point: false,
+            score_class: String::new(),
+            next_airing_episode: None,
+            next_airing_at: None,
+            synonyms: Vec::new(),
+            streaming_episodes: Vec::new(),
+            relations: Vec::new(),
+        }
+    }
+
+    fn related_entry(
+        id: i64,
+        title_english: &str,
+        episodes: Option<i32>,
+    ) -> anilist::RelatedEntry {
+        anilist::RelatedEntry {
+            id,
+            id_mal: None,
+            title_romaji: title_english.to_string(),
+            title_english: title_english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes,
+            relation_type: "SIDE_STORY".to_string(),
+            season_year: Some(2014),
+            media_type: "ANIME".to_string(),
+        }
+    }
+
+    /// End-to-end exercise of the Phase 2 auto-expand route writer.
+    /// Mirrors the real JoJo S1-S3 megapack case: the parent entry
+    /// ("JoJo's Bizarre Adventure") owns the Phantom Blood / Battle
+    /// Tendency files and a sibling relation ("Stardust Crusaders")
+    /// owns the S3 files. After the pure inner fn runs, we expect two
+    /// route rows to land in `grabbed_torrent_series` — one per series
+    /// — with the unclaimed (parent) files routing to the franchise
+    /// root.
+    ///
+    /// The fn is split into outer (qBit metadata wait) + inner
+    /// (`_with_files`) precisely so this test can feed synthetic
+    /// filenames without spinning up qBittorrent.
+    #[tokio::test]
+    async fn auto_expand_routes_sibling_and_parent_files() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        // Seed the parent series row. The real grab path calls
+        // series::upsert first, so this matches production flow.
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 801,
+                mal_id: None,
+                title: "JoJo's Bizarre Adventure",
+                title_romaji: "JoJo no Kimyou na Bouken",
+                title_english: "JoJo's Bizarre Adventure",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(26),
+                season_year: Some(2012),
+                end_year: Some(2013),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        // Record a grab row so there's a grab_id for the routes to
+        // attach to. `record_grab` returns Ok(Some(id)) on fresh insert.
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "dummyhash0000000000000000000000000000000",
+            "[Group] JoJo Megapack (BD 1080p)",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab row inserted");
+
+        // Construct a parent AnimeDetail with one sibling relation.
+        // The sibling title must carry an extractable trailing
+        // subtitle ("Stardust Crusaders") for detect_sibling_entries
+        // to find a needle to match.
+        let mut parent_detail = empty_anime_detail(801, "JoJo's Bizarre Adventure");
+        parent_detail.relations.push(related_entry(
+            802,
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            Some(24),
+        ));
+
+        // Two sibling files (match the Stardust Crusaders needle) and
+        // two parent files (bare franchise title, no sibling subtitle).
+        let filenames = vec![
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 01 [BD 1080p].mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - 02 [BD 1080p].mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - 01 [BD 1080p].mkv".to_string(),
+            "[Group] JoJo no Kimyou na Bouken - 02 [BD 1080p].mkv".to_string(),
+        ];
+
+        let added = auto_expand_library_from_pack_with_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &[1, 2],
+            grab_id,
+            "[Group] JoJo Megapack (BD 1080p)",
+        )
+        .await;
+
+        assert_eq!(added, 1, "one new sibling (Stardust Crusaders) expected");
+
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(routes.len(), 2, "sibling route + parent route expected");
+
+        // The sibling route: claims file indices 0 and 1, its series_id
+        // differs from the parent, and the matched subtitle is the one
+        // trailing_subtitle_of extracted from the relation title.
+        let sibling_route = routes
+            .iter()
+            .find(|r| r.series_id != parent_id)
+            .expect("sibling route present");
+        assert_eq!(sibling_route.file_indices, vec![0, 1]);
+        assert_eq!(sibling_route.matched_subtitle, "Stardust Crusaders");
+
+        // The parent route: claims the unclaimed media files (2 and 3)
+        // and reuses the caller-supplied episode numbers verbatim.
+        let parent_route = routes
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route present");
+        assert_eq!(parent_route.file_indices, vec![2, 3]);
+        assert_eq!(parent_route.episode_numbers, vec![1, 2]);
+    }
+
+    /// When the file list has no sibling matches, the inner fn is a
+    /// no-op: no sibling series get upserted and no route rows get
+    /// written. This exercises the early-return after
+    /// `detect_sibling_entries_in_pack` returns an empty vec — the
+    /// production path relies on that branch to avoid polluting the
+    /// library with ghost rows for regular single-series grabs.
+    #[tokio::test]
+    async fn auto_expand_noop_when_no_siblings_detected() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 901,
+                mal_id: None,
+                title: "Sono Bisque Doll wa Koi wo Suru",
+                title_romaji: "Sono Bisque Doll wa Koi wo Suru",
+                title_english: "My Dress-Up Darling",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2022),
+                end_year: Some(2022),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "dummyhash1111111111111111111111111111111",
+            "[Group] My Dress-Up Darling S01 (BD 1080p)",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab row inserted");
+
+        // No relations on the parent detail → no sibling candidates
+        // even though the file list is full of media files.
+        let parent_detail = empty_anime_detail(901, "My Dress-Up Darling");
+        let filenames = vec![
+            "[Group] My Dress-Up Darling - 01 [BD 1080p].mkv".to_string(),
+            "[Group] My Dress-Up Darling - 02 [BD 1080p].mkv".to_string(),
+        ];
+
+        let added = auto_expand_library_from_pack_with_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &[1, 2],
+            grab_id,
+            "[Group] My Dress-Up Darling S01 (BD 1080p)",
+        )
+        .await;
+
+        assert_eq!(added, 0);
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert!(
+            routes.is_empty(),
+            "no sibling → no routes, post-processing falls back to grab.series_id"
+        );
+    }
 }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -1992,7 +1992,54 @@ async fn auto_expand_library_from_pack_with_files(
     )
     .await;
 
-    let siblings = auto_search::detect_sibling_entries_in_pack(filenames, parent_detail);
+    // Depth-1 transitive relation walk: AniList's relation graph
+    // has missing direct edges across split sagas (Monogatari is
+    // the motivating case — Owarimonogatari 21262 does not list
+    // Owarimonogatari 2nd Season 99423 as a direct neighbor, but
+    // reaches it via the shared saga graph). Before running sibling
+    // detection we fetch each walkable direct neighbor's AL detail,
+    // then graft its OWN relations onto the parent so
+    // `detect_sibling_entries_in_pack` sees a broader candidate
+    // pool. Fetches are capped by
+    // `auto_search::TRANSITIVE_WALK_MAX_FETCHES` and every call
+    // goes through the AL detail cache so repeat grabs within the
+    // TTL are free. Failures are soft — any neighbor we can't fetch
+    // is silently skipped and detection falls back to the parent's
+    // direct relations.
+    let mut neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> =
+        std::collections::HashMap::new();
+    let mut fetched = 0_usize;
+    for rel in &parent_detail.relations {
+        if fetched >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
+            break;
+        }
+        if !auto_search::is_transitive_walk_source(&rel.relation_type) {
+            continue;
+        }
+        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        if rel.id <= 0 {
+            continue;
+        }
+        match anilist::get_anime_detail(rel.id).await {
+            Ok(detail) => {
+                neighbor_details.insert(rel.id, detail);
+                fetched += 1;
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "auto-expand: transitive neighbor fetch failed rel_id={} rel_type={} err={}",
+                    rel.id,
+                    rel.relation_type,
+                    e
+                );
+            }
+        }
+    }
+    let expanded_parent =
+        auto_search::expand_parent_with_transitive_relations(parent_detail, &neighbor_details);
+    let siblings = auto_search::detect_sibling_entries_in_pack(filenames, &expanded_parent);
     if siblings.is_empty() {
         logger::info(
             db,

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2333,6 +2333,7 @@ async fn run_auto_search_targets_with_upgrades(
                                     &result.title,
                                     &result.group,
                                     result.size_bytes,
+                                    result.is_batch,
                                 ).await;
                             }
                             // Phase 2 sibling auto-expand: when the
@@ -2730,6 +2731,7 @@ pub async fn search_batch_releases(
                         &result.title,
                         &result.group,
                         result.size_bytes,
+                        result.is_batch,
                     ).await;
                 }
             }
@@ -2981,6 +2983,7 @@ pub async fn grab_batch_result(
                 &title,
                 &group,
                 size_bytes,
+                true,
             ).await;
         }
         // Phase 2 sibling auto-expand. Skip when selective narrowing
@@ -3154,7 +3157,7 @@ pub async fn grab_interactive_result(
             &state.db, &info_hash, &title, sid, &[episode_number], false,
         ).await;
         let _ = episode_tags::record_grab(
-            &state.db, sid, episode_number, &classification, &title, &group, size_bytes,
+            &state.db, sid, episode_number, &classification, &title, &group, size_bytes, false,
         ).await;
     }
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -78,17 +78,24 @@ pub struct GrabHistoryEntry {
     pub quality_tag: String,
     pub release_title: String,
     pub release_group: String,
-    /// On-disk torrent name. Seeded from the Nyaa release title at grab
-    /// time, overwritten with the actual qBittorrent torrent name when
-    /// post-processing completes — useful when qBit renamed the torrent
-    /// via an auto-management rule and the user is trying to reconcile
-    /// what they see in qBit's UI with Ryokan's history.
-    pub torrent_name: String,
-    /// Individual imported file size for completed entries; falls back to
-    /// the Nyaa-reported total torrent size for grabbed/pending entries.
-    /// Zero if the grab predates the size_bytes column (pre-migration
-    /// rows) or the size couldn't be determined.
+    /// Post-processed on-disk file name for this episode. Seeded with
+    /// the Nyaa release title at grab time, then overwritten with the
+    /// Sonarr-style renamed file once post-processing imports the
+    /// episode (e.g. `Jujutsu Kaisen - S01E06 - Hidden Inventory.mkv`).
+    /// This is distinct from `release_title`, which carries the batch
+    /// torrent's title unchanged even for per-episode rows of a pack.
+    pub file_name: String,
+    /// Size reported at grab time. For batch grabs this is the **whole
+    /// torrent** total (same value replicated across every episode row
+    /// of the batch — the episode detail modal reads it as "this came
+    /// from an X GiB batch"). For single-episode grabs it is refined to
+    /// the imported file's true size at post-process time. Zero only
+    /// for pre-migration rows or cases where the size was never known.
     pub size_bytes: i64,
+    /// True when the originating grab was a batch/pack. Used by the UI
+    /// to decide whether `size_bytes` represents a whole-torrent total
+    /// or a single-file size.
+    pub is_batch: bool,
     pub grabbed_at: String,
     pub state: String,
 }
@@ -135,6 +142,7 @@ pub struct EpisodeQualityTag {
 /// are written alongside it on `episode_quality_tags`. `manual_override` is
 /// intentionally preserved across re-grabs — a user-set override should
 /// stick even when a newer grab comes in.
+#[allow(clippy::too_many_arguments)]
 pub async fn record_grab(
     db: &SqlitePool,
     series_id: i64,
@@ -143,6 +151,7 @@ pub async fn record_grab(
     release_title: &str,
     release_group: &str,
     size_bytes: i64,
+    is_batch: bool,
 ) -> Result<i64, sqlx::Error> {
     let quality_tag = classification.label();
     let source_str = classification.source.as_str();
@@ -159,14 +168,19 @@ pub async fn record_grab(
     let evidence_json =
         serde_json::to_string(&classification.evidence).unwrap_or_default();
 
-    // Seed `torrent_name` with the Nyaa release title — post-processing
-    // will overwrite it with the real qBit torrent name once the
-    // download resolves. `size_bytes` starts as the Nyaa-reported total
-    // torrent size and gets replaced with the individual imported file
-    // size in `mark_grab_history_completed`.
+    // Seed `file_name` with the Nyaa release title. For non-batch grabs
+    // post-processing later overwrites it with the Sonarr-style renamed
+    // on-disk file. For batch grabs each per-episode row gets its own
+    // on-disk file name too, populated from the landed filename rather
+    // than the batch torrent's title. `size_bytes` is whatever Nyaa
+    // reported for the whole torrent — for a batch it stays as the
+    // pack total (every episode row of the batch has the same value);
+    // for a single-episode it gets refined to the per-file size at
+    // import time.
+    let is_batch_i: i64 = if is_batch { 1 } else { 0 };
     let history_id: i64 = sqlx::query_scalar(
-        "INSERT INTO episode_grab_history (series_id, episode_number, quality_tag, release_title, release_group, torrent_name, size_bytes, state)
-         VALUES (?, ?, ?, ?, ?, ?, ?, 'grabbed')
+        "INSERT INTO episode_grab_history (series_id, episode_number, quality_tag, release_title, release_group, file_name, size_bytes, is_batch, state)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'grabbed')
          RETURNING id",
     )
     .bind(series_id)
@@ -176,6 +190,7 @@ pub async fn record_grab(
     .bind(release_group)
     .bind(release_title)
     .bind(size_bytes)
+    .bind(is_batch_i)
     .fetch_one(db)
     .await?;
 
@@ -288,8 +303,9 @@ pub async fn get_grab_history(
 ) -> Result<Vec<GrabHistoryEntry>, sqlx::Error> {
     let rows = sqlx::query(
         "SELECT id, quality_tag, release_title, release_group,
-                COALESCE(torrent_name, '') AS torrent_name,
+                COALESCE(file_name, '') AS file_name,
                 COALESCE(size_bytes, 0) AS size_bytes,
+                COALESCE(is_batch, 0) AS is_batch,
                 grabbed_at, state
          FROM episode_grab_history
          WHERE series_id = ? AND episode_number = ?
@@ -302,15 +318,19 @@ pub async fn get_grab_history(
 
     Ok(rows
         .iter()
-        .map(|row| GrabHistoryEntry {
-            id: row.get("id"),
-            quality_tag: row.get("quality_tag"),
-            release_title: row.get("release_title"),
-            release_group: row.get("release_group"),
-            torrent_name: row.get("torrent_name"),
-            size_bytes: row.get("size_bytes"),
-            grabbed_at: row.get("grabbed_at"),
-            state: row.get("state"),
+        .map(|row| {
+            let is_batch_i: i64 = row.get("is_batch");
+            GrabHistoryEntry {
+                id: row.get("id"),
+                quality_tag: row.get("quality_tag"),
+                release_title: row.get("release_title"),
+                release_group: row.get("release_group"),
+                file_name: row.get("file_name"),
+                size_bytes: row.get("size_bytes"),
+                is_batch: is_batch_i != 0,
+                grabbed_at: row.get("grabbed_at"),
+                state: row.get("state"),
+            }
         })
         .collect())
 }
@@ -492,30 +512,35 @@ pub async fn mark_completed(
 }
 
 /// Flip the newest 'grabbed' `episode_grab_history` row for an episode to
-/// 'completed', stamping in the real on-disk torrent name and the
-/// *individual* imported file's size. Called by post-processing once per
-/// imported file, immediately before / alongside `mark_completed`.
+/// 'completed', stamping in the Sonarr-style post-processed on-disk file
+/// name and (for non-batch rows only) refining `size_bytes` to the
+/// imported file's true size. Called by post-processing once per imported
+/// file, immediately before / alongside `mark_completed`.
 ///
 /// Only the latest grabbed row for that episode is touched — older rows
 /// from previous grabs stay as-is (they'll be 'grabbed' forever or were
-/// already marked 'failed'/'removed' by the upgrade/removal path). This
-/// mirrors `mark_grab_failed`'s "newest matching row" semantics but for
-/// the happy path.
+/// already marked 'failed'/'removed' by the upgrade/removal path).
 ///
-/// `torrent_name` is the qBittorrent torrent name (not the Nyaa release
-/// title); `size_bytes` is the single file's size, not the batch total.
+/// `file_name` is the on-disk basename after post-processing's rename
+/// step (e.g. `Jujutsu Kaisen - S01E06 - Hidden Inventory.mkv`).
+/// `file_size_bytes` is the single imported file's size.
+///
+/// The `size_bytes` CASE guard enforces the invariant that batch rows
+/// continue to hold the whole-torrent total (not the per-episode file
+/// size), so the episode detail modal can surface "this episode came
+/// from an X GiB batch" without losing the pack total on import.
 pub async fn mark_grab_history_completed(
     db: &SqlitePool,
     series_id: i64,
     episode_number: i32,
-    torrent_name: &str,
-    size_bytes: i64,
+    file_name: &str,
+    file_size_bytes: i64,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
         "UPDATE episode_grab_history
          SET state = 'completed',
-             torrent_name = ?,
-             size_bytes = ?
+             file_name = ?,
+             size_bytes = CASE WHEN COALESCE(is_batch, 0) = 1 THEN size_bytes ELSE ? END
          WHERE id = (
              SELECT id FROM episode_grab_history
              WHERE series_id = ? AND episode_number = ? AND state = 'grabbed'
@@ -523,8 +548,8 @@ pub async fn mark_grab_history_completed(
              LIMIT 1
          )",
     )
-    .bind(torrent_name)
-    .bind(size_bytes)
+    .bind(file_name)
+    .bind(file_size_bytes)
     .bind(series_id)
     .bind(episode_number)
     .execute(db)

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -78,6 +78,17 @@ pub struct GrabHistoryEntry {
     pub quality_tag: String,
     pub release_title: String,
     pub release_group: String,
+    /// On-disk torrent name. Seeded from the Nyaa release title at grab
+    /// time, overwritten with the actual qBittorrent torrent name when
+    /// post-processing completes — useful when qBit renamed the torrent
+    /// via an auto-management rule and the user is trying to reconcile
+    /// what they see in qBit's UI with Ryokan's history.
+    pub torrent_name: String,
+    /// Individual imported file size for completed entries; falls back to
+    /// the Nyaa-reported total torrent size for grabbed/pending entries.
+    /// Zero if the grab predates the size_bytes column (pre-migration
+    /// rows) or the size couldn't be determined.
+    pub size_bytes: i64,
     pub grabbed_at: String,
     pub state: String,
 }
@@ -131,6 +142,7 @@ pub async fn record_grab(
     classification: &ClassificationResult,
     release_title: &str,
     release_group: &str,
+    size_bytes: i64,
 ) -> Result<i64, sqlx::Error> {
     let quality_tag = classification.label();
     let source_str = classification.source.as_str();
@@ -147,9 +159,14 @@ pub async fn record_grab(
     let evidence_json =
         serde_json::to_string(&classification.evidence).unwrap_or_default();
 
+    // Seed `torrent_name` with the Nyaa release title — post-processing
+    // will overwrite it with the real qBit torrent name once the
+    // download resolves. `size_bytes` starts as the Nyaa-reported total
+    // torrent size and gets replaced with the individual imported file
+    // size in `mark_grab_history_completed`.
     let history_id: i64 = sqlx::query_scalar(
-        "INSERT INTO episode_grab_history (series_id, episode_number, quality_tag, release_title, release_group, state)
-         VALUES (?, ?, ?, ?, ?, 'grabbed')
+        "INSERT INTO episode_grab_history (series_id, episode_number, quality_tag, release_title, release_group, torrent_name, size_bytes, state)
+         VALUES (?, ?, ?, ?, ?, ?, ?, 'grabbed')
          RETURNING id",
     )
     .bind(series_id)
@@ -157,6 +174,8 @@ pub async fn record_grab(
     .bind(&quality_tag)
     .bind(release_title)
     .bind(release_group)
+    .bind(release_title)
+    .bind(size_bytes)
     .fetch_one(db)
     .await?;
 
@@ -259,18 +278,22 @@ pub async fn get_for_series(
     Ok(map)
 }
 
-/// Get grab history for a specific episode (newest first, up to 10 entries).
+/// Get grab history for a specific episode, newest first. No LIMIT — the
+/// modal UI scrolls past the first 10 entries, and there are no known
+/// series with enough grabs for an unbounded SELECT to be a problem.
 pub async fn get_grab_history(
     db: &SqlitePool,
     series_id: i64,
     episode_number: i32,
 ) -> Result<Vec<GrabHistoryEntry>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, quality_tag, release_title, release_group, grabbed_at, state
+        "SELECT id, quality_tag, release_title, release_group,
+                COALESCE(torrent_name, '') AS torrent_name,
+                COALESCE(size_bytes, 0) AS size_bytes,
+                grabbed_at, state
          FROM episode_grab_history
          WHERE series_id = ? AND episode_number = ?
-         ORDER BY grabbed_at DESC
-         LIMIT 10",
+         ORDER BY grabbed_at DESC",
     )
     .bind(series_id)
     .bind(episode_number)
@@ -284,6 +307,8 @@ pub async fn get_grab_history(
             quality_tag: row.get("quality_tag"),
             release_title: row.get("release_title"),
             release_group: row.get("release_group"),
+            torrent_name: row.get("torrent_name"),
+            size_bytes: row.get("size_bytes"),
             grabbed_at: row.get("grabbed_at"),
             state: row.get("state"),
         })
@@ -463,6 +488,47 @@ pub async fn mark_completed(
         .execute(db)
         .await?;
     }
+    Ok(())
+}
+
+/// Flip the newest 'grabbed' `episode_grab_history` row for an episode to
+/// 'completed', stamping in the real on-disk torrent name and the
+/// *individual* imported file's size. Called by post-processing once per
+/// imported file, immediately before / alongside `mark_completed`.
+///
+/// Only the latest grabbed row for that episode is touched — older rows
+/// from previous grabs stay as-is (they'll be 'grabbed' forever or were
+/// already marked 'failed'/'removed' by the upgrade/removal path). This
+/// mirrors `mark_grab_failed`'s "newest matching row" semantics but for
+/// the happy path.
+///
+/// `torrent_name` is the qBittorrent torrent name (not the Nyaa release
+/// title); `size_bytes` is the single file's size, not the batch total.
+pub async fn mark_grab_history_completed(
+    db: &SqlitePool,
+    series_id: i64,
+    episode_number: i32,
+    torrent_name: &str,
+    size_bytes: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE episode_grab_history
+         SET state = 'completed',
+             torrent_name = ?,
+             size_bytes = ?
+         WHERE id = (
+             SELECT id FROM episode_grab_history
+             WHERE series_id = ? AND episode_number = ? AND state = 'grabbed'
+             ORDER BY grabbed_at DESC
+             LIMIT 1
+         )",
+    )
+    .bind(torrent_name)
+    .bind(size_bytes)
+    .bind(series_id)
+    .bind(episode_number)
+    .execute(db)
+    .await?;
     Ok(())
 }
 

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -484,3 +484,120 @@ pub struct GrabbedTorrentWithSeries {
     pub series_title: String,
     pub anilist_id: i64,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::series;
+
+    /// Round-trip a GrabSeriesRoute through record_grab_series_routes
+    /// + get_series_routes to verify the new episode_offset column is
+    /// written and read correctly. Covers Commit 3's schema plumbing
+    /// (ALTER TABLE ADD COLUMN + INSERT bind + SELECT with COALESCE).
+    #[tokio::test]
+    async fn grab_series_route_round_trip_preserves_episode_offset() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21320,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(13),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let (sibling_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21860,
+                mal_id: None,
+                title: "Owarimonogatari Second Season",
+                title_romaji: "Owarimonogatari Second Season",
+                title_english: "Owarimonogatari Second Season",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(7),
+                season_year: Some(2017),
+                end_year: Some(2017),
+            },
+        )
+        .await
+        .expect("sibling upsert");
+
+        let grab_id = record_grab(
+            &db,
+            "roundtriphash0000000000000000000000000000",
+            "[smol] Monogatari S07 (Owarimonogatari) [BD 1080p]",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        let routes = vec![
+            // Parent route: no offset.
+            GrabSeriesRoute {
+                grab_id,
+                series_id: parent_id,
+                file_indices: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+                episode_numbers: (1..=13).collect(),
+                matched_subtitle: String::new(),
+                episode_offset: 0,
+            },
+            // Sibling route: absolute-numbered, offset = parent cap.
+            GrabSeriesRoute {
+                grab_id,
+                series_id: sibling_id,
+                file_indices: vec![13, 14, 15, 16, 17, 18, 19],
+                episode_numbers: (14..=20).collect(),
+                matched_subtitle: "episode-range fallback (14..=20)".to_string(),
+                episode_offset: 13,
+            },
+        ];
+
+        record_grab_series_routes(&db, &routes)
+            .await
+            .expect("record routes");
+
+        let read_back = get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(read_back.len(), 2);
+
+        let parent_route = read_back
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route");
+        assert_eq!(parent_route.episode_offset, 0);
+
+        let sibling_route = read_back
+            .iter()
+            .find(|r| r.series_id == sibling_id)
+            .expect("sibling route");
+        assert_eq!(sibling_route.episode_offset, 13);
+        assert_eq!(
+            sibling_route.matched_subtitle,
+            "episode-range fallback (14..=20)"
+        );
+        assert_eq!(sibling_route.file_indices.len(), 7);
+    }
+}

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -386,6 +386,38 @@ pub async fn find_imported_for_episode(
         .collect())
 }
 
+/// Return the torrent name of the most recent imported grab for this
+/// series, regardless of which episodes the grab's `episode_numbers`
+/// column claims it covers. Used by
+/// `scan_library_for_unclassified` as a fallback to
+/// [`find_imported_for_episode`] when the per-episode lookup misses:
+/// pre-fix batch grabs were recorded with `episode_numbers = []`, so
+/// `json_each` yields nothing and the precise lookup returns empty
+/// even though there's a perfectly good batch grab with a real
+/// release name sitting in the table. For those stale rows we want
+/// to classify against that release name instead of the sanitized
+/// on-disk filename.
+///
+/// Returns `None` when the series has never had an imported grab,
+/// in which case the scanner falls back to the sanitized filename
+/// (correct behavior for externally-imported files Ryokan never
+/// grabbed).
+pub async fn most_recent_imported_torrent_name_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+) -> Option<String> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT torrent_name FROM grabbed_torrents
+         WHERE series_id = ? AND state = 'imported'
+         ORDER BY grabbed_at DESC LIMIT 1",
+    )
+    .bind(series_id)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten()
+}
+
 /// Remove a grabbed torrent record entirely.
 pub async fn remove(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM grabbed_torrents WHERE id = ?")

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -89,6 +89,13 @@ pub struct GrabSeriesRoute {
     pub file_indices: Vec<usize>,
     pub episode_numbers: Vec<i32>,
     pub matched_subtitle: String,
+    /// Amount to subtract from each file's parsed episode number at
+    /// rename/tag time. Non-zero for siblings whose files use
+    /// numbering that's continuous across the parent (e.g. an E14
+    /// file in a 20-ep Owarimonogatari batch is actually Owari S2's
+    /// E01 and needs `episode_offset = 13`). Zero for siblings with
+    /// arc-local numbering.
+    pub episode_offset: i32,
 }
 
 /// Write one or more `grabbed_torrent_series` rows for a freshly
@@ -108,14 +115,15 @@ pub async fn record_grab_series_routes(
             .unwrap_or_else(|_| "[]".to_string());
         sqlx::query(
             r#"INSERT OR REPLACE INTO grabbed_torrent_series
-               (grab_id, series_id, file_indices, episode_numbers, matched_subtitle)
-               VALUES (?, ?, ?, ?, ?)"#,
+               (grab_id, series_id, file_indices, episode_numbers, matched_subtitle, episode_offset)
+               VALUES (?, ?, ?, ?, ?, ?)"#,
         )
         .bind(route.grab_id)
         .bind(route.series_id)
         .bind(&file_indices_json)
         .bind(&eps_json)
         .bind(&route.matched_subtitle)
+        .bind(route.episode_offset)
         .execute(db)
         .await?;
     }
@@ -130,8 +138,11 @@ pub async fn get_series_routes(
     db: &SqlitePool,
     grab_id: i64,
 ) -> Result<Vec<GrabSeriesRoute>, sqlx::Error> {
+    // COALESCE on episode_offset keeps legacy rows (written before
+    // the ALTER TABLE migration) readable as offset=0.
     let rows = sqlx::query(
-        r#"SELECT grab_id, series_id, file_indices, episode_numbers, matched_subtitle
+        r#"SELECT grab_id, series_id, file_indices, episode_numbers, matched_subtitle,
+                  COALESCE(episode_offset, 0) AS episode_offset
            FROM grabbed_torrent_series
            WHERE grab_id = ?"#,
     )
@@ -154,6 +165,7 @@ pub async fn get_series_routes(
                 file_indices: file_idx.into_iter().map(|i| i as usize).collect(),
                 episode_numbers,
                 matched_subtitle: row.get("matched_subtitle"),
+                episode_offset: row.get("episode_offset"),
             }
         })
         .collect())

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -171,6 +171,62 @@ pub async fn get_series_routes(
         .collect())
 }
 
+/// Bulk variant of [`get_series_routes`] — fetches routes for many
+/// grabs in one round-trip and groups by `grab_id`. The download-
+/// progress poller calls this once per poll instead of fanning out
+/// N queries for N pending grabs; the poller runs every few seconds
+/// on every open series page, so the difference matters.
+///
+/// Grabs with no routes are simply absent from the result map; callers
+/// should treat a missing entry as an empty route list.
+pub async fn get_series_routes_for_grabs(
+    db: &SqlitePool,
+    grab_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Vec<GrabSeriesRoute>>, sqlx::Error> {
+    if grab_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+
+    // sqlx doesn't bind `IN (?)` against a slice directly, so build
+    // the placeholder list at runtime. `grab_ids` comes from a
+    // `SELECT id FROM grabbed_torrents` loop so every value is a
+    // trusted i64 — no injection surface.
+    let placeholders = vec!["?"; grab_ids.len()].join(", ");
+    let sql = format!(
+        r#"SELECT grab_id, series_id, file_indices, episode_numbers, matched_subtitle,
+                  COALESCE(episode_offset, 0) AS episode_offset
+           FROM grabbed_torrent_series
+           WHERE grab_id IN ({})"#,
+        placeholders
+    );
+    let mut q = sqlx::query(&sql);
+    for id in grab_ids {
+        q = q.bind(*id);
+    }
+    let rows = q.fetch_all(db).await?;
+
+    let mut grouped: std::collections::HashMap<i64, Vec<GrabSeriesRoute>> =
+        std::collections::HashMap::new();
+    for row in rows {
+        let file_idx_json: String = row.get("file_indices");
+        let file_idx: Vec<i64> =
+            serde_json::from_str(&file_idx_json).unwrap_or_default();
+        let eps_json: String = row.get("episode_numbers");
+        let episode_numbers: Vec<i32> =
+            serde_json::from_str(&eps_json).unwrap_or_default();
+        let route = GrabSeriesRoute {
+            grab_id: row.get("grab_id"),
+            series_id: row.get("series_id"),
+            file_indices: file_idx.into_iter().map(|i| i as usize).collect(),
+            episode_numbers,
+            matched_subtitle: row.get("matched_subtitle"),
+            episode_offset: row.get("episode_offset"),
+        };
+        grouped.entry(route.grab_id).or_default().push(route);
+    }
+    Ok(grouped)
+}
+
 /// Look up the stored `is_batch` flag for a grab by its torrent name.
 /// Returns `None` when the row doesn't exist — that's the case for
 /// externally-imported library files that Ryokan never grabbed, which

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -597,6 +597,19 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
 
+    // Per-route episode offset for the Phase 2 auto-expand path.
+    // Applied by post_processing at rename time to convert a file's
+    // absolute episode number into the sibling's arc-local episode
+    // number (e.g. smol Monogatari batch: E14 → E01 of Owari S2 with
+    // offset 13, NoobSubs JoJo: E25 → E01 of Egypt-hen with offset 24).
+    // Non-offset siblings (filenames numbered arc-local from 1) get
+    // offset 0, matching the legacy default for rows written before
+    // this column existed.
+    sqlx::query("ALTER TABLE grabbed_torrent_series ADD COLUMN episode_offset INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
     // tmdb_id on series is a leftover from before the Kitsu migration;
     // the column is harmless to keep for existing databases.
     sqlx::query("ALTER TABLE series ADD COLUMN tmdb_id INTEGER")

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -16,7 +16,27 @@ pub mod nyaa_description_cache;
 pub mod media_probe_cache;
 pub mod custom_formats;
 
-use sqlx::SqlitePool;
+use sqlx::{Row, SqlitePool};
+
+/// Check whether `column` exists on `table`. Used inside [`migrate`] to
+/// gate idempotent ALTER chains whose "ADD COLUMN then RENAME" shape
+/// would otherwise leave vestigial columns on fresh installs (the ADD
+/// succeeds unconditionally because `.ok()` swallows the
+/// already-migrated case, then the RENAME silently no-ops when the
+/// target already exists). By asking SQLite directly, we can skip the
+/// ADD step entirely on installs where the current column name already
+/// exists.
+async fn column_exists(db: &SqlitePool, table: &str, column: &str) -> bool {
+    // PRAGMA doesn't accept bound parameters, but `table` is a hardcoded
+    // string literal from our own migration code — no user input — so
+    // inline interpolation is safe.
+    let sql = format!("PRAGMA table_info({})", table);
+    let Ok(rows) = sqlx::query(&sql).fetch_all(db).await else {
+        return false;
+    };
+    rows.iter()
+        .any(|r| r.try_get::<String, _>("name").ok().as_deref() == Some(column))
+}
 
 /// Run all database migrations.
 pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
@@ -719,23 +739,24 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // episode detail modal reads this column so each grab-history row
     // shows the per-episode file name — distinct from the batch torrent's
     // release title, which is already in `release_title`. Historically
-    // this column was called `torrent_name`; the two ALTER TABLE lines
-    // below handle both upgrade paths (DB that had `torrent_name` →
-    // renamed; fresh install → CREATE TABLE already has `file_name`).
-    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN torrent_name TEXT NOT NULL DEFAULT ''")
-        .execute(db)
-        .await
-        .ok();
-    sqlx::query("ALTER TABLE episode_grab_history RENAME COLUMN torrent_name TO file_name")
-        .execute(db)
-        .await
-        .ok();
-    // No-op on already-migrated DBs; covers the sliver of rows that were
-    // never renamed because of a race or a partially-migrated install.
-    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN file_name TEXT NOT NULL DEFAULT ''")
-        .execute(db)
-        .await
-        .ok();
+    // this column was called `torrent_name`.
+    //
+    // Upgrade path: check for `file_name` first — a fresh install gets
+    // it from CREATE TABLE above, and an already-migrated install has
+    // it from a prior rename. If it's missing we're on a legacy
+    // `torrent_name` install and need to rename. The defensive ADD
+    // covers the corner case where neither column is present (which
+    // shouldn't happen, but keeps downstream writes safe).
+    if !column_exists(db, "episode_grab_history", "file_name").await {
+        sqlx::query("ALTER TABLE episode_grab_history RENAME COLUMN torrent_name TO file_name")
+            .execute(db)
+            .await
+            .ok();
+        sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN file_name TEXT NOT NULL DEFAULT ''")
+            .execute(db)
+            .await
+            .ok();
+    }
 
     // Episode-file size. For non-batch grabs this gets refined to the
     // imported file's size at post-process time. For batch grabs it

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -696,8 +696,9 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
             quality_tag TEXT NOT NULL DEFAULT '',
             release_title TEXT NOT NULL DEFAULT '',
             release_group TEXT NOT NULL DEFAULT '',
-            torrent_name TEXT NOT NULL DEFAULT '',
+            file_name TEXT NOT NULL DEFAULT '',
             size_bytes INTEGER NOT NULL DEFAULT 0,
+            is_batch INTEGER NOT NULL DEFAULT 0,
             state TEXT NOT NULL DEFAULT 'grabbed',
             grabbed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
@@ -711,22 +712,47 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
 
-    // Original on-disk torrent name — seeded at grab time from the Nyaa
-    // release title, then overwritten at post-process time with the actual
-    // qBittorrent torrent name (which may differ for renamed/auto-managed
-    // torrents). The episode detail modal reads this so the user can see
-    // what qBit actually downloaded, not just what Ryokan asked for.
+    // On-disk *post-processed* file name for this episode. Seeded from the
+    // Nyaa release title at grab time, then overwritten at post-process
+    // time with the final Sonarr-style filename Ryokan renamed the imported
+    // file to (e.g. `Jujutsu Kaisen - S01E06 - Hidden Inventory.mkv`). The
+    // episode detail modal reads this column so each grab-history row
+    // shows the per-episode file name — distinct from the batch torrent's
+    // release title, which is already in `release_title`. Historically
+    // this column was called `torrent_name`; the two ALTER TABLE lines
+    // below handle both upgrade paths (DB that had `torrent_name` →
+    // renamed; fresh install → CREATE TABLE already has `file_name`).
     sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN torrent_name TEXT NOT NULL DEFAULT ''")
         .execute(db)
         .await
         .ok();
+    sqlx::query("ALTER TABLE episode_grab_history RENAME COLUMN torrent_name TO file_name")
+        .execute(db)
+        .await
+        .ok();
+    // No-op on already-migrated DBs; covers the sliver of rows that were
+    // never renamed because of a race or a partially-migrated install.
+    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN file_name TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
 
-    // Episode-file size. At grab time this holds the Nyaa-reported total
-    // torrent size (best available before download). At post-process time
-    // it is replaced with the *individual* imported file's size — batches
-    // span many episodes so the per-episode row should reflect just its
-    // own file, not the aggregate torrent size.
+    // Episode-file size. For non-batch grabs this gets refined to the
+    // imported file's size at post-process time. For batch grabs it
+    // stays as the whole torrent's total reported at grab time — the
+    // episode detail modal surfaces that as "this episode came from an
+    // X GiB batch". The CASE guard in `mark_grab_history_completed`
+    // enforces this asymmetry.
     sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN size_bytes INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
+    // is_batch marker — needed at read time so the UI can decide whether
+    // to surface `size_bytes` as "whole batch" or "single file". It's
+    // also what `mark_grab_history_completed` uses to decide whether to
+    // refine `size_bytes` on import (non-batch only).
+    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN is_batch INTEGER NOT NULL DEFAULT 0")
         .execute(db)
         .await
         .ok();

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -696,6 +696,8 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
             quality_tag TEXT NOT NULL DEFAULT '',
             release_title TEXT NOT NULL DEFAULT '',
             release_group TEXT NOT NULL DEFAULT '',
+            torrent_name TEXT NOT NULL DEFAULT '',
+            size_bytes INTEGER NOT NULL DEFAULT 0,
             state TEXT NOT NULL DEFAULT 'grabbed',
             grabbed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
@@ -708,6 +710,26 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_episode_grab_history_series ON episode_grab_history (series_id, episode_number, grabbed_at DESC)")
         .execute(db)
         .await?;
+
+    // Original on-disk torrent name — seeded at grab time from the Nyaa
+    // release title, then overwritten at post-process time with the actual
+    // qBittorrent torrent name (which may differ for renamed/auto-managed
+    // torrents). The episode detail modal reads this so the user can see
+    // what qBit actually downloaded, not just what Ryokan asked for.
+    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN torrent_name TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+
+    // Episode-file size. At grab time this holds the Nyaa-reported total
+    // torrent size (best available before download). At post-process time
+    // it is replaced with the *individual* imported file's size — batches
+    // span many episodes so the per-episode row should reflect just its
+    // own file, not the aggregate torrent size.
+    sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN size_bytes INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
 
     // auto_grab_on_add: whether to automatically search for monitored episodes after adding a series.
     sqlx::query("ALTER TABLE config ADD COLUMN auto_grab_on_add INTEGER NOT NULL DEFAULT 1")
@@ -964,6 +986,116 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await
     .ok();
+
+    // Rewrite denormalized `quality_tag` strings on pre-existing
+    // `episode_quality_tags` / `episode_grab_history` rows to match the
+    // Sonarr-parity label format the classifier now emits:
+    // `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEBDL-1080p`,
+    // `WEBRip-1080p`, `WEB-1080p`, `HDTV-1080p`, `DVD-480p`, etc. This
+    // migration bridges two prior schemas: (1) very old space-joined
+    // rows like "BluRay 1080p" / "WEB-DL 1080p", and (2) the
+    // intermediate dash-joined rename (`BD-Remux-1080p`, `BD-RAW-1080p`,
+    // `WEBRIP-1080p`) that shipped briefly before the Sonarr-parity
+    // reorder landed.
+    //
+    // `episode_quality_tags` has the structured source/resolution/
+    // web_kind/is_remux/is_bdmv columns, so we regenerate `quality_tag`
+    // directly from ground truth — always correct regardless of which
+    // label format happened to be in the column. `episode_grab_history`
+    // doesn't carry the structured columns (it's a grab-time audit
+    // trail, not a classification store), so we fall back to ordered
+    // REPLACE statements on known legacy patterns. Fully idempotent:
+    // the regen overwrites with the same value on re-runs, and the
+    // REPLACE chain no-ops once its source patterns are gone.
+    sqlx::query(
+        r#"
+        UPDATE episode_quality_tags SET quality_tag = CASE
+            WHEN TRIM(COALESCE(source, '')) = ''
+              OR LOWER(source) = 'unknown' THEN
+                CASE WHEN COALESCE(resolution, '') IN ('', 'Unknown')
+                     THEN 'Unknown' ELSE resolution END
+            ELSE
+                (CASE
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd') THEN 'BD'
+                    WHEN LOWER(source) = 'web' THEN
+                        CASE
+                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webdl', 'web-dl', 'web.dl') THEN 'WEBDL'
+                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webrip', 'web-rip', 'web.rip') THEN 'WEBRip'
+                            ELSE 'WEB'
+                        END
+                    ELSE UPPER(source)
+                END)
+                || CASE WHEN COALESCE(resolution, '') IN ('', 'Unknown')
+                        THEN '' ELSE '-' || resolution END
+                || CASE
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd')
+                         AND COALESCE(is_bdmv, 0) = 1 THEN ' RAW'
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd')
+                         AND COALESCE(is_remux, 0) = 1 THEN ' Remux'
+                    ELSE ''
+                END
+        END
+        "#,
+    )
+    .execute(db)
+    .await
+    .ok();
+
+    // `episode_grab_history` replacements. Two-pass approach, since
+    // SQLite REPLACE is a dumb substring swap and can't reorder tokens
+    // around a variable-width resolution in one shot:
+    //
+    //   Pass A — normalize legacy space-joined tokens to the
+    //            intermediate dash-joined form ("BluRay BDMV 1080p" →
+    //            "BD-RAW-1080p", "WEB-DL 1080p" → "WEBDL-1080p", etc.).
+    //            Only the BluRay BDMV/Remux/plain and WEB variants need
+    //            ordering care: the qualified BluRay patterns must fire
+    //            before the generic "BluRay " prefix is stripped.
+    //
+    //   Pass B — reorder `BD-{RAW|Remux}-{res}` into the final
+    //            Sonarr-parity `BD-{res} {RAW|Remux}` form. REPLACE
+    //            needs one entry per supported resolution because it
+    //            can't swap tokens generically.
+    //
+    // The straggler "WEBRIP-" → "WEBRip-" entry at the end fixes the
+    // all-caps intermediate form left by the prior rename pass.
+    for (old, new) in [
+        // ── Pass A: legacy space-joined → intermediate dash form ──
+        ("BluRay BDMV ", "BD-RAW-"),
+        ("BluRay Remux ", "BD-Remux-"),
+        ("BluRay ", "BD-"),
+        ("WEB-DL ", "WEBDL-"),
+        ("WEBRip ", "WEBRip-"),
+        ("Web ", "WEB-"),
+        ("HDTV ", "HDTV-"),
+        ("DVD ", "DVD-"),
+        ("TV ", "TV-"),
+        // ── Pass B: intermediate dash form → Sonarr-parity reorder ──
+        ("BD-RAW-480p", "BD-480p RAW"),
+        ("BD-RAW-576p", "BD-576p RAW"),
+        ("BD-RAW-720p", "BD-720p RAW"),
+        ("BD-RAW-1080p", "BD-1080p RAW"),
+        ("BD-RAW-2160p", "BD-2160p RAW"),
+        ("BD-Remux-480p", "BD-480p Remux"),
+        ("BD-Remux-576p", "BD-576p Remux"),
+        ("BD-Remux-720p", "BD-720p Remux"),
+        ("BD-Remux-1080p", "BD-1080p Remux"),
+        ("BD-Remux-2160p", "BD-2160p Remux"),
+        // Case-fix stragglers from the intermediate all-caps form.
+        ("WEBRIP-", "WEBRip-"),
+    ] {
+        let like_pat = format!("%{}%", old);
+        let _ = sqlx::query(
+            "UPDATE episode_grab_history
+             SET quality_tag = REPLACE(quality_tag, ?, ?)
+             WHERE quality_tag LIKE ?",
+        )
+        .bind(old)
+        .bind(new)
+        .bind(like_pat)
+        .execute(db)
+        .await;
+    }
 
     sqlx::query(
         r#"

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -1,13 +1,23 @@
 use serde::{Deserialize, Serialize};
 use crate::services::html::sanitize_rich_description;
 use std::collections::HashMap;
-use std::sync::LazyLock;
-use std::time::Instant;
+use std::sync::{LazyLock, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
-use crate::services::{jikan, kitsu};
+use crate::services::jikan;
 
 const ANILIST_API: &str = "https://graphql.anilist.co";
+
+/// TTL for the search result cache. Short enough to stay fresh, long enough to
+/// absorb bursts of repeat queries (which is what actually hammers AniList/Jikan
+/// during testing or when a user re-searches the same title).
+const SEARCH_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// How long to treat AniList as unavailable after a 429/5xx. If AniList sends a
+/// `Retry-After` header we use that value instead (capped at 5 minutes).
+const ANILIST_COOLDOWN_DEFAULT: Duration = Duration::from_secs(60);
+const ANILIST_COOLDOWN_MAX: Duration = Duration::from_secs(300);
 
 /// In-memory cache TTL for anime detail responses (15 minutes).
 const DETAIL_CACHE_TTL_SECS: u64 = 15 * 60;
@@ -25,6 +35,77 @@ struct CacheEntry {
 
 static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, CacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+
+type SearchCacheEntry = (Instant, Vec<AnimeEntry>);
+
+/// Search result cache, keyed on (provider-mode, normalized query).
+/// Provider-mode is "al" for the normal AniList-first path and "mal" for the
+/// force_mal_fallback path; we keep them separate because they return different
+/// `source` fields per entry and the frontend displays the distinction.
+static SEARCH_CACHE: LazyLock<StdMutex<HashMap<String, SearchCacheEntry>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// Monotonically-set "AniList is in cooldown until Instant". Consulted at the
+/// top of every search so that once we've learned AniList is rate-limiting us,
+/// we stop wasting a round-trip per search (which was dragging Jikan into the
+/// rate-limit bucket too).
+static ANILIST_COOLDOWN_UNTIL: LazyLock<StdMutex<Option<Instant>>> =
+    LazyLock::new(|| StdMutex::new(None));
+
+fn normalize_search_key(force_fallback: bool, query: &str) -> String {
+    let folded: String = query
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    format!("{}::{}", if force_fallback { "mal" } else { "al" }, folded)
+}
+
+fn search_cache_get(key: &str) -> Option<Vec<AnimeEntry>> {
+    let now = Instant::now();
+    let mut cache = SEARCH_CACHE.lock().ok()?;
+    if let Some((fetched_at, results)) = cache.get(key) {
+        if now.duration_since(*fetched_at) <= SEARCH_CACHE_TTL {
+            return Some(results.clone());
+        }
+    }
+    cache.remove(key);
+    None
+}
+
+fn search_cache_put(key: String, results: Vec<AnimeEntry>) {
+    if let Ok(mut cache) = SEARCH_CACHE.lock() {
+        // Bound the cache. Simple heuristic — if we're >200 entries, drop expired
+        // ones; if still too big, just clear. Search queries are long-tail anyway.
+        if cache.len() > 200 {
+            let now = Instant::now();
+            cache.retain(|_, (t, _)| now.duration_since(*t) <= SEARCH_CACHE_TTL);
+            if cache.len() > 200 {
+                cache.clear();
+            }
+        }
+        cache.insert(key, (Instant::now(), results));
+    }
+}
+
+fn anilist_cooldown_active() -> bool {
+    if let Ok(guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+        if let Some(until) = *guard {
+            return Instant::now() < until;
+        }
+    }
+    false
+}
+
+fn set_anilist_cooldown(retry_after_secs: Option<u64>) {
+    let dur = retry_after_secs
+        .map(Duration::from_secs)
+        .unwrap_or(ANILIST_COOLDOWN_DEFAULT)
+        .min(ANILIST_COOLDOWN_MAX);
+    if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+        *guard = Some(Instant::now() + dur);
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct AnimeEntry {
@@ -53,11 +134,36 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
     if query.is_empty() {
         return Ok(Vec::new());
     }
+
+    // 1. Cache lookup — skip all upstream work for repeat queries within the TTL.
+    let cache_key = normalize_search_key(force_mal_fallback, query);
+    if let Some(cached) = search_cache_get(&cache_key) {
+        tracing::debug!("anilist search cache hit for {:?} ({} results)", query, cached.len());
+        return Ok(cached);
+    }
+
     if force_mal_fallback {
-        return match jikan::search_anime(query).await {
-            Ok(results) if !results.is_empty() => Ok(results),
-            Ok(_) | Err(_) => kitsu::search_anime(query).await,
-        };
+        let results = fallback_jikan(query, None).await?;
+        search_cache_put(cache_key, results.clone());
+        return Ok(results);
+    }
+
+    // 2. If AniList is known to be rate-limited, don't bother hitting it — go
+    //    straight to Jikan. This is the key fix for the "both APIs rate-limited
+    //    at once" symptom: previously every search during the 60s AL cooldown
+    //    still pinged AL, got another 429, then called Jikan, burning Jikan's
+    //    (stricter) rate-limit budget alongside.
+    if anilist_cooldown_active() {
+        tracing::debug!(
+            "anilist search skipping AniList for {:?} (still in cooldown)",
+            query
+        );
+        let results = fallback_jikan(
+            query,
+            Some("AniList rate-limited (skipped during cooldown)".to_string()),
+        ).await?;
+        search_cache_put(cache_key, results.clone());
+        return Ok(results);
     }
 
     let gql = serde_json::json!({
@@ -86,27 +192,85 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
     });
 
     let client = reqwest::Client::new();
-    let resp = client
+    let resp = match client
         .post(ANILIST_API)
         .header("User-Agent", "Ryokan/0.1")
         .json(&gql)
         .send()
         .await
-        .map_err(|e| format!("AniList request failed: {}", e))?;
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(
+                "AniList request failed for query {:?}: {}; falling back to Jikan/MAL",
+                query, e
+            );
+            let results = fallback_jikan(
+                query,
+                Some(format!("AniList unreachable: {}", e)),
+            ).await?;
+            search_cache_put(cache_key, results.clone());
+            return Ok(results);
+        }
+    };
 
     let status = resp.status();
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse AniList response: {}", e))?;
 
-    if status == reqwest::StatusCode::FORBIDDEN {
-        tracing::warn!("AniList search 403 for query {:?}; falling back to Jikan/MAL", query);
-        return match jikan::search_anime(query).await {
-            Ok(results) if !results.is_empty() => Ok(results),
-            Ok(_) | Err(_) => kitsu::search_anime(query).await,
+    // Silently fall back to Jikan/MAL on transient AniList outages:
+    //   403 — Cloudflare challenge / geo-block
+    //   429 — rate limit (30 req/min anon)
+    //   5xx — upstream outage
+    // These are the cases where the user's search should just Work via a
+    // fallback provider rather than surfacing a cryptic HTTP error.
+    if status == reqwest::StatusCode::FORBIDDEN
+        || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+        || status.is_server_error()
+    {
+        let retry_after_secs = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+        tracing::warn!(
+            "AniList search HTTP {} for query {:?} (retry-after={:?}); falling back to Jikan/MAL",
+            status, query, retry_after_secs
+        );
+        // Start a cooldown so subsequent searches in this window skip AL entirely.
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+            set_anilist_cooldown(retry_after_secs);
+        }
+        let reason = match status.as_u16() {
+            429 => format!(
+                "AniList rate-limited{}",
+                retry_after_secs
+                    .map(|r| format!(" (retry in {}s)", r))
+                    .unwrap_or_default()
+            ),
+            403 => "AniList blocked our request (Cloudflare challenge)".to_string(),
+            code => format!("AniList upstream error (HTTP {})", code),
         };
+        let results = fallback_jikan(query, Some(reason)).await?;
+        search_cache_put(cache_key, results.clone());
+        return Ok(results);
     }
+
+    // Read the body as text first so a non-JSON error body (common on 4xx/5xx)
+    // produces a useful error instead of "Failed to parse AniList response".
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("AniList response read failed (HTTP {}): {}", status, e))?;
+
+    let body: serde_json::Value = match serde_json::from_str(&body_text) {
+        Ok(v) => v,
+        Err(parse_err) => {
+            if !status.is_success() {
+                let snippet: String = body_text.chars().take(200).collect();
+                return Err(format!("AniList search failed (HTTP {}): {}", status, snippet.trim()));
+            }
+            return Err(format!("Failed to parse AniList response: {}", parse_err));
+        }
+    };
 
     if !status.is_success() {
         let msg = extract_graphql_error(&body).unwrap_or_else(|| body.to_string());
@@ -119,10 +283,13 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
 
     let media = match body["data"]["Page"]["media"].as_array() {
         Some(arr) => arr,
-        None => return Ok(Vec::new()),
+        None => {
+            search_cache_put(cache_key, Vec::new());
+            return Ok(Vec::new());
+        }
     };
 
-    let entries = media
+    let entries: Vec<AnimeEntry> = media
         .iter()
         .map(|m| AnimeEntry {
             id: m["id"].as_i64().unwrap_or(0),
@@ -140,7 +307,52 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
         })
         .collect();
 
+    search_cache_put(cache_key, entries.clone());
     Ok(entries)
+}
+
+/// Shared fallback helper used when AniList is unavailable or force_mal_fallback is set.
+/// Tries Jikan (MAL-backed). If Jikan also fails, `compose_search_error` builds a
+/// user-friendly combined message for the frontend.
+async fn fallback_jikan(
+    query: &str,
+    anilist_reason: Option<String>,
+) -> Result<Vec<AnimeEntry>, String> {
+    match jikan::search_anime(query).await {
+        Ok(results) => Ok(results),
+        Err(jikan_err) => Err(compose_search_error(anilist_reason.as_deref(), &jikan_err)),
+    }
+}
+
+/// Produce a clean, human-readable error message from an AniList failure reason
+/// (optional — e.g. "AniList rate-limited (retry in 28s)") and a Jikan failure
+/// reason. Callers see something like:
+///   "Both AniList and Jikan/MAL are rate-limited right now. Try again in ~30s."
+/// instead of a raw JSON dump concatenation.
+fn compose_search_error(anilist_reason: Option<&str>, jikan_err: &str) -> String {
+    let al_rate_limited = anilist_reason
+        .map(|r| r.contains("rate-limited") || r.contains("429"))
+        .unwrap_or(false);
+    let jikan_rate_limited = jikan_err.contains("rate-limited") || jikan_err.contains("429");
+
+    if al_rate_limited && jikan_rate_limited {
+        // Try to surface the AL retry hint if we parsed one earlier.
+        let hint = anilist_reason
+            .and_then(|r| {
+                let start = r.find("retry in ")?;
+                let tail = &r[start + "retry in ".len()..];
+                let end = tail.find(')').unwrap_or(tail.len());
+                Some(tail[..end].to_string())
+            })
+            .map(|s| format!(" Try again in ~{}.", s))
+            .unwrap_or_else(|| " Try again in a minute.".to_string());
+        return format!("Both AniList and Jikan/MAL are rate-limited right now.{}", hint);
+    }
+
+    match anilist_reason {
+        Some(al) => format!("{}. MAL/Jikan fallback also failed: {}", al, jikan_err),
+        None => format!("MAL/Jikan search failed: {}", jikan_err),
+    }
 }
 
 
@@ -547,4 +759,86 @@ fn extract_graphql_error(body: &serde_json::Value) -> Option<String> {
         .and_then(|errs| errs.first())
         .and_then(|err| err["message"].as_str())
         .map(|s| s.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_search_key_folds_whitespace_and_case() {
+        assert_eq!(
+            normalize_search_key(false, "  Jojo  Part  3 "),
+            "al::jojo part 3"
+        );
+        assert_eq!(
+            normalize_search_key(true, "\tFrieren\n"),
+            "mal::frieren"
+        );
+    }
+
+    #[test]
+    fn normalize_search_key_separates_al_from_mal_modes() {
+        assert_ne!(
+            normalize_search_key(false, "Bleach"),
+            normalize_search_key(true, "Bleach")
+        );
+    }
+
+    #[test]
+    fn compose_error_when_both_rate_limited_suggests_retry() {
+        let msg = compose_search_error(
+            Some("AniList rate-limited (retry in 28s)"),
+            "Jikan rate-limited (HTTP 429): You are being rate-limited",
+        );
+        assert!(msg.contains("Both AniList and Jikan/MAL are rate-limited"), "msg was: {}", msg);
+        assert!(msg.contains("28s"), "retry hint lost: {}", msg);
+    }
+
+    #[test]
+    fn compose_error_falls_back_when_only_one_rate_limited() {
+        let msg = compose_search_error(
+            Some("AniList rate-limited (retry in 28s)"),
+            "Jikan unreachable: connection refused",
+        );
+        assert!(msg.starts_with("AniList rate-limited"), "msg was: {}", msg);
+        assert!(msg.contains("connection refused"), "jikan detail lost: {}", msg);
+        assert!(!msg.contains("Both AniList and Jikan/MAL"), "wrong branch: {}", msg);
+    }
+
+    #[test]
+    fn compose_error_without_anilist_reason_uses_mal_prefix() {
+        let msg = compose_search_error(None, "Jikan HTTP 500: upstream down");
+        assert!(msg.starts_with("MAL/Jikan search failed"), "msg was: {}", msg);
+        assert!(msg.contains("upstream down"));
+    }
+
+    #[test]
+    fn search_cache_roundtrips_and_expires_on_ttl_mismatch() {
+        // We can't sleep for 60s in tests, but we can validate that distinct
+        // keys don't collide and that a put/get returns the same Vec.
+        let key = normalize_search_key(false, "test query unique 1");
+        let entries = vec![AnimeEntry {
+            id: 42,
+            id_mal: None,
+            title_romaji: "Test".into(),
+            title_english: "".into(),
+            title_native: "".into(),
+            cover_url: "".into(),
+            format: "TV".into(),
+            status: "FINISHED".into(),
+            status_display: "Finished".into(),
+            episodes: Some(12),
+            season_year: Some(2020),
+            source: "anilist".into(),
+        }];
+        search_cache_put(key.clone(), entries.clone());
+        let got = search_cache_get(&key).expect("cached value should be present");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].id, 42);
+
+        // A different normalized key should miss.
+        let other = normalize_search_key(false, "completely different");
+        assert!(search_cache_get(&other).is_none());
+    }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -160,6 +160,7 @@ pub async fn find_all_for_target(
 
     let expected_season = infer_season_from_detail(detail);
     let sibling_aliases = collect_sibling_aliases(detail, &aliases);
+    let sibling_precompute = SiblingRejectPrecompute::build(&aliases, &sibling_aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -180,7 +181,7 @@ pub async fn find_all_for_target(
 
     let ctx = InteractiveQueryCtx {
         aliases: &aliases,
-        sibling_aliases: &sibling_aliases,
+        sibling_precompute: &sibling_precompute,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -192,13 +193,23 @@ pub async fn find_all_for_target(
     // but filter by season and episode to avoid showing wrong-season results.
     run_queries_interactive(&queries, ctx, &mut seen, &mut candidates).await;
 
-    // Try extended aliases if primary queries found nothing.
+    // Try extended aliases if primary queries found nothing. Extended
+    // aliases expand the own-side of the sibling-rejection comparison,
+    // so rebuild the precompute with the full alias list — otherwise
+    // an extended alias that legitimately overlaps with a sibling (e.g.
+    // a synonym that happens to share tokens) would look like a sibling
+    // win and get rejected.
     if candidates.is_empty() {
         let extended = collect_extended_aliases(detail);
         if !extended.is_empty() {
             let ext_queries = build_queries_from_aliases(&extended, target);
             let all_aliases = [aliases.clone(), extended].concat();
-            let ext_ctx = InteractiveQueryCtx { aliases: &all_aliases, ..ctx };
+            let ext_precompute = SiblingRejectPrecompute::build(&all_aliases, &sibling_aliases);
+            let ext_ctx = InteractiveQueryCtx {
+                aliases: &all_aliases,
+                sibling_precompute: &ext_precompute,
+                ..ctx
+            };
             run_queries_interactive(&ext_queries, ext_ctx, &mut seen, &mut candidates).await;
         }
     }
@@ -350,6 +361,7 @@ pub async fn collect_scored_batches_for_target(
 
     let expected_season = infer_season_from_detail(detail);
     let sibling_aliases = collect_sibling_aliases(detail, &aliases);
+    let sibling_precompute = SiblingRejectPrecompute::build(&aliases, &sibling_aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -372,7 +384,7 @@ pub async fn collect_scored_batches_for_target(
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
-        sibling_aliases: &sibling_aliases,
+        sibling_precompute: &sibling_precompute,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -517,6 +529,7 @@ async fn collect_scored_for_target(
 
     let expected_season = infer_season_from_detail(detail);
     let sibling_aliases = collect_sibling_aliases(detail, &aliases);
+    let sibling_precompute = SiblingRejectPrecompute::build(&aliases, &sibling_aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -552,7 +565,7 @@ async fn collect_scored_for_target(
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
-        sibling_aliases: &sibling_aliases,
+        sibling_precompute: &sibling_precompute,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -566,13 +579,21 @@ async fn collect_scored_for_target(
     // Phase 1: standard queries (primary aliases + episode variants).
     run_queries(&queries, ctx, &mut seen, &mut candidates).await;
 
-    // Phase 1.5: if no candidates, try extended aliases (synonyms + decomposed sub-phrases).
+    // Phase 1.5: if no candidates, try extended aliases (synonyms +
+    // decomposed sub-phrases). Rebuild the sibling precompute with the
+    // full alias list so own-vs-sibling overlap comparisons see the
+    // extended aliases too.
     if candidates.is_empty() {
         let extended = collect_extended_aliases(detail);
         if !extended.is_empty() {
             let ext_queries = build_queries_from_aliases(&extended, target);
             let all_aliases = [aliases.clone(), extended].concat();
-            let ext_ctx = AutoQueryCtx { aliases: &all_aliases, ..ctx };
+            let ext_precompute = SiblingRejectPrecompute::build(&all_aliases, &sibling_aliases);
+            let ext_ctx = AutoQueryCtx {
+                aliases: &all_aliases,
+                sibling_precompute: &ext_precompute,
+                ..ctx
+            };
             run_queries(&ext_queries, ext_ctx, &mut seen, &mut candidates).await;
         }
     }
@@ -680,11 +701,14 @@ async fn collect_scored_for_target(
 #[derive(Clone, Copy)]
 struct AutoQueryCtx<'a> {
     aliases: &'a [String],
-    /// Titles of sibling entries (sequels, prequels, side stories) from
-    /// AniList relations. A release whose token overlap with any sibling
-    /// beats its overlap with every own-alias is rejected — see
-    /// `collect_sibling_aliases` for the JJK S1→S3 motivating case.
-    sibling_aliases: &'a [String],
+    /// Precomputed token sets for own + sibling aliases, used by
+    /// [`sibling_match_rejects`] to reject a release that looks MORE
+    /// like a sequel/prequel/side-story than the target. Built once
+    /// at the top of the collect function so the ~50-candidates ×
+    /// ~5-siblings normalize/tokenize loop runs once per sweep
+    /// instead of once per candidate. See `collect_sibling_aliases`
+    /// for the JJK S1→S3 motivating case.
+    sibling_precompute: &'a SiblingRejectPrecompute,
     preferred_groups: &'a [String],
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
@@ -709,7 +733,7 @@ struct AutoQueryCtx<'a> {
 #[derive(Clone, Copy)]
 struct InteractiveQueryCtx<'a> {
     aliases: &'a [String],
-    sibling_aliases: &'a [String],
+    sibling_precompute: &'a SiblingRejectPrecompute,
     preferred_groups: &'a [String],
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
@@ -781,7 +805,7 @@ async fn run_queries(
                     if !matches_target(
                         &result.title,
                         ctx.aliases,
-                        ctx.sibling_aliases,
+                        ctx.sibling_precompute,
                         ctx.target,
                         ctx.expected_season,
                         ctx.batch_episode_match && result.is_batch,
@@ -866,7 +890,7 @@ async fn run_queries_interactive(
             // Sibling rejection: same sequel/prequel guard as the auto
             // path — a release that matches a sibling more tightly than
             // us is almost certainly for the sibling.
-            if sibling_match_rejects(&title_tokens, ctx.aliases, ctx.sibling_aliases) {
+            if sibling_match_rejects(&normalized_title, &title_tokens, ctx.sibling_precompute) {
                 continue;
             }
             // Season check: reject results clearly from a different season
@@ -1142,6 +1166,55 @@ pub fn collect_sibling_aliases(detail: &AnimeDetail, own_aliases: &[String]) -> 
     dedupe_strings(out)
 }
 
+/// Precomputed normalized token sets for the own-alias and sibling-alias
+/// lists used by [`sibling_match_rejects`]. Built once per target sweep
+/// (per call to `find_all_for_target` / `collect_scored_for_target` /
+/// `collect_scored_batches_for_target`) and reused across every release
+/// candidate the sweep checks against the target, instead of re-running
+/// `normalize_title` + `token_set` on the same alias strings ~50×
+/// (candidates) per target. Pure perf hoist — the rejection semantics
+/// are identical to the prior per-call implementation.
+#[derive(Debug, Clone, Default)]
+pub struct SiblingRejectPrecompute {
+    /// Token sets for own aliases. Used to find the best target-alias
+    /// overlap with any release — a sibling only wins if it beats this
+    /// number strictly.
+    own_token_sets: Vec<HashSet<String>>,
+    /// Sibling entries as `(normalized_title, token_set)` pairs. The
+    /// normalized title is kept alongside its token set so the
+    /// contiguous-substring fallback has a stable, deterministic string
+    /// to match against (the old implementation rebuilt this from
+    /// `HashSet::iter()` per call, which is nondeterministic order and
+    /// would silently misbehave on contiguous-substring checks).
+    siblings: Vec<(String, HashSet<String>)>,
+}
+
+impl SiblingRejectPrecompute {
+    pub fn build(own_aliases: &[String], sibling_aliases: &[String]) -> Self {
+        let own_token_sets = own_aliases
+            .iter()
+            .map(|a| token_set(&normalize_title(a)))
+            .collect();
+        let siblings = sibling_aliases
+            .iter()
+            .filter_map(|s| {
+                let normalized = normalize_title(s);
+                let tokens = token_set(&normalized);
+                if tokens.is_empty() {
+                    None
+                } else {
+                    Some((normalized, tokens))
+                }
+            })
+            .collect();
+        Self {
+            own_token_sets,
+            siblings,
+        }
+    }
+
+}
+
 /// Reject a release when it looks MORE like one of our siblings than
 /// it does like us. The check compares token overlap: if any sibling
 /// alias shares strictly more tokens with the release than the best
@@ -1155,11 +1228,11 @@ pub fn collect_sibling_aliases(detail: &AnimeDetail, own_aliases: &[String]) -> 
 /// the sibling check is the last defense against "plausibly us" also
 /// being "more plausibly a sibling".
 fn sibling_match_rejects(
+    normalized_release: &str,
     normalized_release_tokens: &HashSet<String>,
-    own_aliases: &[String],
-    sibling_aliases: &[String],
+    precompute: &SiblingRejectPrecompute,
 ) -> bool {
-    if sibling_aliases.is_empty() {
+    if precompute.siblings.is_empty() {
         return false;
     }
 
@@ -1167,23 +1240,16 @@ fn sibling_match_rejects(
     // Using absolute overlap count (not ratio) so a sibling with 4 matching
     // tokens beats a target alias with 2 matching tokens even if the target
     // alias has fewer tokens overall.
-    let best_own_overlap: usize = own_aliases
+    let best_own_overlap: usize = precompute
+        .own_token_sets
         .iter()
-        .map(|a| {
-            let tokens = token_set(&normalize_title(a));
-            normalized_release_tokens.intersection(&tokens).count()
-        })
+        .map(|tokens| normalized_release_tokens.intersection(tokens).count())
         .max()
         .unwrap_or(0);
 
-    for sibling in sibling_aliases {
-        let normalized_sibling = normalize_title(sibling);
-        let sibling_tokens = token_set(&normalized_sibling);
-        if sibling_tokens.is_empty() {
-            continue;
-        }
+    for (normalized_sibling, sibling_tokens) in &precompute.siblings {
         let sibling_overlap = normalized_release_tokens
-            .intersection(&sibling_tokens)
+            .intersection(sibling_tokens)
             .count();
         // Strictly greater: a tie means both the target and the sibling
         // match equally well, which is the normal case for a release
@@ -1196,15 +1262,10 @@ fn sibling_match_rejects(
             // ALL of its tokens appear in the release. This prevents
             // freak two-token overlaps ("side story" + some other
             // common fragment) from tripping the rejection.
-            let normalized_release_joined: String = normalized_release_tokens
-                .iter()
-                .cloned()
-                .collect::<Vec<_>>()
-                .join(" ");
             let all_tokens_present = sibling_tokens
                 .iter()
                 .all(|t| normalized_release_tokens.contains(t));
-            if all_tokens_present || normalized_release_joined.contains(&normalized_sibling) {
+            if all_tokens_present || normalized_release.contains(normalized_sibling.as_str()) {
                 return true;
             }
         }
@@ -1317,7 +1378,7 @@ pub fn dedupe_strings(values: Vec<String>) -> Vec<String> {
 pub fn matches_target(
     title: &str,
     aliases: &[String],
-    sibling_aliases: &[String],
+    sibling_precompute: &SiblingRejectPrecompute,
     target: &SearchTarget,
     expected_season: i32,
     allow_batch_episode: bool,
@@ -1338,7 +1399,7 @@ pub fn matches_target(
     // Sibling rejection: if the release looks more like a sequel /
     // prequel / side story than it looks like us, reject. See the
     // JJK S1→S3 case in the `collect_sibling_aliases` docstring.
-    if sibling_match_rejects(&title_tokens, aliases, sibling_aliases) {
+    if sibling_match_rejects(&normalized_title, &title_tokens, sibling_precompute) {
         return false;
     }
 
@@ -2797,6 +2858,7 @@ mod tests {
             "Main Title: Subtitle One".to_string(),
             "Main Title: Subtitle Two".to_string(),
         ];
+        let no_siblings = SiblingRejectPrecompute::build(&aliases, &[]);
         let unrelated_release =
             "[Group] Totally Different Show - Subtitle One-Word Thing - 01 [1080p].mkv";
         // The release shares only the word "Subtitle" with the primary
@@ -2809,7 +2871,7 @@ mod tests {
             !matches_target(
                 unrelated_release,
                 &aliases,
-                &[],
+                &no_siblings,
                 &SearchTarget::Episode(1),
                 0,
                 false,
@@ -2821,11 +2883,12 @@ mod tests {
     #[test]
     fn matches_target_accepts_release_with_full_primary_alias_substring() {
         let aliases = vec!["Main Title Subtitle One".to_string()];
+        let no_siblings = SiblingRejectPrecompute::build(&aliases, &[]);
         let good_release = "[Group] Main Title Subtitle One [BD 1080p].mkv";
         assert!(matches_target(
             good_release,
             &aliases,
-            &[],
+            &no_siblings,
             &SearchTarget::Single,
             0,
             false,
@@ -2844,12 +2907,13 @@ mod tests {
         // sibling wins and the release is rejected.
         let own = vec!["Jujutsu Kaisen".to_string()];
         let siblings = vec!["Jujutsu Kaisen: Shimetsu Kaiyuu".to_string()];
+        let precompute = SiblingRejectPrecompute::build(&own, &siblings);
         let release = "[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen - 06 [1080p CR WEBRip HEVC AAC].mkv";
         assert!(
             !matches_target(
                 release,
                 &own,
-                &siblings,
+                &precompute,
                 &SearchTarget::Episode(6),
                 1,
                 false,
@@ -2866,11 +2930,12 @@ mod tests {
         // overlap — so the sibling check is a no-op.
         let own = vec!["Jujutsu Kaisen".to_string()];
         let siblings = vec!["Jujutsu Kaisen: Shimetsu Kaiyuu".to_string()];
+        let precompute = SiblingRejectPrecompute::build(&own, &siblings);
         let release = "[Erai-raws] Jujutsu Kaisen - 06 [1080p].mkv";
         assert!(matches_target(
             release,
             &own,
-            &siblings,
+            &precompute,
             &SearchTarget::Episode(6),
             1,
             false,
@@ -2886,11 +2951,12 @@ mod tests {
             "Jujutsu Kaisen".to_string(),
             "Jujutsu Kaisen: Kaigyoku Gyokusetsu".to_string(),
         ];
+        let precompute = SiblingRejectPrecompute::build(&own, &siblings);
         let release = "[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen - 06 [1080p].mkv";
         assert!(matches_target(
             release,
             &own,
-            &siblings,
+            &precompute,
             &SearchTarget::Episode(6),
             0,
             false,

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
-use std::sync::LazyLock;
+use std::collections::{HashMap, HashSet};
+use std::sync::{LazyLock, Mutex as StdMutex};
+use std::time::{Duration, Instant};
 
 use regex_lite::Regex;
 use sqlx::SqlitePool;
@@ -1188,7 +1189,7 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
 /// (smol's `Monogatari (Season 9)` megapack for Kizumonogatari Part 2
 /// is the canonical example). The text-query sweep can't find them;
 /// we go direct to `/view/<id>` and inject the result ourselves.
-#[derive(Default)]
+#[derive(Default, Clone)]
 struct SeaDexPayload {
     hashes: HashSet<String>,
     /// Synthetic candidates fetched directly from each SeaDex-curated
@@ -1196,6 +1197,39 @@ struct SeaDexPayload {
     /// fails, or when every fetch fails. Merged into the candidate
     /// pool by the caller before the text-query sweep runs.
     candidates: Vec<SearchResult>,
+}
+
+/// 5-minute in-memory cache for SeaDex lookups, keyed by AniList ID.
+///
+/// A single auto-search sweep across a multi-target batch (`find_all_for_target`,
+/// `collect_scored_batches_for_target`, `collect_scored_for_target`)
+/// can round-trip releases.moe several times per target, and each hit
+/// also fetches every SeaDex-best torrent's Nyaa view page. For a
+/// JoJo S1–S5 sweep that's up to ~5 × (1 + N) HTTP requests — enough
+/// to throttle both releases.moe and Nyaa on a cold start.
+///
+/// The cache amortizes the cost to one round-trip per target per
+/// 5-minute window. Config changes (preferred groups, resolution)
+/// affect how candidates get *scored* downstream, not what SeaDex
+/// returns, so keying by anilist_id alone is correct.
+const SEADEX_CACHE_TTL: Duration = Duration::from_secs(300);
+static SEADEX_CACHE: LazyLock<StdMutex<HashMap<i64, (Instant, SeaDexPayload)>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+fn seadex_cache_get(anilist_id: i64) -> Option<SeaDexPayload> {
+    let cache = SEADEX_CACHE.lock().ok()?;
+    let (fetched_at, payload) = cache.get(&anilist_id)?;
+    if fetched_at.elapsed() < SEADEX_CACHE_TTL {
+        Some(payload.clone())
+    } else {
+        None
+    }
+}
+
+fn seadex_cache_put(anilist_id: i64, payload: SeaDexPayload) {
+    if let Ok(mut cache) = SEADEX_CACHE.lock() {
+        cache.insert(anilist_id, (Instant::now(), payload));
+    }
 }
 
 async fn fetch_seadex_payload(
@@ -1228,6 +1262,14 @@ async fn fetch_seadex_payload(
         )
         .await;
         return SeaDexPayload::default();
+    }
+    if let Some(cached) = seadex_cache_get(anilist_id) {
+        tracing::debug!(
+            "seadex: cache hit for anilist_id={anilist_id} ({} hash(es), {} candidate(s))",
+            cached.hashes.len(),
+            cached.candidates.len()
+        );
+        return cached;
     }
     tracing::debug!("seadex: fetching releases.moe entry for anilist_id={anilist_id}");
     match seadex::lookup(anilist_id).await {
@@ -1295,7 +1337,9 @@ async fn fetch_seadex_payload(
                     }
                 }
             }
-            SeaDexPayload { hashes, candidates }
+            let payload = SeaDexPayload { hashes, candidates };
+            seadex_cache_put(anilist_id, payload.clone());
+            payload
         }
         Ok(None) => {
             tracing::debug!(
@@ -1308,7 +1352,13 @@ async fn fetch_seadex_payload(
                 &format!("anilist_id={anilist_id}"),
             )
             .await;
-            SeaDexPayload::default()
+            // Cache the "no entry" result so we don't re-hit releases.moe
+            // for the same anilist_id within the TTL window. Err paths
+            // are intentionally NOT cached — transient failures should
+            // retry on the next call.
+            let payload = SeaDexPayload::default();
+            seadex_cache_put(anilist_id, payload.clone());
+            payload
         }
         Err(e) => {
             tracing::warn!(
@@ -1344,16 +1394,23 @@ fn seadex_gates(
 }
 
 /// True if `info_hash` (non-empty) is in the SeaDex best-hashes set.
-/// Comparison is case-insensitive via lowercase normalization — the
-/// hash set is populated with lowercase hashes by `seadex::best_hashes`,
-/// and Nyaa-scraped hashes come through `extract_hash` already
-/// lowercased, but the explicit `to_ascii_lowercase` here keeps the
-/// contract obvious at the call sites.
+///
+/// **Both inputs must already be lowercase.** `seadex::best_hashes`
+/// populates the set with lowercase strings, and `extract_hash` in
+/// `services::nyaa` lowercases every scraped magnet hash at parse
+/// time. Enforced by `debug_assert!` so a future caller that forgets
+/// fails loudly in tests. The previous version called
+/// `info_hash.to_ascii_lowercase()` on every invocation — one
+/// allocation per candidate × per CF, which adds up on a batch sweep.
 fn is_seadex_match(info_hash: &str, seadex_hashes: &HashSet<String>) -> bool {
     if info_hash.is_empty() || seadex_hashes.is_empty() {
         return false;
     }
-    seadex_hashes.contains(&info_hash.to_ascii_lowercase())
+    debug_assert!(
+        !info_hash.chars().any(|c| c.is_ascii_uppercase()),
+        "is_seadex_match: info_hash must be lowercase, got {info_hash:?}"
+    );
+    seadex_hashes.contains(info_hash)
 }
 
 /// Human-readable short label for a series, used in SeaDex lookup log
@@ -1732,13 +1789,24 @@ static RE_PART_N: LazyLock<Regex> = LazyLock::new(||
     Regex::new(r"(?i)\b(?:part|chapter|movie|film)\s*(\d{1,2})\b").unwrap()
 );
 
-/// Bare Roman numeral at a word boundary. Covers the I–X range, which
-/// spans every multi-part anime film series we care about. Matches at
-/// end of string or before common separators (`:` for subtitle, space,
-/// `-`) so titles like "Kizumonogatari II: Nekketsu-hen" and
-/// "Rebuild of Evangelion III" both resolve cleanly.
+/// Roman numeral at a word boundary, II–IX only. Matches at end of
+/// string or before common separators (`:` for subtitle, space, `-`)
+/// so titles like "Kizumonogatari II: Nekketsu-hen" and "Rebuild of
+/// Evangelion III" both resolve cleanly.
+///
+/// **Single-letter Romans (`I`, `V`, `X`) are deliberately excluded.**
+/// Matching bare `I` would fire on any anime title containing the
+/// English pronoun — "I Want to Eat Your Pancreas", "I, Robot" — and
+/// resolve them as part 1, causing `pick_by_part_number` to narrow a
+/// megapack to the wrong file. Bare `V` and `X` carry the same risk
+/// ("V for Vendetta", "X/1999"). The tradeoff is that trilogy first
+/// entries titled "Kizumonogatari I" no longer narrow to E01 inside a
+/// megapack — they fall through to the full pack instead, which is
+/// fine because users rarely grab a trilogy's opening chapter in
+/// isolation. Explicit markers like "Part 1" / "Chapter 1" still
+/// work via [`RE_PART_N`].
 static RE_ROMAN_PART: LazyLock<Regex> = LazyLock::new(||
-    Regex::new(r"(?i)\b(i{1,3}|iv|v|vi{1,3}|ix|x)\b(?:\s*[:\-]|$|\s)").unwrap()
+    Regex::new(r"(?i)\b(ii{1,2}|iv|vi{1,3}|ix)\b(?:\s*[:\-]|$|\s)").unwrap()
 );
 
 /// Extract the "part number" from an AniList detail's titles. Returns
@@ -1852,6 +1920,27 @@ pub fn pick_wanted_file_indices(
     None
 }
 
+/// Narrow a megapack to the files that correspond to the target's
+/// part number.
+///
+/// **Assumes 1 part = 1 episode number in the filename.** Works for
+/// the canonical smol Monogatari pack (Kizumonogatari I/II/III land
+/// as S09E01/S09E02/S09E03) and similar per-episode layouts. Breaks
+/// for releases where a single "part" spans multiple files — e.g.
+/// multi-file BDMV rips of a single film, or "Part 2 E13-E24" —
+/// because `parse_release_numbers(filename).contains(&part)` then
+/// matches the wrong files entirely. Rebuild of Evangelion 1.0/2.0/3.0
+/// happens to fall through to `None` for a different reason:
+/// `parse_release_numbers` doesn't capture `2.22`-style decimal parts,
+/// so the match set is empty and the caller keeps the whole pack —
+/// which is the safe outcome.
+///
+/// Returns `None` when:
+/// - no files match (keep-everything is safer than picking wrong),
+/// - every file matches (nothing was actually narrowed),
+/// - the match set exceeds the target's expected episode count (guards
+///   against a `part=1` query sweeping in every episode in a 24-ep TV
+///   season when the target is actually a 2-ep OVA).
 fn pick_by_part_number(
     filenames: &[String],
     part: i32,
@@ -2075,19 +2164,29 @@ pub struct SiblingMatch {
 }
 
 /// Relation types we'll consider in-pack candidates when scanning an
-/// AniList relation graph for siblings. Excludes source material
-/// (`ADAPTATION`, `SOURCE`, `COMPILATION`, `CONTAINS`) because those
-/// point at manga / LN / book entries that will never appear in an
-/// anime torrent. Everything else — `SEQUEL`, `PREQUEL`, `SIDE_STORY`,
-/// `PARENT`, `ALTERNATIVE`, `SPIN_OFF`, `CHARACTER`, `SUMMARY`,
-/// `OTHER` — passes through because the downstream subtitle-match +
-/// episode-count cap are already doing the real false-positive
-/// filtering. This gate is just a performance filter that avoids
-/// normalizing obvious non-anime titles against every filename.
+/// AniList relation graph for siblings. Excludes:
+///
+/// - **Source material** (`ADAPTATION`, `SOURCE`, `COMPILATION`,
+///   `CONTAINS`) — these point at manga / LN / book entries that
+///   will never appear in an anime torrent.
+/// - **Off-series tie-ins** (`CHARACTER`, `OTHER`) — `CHARACTER`
+///   links to shared-universe spinoffs that share no animation DNA
+///   with the parent (e.g. a crossover cameo), and `OTHER` is
+///   AniList's dumping ground for unusual relations (promotional
+///   videos, live-action adaptations, disambiguation links, etc.).
+///   Both are noisy enough that including them mostly pads the
+///   candidate list with entries that never match.
+///
+/// Everything else — `SEQUEL`, `PREQUEL`, `SIDE_STORY`, `PARENT`,
+/// `ALTERNATIVE`, `SPIN_OFF`, `SUMMARY` — passes through because the
+/// downstream subtitle-match + episode-count cap are already doing
+/// the real false-positive filtering. This gate is a performance
+/// filter that avoids normalizing obviously-wrong candidates against
+/// every filename.
 fn is_pack_candidate_relation(relation_type: &str) -> bool {
     !matches!(
         relation_type,
-        "ADAPTATION" | "SOURCE" | "COMPILATION" | "CONTAINS"
+        "ADAPTATION" | "SOURCE" | "COMPILATION" | "CONTAINS" | "CHARACTER" | "OTHER"
     )
 }
 
@@ -2628,14 +2727,31 @@ mod tests {
     }
 
     #[test]
-    fn extract_part_number_ignores_roman_i_alone() {
-        // "Part I" is a part marker, but ambiguous bare Roman numeral
-        // "I" at the end of a title still resolves to 1 — the Roman
-        // regex accepts it. That's intentional: a trilogy's first
-        // entry is titled "Kizumonogatari I: Tekketsu-hen", and the
-        // user may want to grab that part specifically.
+    fn extract_part_number_drops_bare_roman_i_on_kizu_first_entry() {
+        // Kizumonogatari I no longer resolves to Some(1) — see the
+        // RE_ROMAN_PART docstring. Dropping bare single-letter Romans
+        // trades selective narrowing for entry 1 of a trilogy against
+        // not false-positiving any title containing an English pronoun
+        // "I". Users who want Kizu I specifically still get the whole
+        // smol pack (no selective narrowing), which is the acceptable
+        // fallback for this edge case.
         let d = detail_with_titles("Kizumonogatari I: Tekketsu-hen", "Kizumonogatari I: Tekketsu-hen");
-        assert_eq!(extract_part_number(&d), Some(1));
+        assert_eq!(extract_part_number(&d), None);
+    }
+
+    #[test]
+    fn extract_part_number_rejects_bare_roman_on_english_pronoun() {
+        // "I Want to Eat Your Pancreas" must NOT resolve to Some(1).
+        // Otherwise, if the user ever grabbed a Monogatari-style
+        // megapack with this detail as the target, pick_by_part_number
+        // would narrow to "files containing episode 1" for an
+        // unrelated film. The same concern motivates dropping bare V
+        // ("V for Vendetta") and bare X ("X/1999").
+        let d = detail_with_titles(
+            "I Want to Eat Your Pancreas",
+            "Kimi no Suizou wo Tabetai",
+        );
+        assert_eq!(extract_part_number(&d), None);
     }
 
     #[test]

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2430,17 +2430,23 @@ pub struct SiblingMatch {
     /// How many episodes to subtract from each file's parsed episode
     /// number before treating it as an episode of this sibling.
     ///
-    /// Set to `parent_cap` when the sibling's files use numbering that
-    /// is continuous across the parent (e.g. a 20-ep Owarimonogatari
-    /// batch with `S07E14 - Owarimonogatari Second Season` — E14 is
-    /// Owari S2 episode 1 and needs offset 13 applied). Set to 0 when
-    /// the sibling's files use their own arc-local numbering (e.g. an
-    /// Egypt-hen pack with `Stardust Crusaders S03E01` filenames).
+    /// Set to `min_ep - 1` (where `min_ep` is the smallest parsed
+    /// episode number in this sibling's files) when the sibling uses
+    /// numbering continuous with the parent — e.g. a 20-ep
+    /// Owarimonogatari batch with `S07E14 - Owarimonogatari Second
+    /// Season` resolves E14 to local ep 1 via offset 13. Set to 0
+    /// when the sibling's files use their own arc-local numbering
+    /// (e.g. an Egypt-hen pack with `Stardust Crusaders S03E01`
+    /// filenames already starting at 1).
     ///
     /// Detection rule: if `min(sibling_file_ep_nums) > parent_cap`,
-    /// offset = `parent_cap`; otherwise offset = 0. Computed
-    /// per-sibling regardless of whether the match came from the
-    /// subtitle path or the episode-range fallback.
+    /// offset = `min_ep - 1`; otherwise offset = 0. Using `min_ep - 1`
+    /// rather than `parent_cap` is what makes BD-split cases work,
+    /// where the release partitioned the parent into more files than
+    /// AL's episode count (merged long-runtime episodes get split,
+    /// pushing the sibling's first episode past `parent_cap + 1`).
+    /// Computed per-sibling regardless of whether the match came from
+    /// the subtitle path or the episode-range fallback.
     pub episode_offset: i32,
 }
 
@@ -3066,7 +3072,21 @@ fn detect_sibling_via_episode_range(
     //
     // Needles shorter than 8 chars are rejected to avoid false
     // positives from short titles colliding with episode markers
-    // (e.g. "Show 2" matching "Show - 02").
+    // or common filename tokens (e.g. "Show 2" matching "Show - 02",
+    // or a 4-letter romaji title colliding with a group tag). 8 is
+    // a heuristic floor: it keeps the substring match cheap while
+    // still covering the vast majority of anime titles.
+    //
+    // Known tradeoff: short-title series (Bleach, Naruto, Gintama,
+    // K-On!, One Piece) have normalized-title lengths below 8 chars
+    // and bypass the filename-subtitle pre-pass entirely. Those
+    // series fall through to the numeric packing path, which handles
+    // them correctly via episode-range analysis — the filename
+    // pre-pass is only load-bearing for long-title franchises that
+    // share a numbering scheme across split sagas (Monogatari is
+    // the motivating case). If you ever need to lower this floor,
+    // add a collision check against known episode-marker shapes
+    // first, or the Bleach/Naruto falsies will come roaring back.
     #[derive(Clone, Copy)]
     enum NeedleSource {
         Parent,

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2509,15 +2509,42 @@ pub fn detect_sibling_entries_in_pack(
         return Vec::new();
     }
 
+    let parent_label = if !parent_detail.title_english.is_empty() {
+        parent_detail.title_english.as_str()
+    } else {
+        parent_detail.title_romaji.as_str()
+    };
+    tracing::debug!(
+        "auto-expand: detect_siblings starting parent='{}' parent_anilist_id={} parent_episodes={:?} relations={} files={}",
+        parent_label,
+        parent_detail.id,
+        parent_detail.episodes,
+        parent_detail.relations.len(),
+        filenames.len()
+    );
+
     // Candidates: one entry per relation that produced a usable
     // subtitle. Stored by index into `parent_detail.relations` to
     // avoid borrowing complications during the materialize pass.
     let mut candidates: Vec<(usize, String, String)> = Vec::new(); // (rel_idx, raw subtitle, normalized needle)
     for (rel_idx, rel) in parent_detail.relations.iter().enumerate() {
+        let rel_label = if !rel.title_english.is_empty() {
+            rel.title_english.as_str()
+        } else {
+            rel.title_romaji.as_str()
+        };
         if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            tracing::debug!(
+                "auto-expand: subtitle skip rel='{}' reason=media_type={}",
+                rel_label, rel.media_type
+            );
             continue;
         }
         if !is_pack_candidate_relation(&rel.relation_type) {
+            tracing::debug!(
+                "auto-expand: subtitle skip rel='{}' reason=relation_type={}",
+                rel_label, rel.relation_type
+            );
             continue;
         }
         let sibling_title = if !rel.title_english.is_empty() {
@@ -2525,17 +2552,37 @@ pub fn detect_sibling_entries_in_pack(
         } else if !rel.title_romaji.is_empty() {
             rel.title_romaji.as_str()
         } else {
+            tracing::debug!(
+                "auto-expand: subtitle skip rel_idx={} reason=no-title relation_type={}",
+                rel_idx, rel.relation_type
+            );
             continue;
         };
         let Some(subtitle) = trailing_subtitle_of(sibling_title) else {
+            tracing::debug!(
+                "auto-expand: subtitle skip rel='{}' reason=no-trailing-subtitle relation_type={}",
+                sibling_title, rel.relation_type
+            );
             continue;
         };
         let needle = normalize_subtitle(&subtitle);
         if needle.is_empty() {
+            tracing::debug!(
+                "auto-expand: subtitle skip rel='{}' reason=empty-needle subtitle='{}'",
+                sibling_title, subtitle
+            );
             continue;
         }
+        tracing::debug!(
+            "auto-expand: subtitle candidate rel='{}' relation_type={} subtitle='{}' needle='{}'",
+            sibling_title, rel.relation_type, subtitle, needle
+        );
         candidates.push((rel_idx, subtitle, needle));
     }
+    tracing::debug!(
+        "auto-expand: subtitle path produced {} candidate(s)",
+        candidates.len()
+    );
 
     // NOTE: intentionally do NOT early-return on empty `candidates`.
     // The subtitle path can't find siblings whose titles either lack
@@ -2610,11 +2657,11 @@ pub fn detect_sibling_entries_in_pack(
     }
 
     // Episode-range fallback: if the subtitle path came up empty
-    // (e.g. a NoobSubs-style pack where filenames carry plain episode
-    // numbers and no arc name, so `trailing_subtitle_of` + substring
-    // matching cannot find siblings), try to attribute episode-number
-    // overflow (files whose ep > parent's episode count) to a sibling
-    // whose own episode count makes the range fit.
+    // (e.g. a pack whose filenames carry plain episode numbers with
+    // no arc name, so `trailing_subtitle_of` + substring matching
+    // cannot find siblings), try to attribute episode-number overflow
+    // (files whose ep > parent's episode count) to a sibling whose own
+    // episode count makes the range fit.
     //
     // Only runs when `out.is_empty()` — i.e. the primary subtitle path
     // produced zero matches. If even one sibling was subtitle-matched,
@@ -2691,29 +2738,48 @@ fn detect_sibling_via_episode_range(
     parent_detail: &AnimeDetail,
 ) -> Option<SiblingMatch> {
     let parent_cap = parent_detail.episodes.unwrap_or(0);
+    tracing::debug!(
+        "auto-expand: fallback start parent_cap={} relations={}",
+        parent_cap,
+        parent_detail.relations.len()
+    );
     if parent_cap <= 0 {
+        tracing::debug!("auto-expand: fallback bail reason=parent_cap<=0 (parent has no episode count)");
         return None;
     }
 
     // Parse episodes per file (media files only).
     let mut overflow: Vec<(usize, i32)> = Vec::new();
+    let mut media_count: usize = 0;
+    let mut parsed_count: usize = 0;
     for (idx, name) in filenames.iter().enumerate() {
         if !is_media_filename(name) {
             continue;
         }
+        media_count += 1;
         let Some((_, ep)) = media::parse_episode_number(&name.to_ascii_lowercase()) else {
             continue;
         };
+        parsed_count += 1;
         if ep > parent_cap {
             overflow.push((idx, ep));
         }
     }
+    tracing::debug!(
+        "auto-expand: fallback overflow scan media_files={} parsed={} overflow_files={} parent_cap={}",
+        media_count, parsed_count, overflow.len(), parent_cap
+    );
     if overflow.is_empty() {
+        tracing::debug!("auto-expand: fallback bail reason=no-overflow-files (no parsed ep > parent_cap)");
         return None;
     }
     let overflow_min = overflow.iter().map(|(_, e)| *e).min().unwrap();
     let overflow_max = overflow.iter().map(|(_, e)| *e).max().unwrap();
     let overflow_count = overflow.len();
+    tracing::debug!(
+        "auto-expand: fallback overflow range [{}..={}] count={}",
+        overflow_min, overflow_max, overflow_count
+    );
 
     // Parent title prefixes for continuation matching. Both english
     // and romaji forms are tried because AniList releases are
@@ -2724,19 +2790,42 @@ fn detect_sibling_via_episode_range(
         .into_iter()
         .filter(|s| !s.is_empty())
         .collect();
+    tracing::debug!(
+        "auto-expand: fallback parent prefixes en='{}' ro='{}'",
+        parent_en, parent_ro
+    );
 
     // Walk relations for viable candidates.
     let mut viable: Vec<(usize, bool)> = Vec::new(); // (rel_idx, title_prefix_matched)
     for (rel_idx, rel) in parent_detail.relations.iter().enumerate() {
+        let rel_label = if !rel.title_english.is_empty() {
+            rel.title_english.as_str()
+        } else {
+            rel.title_romaji.as_str()
+        };
         if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            tracing::debug!(
+                "auto-expand: fallback skip rel='{}' reason=media_type={}",
+                rel_label, rel.media_type
+            );
             continue;
         }
         if !is_pack_candidate_relation(&rel.relation_type) {
+            tracing::debug!(
+                "auto-expand: fallback skip rel='{}' reason=relation_type={}",
+                rel_label, rel.relation_type
+            );
             continue;
         }
         let sib_cap = match rel.episodes {
             Some(n) if n > 0 => n,
-            _ => continue,
+            _ => {
+                tracing::debug!(
+                    "auto-expand: fallback skip rel='{}' reason=no-episode-count episodes={:?} relation_type={}",
+                    rel_label, rel.episodes, rel.relation_type
+                );
+                continue;
+            }
         };
 
         // Title-prefix test against both english and romaji forms of
@@ -2752,6 +2841,10 @@ fn detect_sibling_via_episode_range(
         });
         let is_sequel = rel.relation_type.eq_ignore_ascii_case("SEQUEL");
         if !title_prefix_matched && !is_sequel {
+            tracing::debug!(
+                "auto-expand: fallback skip rel='{}' reason=neither-sequel-nor-title-prefix relation_type={} rel_en='{}' rel_ro='{}'",
+                rel_label, rel.relation_type, rel_en, rel_ro
+            );
             continue;
         }
 
@@ -2759,26 +2852,49 @@ fn detect_sibling_via_episode_range(
         let expected_min = parent_cap + 1;
         let expected_max = parent_cap + sib_cap;
         if overflow_min < expected_min || overflow_max > expected_max {
+            tracing::debug!(
+                "auto-expand: fallback skip rel='{}' reason=range-mismatch sib_cap={} expected=[{}..={}] overflow=[{}..={}]",
+                rel_label, sib_cap, expected_min, expected_max, overflow_min, overflow_max
+            );
             continue;
         }
         if !within_episode_slack(overflow_count, sib_cap) {
+            tracing::debug!(
+                "auto-expand: fallback skip rel='{}' reason=slack-cap overflow_count={} sib_cap={}",
+                rel_label, overflow_count, sib_cap
+            );
             continue;
         }
 
+        tracing::debug!(
+            "auto-expand: fallback viable rel='{}' sib_cap={} title_prefix_matched={} is_sequel={}",
+            rel_label, sib_cap, title_prefix_matched, is_sequel
+        );
         viable.push((rel_idx, title_prefix_matched));
     }
 
     let chosen = match viable.len() {
-        0 => return None,
+        0 => {
+            tracing::debug!("auto-expand: fallback bail reason=zero-viable-candidates");
+            return None;
+        }
         1 => viable[0].0,
         _ => {
             // Tiebreaker: prefer title-prefix-matched candidates.
             let prefixed: Vec<usize> =
                 viable.iter().filter(|(_, p)| *p).map(|(i, _)| *i).collect();
             if prefixed.len() == 1 {
+                tracing::debug!(
+                    "auto-expand: fallback tiebreaker resolved via title-prefix viable={}",
+                    viable.len()
+                );
                 prefixed[0]
             } else {
                 // Still ambiguous — refuse to guess.
+                tracing::debug!(
+                    "auto-expand: fallback bail reason=tiebreaker-ambiguous viable={} prefixed={}",
+                    viable.len(), prefixed.len()
+                );
                 return None;
             }
         }
@@ -2788,6 +2904,15 @@ fn detect_sibling_via_episode_range(
     let sib_cap = rel.episodes.unwrap_or(0);
     let mut file_indices: Vec<usize> = overflow.iter().map(|(i, _)| *i).collect();
     file_indices.sort_unstable();
+    let chosen_label = if !rel.title_english.is_empty() {
+        rel.title_english.as_str()
+    } else {
+        rel.title_romaji.as_str()
+    };
+    tracing::debug!(
+        "auto-expand: fallback chose rel='{}' anilist_id={} sib_cap={} files={}",
+        chosen_label, rel.id, sib_cap, file_indices.len()
+    );
 
     Some(SiblingMatch {
         anilist_id: rel.id,
@@ -3782,41 +3907,41 @@ mod tests {
     // ── Layer 2: episode-range fallback ────────────────────────────
 
     #[test]
-    fn detect_siblings_fallback_catches_noobsubs_jojo_single_word_arc() {
-        // NoobSubs JoJo SDC+Egypt-hen pack: filenames are plain
-        // "Stardust Crusaders - NN" with no arc subtitle for the
-        // Egypt-hen portion. Subtitle detection cannot fire because
-        // Egypt-hen's trailing subtitle is single-word ("Egypt-hen")
-        // and rejected by `trailing_subtitle_of`'s ≥2-token rule.
-        // Episode-range fallback should pick up files 25-48 and
-        // attribute them to Egypt-hen with episode_offset=24.
-        let mut parent = detail_with_titles(
-            "JoJo's Bizarre Adventure: Stardust Crusaders",
-            "JoJo no Kimyou na Bouken: Stardust Crusaders",
-        );
+    fn detect_siblings_fallback_catches_bare_number_pack_single_word_arc() {
+        // 48-file continuation pack using bare space-delimited episode
+        // numbers followed by a quality bracket (no `S01E01`, no
+        // `- 25`), where the sibling's trailing subtitle is a single
+        // word and thus rejected by `trailing_subtitle_of`'s ≥2-token
+        // rule. The subtitle path produces zero matches and files
+        // 25-48 must come through the episode-range fallback, which
+        // attributes them to the sibling with
+        // `episode_offset = parent_cap`.
+        //
+        // Filenames here are synthetic token strings — the only thing
+        // the test cares about is the bare-digit + quality-bracket
+        // shape, since that's what `parse_episode_number`'s new
+        // RE_BARE_NUM_BRACKET branch keys on.
+        let mut parent = detail_with_titles("Parent Show", "Parent Show Romaji");
         parent.id = 20474;
         parent.episodes = Some(24);
         parent.relations = vec![related(
             20799,
-            "JoJo's Bizarre Adventure: Stardust Crusaders - Egypt-hen",
-            "JoJo no Kimyou na Bouken: Stardust Crusaders - Egypt-hen",
+            "Parent Show - Coda",
+            "Parent Show - Coda",
             "SEQUEL",
             Some(24),
         )];
 
         let mut files: Vec<String> = Vec::new();
         for n in 1..=48 {
-            files.push(format!(
-                "[NoobSubs] JoJo's Bizarre Adventure Stardust Crusaders - {:02}.mkv",
-                n
-            ));
+            files.push(format!("fixture-parent-show {:02} (bd-1080p) [hash].mkv", n));
         }
 
         let siblings = detect_sibling_entries_in_pack(&files, &parent);
         assert_eq!(siblings.len(), 1, "fallback should find one sibling");
         let s = &siblings[0];
         assert_eq!(s.anilist_id, 20799);
-        // Egypt-hen claims files 24..48 (indices 24..=47 → eps 25..=48).
+        // Sibling claims files 24..48 (indices 24..=47 → eps 25..=48).
         assert_eq!(s.file_indices.len(), 24);
         assert_eq!(*s.file_indices.first().unwrap(), 24);
         assert_eq!(*s.file_indices.last().unwrap(), 47);

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2471,6 +2471,124 @@ fn is_pack_candidate_relation(relation_type: &str) -> bool {
     )
 }
 
+/// Maximum number of depth-1 AniList fetches per auto-expand grab.
+/// Bounds our AL API usage so a deeply-linked franchise doesn't blow
+/// past the background rate limits when we try to graft transitive
+/// relations onto the parent's relation list. Any franchise needing
+/// more than 10 hops out from the parent is almost certainly a
+/// signal-to-noise loss anyway.
+pub const TRANSITIVE_WALK_MAX_FETCHES: usize = 10;
+
+/// Which of `parent.relations`' edges warrant walking one hop
+/// further to graft their own relations onto the parent? This is a
+/// NARROWER gate than [`is_pack_candidate_relation`] because each
+/// step we take is an extra AL fetch — we only chase franchise-core
+/// links (not SUMMARY, not ALTERNATIVE / alternate retellings) to
+/// avoid pulling in genuinely unrelated entries that happen to be
+/// loosely associated.
+///
+/// Motivating case: Owarimonogatari (AL 21262) does not list
+/// Owarimonogatari 2nd Season (AL 99423) in its direct relations,
+/// but its PREQUEL Monogatari Series Second Season does reach it
+/// via the saga's shared continuation graph. Walking PREQUEL
+/// outward from the parent is what lets sibling detection find it.
+pub fn is_transitive_walk_source(relation_type: &str) -> bool {
+    matches!(
+        relation_type,
+        "PREQUEL" | "SEQUEL" | "PARENT" | "SIDE_STORY" | "SPIN_OFF"
+    )
+}
+
+/// Build the set of depth-1 transitive relations to graft onto
+/// `parent.relations`. For every direct relation whose type passes
+/// [`is_transitive_walk_source`] and which appears in
+/// `neighbor_details` (the caller is responsible for fetching the
+/// map from AL), pull in that neighbor's OWN relations — filtered
+/// through [`is_pack_candidate_relation`] and de-duplicated against
+/// the parent id plus every id already present in `parent.relations`.
+///
+/// Pure function: takes a pre-fetched neighbor map so it's
+/// deterministic and testable without live AniList. The caller is
+/// responsible for honoring [`TRANSITIVE_WALK_MAX_FETCHES`] when
+/// populating the map.
+///
+/// # Why a graft (not a rewalk)
+///
+/// We don't recursively walk the graph — one hop is enough to catch
+/// the Monogatari / JoJo-style missing-edge cases without pulling in
+/// unrelated franchises. Going depth-2 would start grafting e.g.
+/// side-story side-stories that have nothing to do with the grabbed
+/// pack, and each extra hop is another AL API call per grab.
+pub fn transitive_relation_graft(
+    parent: &AnimeDetail,
+    neighbor_details: &std::collections::HashMap<i64, AnimeDetail>,
+) -> Vec<RelatedEntry> {
+    if parent.id <= 0 {
+        return Vec::new();
+    }
+    // Track ids we've already accepted to avoid duplicates and
+    // cycles. Seed with the parent id and every direct-relation id
+    // so a neighbor's relation list can't re-add either.
+    let mut seen: std::collections::HashSet<i64> =
+        std::collections::HashSet::with_capacity(parent.relations.len() + 1);
+    seen.insert(parent.id);
+    for direct in &parent.relations {
+        seen.insert(direct.id);
+    }
+
+    let mut graft: Vec<RelatedEntry> = Vec::new();
+    for direct in &parent.relations {
+        if !is_transitive_walk_source(&direct.relation_type) {
+            continue;
+        }
+        if !direct.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        let Some(neighbor_detail) = neighbor_details.get(&direct.id) else {
+            continue;
+        };
+        for hop in &neighbor_detail.relations {
+            if hop.id <= 0 {
+                continue;
+            }
+            if !seen.insert(hop.id) {
+                continue;
+            }
+            if !hop.media_type.eq_ignore_ascii_case("ANIME") {
+                continue;
+            }
+            if !is_pack_candidate_relation(&hop.relation_type) {
+                continue;
+            }
+            graft.push(hop.clone());
+        }
+    }
+    graft
+}
+
+/// Return a cloned `parent` whose `relations` vec has been extended
+/// by [`transitive_relation_graft`]. When the graft is empty this
+/// still returns a clone so the caller can pass a single
+/// `&AnimeDetail` into sibling detection regardless of whether the
+/// walk found anything.
+pub fn expand_parent_with_transitive_relations(
+    parent: &AnimeDetail,
+    neighbor_details: &std::collections::HashMap<i64, AnimeDetail>,
+) -> AnimeDetail {
+    let graft = transitive_relation_graft(parent, neighbor_details);
+    if graft.is_empty() {
+        return parent.clone();
+    }
+    tracing::debug!(
+        "auto-expand: transitive walk grafted {} additional relation(s) onto parent id={}",
+        graft.len(),
+        parent.id
+    );
+    let mut expanded = parent.clone();
+    expanded.relations.extend(graft);
+    expanded
+}
+
 /// Detect sibling anime entries (sequel / prequel / side story /
 /// etc. of the parent) whose own episodes are present in a megapack
 /// release's file list.
@@ -4122,6 +4240,333 @@ mod tests {
         assert_eq!(*s.file_indices.last().unwrap(), 19);
         assert!(s.matched_subtitle.starts_with("episode-range fallback"));
         assert_eq!(s.episode_offset, 13, "absolute numbering → offset = parent cap");
+    }
+
+    // ── transitive_relation_graft ────────────────────────────────────
+
+    /// Build an `AnimeDetail` with a specific id, titles, episode
+    /// count, and a pre-populated relation list. Used by the
+    /// transitive-walk tests to construct the neighbor details that
+    /// the graft helper walks into.
+    fn detail_with_relations(
+        id: i64,
+        english: &str,
+        romaji: &str,
+        episodes: Option<i32>,
+        relations: Vec<RelatedEntry>,
+    ) -> AnimeDetail {
+        let mut d = detail_with_titles(english, romaji);
+        d.id = id;
+        d.episodes = episodes;
+        d.relations = relations;
+        d.format = "TV".to_string();
+        d
+    }
+
+    #[test]
+    fn transitive_graft_pulls_in_second_hop_when_direct_relations_are_missing_edge() {
+        // Parent has ONE direct PREQUEL neighbor. That neighbor's own
+        // relations include a sibling that is NOT in the parent's
+        // direct relations — the missing-edge case the walk exists to
+        // fix. Graft should surface the missing sibling.
+        let parent_id = 100;
+        let neighbor_id = 200;
+        let missing_sibling_id = 300;
+
+        let parent = detail_with_relations(
+            parent_id,
+            "Parent Show",
+            "Parent Show",
+            Some(12),
+            vec![related(
+                neighbor_id,
+                "Neighbor",
+                "Neighbor",
+                "PREQUEL",
+                Some(26),
+            )],
+        );
+        let neighbor = detail_with_relations(
+            neighbor_id,
+            "Neighbor",
+            "Neighbor",
+            Some(26),
+            vec![
+                // Back-edge to parent — must be deduped out.
+                related(parent_id, "Parent Show", "Parent Show", "SEQUEL", Some(12)),
+                // The sibling we want to surface.
+                related(
+                    missing_sibling_id,
+                    "Parent Show Continuation",
+                    "Parent Show Continuation",
+                    "SEQUEL",
+                    Some(7),
+                ),
+            ],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(neighbor_id, neighbor);
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert_eq!(graft.len(), 1, "back-edge to parent must be deduped");
+        assert_eq!(graft[0].id, missing_sibling_id);
+    }
+
+    #[test]
+    fn transitive_graft_skips_non_walkable_relation_types() {
+        // Parent has an ADAPTATION neighbor (manga). The walk must
+        // NOT fetch into it even if we seed the map — is_pack_candidate
+        // already blocks ADAPTATION as a direct sibling, and
+        // is_transitive_walk_source must also block it as a walk
+        // source.
+        let parent = detail_with_relations(
+            1,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![related(2, "Manga", "Manga", "ADAPTATION", None)],
+        );
+        // Seed neighbor map anyway — graft should ignore it because
+        // the direct relation's type isn't walkable.
+        let neighbor = detail_with_relations(
+            2,
+            "Manga",
+            "Manga",
+            None,
+            vec![related(3, "Something Else", "Something Else", "SEQUEL", Some(13))],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor);
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert!(
+            graft.is_empty(),
+            "ADAPTATION direct relation must not be walked"
+        );
+    }
+
+    #[test]
+    fn transitive_graft_dedupes_against_direct_relations() {
+        // Parent already has a direct relation to id=5. Its neighbor
+        // (reachable via PREQUEL) also lists id=5 as a sibling. The
+        // graft must NOT return id=5 again — it's already in the
+        // parent's direct list.
+        let parent = detail_with_relations(
+            1,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![
+                related(2, "Neighbor", "Neighbor", "PREQUEL", Some(26)),
+                related(5, "Already Direct", "Already Direct", "SEQUEL", Some(7)),
+            ],
+        );
+        let neighbor = detail_with_relations(
+            2,
+            "Neighbor",
+            "Neighbor",
+            Some(26),
+            vec![
+                related(5, "Already Direct", "Already Direct", "SEQUEL", Some(7)),
+                // Also a truly new one.
+                related(9, "Genuinely New", "Genuinely New", "SEQUEL", Some(12)),
+            ],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor);
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert_eq!(graft.len(), 1, "id=5 must be deduped against direct");
+        assert_eq!(graft[0].id, 9);
+    }
+
+    #[test]
+    fn transitive_graft_filters_adaptation_hops() {
+        // Parent's neighbor is a valid PREQUEL. But that neighbor's
+        // OWN relations include a manga ADAPTATION. The hop filter
+        // (is_pack_candidate_relation) must discard ADAPTATION hops
+        // so they're never considered as siblings.
+        let parent = detail_with_relations(
+            1,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![related(2, "Neighbor", "Neighbor", "PREQUEL", Some(26))],
+        );
+        let neighbor = detail_with_relations(
+            2,
+            "Neighbor",
+            "Neighbor",
+            Some(26),
+            vec![
+                {
+                    let mut r = related(3, "Manga Source", "Manga Source", "ADAPTATION", None);
+                    r.media_type = "MANGA".to_string();
+                    r
+                },
+                related(4, "Anime Sequel", "Anime Sequel", "SEQUEL", Some(12)),
+            ],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor);
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert_eq!(graft.len(), 1);
+        assert_eq!(graft[0].id, 4);
+    }
+
+    #[test]
+    fn transitive_graft_returns_empty_when_parent_id_is_non_positive() {
+        // Provenance gate: don't graft for Jikan-sourced details.
+        let parent = detail_with_relations(
+            -123,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![related(2, "Neighbor", "Neighbor", "PREQUEL", Some(26))],
+        );
+        let neighbor = detail_with_relations(
+            2,
+            "Neighbor",
+            "Neighbor",
+            Some(26),
+            vec![related(3, "Sibling", "Sibling", "SEQUEL", Some(12))],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor);
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert!(graft.is_empty());
+    }
+
+    #[test]
+    fn transitive_graft_ignores_missing_neighbors_in_map() {
+        // If the caller hit the fetch cap and didn't populate every
+        // neighbor, graft must silently skip the un-fetched ones.
+        let parent = detail_with_relations(
+            1,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![
+                related(2, "Fetched Neighbor", "Fetched Neighbor", "PREQUEL", Some(26)),
+                related(7, "Unfetched Neighbor", "Unfetched Neighbor", "SEQUEL", Some(26)),
+            ],
+        );
+        let neighbor_2 = detail_with_relations(
+            2,
+            "Fetched Neighbor",
+            "Fetched Neighbor",
+            Some(26),
+            vec![related(5, "New Sibling", "New Sibling", "SEQUEL", Some(12))],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor_2);
+        // Note: id=7 is intentionally NOT in the map.
+
+        let graft = transitive_relation_graft(&parent, &neighbors);
+        assert_eq!(graft.len(), 1);
+        assert_eq!(graft[0].id, 5);
+    }
+
+    #[test]
+    fn expand_parent_with_transitive_relations_extends_relations_vec() {
+        // Integration: the wrapper appends the graft onto the cloned
+        // parent's relations vec. Previously-present relations stay.
+        let parent = detail_with_relations(
+            1,
+            "Parent",
+            "Parent",
+            Some(12),
+            vec![related(2, "Neighbor", "Neighbor", "PREQUEL", Some(26))],
+        );
+        let neighbor = detail_with_relations(
+            2,
+            "Neighbor",
+            "Neighbor",
+            Some(26),
+            vec![related(3, "Grafted", "Grafted", "SEQUEL", Some(13))],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(2, neighbor);
+
+        let expanded = expand_parent_with_transitive_relations(&parent, &neighbors);
+        assert_eq!(expanded.relations.len(), 2);
+        let ids: Vec<i64> = expanded.relations.iter().map(|r| r.id).collect();
+        assert!(ids.contains(&2), "direct relation must remain");
+        assert!(ids.contains(&3), "grafted relation must be appended");
+    }
+
+    #[test]
+    fn expand_parent_with_empty_graft_still_returns_clone() {
+        // When the walk produces no graft (e.g. no walkable direct
+        // relations), the wrapper still returns a cloned detail so
+        // callers can pass a single owned AnimeDetail into sibling
+        // detection regardless.
+        let parent = detail_with_relations(1, "Parent", "Parent", Some(12), vec![]);
+        let neighbors = std::collections::HashMap::new();
+        let expanded = expand_parent_with_transitive_relations(&parent, &neighbors);
+        assert_eq!(expanded.id, parent.id);
+        assert!(expanded.relations.is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_finds_grafted_relation_after_transitive_walk() {
+        // End-to-end: parent has no direct edge to the sibling whose
+        // episodes are in the pack, but a PREQUEL neighbor does. After
+        // running the expand step, detect_sibling_entries_in_pack
+        // should pick up the grafted sibling. This is the Monogatari
+        // missing-edge case modeled structurally.
+        let parent_id = 21262;
+        let neighbor_id = 20899;
+        let grafted_id = 99423;
+
+        let parent = detail_with_relations(
+            parent_id,
+            "Parent Show",
+            "Parent Show",
+            Some(12),
+            vec![related(
+                neighbor_id,
+                "Parent Show Franchise",
+                "Parent Show Franchise",
+                "PREQUEL",
+                Some(26),
+            )],
+        );
+        let neighbor = detail_with_relations(
+            neighbor_id,
+            "Parent Show Franchise",
+            "Parent Show Franchise",
+            Some(26),
+            vec![related(
+                grafted_id,
+                "Parent Show: Continuation Arc",
+                "Parent Show: Continuation Arc",
+                "SEQUEL",
+                Some(7),
+            )],
+        );
+        let mut neighbors = std::collections::HashMap::new();
+        neighbors.insert(neighbor_id, neighbor);
+
+        let expanded = expand_parent_with_transitive_relations(&parent, &neighbors);
+
+        // Subtitle path: filenames mention "Continuation Arc" as the
+        // trailing subtitle. Use synthetic tokens — no real group or
+        // real release title formatting claimed here.
+        let files: Vec<String> = (1..=7)
+            .map(|n| format!("fixture-parent-show continuation arc - {:02} (bd 1080p) [hash].mkv", n))
+            .collect();
+
+        let siblings = detect_sibling_entries_in_pack(&files, &expanded);
+        assert_eq!(
+            siblings.len(),
+            1,
+            "grafted sibling should be detected after transitive walk"
+        );
+        assert_eq!(siblings[0].anilist_id, grafted_id);
+        assert_eq!(siblings[0].file_indices.len(), 7);
     }
 
     #[test]

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -519,10 +519,20 @@ async fn collect_scored_for_target(
     // view URLs — this is how the smol Kizumonogatari pack (titled
     // `[smol] Monogatari (Season 9) ...`) gets into the pool for a
     // Kizumonogatari Part 2 target whose text queries would never
-    // match the smol filename. The batch filter at `run_queries`
-    // already has a SeaDex-match bypass so `allow_batch=false` targets
-    // still see SeaDex-curated megapacks.
+    // match the smol filename.
+    //
+    // Per-episode auto-search targets (`allow_batch=false`) mean "don't
+    // add batches in this search" — the user has explicitly opted out
+    // of batch grabs for episode search. Without this filter, every
+    // episode search on a SeaDex-curated series with a megapack
+    // top-hit would resurrect that batch into the candidate pool,
+    // bypassing the setting. SeaDex curation does not override the
+    // user's batch-allowed policy; it only overrides the heuristic
+    // title-matching gate inside `run_queries`.
     for result in seadex_payload.candidates {
+        if !allow_batch && result.is_batch {
+            continue;
+        }
         let dedupe_key = if !result.info_hash.is_empty() {
             result.info_hash.clone()
         } else {
@@ -743,11 +753,19 @@ async fn run_queries(
                 // otherwise fail `matches_target` (e.g. smol's
                 // `Monogatari (Season 9)` release for a Kizumonogatari
                 // Part 2 target).
+                //
+                // Batch filter runs unconditionally even for SeaDex
+                // matches: an episode-search target with `allow_batch=
+                // false` is an explicit "don't pull batches during
+                // per-episode search" request from the user, and
+                // silently letting SeaDex-curated batches through would
+                // bypass that setting. SeaDex bypasses *heuristic* title
+                // matching, not the user's batch-allowed policy.
+                if !ctx.allow_batch && result.is_batch {
+                    continue;
+                }
                 let is_seadex_best = is_seadex_match(&result.info_hash, ctx.seadex_hashes);
                 if !is_seadex_best {
-                    if !ctx.allow_batch && result.is_batch {
-                        continue;
-                    }
                     if !matches_target(&result.title, ctx.aliases, ctx.target, ctx.expected_season, ctx.batch_episode_match && result.is_batch) {
                         continue;
                     }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -159,6 +159,7 @@ pub async fn find_all_for_target(
     let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
+    let sibling_aliases = collect_sibling_aliases(detail, &aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -179,6 +180,7 @@ pub async fn find_all_for_target(
 
     let ctx = InteractiveQueryCtx {
         aliases: &aliases,
+        sibling_aliases: &sibling_aliases,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -347,6 +349,7 @@ pub async fn collect_scored_batches_for_target(
     let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
+    let sibling_aliases = collect_sibling_aliases(detail, &aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -369,6 +372,7 @@ pub async fn collect_scored_batches_for_target(
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
+        sibling_aliases: &sibling_aliases,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -512,6 +516,7 @@ async fn collect_scored_for_target(
     let seadex_hashes = seadex_payload.hashes;
 
     let expected_season = infer_season_from_detail(detail);
+    let sibling_aliases = collect_sibling_aliases(detail, &aliases);
     let mut seen = HashSet::new();
     let mut candidates: Vec<SearchResult> = Vec::new();
 
@@ -547,6 +552,7 @@ async fn collect_scored_for_target(
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
+        sibling_aliases: &sibling_aliases,
         preferred_groups: &preferred_groups,
         preferred_resolution: &preferred_res,
         target,
@@ -674,6 +680,11 @@ async fn collect_scored_for_target(
 #[derive(Clone, Copy)]
 struct AutoQueryCtx<'a> {
     aliases: &'a [String],
+    /// Titles of sibling entries (sequels, prequels, side stories) from
+    /// AniList relations. A release whose token overlap with any sibling
+    /// beats its overlap with every own-alias is rejected — see
+    /// `collect_sibling_aliases` for the JJK S1→S3 motivating case.
+    sibling_aliases: &'a [String],
     preferred_groups: &'a [String],
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
@@ -698,6 +709,7 @@ struct AutoQueryCtx<'a> {
 #[derive(Clone, Copy)]
 struct InteractiveQueryCtx<'a> {
     aliases: &'a [String],
+    sibling_aliases: &'a [String],
     preferred_groups: &'a [String],
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
@@ -766,7 +778,14 @@ async fn run_queries(
                 }
                 let is_seadex_best = is_seadex_match(&result.info_hash, ctx.seadex_hashes);
                 if !is_seadex_best {
-                    if !matches_target(&result.title, ctx.aliases, ctx.target, ctx.expected_season, ctx.batch_episode_match && result.is_batch) {
+                    if !matches_target(
+                        &result.title,
+                        ctx.aliases,
+                        ctx.sibling_aliases,
+                        ctx.target,
+                        ctx.expected_season,
+                        ctx.batch_episode_match && result.is_batch,
+                    ) {
                         continue;
                     }
                 } else {
@@ -842,6 +861,12 @@ async fn run_queries_interactive(
                     || token_overlap_ratio(&title_tokens, &token_set(&normalized_alias)) >= 0.5
             });
             if !alias_match {
+                continue;
+            }
+            // Sibling rejection: same sequel/prequel guard as the auto
+            // path — a release that matches a sibling more tightly than
+            // us is almost certainly for the sibling.
+            if sibling_match_rejects(&title_tokens, ctx.aliases, ctx.sibling_aliases) {
                 continue;
             }
             // Season check: reject results clearly from a different season
@@ -1046,6 +1071,147 @@ pub fn collect_aliases(detail: &AnimeDetail) -> Vec<String> {
     ])
 }
 
+/// Distinctive titles of this series' siblings (sequels, prequels, side
+/// stories, alternative versions, spin-offs, summaries) — used to reject
+/// releases that look MORE like a sibling than the target.
+///
+/// The motivating bug: auto-searching for Jujutsu Kaisen S1 E6 grabbed a
+/// release titled `[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen -
+/// 06`, which is actually an S2/S3 arc. The existing season_mismatch()
+/// heuristic only catches explicit `S02` / `Season 2` markers; an arc
+/// title like "Shimetsu Kaiyuu" slips through. But AniList knows that
+/// "Jujutsu Kaisen: Shimetsu Kaiyuu" is a SEQUEL of JJK S1 — so we can
+/// use the relation graph to derive the distinctive tokens that, when
+/// present in a release filename, mean "this is the sibling, not me".
+///
+/// Returns sibling titles only where the sibling's normalized title is
+/// NOT a substring of any of this target's own aliases (otherwise the
+/// sibling title would match the target too — e.g. a prequel sharing
+/// the base franchise name is not a useful discriminator). The returned
+/// titles are still raw (un-normalized) so the matching logic can
+/// re-normalize them the same way it does the release title.
+pub fn collect_sibling_aliases(detail: &AnimeDetail, own_aliases: &[String]) -> Vec<String> {
+    if detail.id <= 0 || detail.relations.is_empty() {
+        return Vec::new();
+    }
+
+    // Normalized own-alias set — used to filter out sibling titles that
+    // are themselves substrings of one of our own aliases (those would
+    // substring-match us too, so they're not distinctive).
+    let normalized_own: Vec<String> = own_aliases
+        .iter()
+        .map(|a| normalize_title(a))
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    let mut out: Vec<String> = Vec::new();
+    for rel in &detail.relations {
+        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        if !is_pack_candidate_relation(&rel.relation_type) {
+            continue;
+        }
+        // Consider all three title fields so romaji-only or native-only
+        // titles still contribute. The de-dup below squashes repeats.
+        for raw in [
+            rel.title_english.as_str(),
+            rel.title_romaji.as_str(),
+            rel.title_native.as_str(),
+        ] {
+            if raw.is_empty() {
+                continue;
+            }
+            let normalized = normalize_title(raw);
+            // Need ≥ 2 tokens for the sibling title to be a meaningful
+            // discriminator — a single token is too generic and will
+            // false-positive on unrelated releases that happen to share
+            // a common word.
+            if normalized.split_whitespace().count() < 2 {
+                continue;
+            }
+            // Skip sibling titles whose normalized form is a substring
+            // of one of our own aliases — those can't tell us apart
+            // from the target.
+            if normalized_own.iter().any(|own| own.contains(&normalized)) {
+                continue;
+            }
+            out.push(raw.to_string());
+        }
+    }
+    dedupe_strings(out)
+}
+
+/// Reject a release when it looks MORE like one of our siblings than
+/// it does like us. The check compares token overlap: if any sibling
+/// alias shares strictly more tokens with the release than the best
+/// target alias does, the release is for the sibling.
+///
+/// Returns `true` to reject, `false` to keep.
+///
+/// Called from `matches_target` and the interactive-search path. Both
+/// are guarded by an upstream basic alias-match, so by the time we get
+/// here the release already passes the "could plausibly be us" gate —
+/// the sibling check is the last defense against "plausibly us" also
+/// being "more plausibly a sibling".
+fn sibling_match_rejects(
+    normalized_release_tokens: &HashSet<String>,
+    own_aliases: &[String],
+    sibling_aliases: &[String],
+) -> bool {
+    if sibling_aliases.is_empty() {
+        return false;
+    }
+
+    // Best token overlap COUNT between release and any of our own aliases.
+    // Using absolute overlap count (not ratio) so a sibling with 4 matching
+    // tokens beats a target alias with 2 matching tokens even if the target
+    // alias has fewer tokens overall.
+    let best_own_overlap: usize = own_aliases
+        .iter()
+        .map(|a| {
+            let tokens = token_set(&normalize_title(a));
+            normalized_release_tokens.intersection(&tokens).count()
+        })
+        .max()
+        .unwrap_or(0);
+
+    for sibling in sibling_aliases {
+        let normalized_sibling = normalize_title(sibling);
+        let sibling_tokens = token_set(&normalized_sibling);
+        if sibling_tokens.is_empty() {
+            continue;
+        }
+        let sibling_overlap = normalized_release_tokens
+            .intersection(&sibling_tokens)
+            .count();
+        // Strictly greater: a tie means both the target and the sibling
+        // match equally well, which is the normal case for a release
+        // like "Jujutsu Kaisen - 06" where sibling "Jujutsu Kaisen 2nd
+        // Season" also overlaps on {jujutsu, kaisen}. Only reject when
+        // the sibling picks up EXTRA tokens that the target doesn't.
+        if sibling_overlap > best_own_overlap {
+            // Also require that the sibling's entire normalized title
+            // is either a contiguous substring of the release or that
+            // ALL of its tokens appear in the release. This prevents
+            // freak two-token overlaps ("side story" + some other
+            // common fragment) from tripping the rejection.
+            let normalized_release_joined: String = normalized_release_tokens
+                .iter()
+                .cloned()
+                .collect::<Vec<_>>()
+                .join(" ");
+            let all_tokens_present = sibling_tokens
+                .iter()
+                .all(|t| normalized_release_tokens.contains(t));
+            if all_tokens_present || normalized_release_joined.contains(&normalized_sibling) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Extended aliases: synonyms + decomposed sub-phrases from compound titles.
 /// Only used as a fallback when primary aliases don't find results.
 pub fn collect_extended_aliases(detail: &AnimeDetail) -> Vec<String> {
@@ -1148,7 +1314,14 @@ pub fn dedupe_strings(values: Vec<String>) -> Vec<String> {
     out
 }
 
-pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, expected_season: i32, allow_batch_episode: bool) -> bool {
+pub fn matches_target(
+    title: &str,
+    aliases: &[String],
+    sibling_aliases: &[String],
+    target: &SearchTarget,
+    expected_season: i32,
+    allow_batch_episode: bool,
+) -> bool {
     let normalized_title = normalize_title(title);
     let title_tokens = token_set(&normalized_title);
 
@@ -1159,6 +1332,13 @@ pub fn matches_target(title: &str, aliases: &[String], target: &SearchTarget, ex
     });
 
     if !alias_match {
+        return false;
+    }
+
+    // Sibling rejection: if the release looks more like a sequel /
+    // prequel / side story than it looks like us, reject. See the
+    // JJK S1→S3 case in the `collect_sibling_aliases` docstring.
+    if sibling_match_rejects(&title_tokens, aliases, sibling_aliases) {
         return false;
     }
 
@@ -2629,6 +2809,7 @@ mod tests {
             !matches_target(
                 unrelated_release,
                 &aliases,
+                &[],
                 &SearchTarget::Episode(1),
                 0,
                 false,
@@ -2644,7 +2825,73 @@ mod tests {
         assert!(matches_target(
             good_release,
             &aliases,
+            &[],
             &SearchTarget::Single,
+            0,
+            false,
+        ));
+    }
+
+    #[test]
+    fn matches_target_rejects_sibling_arc_release() {
+        // Regression: auto-searching JJK S1 E6 used to grab
+        // `[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen - 06`
+        // because the sibling arc title has no explicit "S02"/"Season 2"
+        // marker for `season_mismatch` to catch, but "Jujutsu Kaisen" is
+        // a substring of the release. The sibling check resolves this:
+        // the sibling alias "Jujutsu Kaisen: Shimetsu Kaiyuu" has 4
+        // overlapping tokens with the release vs the target's 2, so the
+        // sibling wins and the release is rejected.
+        let own = vec!["Jujutsu Kaisen".to_string()];
+        let siblings = vec!["Jujutsu Kaisen: Shimetsu Kaiyuu".to_string()];
+        let release = "[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen - 06 [1080p CR WEBRip HEVC AAC].mkv";
+        assert!(
+            !matches_target(
+                release,
+                &own,
+                &siblings,
+                &SearchTarget::Episode(6),
+                1,
+                false,
+            ),
+            "sibling arc release must not match the base-franchise target"
+        );
+    }
+
+    #[test]
+    fn matches_target_keeps_base_franchise_release_despite_siblings() {
+        // Symmetric: with the same sibling list, a plain JJK S1 release
+        // should still match the target. The sibling overlaps on only
+        // 2 tokens ({jujutsu, kaisen}) — the same as the target's own
+        // overlap — so the sibling check is a no-op.
+        let own = vec!["Jujutsu Kaisen".to_string()];
+        let siblings = vec!["Jujutsu Kaisen: Shimetsu Kaiyuu".to_string()];
+        let release = "[Erai-raws] Jujutsu Kaisen - 06 [1080p].mkv";
+        assert!(matches_target(
+            release,
+            &own,
+            &siblings,
+            &SearchTarget::Episode(6),
+            1,
+            false,
+        ));
+    }
+
+    #[test]
+    fn matches_target_keeps_target_arc_release_against_unrelated_sibling() {
+        // A JJK S2 Shibuya Incident target should still accept its own
+        // arc release even when the sibling list includes another arc.
+        let own = vec!["Jujutsu Kaisen: Shimetsu Kaiyuu".to_string()];
+        let siblings = vec![
+            "Jujutsu Kaisen".to_string(),
+            "Jujutsu Kaisen: Kaigyoku Gyokusetsu".to_string(),
+        ];
+        let release = "[Erai-raws] Jujutsu Kaisen: Shimetsu Kaiyuu - Zenpen - 06 [1080p].mkv";
+        assert!(matches_target(
+            release,
+            &own,
+            &siblings,
+            &SearchTarget::Episode(6),
             0,
             false,
         ));

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2786,9 +2786,7 @@ pub fn detect_sibling_entries_in_pack(
     // we defer to that path and accept the known limitation that this
     // fallback can't supplement partial matches.
     if out.is_empty() {
-        if let Some(m) = detect_sibling_via_episode_range(filenames, parent_detail) {
-            out.push(m);
-        }
+        out.extend(detect_sibling_via_episode_range(filenames, parent_detail));
     }
 
     // Episode-offset pass: for every detected sibling (regardless of
@@ -2836,7 +2834,13 @@ fn compute_sibling_episode_offset(
 }
 
 /// Layer 2 fallback: attribute files whose parsed episode number
-/// exceeds `parent_cap` to a single sibling relation that
+/// exceeds `parent_cap` to one or more sibling relations via an
+/// iterative sequential-packing algorithm. Each round picks the best
+/// unclaimed candidate for the next contiguous slot
+/// `[base+1..=base+sib_cap]` (starting at `base = parent_cap`) and
+/// advances `base` by `sib_cap` after consuming that slot's files.
+///
+/// A candidate is eligible for a round if it
 ///
 /// 1. passes the pack-candidate relation-type gate,
 /// 2. is either a direct `SEQUEL` OR has a title that prefixes the
@@ -2844,17 +2848,27 @@ fn compute_sibling_episode_offset(
 ///    `SEQUEL` is semantically wrong — e.g. Owarimonogatari's listed
 ///    SEQUEL is Tsukimonogatari, but the same-title continuation is
 ///    Owarimonogatari Second Season),
-/// 3. has a known episode count,
-/// 4. and whose implied absolute episode range
-///    `(parent_cap + 1)..=(parent_cap + sibling_cap)` contains every
-///    overflow file.
+/// 3. has a known episode count, and
+/// 4. has at least `ceil(sib_cap * 0.75)` (floor 1) files from the
+///    remaining overflow whose parsed `ep` falls into its expected
+///    range. Partial fit is allowed — we don't demand that every
+///    overflow file land inside the candidate's range, because real-
+///    world absolute-numbered packs often bundle tail-end siblings
+///    (e.g. a 1-episode sequel movie) that aren't in the grafted
+///    relation pool. Files outside the chosen candidate's range
+///    carry over to the next round.
 ///
-/// If multiple siblings fit, prefer the title-prefix-matched one as a
-/// tiebreaker; if that's still ambiguous, bail. If zero fit, bail.
+/// Round winner is the scored candidate with the most files in its
+/// expected range. Tiebreaker order: title-prefix-matched beats
+/// non-prefix; smaller `sib_cap` beats larger (favors the tighter
+/// fit). If the top two are tied on all criteria, the round bails
+/// and the loop terminates — we'd rather return partial results
+/// than guess. A first-round bail returns an empty `Vec`; a later-
+/// round bail keeps results from previous rounds.
 fn detect_sibling_via_episode_range(
     filenames: &[String],
     parent_detail: &AnimeDetail,
-) -> Option<SiblingMatch> {
+) -> Vec<SiblingMatch> {
     let parent_cap = parent_detail.episodes.unwrap_or(0);
     tracing::debug!(
         "auto-expand: fallback start parent_cap={} relations={}",
@@ -2863,7 +2877,7 @@ fn detect_sibling_via_episode_range(
     );
     if parent_cap <= 0 {
         tracing::debug!("auto-expand: fallback bail reason=parent_cap<=0 (parent has no episode count)");
-        return None;
+        return Vec::new();
     }
 
     // Parse episodes per file (media files only).
@@ -2889,7 +2903,7 @@ fn detect_sibling_via_episode_range(
     );
     if overflow.is_empty() {
         tracing::debug!("auto-expand: fallback bail reason=no-overflow-files (no parsed ep > parent_cap)");
-        return None;
+        return Vec::new();
     }
     let overflow_min = overflow.iter().map(|(_, e)| *e).min().unwrap();
     let overflow_max = overflow.iter().map(|(_, e)| *e).max().unwrap();
@@ -2913,8 +2927,15 @@ fn detect_sibling_via_episode_range(
         parent_en, parent_ro
     );
 
-    // Walk relations for viable candidates.
-    let mut viable: Vec<(usize, bool)> = Vec::new(); // (rel_idx, title_prefix_matched)
+    // Collect viable candidates ONCE (type/media/episode-count +
+    // prefix-or-sequel gates). Per-round range fit is decided inside
+    // the packing loop so each round can see the current `base`.
+    struct RangeCandidate {
+        rel_idx: usize,
+        sib_cap: i32,
+        title_prefix_matched: bool,
+    }
+    let mut candidates: Vec<RangeCandidate> = Vec::new();
     for (rel_idx, rel) in parent_detail.relations.iter().enumerate() {
         let rel_label = if !rel.title_english.is_empty() {
             rel.title_english.as_str()
@@ -2966,91 +2987,177 @@ fn detect_sibling_via_episode_range(
             continue;
         }
 
-        // Range-fit check.
-        let expected_min = parent_cap + 1;
-        let expected_max = parent_cap + sib_cap;
-        if overflow_min < expected_min || overflow_max > expected_max {
-            tracing::debug!(
-                "auto-expand: fallback skip rel='{}' reason=range-mismatch sib_cap={} expected=[{}..={}] overflow=[{}..={}]",
-                rel_label, sib_cap, expected_min, expected_max, overflow_min, overflow_max
-            );
-            continue;
-        }
-        if !within_episode_slack(overflow_count, sib_cap) {
-            tracing::debug!(
-                "auto-expand: fallback skip rel='{}' reason=slack-cap overflow_count={} sib_cap={}",
-                rel_label, overflow_count, sib_cap
-            );
-            continue;
-        }
-
         tracing::debug!(
-            "auto-expand: fallback viable rel='{}' sib_cap={} title_prefix_matched={} is_sequel={}",
+            "auto-expand: fallback candidate rel='{}' sib_cap={} title_prefix_matched={} is_sequel={}",
             rel_label, sib_cap, title_prefix_matched, is_sequel
         );
-        viable.push((rel_idx, title_prefix_matched));
+        candidates.push(RangeCandidate {
+            rel_idx,
+            sib_cap,
+            title_prefix_matched,
+        });
     }
 
-    let chosen = match viable.len() {
-        0 => {
-            tracing::debug!("auto-expand: fallback bail reason=zero-viable-candidates");
-            return None;
+    if candidates.is_empty() {
+        tracing::debug!("auto-expand: fallback bail reason=zero-viable-candidates");
+        return Vec::new();
+    }
+
+    // Sanity check: if the overflow is wildly larger than the sum
+    // of all candidate capacities, the pack almost certainly doesn't
+    // correspond to the sibling pool we see — e.g., an absolute-
+    // numbered mega-franchise where most of the real siblings aren't
+    // in our graph at all. Refuse to attribute a tiny fraction of
+    // the overflow to one sibling in that case.
+    let total_candidate_capacity: i32 = candidates.iter().map(|c| c.sib_cap).sum();
+    if !within_episode_slack(overflow_count, total_candidate_capacity) {
+        tracing::debug!(
+            "auto-expand: fallback bail reason=overflow-exceeds-total-capacity overflow_count={} total_capacity={}",
+            overflow_count, total_candidate_capacity
+        );
+        return Vec::new();
+    }
+
+    // Iterative sequential packing.
+    let mut results: Vec<SiblingMatch> = Vec::new();
+    let mut base: i32 = parent_cap;
+    let mut claimed_rel_idxs: std::collections::HashSet<usize> =
+        std::collections::HashSet::new();
+    let mut claimed_file_idxs: std::collections::HashSet<usize> =
+        std::collections::HashSet::new();
+
+    loop {
+        // Short-circuit when there are no more overflow files beyond
+        // the current base to attribute.
+        let remaining_files: Vec<(usize, i32)> = overflow
+            .iter()
+            .filter(|(f_idx, ep)| !claimed_file_idxs.contains(f_idx) && *ep > base)
+            .copied()
+            .collect();
+        if remaining_files.is_empty() {
+            break;
         }
-        1 => viable[0].0,
-        _ => {
-            // Tiebreaker: prefer title-prefix-matched candidates.
-            let prefixed: Vec<usize> =
-                viable.iter().filter(|(_, p)| *p).map(|(i, _)| *i).collect();
-            if prefixed.len() == 1 {
+
+        // Score every unclaimed candidate for this round.
+        struct Scored {
+            rel_idx: usize,
+            sib_cap: i32,
+            file_indices: Vec<usize>,
+            title_prefix_matched: bool,
+        }
+        let mut scored: Vec<Scored> = Vec::new();
+        for cand in &candidates {
+            if claimed_rel_idxs.contains(&cand.rel_idx) {
+                continue;
+            }
+            let expected_min = base + 1;
+            let expected_max = base + cand.sib_cap;
+            let in_range: Vec<usize> = remaining_files
+                .iter()
+                .filter(|(_, ep)| *ep >= expected_min && *ep <= expected_max)
+                .map(|(idx, _)| *idx)
+                .collect();
+            // Partial-fit threshold: at least ceil(sib_cap * 0.75)
+            // files, floor 1. Keeps 1-episode movies accept-able
+            // without letting a 12-ep sibling win on 1/12 files.
+            let threshold = ((cand.sib_cap as f32) * 0.75).ceil() as i32;
+            let threshold = threshold.max(1) as usize;
+            if in_range.len() < threshold {
+                continue;
+            }
+            scored.push(Scored {
+                rel_idx: cand.rel_idx,
+                sib_cap: cand.sib_cap,
+                file_indices: in_range,
+                title_prefix_matched: cand.title_prefix_matched,
+            });
+        }
+
+        if scored.is_empty() {
+            tracing::debug!(
+                "auto-expand: fallback packing stop reason=no-viable-candidate-for-round base={}",
+                base
+            );
+            break;
+        }
+
+        // Sort by: file_count DESC, title_prefix DESC, sib_cap ASC.
+        // Then detect ambiguity if the top two are fully tied.
+        scored.sort_by(|a, b| {
+            b.file_indices
+                .len()
+                .cmp(&a.file_indices.len())
+                .then(b.title_prefix_matched.cmp(&a.title_prefix_matched))
+                .then(a.sib_cap.cmp(&b.sib_cap))
+        });
+
+        if scored.len() >= 2 {
+            let top = &scored[0];
+            let next = &scored[1];
+            if top.file_indices.len() == next.file_indices.len()
+                && top.title_prefix_matched == next.title_prefix_matched
+                && top.sib_cap == next.sib_cap
+            {
                 tracing::debug!(
-                    "auto-expand: fallback tiebreaker resolved via title-prefix viable={}",
-                    viable.len()
+                    "auto-expand: fallback packing stop reason=round-ambiguous base={} candidates_tied={}",
+                    base, scored.len()
                 );
-                prefixed[0]
-            } else {
-                // Still ambiguous — refuse to guess.
-                tracing::debug!(
-                    "auto-expand: fallback bail reason=tiebreaker-ambiguous viable={} prefixed={}",
-                    viable.len(), prefixed.len()
-                );
-                return None;
+                break;
             }
         }
-    };
 
-    let rel = &parent_detail.relations[chosen];
-    let sib_cap = rel.episodes.unwrap_or(0);
-    let mut file_indices: Vec<usize> = overflow.iter().map(|(i, _)| *i).collect();
-    file_indices.sort_unstable();
-    let chosen_label = if !rel.title_english.is_empty() {
-        rel.title_english.as_str()
-    } else {
-        rel.title_romaji.as_str()
-    };
+        let winner = scored.into_iter().next().unwrap();
+        claimed_rel_idxs.insert(winner.rel_idx);
+        for f in &winner.file_indices {
+            claimed_file_idxs.insert(*f);
+        }
+
+        let rel = &parent_detail.relations[winner.rel_idx];
+        let chosen_label = if !rel.title_english.is_empty() {
+            rel.title_english.as_str()
+        } else {
+            rel.title_romaji.as_str()
+        };
+        tracing::debug!(
+            "auto-expand: fallback packing round picked rel='{}' anilist_id={} sib_cap={} files={} base_before={} base_after={}",
+            chosen_label,
+            rel.id,
+            winner.sib_cap,
+            winner.file_indices.len(),
+            base,
+            base + winner.sib_cap
+        );
+
+        let mut file_indices = winner.file_indices.clone();
+        file_indices.sort_unstable();
+        results.push(SiblingMatch {
+            anilist_id: rel.id,
+            mal_id: rel.id_mal,
+            title_romaji: rel.title_romaji.clone(),
+            title_english: rel.title_english.clone(),
+            title_native: rel.title_native.clone(),
+            cover_url: rel.cover_url.clone(),
+            format: rel.format.clone(),
+            status: rel.status.clone(),
+            episodes: rel.episodes,
+            season_year: rel.season_year,
+            matched_subtitle: format!(
+                "episode-range fallback ({}..={})",
+                base + 1,
+                base + winner.sib_cap
+            ),
+            file_indices,
+            episode_offset: 0, // populated by the offset pass in the caller
+        });
+        base += winner.sib_cap;
+    }
+
     tracing::debug!(
-        "auto-expand: fallback chose rel='{}' anilist_id={} sib_cap={} files={}",
-        chosen_label, rel.id, sib_cap, file_indices.len()
+        "auto-expand: fallback packing done siblings={} remaining_overflow_unattributed={}",
+        results.len(),
+        overflow_count - claimed_file_idxs.len()
     );
-
-    Some(SiblingMatch {
-        anilist_id: rel.id,
-        mal_id: rel.id_mal,
-        title_romaji: rel.title_romaji.clone(),
-        title_english: rel.title_english.clone(),
-        title_native: rel.title_native.clone(),
-        cover_url: rel.cover_url.clone(),
-        format: rel.format.clone(),
-        status: rel.status.clone(),
-        episodes: rel.episodes,
-        season_year: rel.season_year,
-        matched_subtitle: format!(
-            "episode-range fallback ({}..={})",
-            parent_cap + 1,
-            parent_cap + sib_cap
-        ),
-        file_indices,
-        episode_offset: 0, // populated by the offset pass in the caller
-    })
+    results
 }
 
 /// Lowercase ASCII-alphanumeric chars and collapse non-alphanumeric
@@ -4240,6 +4347,83 @@ mod tests {
         assert_eq!(*s.file_indices.last().unwrap(), 19);
         assert!(s.matched_subtitle.starts_with("episode-range fallback"));
         assert_eq!(s.episode_offset, 13, "absolute numbering → offset = parent cap");
+    }
+
+    #[test]
+    fn detect_siblings_fallback_partial_fit_multi_sibling_owari_with_zoku() {
+        // Real-world progression of the smol Owari case: the pack has
+        // 20 files (S07E01..=E20) but parent_cap = 12 (some AL data
+        // sources report Owarimonogatari with 12 ep count), so
+        // overflow = 8 files (eps 13..=20). The only graph-visible
+        // sibling is Owarimonogatari Second Season (7 eps). The 8th
+        // overflow file is Zoku Owarimonogatari, a 1-episode movie
+        // that either isn't grafted or has no episodes count.
+        //
+        // Expected: packing loop picks Owari S2 for 7 of 8 overflow
+        // files (partial fit, threshold = ceil(7*0.75) = 6), ep 20
+        // falls out as unattributed. Emitting one partial-fit
+        // sibling is better than bailing entirely, because the 7
+        // files that DO fit cleanly are definitively Owari S2.
+        let mut parent = detail_with_titles("Owarimonogatari", "Owarimonogatari");
+        parent.id = 21320;
+        parent.episodes = Some(12);
+        parent.relations = vec![
+            // Direct SEQUEL is Tsukimonogatari — fits the first 4
+            // overflow eps but not title-prefixed.
+            related(
+                20787,
+                "Tsukimonogatari",
+                "Tsukimonogatari",
+                "SEQUEL",
+                Some(4),
+            ),
+            // Same-title continuation, transitively grafted as
+            // SIDE_STORY. Owari S2 takes precedence because it's
+            // title-prefixed AND covers more of the overflow in
+            // round 1.
+            related(
+                21860,
+                "Owarimonogatari Second Season",
+                "Owarimonogatari Second Season",
+                "SIDE_STORY",
+                Some(7),
+            ),
+        ];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=12 {
+            files.push(format!(
+                "fixture-monogatari-s07e{:02}-owarimonogatari-bd-1080p.mkv",
+                n
+            ));
+        }
+        for n in 13..=19 {
+            files.push(format!(
+                "fixture-monogatari-s07e{:02}-owarimonogatari-second-season-bd-1080p.mkv",
+                n
+            ));
+        }
+        files.push(
+            "fixture-monogatari-s07e20-zoku-owarimonogatari-bd-1080p.mkv".to_string(),
+        );
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1, "must emit Owari S2 as partial fit");
+        let s = &siblings[0];
+        assert_eq!(s.anilist_id, 21860);
+        assert_eq!(
+            s.file_indices.len(),
+            7,
+            "seven files in [13..=19] must be claimed"
+        );
+        assert_eq!(*s.file_indices.first().unwrap(), 12);
+        assert_eq!(*s.file_indices.last().unwrap(), 18);
+        // File index 19 (ep 20, Zoku) must NOT be claimed — it falls
+        // outside Owari S2's range and no other candidate can cover it.
+        assert!(
+            !s.file_indices.contains(&19),
+            "ep 20 Zoku file must remain unattributed"
+        );
+        assert_eq!(s.episode_offset, 12, "absolute numbering → offset = parent cap");
     }
 
     // ── transitive_relation_graft ────────────────────────────────────

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2812,6 +2812,19 @@ pub fn detect_sibling_entries_in_pack(
 }
 
 /// Per-sibling offset detection. See [`SiblingMatch::episode_offset`].
+///
+/// Returns `min_ep - 1` when the sibling's smallest parsed episode
+/// exceeds `parent_cap` — that makes the offset subtract out to a
+/// local ep 1 regardless of how the pack aligns with AL's count.
+/// Returns `0` when the sibling's episodes sit within the parent's
+/// range (arc-local numbering, no offset needed).
+///
+/// In the common case where filenames use continuous numbering
+/// starting at `parent_cap + 1`, `min_ep - 1 == parent_cap`, matching
+/// the older behavior. When the pack's partition disagrees with AL
+/// (e.g. a BD that splits a merged long-runtime episode into two
+/// halves), `min_ep - 1 > parent_cap` and the offset correctly shifts
+/// the sibling's first file to local ep 1 anyway.
 fn compute_sibling_episode_offset(
     file_indices: &[usize],
     filenames: &[String],
@@ -2828,7 +2841,7 @@ fn compute_sibling_episode_offset(
         .map(|(_, ep)| ep)
         .min();
     match min_ep {
-        Some(m) if m > parent_cap => parent_cap,
+        Some(m) if m > parent_cap => m - 1,
         _ => 0,
     }
 }
@@ -3018,13 +3031,175 @@ fn detect_sibling_via_episode_range(
         return Vec::new();
     }
 
-    // Iterative sequential packing.
+    // Shared claim state for the filename-subtitle pre-pass and the
+    // numeric packing loop below. Filename claims go in first and
+    // the loop naturally skips anything they've already consumed.
     let mut results: Vec<SiblingMatch> = Vec::new();
-    let mut base: i32 = parent_cap;
     let mut claimed_rel_idxs: std::collections::HashSet<usize> =
         std::collections::HashSet::new();
     let mut claimed_file_idxs: std::collections::HashSet<usize> =
         std::collections::HashSet::new();
+
+    // ── Filename-subtitle pre-pass ────────────────────────────────
+    //
+    // AL's `parent.episodes` can disagree with how a specific release
+    // partitions its files. The canonical example is Owarimonogatari
+    // on BD: AL reports 12 eps (the first aired episode was 48 min
+    // and AL groups it as one) but the [smol] BD release splits the
+    // 48-min ep 1 back into two ~24-min halves, so the pack has 13
+    // Owarimonogatari files (S07E01..=E13) followed by 7 Owari S2
+    // files (S07E14..=E20). Forward-aligned numeric packing anchored
+    // at `parent_cap = 12` would mis-route S07E13 (Owari 1 ep 13)
+    // into Owari S2 as "ep 1" and leave S07E20 (the real Owari S2
+    // finale) hanging under the parent.
+    //
+    // The filenames themselves carry ground truth: `S07E13 -
+    // Owarimonogatari (...)` vs `S07E14 - Owarimonogatari Second
+    // Season (...)`. So before numeric packing runs, scan each
+    // overflow file for a substring match against the parent's or a
+    // candidate's normalized title. Longest-prefix wins (so "Owari…
+    // Second Season" beats plain "Owari…"). Parent-matched files are
+    // dropped from the overflow pool (they fall to parent by default);
+    // candidate-matched files are pre-claimed to that candidate and
+    // the candidate is marked consumed so numeric packing can't
+    // duplicate-claim it.
+    //
+    // Needles shorter than 8 chars are rejected to avoid false
+    // positives from short titles colliding with episode markers
+    // (e.g. "Show 2" matching "Show - 02").
+    #[derive(Clone, Copy)]
+    enum NeedleSource {
+        Parent,
+        Candidate(usize), // index into `candidates`
+    }
+    const MIN_FILENAME_NEEDLE_LEN: usize = 8;
+    let mut needles: Vec<(NeedleSource, String)> = Vec::new();
+    for p in [parent_en.as_str(), parent_ro.as_str()] {
+        if p.len() >= MIN_FILENAME_NEEDLE_LEN
+            && !needles.iter().any(|(_, n)| n == p)
+        {
+            needles.push((NeedleSource::Parent, p.to_string()));
+        }
+    }
+    for (cand_idx, cand) in candidates.iter().enumerate() {
+        let rel = &parent_detail.relations[cand.rel_idx];
+        let en = normalize_subtitle(&rel.title_english);
+        let ro = normalize_subtitle(&rel.title_romaji);
+        for n in [en, ro] {
+            if n.len() >= MIN_FILENAME_NEEDLE_LEN
+                && !needles.iter().any(|(_, x)| x == &n)
+            {
+                needles.push((NeedleSource::Candidate(cand_idx), n));
+            }
+        }
+    }
+    tracing::debug!(
+        "auto-expand: fallback filename-subtitle needles={}",
+        needles.len()
+    );
+
+    let mut filename_claimed_by_cand: std::collections::HashMap<usize, Vec<usize>> =
+        std::collections::HashMap::new();
+    // Parent pre-claims are staged separately: in bare-number packs
+    // every file matches parent's root title, so unconditionally
+    // consuming them would strip the whole overflow and starve the
+    // numeric packing loop. Only apply them if at least one sibling
+    // was pre-claimed (i.e., the filenames actually distinguish arcs).
+    let mut filename_claimed_parent: Vec<usize> = Vec::new();
+    for (f_idx, ep) in overflow.iter() {
+        let norm = normalize_subtitle(&filenames[*f_idx]);
+        let mut best: Option<(NeedleSource, usize)> = None;
+        for (source, needle) in &needles {
+            if !norm.contains(needle) {
+                continue;
+            }
+            let len = needle.len();
+            match best {
+                Some((_, cur)) if cur >= len => {}
+                _ => best = Some((*source, len)),
+            }
+        }
+        match best {
+            Some((NeedleSource::Parent, len)) => {
+                filename_claimed_parent.push(*f_idx);
+                tracing::debug!(
+                    "auto-expand: fallback filename-subtitle file_idx={} ep={} → parent (needle_len={})",
+                    f_idx, ep, len
+                );
+            }
+            Some((NeedleSource::Candidate(cand_idx), len)) => {
+                filename_claimed_by_cand
+                    .entry(cand_idx)
+                    .or_default()
+                    .push(*f_idx);
+                tracing::debug!(
+                    "auto-expand: fallback filename-subtitle file_idx={} ep={} → candidate[{}] (needle_len={})",
+                    f_idx, ep, cand_idx, len
+                );
+            }
+            None => {}
+        }
+    }
+
+    let have_sibling_evidence = !filename_claimed_by_cand.is_empty();
+    if have_sibling_evidence {
+        for f_idx in &filename_claimed_parent {
+            claimed_file_idxs.insert(*f_idx);
+        }
+        tracing::debug!(
+            "auto-expand: fallback filename-subtitle applied {} parent pre-claims",
+            filename_claimed_parent.len()
+        );
+    } else if !filename_claimed_parent.is_empty() {
+        tracing::debug!(
+            "auto-expand: fallback filename-subtitle discarded {} parent pre-claims (no sibling evidence)",
+            filename_claimed_parent.len()
+        );
+    }
+
+    for (cand_idx, mut file_indices) in filename_claimed_by_cand.into_iter() {
+        let cand = &candidates[cand_idx];
+        let rel = &parent_detail.relations[cand.rel_idx];
+        if !within_episode_slack(file_indices.len(), cand.sib_cap) {
+            tracing::debug!(
+                "auto-expand: fallback filename-subtitle skip cand[{}] reason=slack-cap files={} sib_cap={}",
+                cand_idx, file_indices.len(), cand.sib_cap
+            );
+            continue;
+        }
+        file_indices.sort_unstable();
+        claimed_rel_idxs.insert(cand.rel_idx);
+        for f in &file_indices {
+            claimed_file_idxs.insert(*f);
+        }
+        let label = if !rel.title_english.is_empty() {
+            rel.title_english.as_str()
+        } else {
+            rel.title_romaji.as_str()
+        };
+        tracing::debug!(
+            "auto-expand: fallback filename-subtitle emitted sibling rel='{}' id={} files={}",
+            label, rel.id, file_indices.len()
+        );
+        results.push(SiblingMatch {
+            anilist_id: rel.id,
+            mal_id: rel.id_mal,
+            title_romaji: rel.title_romaji.clone(),
+            title_english: rel.title_english.clone(),
+            title_native: rel.title_native.clone(),
+            cover_url: rel.cover_url.clone(),
+            format: rel.format.clone(),
+            status: rel.status.clone(),
+            episodes: rel.episodes,
+            season_year: rel.season_year,
+            matched_subtitle: "episode-range fallback (filename subtitle match)".to_string(),
+            file_indices,
+            episode_offset: 0, // populated by the offset pass in the caller
+        });
+    }
+
+    // ── Iterative sequential packing ──────────────────────────────
+    let mut base: i32 = parent_cap;
 
     loop {
         // Short-circuit when there are no more overflow files beyond
@@ -4424,6 +4599,88 @@ mod tests {
             "ep 20 Zoku file must remain unattributed"
         );
         assert_eq!(s.episode_offset, 12, "absolute numbering → offset = parent cap");
+    }
+
+    #[test]
+    fn detect_siblings_fallback_filename_subtitle_corrects_bd_split_first_ep() {
+        // Real-world case from the live [smol] Owarimonogatari grab
+        // (reported 2026-04-15): the BD release splits the 48-min
+        // first aired episode back into two ~24-min halves, so the
+        // pack has 13 Owari 1 files (S07E01..=E13) followed by 7
+        // Owari 2 files (S07E14..=E20). But AniList reports the
+        // parent as 12 eps (it groups the merged broadcast ep 1 as
+        // one). Forward-aligned numeric packing anchored at
+        // parent_cap=12 would misroute S07E13 (Owari 1's last ep) to
+        // Owari S2 as "ep 1" and leave S07E20 (the real Owari S2
+        // finale) hanging under the parent.
+        //
+        // The filename subtitle pre-pass fixes this: S07E13's file-
+        // name only contains "Owarimonogatari", matching the parent
+        // title, so it's parent-pre-claimed. S07E14..=E20 contain
+        // "Owarimonogatari Second Season", matching the sibling
+        // title (longer → wins), so those 7 files are sibling-pre-
+        // claimed. The episode offset comes out to 13 (min_ep - 1),
+        // so post-processing renames S07E14..=E20 to Owari S2
+        // E01..=E07 correctly.
+        //
+        // Filenames are taken directly from the user's grab; they
+        // correspond to a specific real release of a real group.
+        let mut parent = detail_with_titles("Owarimonogatari", "Owarimonogatari");
+        parent.id = 21262;
+        parent.episodes = Some(12); // AL undercount — BD has 13 files for parent
+        parent.relations = vec![
+            related(20787, "Tsukimonogatari", "Tsukimonogatari", "SEQUEL", Some(4)),
+            related(
+                21745,
+                "Owarimonogatari Second Season",
+                "Owarimonogatari Second Season",
+                "SEQUEL",
+                Some(7),
+            ),
+        ];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=13 {
+            files.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari (BD 1080p HEVC Opus) [DEADBEEF].mkv",
+                n
+            ));
+        }
+        for n in 14..=20 {
+            files.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari Second Season (Ge) (BD 1080p HEVC Opus) [DEADBEEF].mkv",
+                n
+            ));
+        }
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(
+            siblings.len(),
+            1,
+            "filename subtitle pre-pass should identify Owari S2"
+        );
+        let s = &siblings[0];
+        assert_eq!(s.anilist_id, 21745);
+        assert_eq!(
+            s.file_indices.len(),
+            7,
+            "Owari S2 should claim exactly the 7 S07E14..=E20 files"
+        );
+        // File indices 13..=19 correspond to S07E14..=E20 (files
+        // vec is 0-indexed).
+        assert_eq!(*s.file_indices.first().unwrap(), 13);
+        assert_eq!(*s.file_indices.last().unwrap(), 19);
+        // Critically: file index 12 (S07E13) must NOT be claimed —
+        // that's Owari 1's last ep, and misrouting it was the bug.
+        assert!(
+            !s.file_indices.contains(&12),
+            "S07E13 (Owari 1 ep 13) must stay with parent"
+        );
+        // Offset: min_ep = 14, so offset = 13 (not parent_cap = 12).
+        // S07E14 → 14 - 13 = Owari S2 ep 1. Correct.
+        assert_eq!(
+            s.episode_offset, 13,
+            "offset must be min_ep - 1 = 13 so Owari S2 starts at local ep 1"
+        );
     }
 
     // ── transitive_relation_graft ────────────────────────────────────

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2427,6 +2427,21 @@ pub struct SiblingMatch {
     /// value — [`detect_sibling_entries_in_pack`] resolves overlaps by
     /// longest-subtitle-wins.
     pub file_indices: Vec<usize>,
+    /// How many episodes to subtract from each file's parsed episode
+    /// number before treating it as an episode of this sibling.
+    ///
+    /// Set to `parent_cap` when the sibling's files use numbering that
+    /// is continuous across the parent (e.g. a 20-ep Owarimonogatari
+    /// batch with `S07E14 - Owarimonogatari Second Season` — E14 is
+    /// Owari S2 episode 1 and needs offset 13 applied). Set to 0 when
+    /// the sibling's files use their own arc-local numbering (e.g. an
+    /// Egypt-hen pack with `Stardust Crusaders S03E01` filenames).
+    ///
+    /// Detection rule: if `min(sibling_file_ep_nums) > parent_cap`,
+    /// offset = `parent_cap`; otherwise offset = 0. Computed
+    /// per-sibling regardless of whether the match came from the
+    /// subtitle path or the episode-range fallback.
+    pub episode_offset: i32,
 }
 
 /// Relation types we'll consider in-pack candidates when scanning an
@@ -2522,9 +2537,12 @@ pub fn detect_sibling_entries_in_pack(
         candidates.push((rel_idx, subtitle, needle));
     }
 
-    if candidates.is_empty() {
-        return Vec::new();
-    }
+    // NOTE: intentionally do NOT early-return on empty `candidates`.
+    // The subtitle path can't find siblings whose titles either lack
+    // a delimiter or use a single-word / generic-ordinal subtitle
+    // (Egypt-hen, Second Season), but the episode-range fallback
+    // below may still attribute overflow files to a relation by
+    // episode count + title prefix. Let the fallback run.
 
     // First pass: for each media file, pick the candidate with the
     // LONGEST normalized needle that substring-matches the filename.
@@ -2586,10 +2604,210 @@ pub fn detect_sibling_entries_in_pack(
             season_year: rel.season_year,
             matched_subtitle: subtitle,
             file_indices,
+            // Populated in the offset pass below after fallback runs.
+            episode_offset: 0,
         });
     }
 
+    // Episode-range fallback: if the subtitle path came up empty
+    // (e.g. a NoobSubs-style pack where filenames carry plain episode
+    // numbers and no arc name, so `trailing_subtitle_of` + substring
+    // matching cannot find siblings), try to attribute episode-number
+    // overflow (files whose ep > parent's episode count) to a sibling
+    // whose own episode count makes the range fit.
+    //
+    // Only runs when `out.is_empty()` — i.e. the primary subtitle path
+    // produced zero matches. If even one sibling was subtitle-matched,
+    // we defer to that path and accept the known limitation that this
+    // fallback can't supplement partial matches.
+    if out.is_empty() {
+        if let Some(m) = detect_sibling_via_episode_range(filenames, parent_detail) {
+            out.push(m);
+        }
+    }
+
+    // Episode-offset pass: for every detected sibling (regardless of
+    // code path), compute `episode_offset` from its own matched file
+    // ep_nums. If the sibling's smallest parsed ep exceeds the parent's
+    // episode count, the filenames are continuous-numbered across the
+    // parent/sibling boundary and need `offset = parent_cap` applied
+    // downstream (e.g. smol Owari: E14 is Owari S2 episode 1). If the
+    // smallest ep is ≤ parent_cap, the filenames use arc-local numbering
+    // and no offset is needed.
+    let parent_cap = parent_detail.episodes.unwrap_or(0);
+    if parent_cap > 0 {
+        for m in out.iter_mut() {
+            m.episode_offset = compute_sibling_episode_offset(
+                &m.file_indices,
+                filenames,
+                parent_cap,
+            );
+        }
+    }
+
     out
+}
+
+/// Per-sibling offset detection. See [`SiblingMatch::episode_offset`].
+fn compute_sibling_episode_offset(
+    file_indices: &[usize],
+    filenames: &[String],
+    parent_cap: i32,
+) -> i32 {
+    if parent_cap <= 0 {
+        return 0;
+    }
+    let min_ep = file_indices
+        .iter()
+        .filter_map(|&i| filenames.get(i))
+        .filter(|n| is_media_filename(n))
+        .filter_map(|n| media::parse_episode_number(&n.to_ascii_lowercase()))
+        .map(|(_, ep)| ep)
+        .min();
+    match min_ep {
+        Some(m) if m > parent_cap => parent_cap,
+        _ => 0,
+    }
+}
+
+/// Layer 2 fallback: attribute files whose parsed episode number
+/// exceeds `parent_cap` to a single sibling relation that
+///
+/// 1. passes the pack-candidate relation-type gate,
+/// 2. is either a direct `SEQUEL` OR has a title that prefixes the
+///    parent's title (catches continuations where AniList's listed
+///    `SEQUEL` is semantically wrong — e.g. Owarimonogatari's listed
+///    SEQUEL is Tsukimonogatari, but the same-title continuation is
+///    Owarimonogatari Second Season),
+/// 3. has a known episode count,
+/// 4. and whose implied absolute episode range
+///    `(parent_cap + 1)..=(parent_cap + sibling_cap)` contains every
+///    overflow file.
+///
+/// If multiple siblings fit, prefer the title-prefix-matched one as a
+/// tiebreaker; if that's still ambiguous, bail. If zero fit, bail.
+fn detect_sibling_via_episode_range(
+    filenames: &[String],
+    parent_detail: &AnimeDetail,
+) -> Option<SiblingMatch> {
+    let parent_cap = parent_detail.episodes.unwrap_or(0);
+    if parent_cap <= 0 {
+        return None;
+    }
+
+    // Parse episodes per file (media files only).
+    let mut overflow: Vec<(usize, i32)> = Vec::new();
+    for (idx, name) in filenames.iter().enumerate() {
+        if !is_media_filename(name) {
+            continue;
+        }
+        let Some((_, ep)) = media::parse_episode_number(&name.to_ascii_lowercase()) else {
+            continue;
+        };
+        if ep > parent_cap {
+            overflow.push((idx, ep));
+        }
+    }
+    if overflow.is_empty() {
+        return None;
+    }
+    let overflow_min = overflow.iter().map(|(_, e)| *e).min().unwrap();
+    let overflow_max = overflow.iter().map(|(_, e)| *e).max().unwrap();
+    let overflow_count = overflow.len();
+
+    // Parent title prefixes for continuation matching. Both english
+    // and romaji forms are tried because AniList releases are
+    // commonly titled in either.
+    let parent_en = normalize_subtitle(&parent_detail.title_english);
+    let parent_ro = normalize_subtitle(&parent_detail.title_romaji);
+    let parent_prefixes: Vec<&str> = [parent_en.as_str(), parent_ro.as_str()]
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    // Walk relations for viable candidates.
+    let mut viable: Vec<(usize, bool)> = Vec::new(); // (rel_idx, title_prefix_matched)
+    for (rel_idx, rel) in parent_detail.relations.iter().enumerate() {
+        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        if !is_pack_candidate_relation(&rel.relation_type) {
+            continue;
+        }
+        let sib_cap = match rel.episodes {
+            Some(n) if n > 0 => n,
+            _ => continue,
+        };
+
+        // Title-prefix test against both english and romaji forms of
+        // the relation. A match requires the relation's normalized
+        // title to *start with* a parent prefix AND be strictly longer
+        // (exact equality would be a self-match, not a continuation).
+        let rel_en = normalize_subtitle(&rel.title_english);
+        let rel_ro = normalize_subtitle(&rel.title_romaji);
+        let title_prefix_matched = parent_prefixes.iter().any(|p| {
+            let p_len = p.len();
+            (!rel_en.is_empty() && rel_en.len() > p_len && rel_en.starts_with(p))
+                || (!rel_ro.is_empty() && rel_ro.len() > p_len && rel_ro.starts_with(p))
+        });
+        let is_sequel = rel.relation_type.eq_ignore_ascii_case("SEQUEL");
+        if !title_prefix_matched && !is_sequel {
+            continue;
+        }
+
+        // Range-fit check.
+        let expected_min = parent_cap + 1;
+        let expected_max = parent_cap + sib_cap;
+        if overflow_min < expected_min || overflow_max > expected_max {
+            continue;
+        }
+        if !within_episode_slack(overflow_count, sib_cap) {
+            continue;
+        }
+
+        viable.push((rel_idx, title_prefix_matched));
+    }
+
+    let chosen = match viable.len() {
+        0 => return None,
+        1 => viable[0].0,
+        _ => {
+            // Tiebreaker: prefer title-prefix-matched candidates.
+            let prefixed: Vec<usize> =
+                viable.iter().filter(|(_, p)| *p).map(|(i, _)| *i).collect();
+            if prefixed.len() == 1 {
+                prefixed[0]
+            } else {
+                // Still ambiguous — refuse to guess.
+                return None;
+            }
+        }
+    };
+
+    let rel = &parent_detail.relations[chosen];
+    let sib_cap = rel.episodes.unwrap_or(0);
+    let mut file_indices: Vec<usize> = overflow.iter().map(|(i, _)| *i).collect();
+    file_indices.sort_unstable();
+
+    Some(SiblingMatch {
+        anilist_id: rel.id,
+        mal_id: rel.id_mal,
+        title_romaji: rel.title_romaji.clone(),
+        title_english: rel.title_english.clone(),
+        title_native: rel.title_native.clone(),
+        cover_url: rel.cover_url.clone(),
+        format: rel.format.clone(),
+        status: rel.status.clone(),
+        episodes: rel.episodes,
+        season_year: rel.season_year,
+        matched_subtitle: format!(
+            "episode-range fallback ({}..={})",
+            parent_cap + 1,
+            parent_cap + sib_cap
+        ),
+        file_indices,
+        episode_offset: 0, // populated by the offset pass in the caller
+    })
 }
 
 /// Lowercase ASCII-alphanumeric chars and collapse non-alphanumeric
@@ -3559,5 +3777,257 @@ mod tests {
         // out by is_media_filename before they can inflate the match
         // set.
         assert_eq!(siblings[0].file_indices, vec![0]);
+    }
+
+    // ── Layer 2: episode-range fallback ────────────────────────────
+
+    #[test]
+    fn detect_siblings_fallback_catches_noobsubs_jojo_single_word_arc() {
+        // NoobSubs JoJo SDC+Egypt-hen pack: filenames are plain
+        // "Stardust Crusaders - NN" with no arc subtitle for the
+        // Egypt-hen portion. Subtitle detection cannot fire because
+        // Egypt-hen's trailing subtitle is single-word ("Egypt-hen")
+        // and rejected by `trailing_subtitle_of`'s ≥2-token rule.
+        // Episode-range fallback should pick up files 25-48 and
+        // attribute them to Egypt-hen with episode_offset=24.
+        let mut parent = detail_with_titles(
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            "JoJo no Kimyou na Bouken: Stardust Crusaders",
+        );
+        parent.id = 20474;
+        parent.episodes = Some(24);
+        parent.relations = vec![related(
+            20799,
+            "JoJo's Bizarre Adventure: Stardust Crusaders - Egypt-hen",
+            "JoJo no Kimyou na Bouken: Stardust Crusaders - Egypt-hen",
+            "SEQUEL",
+            Some(24),
+        )];
+
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=48 {
+            files.push(format!(
+                "[NoobSubs] JoJo's Bizarre Adventure Stardust Crusaders - {:02}.mkv",
+                n
+            ));
+        }
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1, "fallback should find one sibling");
+        let s = &siblings[0];
+        assert_eq!(s.anilist_id, 20799);
+        // Egypt-hen claims files 24..48 (indices 24..=47 → eps 25..=48).
+        assert_eq!(s.file_indices.len(), 24);
+        assert_eq!(*s.file_indices.first().unwrap(), 24);
+        assert_eq!(*s.file_indices.last().unwrap(), 47);
+        assert!(s.matched_subtitle.starts_with("episode-range fallback"));
+        // Absolute numbering → offset = parent cap (24).
+        assert_eq!(s.episode_offset, 24);
+    }
+
+    #[test]
+    fn detect_siblings_fallback_rejects_ambiguous_two_sequels() {
+        // Parent with two SEQUEL relations that both fit the overflow
+        // range ambiguously. Neither is title-prefix matched, so the
+        // tiebreaker doesn't save us → bail, fallback returns nothing.
+        let mut parent = detail_with_titles("Parent Show", "");
+        parent.id = 1;
+        parent.episodes = Some(12);
+        parent.relations = vec![
+            related(2, "Unrelated Sequel One", "", "SEQUEL", Some(12)),
+            related(3, "Unrelated Sequel Two", "", "SEQUEL", Some(12)),
+        ];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=24 {
+            files.push(format!("[Group] Parent Show - {:02}.mkv", n));
+        }
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert!(siblings.is_empty(), "ambiguous sequels must bail");
+    }
+
+    #[test]
+    fn detect_siblings_fallback_title_prefix_beats_strict_sequel() {
+        // Owarimonogatari scenario: direct AniList SEQUEL is
+        // Tsukimonogatari (not a continuation of the same title),
+        // but the actual same-title continuation is Owarimonogatari
+        // Second Season. Range-fit alone can't distinguish if both
+        // candidates pass, so title-prefix wins as the tiebreaker.
+        //
+        // Here we give Tsuki an incompatible ep count (can't fit the
+        // overflow) so it's rejected by range-fit first, and Owari S2
+        // is the only survivor — validating the primary path.
+        let mut parent = detail_with_titles("Owarimonogatari", "Owarimonogatari");
+        parent.id = 21320;
+        parent.episodes = Some(13);
+        parent.relations = vec![
+            // Direct SEQUEL relation, wrong continuation — only 4 eps
+            // so it cannot fit a 7-file overflow.
+            related(
+                20787,
+                "Tsukimonogatari",
+                "Tsukimonogatari",
+                "SEQUEL",
+                Some(4),
+            ),
+            // Same-title continuation; AniList may type this as a
+            // SIDE_STORY so we must admit it via title-prefix.
+            related(
+                21860,
+                "Owarimonogatari Second Season",
+                "Owarimonogatari Second Season",
+                "SIDE_STORY",
+                Some(7),
+            ),
+        ];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=20 {
+            files.push(format!("[smol] Monogatari - S07E{:02} - Owarimonogatari.mkv", n));
+        }
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1);
+        let s = &siblings[0];
+        assert_eq!(s.anilist_id, 21860, "must pick Owari S2, not Tsukimonogatari");
+        assert_eq!(s.file_indices.len(), 7);
+        assert_eq!(s.episode_offset, 13, "absolute numbering → offset = parent cap");
+    }
+
+    #[test]
+    fn detect_siblings_fallback_skips_when_no_overflow() {
+        // 12-ep parent, 12 files numbered 01..12 — nothing exceeds the
+        // parent cap, so the fallback must not synthesize siblings.
+        let mut parent = detail_with_titles("Parent Show", "");
+        parent.id = 1;
+        parent.episodes = Some(12);
+        parent.relations = vec![related(2, "Parent Show Second Season", "", "SEQUEL", Some(12))];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=12 {
+            files.push(format!("[Group] Parent Show - {:02}.mkv", n));
+        }
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert!(siblings.is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_fallback_skipped_when_parent_episodes_unknown() {
+        // Airing / unknown-length parent (episodes=None): we can't
+        // safely attribute overflow. Fallback bails.
+        let mut parent = detail_with_titles("Parent Show", "");
+        parent.id = 1;
+        parent.episodes = None;
+        parent.relations = vec![related(2, "Parent Show Second Season", "", "SEQUEL", Some(12))];
+        let files: Vec<String> = (1..=12)
+            .map(|n| format!("[Group] Parent Show - {:02}.mkv", n))
+            .collect();
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert!(siblings.is_empty());
+    }
+
+    #[test]
+    fn detect_siblings_fallback_skipped_when_subtitle_path_found_something() {
+        // Subtitle path hit at least one sibling → fallback is
+        // suppressed. Parent has relation with a usable 2-token
+        // subtitle AND files matching it, so subtitle path produces
+        // results. Fallback won't run even if overflow files exist
+        // (known limitation — fallback doesn't supplement partial
+        // subtitle matches).
+        let mut parent = detail_with_titles("Parent Show", "");
+        parent.id = 1;
+        parent.episodes = Some(12);
+        parent.relations = vec![
+            related(2, "Parent Show: Alpha Beta", "", "SEQUEL", Some(12)),
+            related(3, "Parent Show Third Season", "", "SEQUEL", Some(12)),
+        ];
+        let files: Vec<String> = vec![
+            "[Group] Parent Show - Alpha Beta - 01.mkv".to_string(),
+            "[Group] Parent Show - Alpha Beta - 02.mkv".to_string(),
+            // These would be overflow for a 12-ep parent but subtitle
+            // path already produced matches, so fallback is suppressed.
+            "[Group] Parent Show - 25.mkv".to_string(),
+            "[Group] Parent Show - 26.mkv".to_string(),
+        ];
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].anilist_id, 2);
+    }
+
+    #[test]
+    fn detect_siblings_fallback_handles_absolute_numbered_smol_owari() {
+        // Real-world: [smol] Monogatari batch uses continuous
+        // absolute numbering (E13 Owarimonogatari, E14 Owarimonogatari
+        // Second Season, ...). Subtitle detection can't fire —
+        // "Owarimonogatari Second Season" has no ": " / " - "
+        // delimiter AND its trailing portion is a generic-ordinal
+        // phrase anyway — so the episode-range fallback is the only
+        // path that reaches this release. It picks Owari S2 via
+        // title-prefix matching and the per-sibling offset pass
+        // applies offset=13 so post_processing renames E14..E20 to
+        // E01..E07 of Owari S2.
+        let mut parent = detail_with_titles("Owarimonogatari", "Owarimonogatari");
+        parent.id = 21320;
+        parent.episodes = Some(13);
+        parent.relations = vec![related(
+            21860,
+            "Owarimonogatari Second Season",
+            "Owarimonogatari Second Season",
+            "SIDE_STORY",
+            Some(7),
+        )];
+        let mut files: Vec<String> = Vec::new();
+        for n in 1..=13 {
+            files.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari (BD 1080p).mkv",
+                n
+            ));
+        }
+        for n in 14..=20 {
+            files.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari Second Season (Ge) (BD 1080p).mkv",
+                n
+            ));
+        }
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1, "fallback should find Owari S2");
+        let s = &siblings[0];
+        assert_eq!(s.anilist_id, 21860);
+        // Overflow = files with E14..E20 (indices 13..=19).
+        assert_eq!(s.file_indices.len(), 7);
+        assert_eq!(*s.file_indices.first().unwrap(), 13);
+        assert_eq!(*s.file_indices.last().unwrap(), 19);
+        assert!(s.matched_subtitle.starts_with("episode-range fallback"));
+        assert_eq!(s.episode_offset, 13, "absolute numbering → offset = parent cap");
+    }
+
+    #[test]
+    fn detect_siblings_subtitle_path_keeps_offset_zero_for_arc_local_numbering() {
+        // Subtitle-matched sibling where filenames use arc-local
+        // numbering (E01..Esib_cap within their own arc). The per-
+        // sibling offset pass must leave offset=0 because
+        // min_ep=1 ≤ parent_cap. Contrived parent with a 2-token,
+        // non-ordinal trailing subtitle so the subtitle path fires
+        // deterministically.
+        let mut parent = detail_with_titles("Parent Show", "Parent Show");
+        parent.id = 1;
+        parent.episodes = Some(24);
+        parent.relations = vec![related(
+            2,
+            "Parent Show: Alpha Beta",
+            "Parent Show: Alpha Beta",
+            "SEQUEL",
+            Some(12),
+        )];
+        let files: Vec<String> = (1..=12)
+            .map(|n| format!("[Group] Parent Show - Alpha Beta - {:02}.mkv", n))
+            .collect();
+
+        let siblings = detect_sibling_entries_in_pack(&files, &parent);
+        assert_eq!(siblings.len(), 1);
+        assert_eq!(siblings[0].anilist_id, 2);
+        assert_eq!(siblings[0].file_indices.len(), 12);
+        // min_ep = 1 ≤ parent_cap=24 → offset = 0.
+        assert_eq!(siblings[0].episode_offset, 0);
+        // And the match came from the subtitle path, not the fallback.
+        assert!(!siblings[0].matched_subtitle.starts_with("episode-range fallback"));
     }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1199,7 +1199,7 @@ struct SeaDexPayload {
     candidates: Vec<SearchResult>,
 }
 
-/// 5-minute in-memory cache for SeaDex lookups, keyed by AniList ID.
+/// 24-hour in-memory cache for SeaDex lookups, keyed by AniList ID.
 ///
 /// A single auto-search sweep across a multi-target batch (`find_all_for_target`,
 /// `collect_scored_batches_for_target`, `collect_scored_for_target`)
@@ -1208,11 +1208,18 @@ struct SeaDexPayload {
 /// JoJo S1–S5 sweep that's up to ~5 × (1 + N) HTTP requests — enough
 /// to throttle both releases.moe and Nyaa on a cold start.
 ///
-/// The cache amortizes the cost to one round-trip per target per
-/// 5-minute window. Config changes (preferred groups, resolution)
+/// SeaDex is a curated dataset that updates on the order of days, not
+/// minutes — once the community picks a "best" release for a title it
+/// rarely churns — so a 24h TTL amortizes the cost down to ~1 lookup
+/// per target per day while still catching the occasional revision.
+/// Anything shorter burns network round-trips for no observable
+/// correctness benefit. Config changes (preferred groups, resolution)
 /// affect how candidates get *scored* downstream, not what SeaDex
 /// returns, so keying by anilist_id alone is correct.
-const SEADEX_CACHE_TTL: Duration = Duration::from_secs(300);
+///
+/// The cache lives for the lifetime of the process, so a restart is
+/// the operator's escape hatch if they ever need to force-refresh.
+const SEADEX_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 static SEADEX_CACHE: LazyLock<StdMutex<HashMap<i64, (Instant, SeaDexPayload)>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -2,7 +2,7 @@ use crate::services::html::sanitize_rich_description;
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
-use std::sync::LazyLock;
+use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 
@@ -24,6 +24,53 @@ struct DetailCacheEntry {
 
 static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, DetailCacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
+
+/// When Jikan rate-limits us, remember "unavailable until Instant" so
+/// `search_anime` returns a clean cooldown error immediately rather than
+/// hammering the API and piling up more 429s.
+static JIKAN_COOLDOWN_UNTIL: LazyLock<StdMutex<Option<Instant>>> =
+    LazyLock::new(|| StdMutex::new(None));
+
+const JIKAN_COOLDOWN_DEFAULT: Duration = Duration::from_secs(60);
+const JIKAN_COOLDOWN_MAX: Duration = Duration::from_secs(300);
+
+fn jikan_cooldown_remaining() -> Option<Duration> {
+    let guard = JIKAN_COOLDOWN_UNTIL.lock().ok()?;
+    let until = (*guard)?;
+    let now = Instant::now();
+    if now < until {
+        Some(until - now)
+    } else {
+        None
+    }
+}
+
+fn set_jikan_cooldown(retry_after_secs: Option<u64>) {
+    let dur = retry_after_secs
+        .map(Duration::from_secs)
+        .unwrap_or(JIKAN_COOLDOWN_DEFAULT)
+        .min(JIKAN_COOLDOWN_MAX);
+    if let Ok(mut guard) = JIKAN_COOLDOWN_UNTIL.lock() {
+        *guard = Some(Instant::now() + dur);
+    }
+}
+
+/// Parse Jikan's JSON error body (shape: `{"status":"429","type":"...","message":"..."}`)
+/// into a human-readable one-liner. Falls back to a short snippet if parsing fails.
+fn parse_jikan_error(status: reqwest::StatusCode, body: &str) -> String {
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(body) {
+        if let Some(msg) = v["message"].as_str() {
+            // Take just the first sentence; the rest is usually a docs link.
+            let short = msg.split('.').next().unwrap_or(msg).trim();
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                return format!("Jikan rate-limited (HTTP 429): {}", short);
+            }
+            return format!("Jikan HTTP {}: {}", status.as_u16(), short);
+        }
+    }
+    let snippet: String = body.chars().take(120).collect();
+    format!("Jikan HTTP {}: {}", status.as_u16(), snippet.trim())
+}
 
 #[derive(Debug, Clone)]
 pub struct EpisodeInfo {
@@ -215,6 +262,16 @@ pub async fn search_anime(query: &str) -> Result<Vec<AnimeEntry>, String> {
         return Ok(Vec::new());
     }
 
+    // Short-circuit if a prior request told us Jikan is rate-limiting us.
+    // Prevents the "AL 429 → Jikan 429" cascade that drains Jikan's budget
+    // whenever AniList enters its cooldown window.
+    if let Some(remaining) = jikan_cooldown_remaining() {
+        return Err(format!(
+            "Jikan rate-limited (cooldown {}s remaining)",
+            remaining.as_secs().max(1)
+        ));
+    }
+
     let client = reqwest::Client::new();
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime", api_base.trim_end_matches('/'));
@@ -224,16 +281,24 @@ pub async fn search_anime(query: &str) -> Result<Vec<AnimeEntry>, String> {
         .header("User-Agent", "Ryokan/0.1")
         .send()
         .await
-        .map_err(|e| format!("Jikan search request failed: {}", e))?;
+        .map_err(|e| format!("Jikan unreachable: {}", e))?;
 
     let status = resp.status();
+    let retry_after_secs = resp
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
     let text = resp
         .text()
         .await
         .map_err(|e| format!("Failed to read Jikan search response: {}", e))?;
 
     if !status.is_success() {
-        return Err(format!("Jikan search failed (HTTP {}): {}", status, &text[..text.len().min(200)]));
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+            set_jikan_cooldown(retry_after_secs);
+        }
+        return Err(parse_jikan_error(status, &text));
     }
 
     let body: SearchResponse = serde_json::from_str(&text)

--- a/src/services/kitsu.rs
+++ b/src/services/kitsu.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 
-use crate::services::anilist::{AnimeDetail, AnimeEntry};
+use crate::services::anilist::AnimeDetail;
 use crate::services::html::sanitize_rich_description;
 
 const KITSU_API: &str = "https://kitsu.io/api/edge";
@@ -228,42 +228,6 @@ fn to_candidate(resource: Resource<AnimeAttributes>) -> Option<Candidate> {
         end_date: attrs.end_date,
         average_rating: attrs.average_rating,
     })
-}
-
-pub async fn search_anime(query: &str) -> Result<Vec<AnimeEntry>, String> {
-    let response = fetch_collection::<AnimeAttributes>(
-        &format!("{}/anime", KITSU_API),
-        &[("filter[text]", query.trim()), ("page[limit]", "10")],
-    )
-    .await?;
-
-    let mut out = Vec::new();
-    for item in response.data.into_iter().filter_map(to_candidate) {
-        let titles = candidate_titles(&item);
-        let title_romaji = item
-            .titles
-            .get("en_jp")
-            .cloned()
-            .or_else(|| titles.first().cloned())
-            .unwrap_or_default();
-        let title_english = item.titles.get("en").cloned().unwrap_or_default();
-        let title_native = item.titles.get("ja_jp").cloned().unwrap_or_default();
-        out.push(AnimeEntry {
-            id: item.id,
-            id_mal: None,
-            title_romaji,
-            title_english,
-            title_native,
-            cover_url: first_image(&item.poster_image),
-            format: item.subtype.to_ascii_uppercase(),
-            status: item.status.to_ascii_uppercase().replace(' ', "_"),
-            status_display: item.status.replace('-', " "),
-            episodes: item.episode_count,
-            season_year: parse_year(item.start_date.as_deref()),
-            source: "kitsu".to_string(),
-        });
-    }
-    Ok(out)
 }
 
 async fn best_candidate(queries: &[String], wanted_year: Option<i32>, wanted_eps: Option<i32>) -> Result<Option<Candidate>, String> {

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -43,6 +43,16 @@ static RE_BARE_NUM_BRACKET: LazyLock<Regex> = LazyLock::new(|| {
     // `something 99 (extra) 12 (...)` still resolves to 12, not 99.
     Regex::new(r"(?:^|\s)(\d{1,3})(?:v\d)?\s+[\(\[]").expect("RE_BARE_NUM_BRACKET compiles")
 });
+static RE_NCOP_NCED: LazyLock<Regex> = LazyLock::new(|| {
+    // Creditless OP/ED marker that must NOT be a substring of an
+    // unrelated word. Plain `contains("nced")` trips on any filename
+    // containing "synced", "convinced", "announced", "experienced",
+    // "bounced", etc. — we anchor the left edge to start-of-string or
+    // a non-letter so only real `NCED`/`NCOP` tokens match. The right
+    // edge is left open so glued-digit forms like `NCED01a` / `NCOP01`
+    // (LOGH, some older BDMV rips) still resolve.
+    Regex::new(r"(?:^|[^a-z])(?:ncop|nced)").expect("RE_NCOP_NCED compiles")
+});
 static RE_OVA_EP: LazyLock<Regex> = LazyLock::new(|| {
     // Explicit `OVA NN` / `OVA01` episode marker — used by
     // multi-episode OVA releases (e.g. the JoJo 1993 / 2000 6-episode
@@ -235,8 +245,10 @@ pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
     // small integer suffix (`NCOP 1`, `NCED 1`, or even glued
     // `NCED01a` from LOGH-style packs) that the bare-number
     // fallback below would otherwise mis-parse as episode 1 and
-    // clobber the real ep1. Bail before any pattern fires.
-    if lower.contains("ncop") || lower.contains("nced") {
+    // clobber the real ep1. Bail before any pattern fires. Matched
+    // with a token-boundary regex so incidental substring hits like
+    // `synced`, `convinced`, `announced` don't false-positive.
+    if RE_NCOP_NCED.is_match(lower) {
         return None;
     }
 
@@ -674,18 +686,52 @@ mod tests {
         );
     }
 
-    // ── NCED/NCOP with glued digits (contains guard) ─────────────────
+    #[test]
+    fn title_side_season_digit_does_not_shadow_dash_ep() {
+        // `<Title> <season-digit> - NN.mkv` — when a title-side season
+        // number (e.g. "Show 2") sits before the real ` - NN` episode
+        // marker, RE_DASH_EP must win because it runs before
+        // RE_BARE_NUM_DASH. If someone ever reorders the dispatch so
+        // that RE_BARE_NUM_DASH fires first, this case would quietly
+        // resolve to the season number (2) instead of the episode
+        // (1) and import files under the wrong slot. Regression guard
+        // to pin the ordering.
+        assert_eq!(parse("show 2 - 01.mkv"), Some((None, 1)));
+        assert_eq!(parse("[group] show 2 - 01 [1080p].mkv"), Some((None, 1)));
+        assert_eq!(
+            parse("[group] show 2 - 05 - subtitle [1080p].mkv"),
+            Some((None, 5))
+        );
+    }
+
+    // ── NCED/NCOP with glued digits (token-boundary guard) ───────────
 
     #[test]
     fn nced_glued_to_number_returns_none() {
         // LOGH-style `NCED01a` / `NCOP01` — number is glued directly
-        // to the creditless marker. The top-level contains() guard
-        // catches any filename with `ncop` or `nced` anywhere in the
-        // name, so glued variants are covered without a dedicated
-        // pattern. Synthetic fixtures here because the guard is
-        // substring-based and isn't sensitive to surrounding tokens.
+        // to the creditless marker. The top-level RE_NCOP_NCED guard
+        // anchors the left edge to start-of-string or a non-letter so
+        // glued-digit variants still trip while incidental substring
+        // hits in unrelated words are ignored.
         assert_eq!(parse("show-nced01a.mkv"), None);
         assert_eq!(parse("show-ncop01.mkv"), None);
+    }
+
+    #[test]
+    fn synced_substring_does_not_false_positive_as_nced() {
+        // Regression: the old `contains("nced")` guard tripped on any
+        // filename containing the letters `n-c-e-d` — including common
+        // English words like `synced`, `announced`, `convinced`. The
+        // token-boundary regex requires start-of-string or a non-letter
+        // before the marker so these pass through to the real parser.
+        assert_eq!(
+            parse("[group] synced title - 05 [1080p].mkv"),
+            Some((None, 5))
+        );
+        assert_eq!(
+            parse("[group] announced show - 12 [1080p].mkv"),
+            Some((None, 12))
+        );
     }
 
     // ── Special / SP marker (no SxxExx, out-of-scope) ────────────────

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -43,6 +43,43 @@ static RE_BARE_NUM_BRACKET: LazyLock<Regex> = LazyLock::new(|| {
     // `something 99 (extra) 12 (...)` still resolves to 12, not 99.
     Regex::new(r"(?:^|\s)(\d{1,3})(?:v\d)?\s+[\(\[]").expect("RE_BARE_NUM_BRACKET compiles")
 });
+static RE_OVA_EP: LazyLock<Regex> = LazyLock::new(|| {
+    // Explicit `OVA NN` / `OVA01` episode marker — used by
+    // multi-episode OVA releases (e.g. the JoJo 1993 / 2000 6-episode
+    // OVA sets shaped `<title> - OVA 01.mkv`). Must fire BEFORE the
+    // bare-number branches so `- OVA 01.` resolves to 1 instead of
+    // being shadowed by an earlier title-side digit. Must NOT match
+    // bare `- OVA.` with no trailing digit — single-OVA AL entries
+    // (e.g. Nichijou no 0) legitimately have no episode number and
+    // should fall through to `None` rather than be invented.
+    Regex::new(r"(?:^|[\s._\-])ova\s*(\d{1,3})(?:v\d)?(?:\s|\.|\[|\(|$)")
+        .expect("RE_OVA_EP compiles")
+});
+
+/// Non-episodic subtitle markers that can sit where a real subtitle
+/// would in a `<title> NN - <subtitle>` filename. When the captured
+/// `NN` is followed by one of these markers, it's almost certainly a
+/// season/title number (e.g. `Chihayafuru 2 - OVA - Waga Miyo…`),
+/// not an episode, and the parser must bail rather than import the
+/// file under a mis-numbered slot.
+fn starts_with_non_episode_marker(rest: &str) -> bool {
+    let trimmed = rest.trim_start();
+    const MARKERS: &[&str] = &["ova", "special", "specials"];
+    for tok in MARKERS {
+        if let Some(after) = trimmed.strip_prefix(tok) {
+            // Word boundary: next char must not be another letter or
+            // digit (so `special` matches but `spectral` doesn't).
+            let bounded = match after.as_bytes().first() {
+                None => true,
+                Some(c) => !c.is_ascii_alphanumeric(),
+            };
+            if bounded {
+                return true;
+            }
+        }
+    }
+    false
+}
 
 /// Sanitize a string for use as a folder name on disk.
 /// Replaces filesystem-unsafe characters and trims leading/trailing dots and whitespace.
@@ -183,20 +220,37 @@ fn parse_episode_file(path: &Path, series_root: &Path) -> Option<EpisodeFile> {
 /// - `- 05 (v2)`, `- 05v2`, `[group] Title - 05 [1080p]`
 /// - `E05`, `EP05`, `Ep.05`
 /// - `Episode 05`
+/// - `Title - OVA 01` (multi-episode OVA releases with explicit OVA marker)
 /// - `Title 05 - Subtitle` (no group bracket, bare number before subtitle)
 /// - `Title 05 (1080p) [hash]` (no group bracket, bare number before quality bracket)
+/// - Underscore-delimited filenames (`Title_-_05_-_Subtitle`) are normalized
+///   to space-delimited before matching.
 ///
 /// Returns `None` for files explicitly tagged as creditless openings or
-/// endings (`NCOP`/`NCED`) so they aren't accidentally imported as
-/// episode-numbered content.
+/// endings (`NCOP`/`NCED`), for files where a captured bare-number is
+/// followed by a non-episodic marker like `OVA`/`Special`, and for
+/// single-OVA entries with no trailing digit.
 pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
     // Non-episodic content guard. Creditless openings/endings carry a
-    // small integer suffix (`NCOP 1`, `NCED 1`) that the bare-number
-    // fallback below would otherwise mis-parse as episode 1 and clobber
-    // the real ep1. Bail before any pattern fires.
+    // small integer suffix (`NCOP 1`, `NCED 1`, or even glued
+    // `NCED01a` from LOGH-style packs) that the bare-number
+    // fallback below would otherwise mis-parse as episode 1 and
+    // clobber the real ep1. Bail before any pattern fires.
     if lower.contains("ncop") || lower.contains("nced") {
         return None;
     }
+
+    // Underscore-delimited releases (HGS-Renc, some older groups)
+    // use `_` where most releases use ` `. Normalize once so a
+    // single set of patterns handles both shapes without having to
+    // dual-parse. Only allocates when an underscore is actually
+    // present — most inputs skip the replace.
+    let normalized = if lower.contains('_') {
+        Some(lower.replace('_', " "))
+    } else {
+        None
+    };
+    let lower = normalized.as_deref().unwrap_or(lower);
 
     // SxxExx pattern — most reliable.
     if let Some(caps) = RE_SXEX.captures(lower) {
@@ -223,12 +277,36 @@ pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
         return Some((None, e));
     }
 
+    // Explicit `OVA NN` marker — for multi-episode OVA releases
+    // whose filenames have no SxxExx and no leading `- NN -`. Must
+    // fire before the bare-number branches so that `Title - OVA 01.`
+    // resolves to 1 even when an earlier title token (e.g. a year)
+    // would otherwise shadow it. Bare `- OVA.` with no trailing
+    // digit correctly falls through here because RE_OVA_EP requires
+    // a captured 1-3 digit group.
+    if let Some(caps) = RE_OVA_EP.captures(lower) {
+        let e: i32 = caps.get(1)?.as_str().parse().ok()?;
+        return Some((None, e));
+    }
+
     // Bare-number-before-subtitle fallback. Shape:
     // `<title> NN - <subtitle>.mkv` — first match wins (subtitle may
     // contain its own ` <n> - ` run that should NOT shadow the real
     // episode marker).
     if let Some(caps) = RE_BARE_NUM_DASH.captures(lower) {
         if let Some(m) = caps.get(1) {
+            if let Some(full) = caps.get(0) {
+                // If what follows the ` - ` is a non-episodic marker
+                // (e.g. `Chihayafuru 2 - OVA - Waga Miyo…`), the
+                // captured `2` is a season/title number, not an
+                // episode. Bail with `None` rather than fall through
+                // to further patterns — the subsequent bare-number
+                // branch would re-capture the same false digit.
+                let rest = &lower[full.end()..];
+                if starts_with_non_episode_marker(rest) {
+                    return None;
+                }
+            }
             if let Ok(e) = m.as_str().parse::<i32>() {
                 return Some((None, e));
             }
@@ -537,6 +615,117 @@ mod tests {
         assert_eq!(
             parse("Naruto Arc 5 Sasuke Recovery Mission Arc Folder Icon.mkv"),
             None
+        );
+    }
+
+    // ── OVA episode marker (RE_OVA_EP) ───────────────────────────────
+
+    #[test]
+    fn ova_numbered_after_dash_resolves_to_episode() {
+        // Multi-episode OVA releases with explicit `OVA NN` marker.
+        // The 1993 and 2000 JoJo OVAs are 6 and 13 episodes
+        // respectively — collapsing them all onto episode 1 (the
+        // pre-RE_OVA_EP behavior via grab.episode_numbers fallback)
+        // would silently corrupt the library.
+        assert_eq!(parse("[Judas] JoJo 1993 - OVA 01.mkv"), Some((None, 1)));
+        assert_eq!(parse("[Judas] JoJo 2000 - OVA 01.mkv"), Some((None, 1)));
+    }
+
+    #[test]
+    fn bare_ova_with_no_trailing_digit_returns_none() {
+        // Single-OVA AL entries (e.g. Nichijou no 0, HSotD OVA)
+        // have bare `OVA` with no digit. RE_OVA_EP must NOT fire
+        // (it requires a captured digit), and no other branch
+        // should either. Nichijou specifically is a real AL entry
+        // (https://anilist.co/anime/8857) where mis-parsing `OVA`
+        // as an episode index could have disastrous outcomes.
+        assert_eq!(parse("[Judas] Nichijou - OVA.mkv"), None);
+        assert_eq!(
+            parse("[Polarwindz] High School of the Dead - OVA (BD 1080p HEVC Dual Audio).mkv"),
+            None
+        );
+    }
+
+    #[test]
+    fn s00_ova_subtitle_does_not_shadow_sxxexx() {
+        // `<title> - S00E09 OVA <subtitle>` — the `OVA` sits in the
+        // subtitle portion, not as an episode marker. RE_SXEX must
+        // win first and return the real season 0 / episode 9 so the
+        // OVA token is harmless context, not a re-parse hazard.
+        assert_eq!(
+            parse(
+                "[Sokudo] Boku no Hero Academia - S00E09 OVA Make It Do-or-Die Survival Training Part 2 [1080p AV1][dual audio].mkv"
+            ),
+            Some((Some(0), 9))
+        );
+    }
+
+    // ── Non-episodic marker guard on RE_BARE_NUM_DASH ────────────────
+
+    #[test]
+    fn season_number_before_ova_marker_is_not_episode() {
+        // `<title> N - OVA - <subtitle>.mkv` — the `N` is a season
+        // label (Chihayafuru 2), not an episode number. Without the
+        // marker guard, bare-num-dash would naively capture `2` and
+        // import the OVA file as episode 2 of the main series.
+        assert_eq!(
+            parse("[Judas] CHIHAYAFURU 2 - OVA - Waga Miyo ni Furu Nagame Shima ni.mkv"),
+            None
+        );
+    }
+
+    // ── NCED/NCOP with glued digits (contains guard) ─────────────────
+
+    #[test]
+    fn nced_glued_to_number_returns_none() {
+        // LOGH-style `NCED01a` / `NCOP01` — number is glued directly
+        // to the creditless marker. The top-level contains() guard
+        // catches any filename with `ncop` or `nced` anywhere in the
+        // name, so glued variants are covered without a dedicated
+        // pattern. Synthetic fixtures here because the guard is
+        // substring-based and isn't sensitive to surrounding tokens.
+        assert_eq!(parse("show-nced01a.mkv"), None);
+        assert_eq!(parse("show-ncop01.mkv"), None);
+    }
+
+    // ── Special / SP marker (no SxxExx, out-of-scope) ────────────────
+
+    #[test]
+    fn s03sp_special_marker_returns_none() {
+        // `S03SP01` — SP is Special. RE_SXEX requires a contiguous
+        // `SxxExx` shape so `S03SP01` falls through every pattern
+        // and returns `None`. Specials have ambiguous episode
+        // ordering and should NOT be silently mapped to a numbered
+        // slot; None is the safe outcome.
+        assert_eq!(parse("[Judas] CHIHAYAFURU - S03SP01.mkv"), None);
+    }
+
+    // ── Underscore-delimited filenames (normalization) ───────────────
+
+    #[test]
+    fn underscore_delimited_dash_ep_normalizes_to_space() {
+        // HGS-Renc uses `_` where newer groups use ` `. The
+        // underscore normalization converts `_-_02_-_` to
+        // ` - 02 - ` so RE_DASH_EP matches via the existing path.
+        assert_eq!(
+            parse("[HGS-Renc]_Crusher_Joe_-_02_-_The_Ice_Prison_[BD1080][HEVC].mkv"),
+            Some((None, 2))
+        );
+    }
+
+    // ── High School DxD S00E18 (RE_SXEX existing path) ───────────────
+
+    #[test]
+    fn s00e18_with_double_subtitle_dashes() {
+        // `<title> - S00E18 - <subtitle> (<quality>) [<tag>] [<tag>]`
+        // — multiple ` - ` delimiters around SxxExx. Regression
+        // guard that RE_SXEX wins before any dash-delimited branch
+        // fires on the subtitle segment.
+        assert_eq!(
+            parse(
+                "High School DxD - S00E18 - Holiness Behind the Gym (BD 1080p H.264 FLAC) [Dual Audio] [IK].mkv"
+            ),
+            Some((Some(0), 18))
         );
     }
 }

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -194,9 +194,15 @@ pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
 
 /// Extract quality/resolution from filename.
 fn parse_quality(lower: &str) -> String {
-    // Source type.
+    // Source type. Names match `ClassificationResult::label()` in
+    // `source.rs` so disk-scanned fallback strings render the same as
+    // classifier-derived ones ("BD-1080p", "WEBDL-1080p", etc.). This
+    // path can't distinguish BD Remux / BD-RAW from filename tokens
+    // alone; the classifier handles those through the structured
+    // columns so the quality shown for a properly-classified episode
+    // comes from `tag.quality_tag`, not from here.
     let source = if lower.contains("bluray") || lower.contains("blu-ray") || lower.contains("bdrip") || lower.contains("[bd") || lower.contains("(bd") {
-        "Bluray"
+        "BD"
     } else if lower.contains("webdl") || lower.contains("web-dl") || lower.contains("web dl") {
         "WEBDL"
     } else if lower.contains("webrip") || lower.contains("web-rip") {

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -23,6 +23,26 @@ static RE_E_PREFIX: LazyLock<Regex> = LazyLock::new(|| {
 static RE_EPISODE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"episode\s*(\d{1,4})").expect("RE_EPISODE compiles")
 });
+static RE_BARE_NUM_DASH: LazyLock<Regex> = LazyLock::new(|| {
+    // Bare 1-3 digit episode number followed by ` - <subtitle>`. Used
+    // by no-group-prefix releases shaped like
+    // `<title> NN - <subtitle>.mkv`. The caller takes the FIRST match
+    // because the actual episode marker comes BEFORE the subtitle, and
+    // the subtitle itself can contain incidental ` <number> - ` runs
+    // (e.g. `Show 03 - Title, Part 4 - Coda.mkv` → must resolve 03,
+    // not 4). 1-3 digits keeps 4-digit years out.
+    Regex::new(r"(?:^|\s)(\d{1,3})(?:v\d)?\s+-\s").expect("RE_BARE_NUM_DASH compiles")
+});
+static RE_BARE_NUM_BRACKET: LazyLock<Regex> = LazyLock::new(|| {
+    // Bare 1-3 digit episode number followed by a quality `(...)` or
+    // hash `[...]` bracket. Catches packs whose filenames are
+    // space-delimited rather than `S01E01` or `- 01` — i.e. shaped
+    // like `<title tokens> NN (<quality>) [<hash>].mkv`. 1-3 digits
+    // keeps 4-digit years from being read as episode numbers. The
+    // caller picks the rightmost match so a title token like
+    // `something 99 (extra) 12 (...)` still resolves to 12, not 99.
+    Regex::new(r"(?:^|\s)(\d{1,3})(?:v\d)?\s+[\(\[]").expect("RE_BARE_NUM_BRACKET compiles")
+});
 
 /// Sanitize a string for use as a folder name on disk.
 /// Replaces filesystem-unsafe characters and trims leading/trailing dots and whitespace.
@@ -163,7 +183,21 @@ fn parse_episode_file(path: &Path, series_root: &Path) -> Option<EpisodeFile> {
 /// - `- 05 (v2)`, `- 05v2`, `[group] Title - 05 [1080p]`
 /// - `E05`, `EP05`, `Ep.05`
 /// - `Episode 05`
+/// - `Title 05 - Subtitle` (no group bracket, bare number before subtitle)
+/// - `Title 05 (1080p) [hash]` (no group bracket, bare number before quality bracket)
+///
+/// Returns `None` for files explicitly tagged as creditless openings or
+/// endings (`NCOP`/`NCED`) so they aren't accidentally imported as
+/// episode-numbered content.
 pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
+    // Non-episodic content guard. Creditless openings/endings carry a
+    // small integer suffix (`NCOP 1`, `NCED 1`) that the bare-number
+    // fallback below would otherwise mis-parse as episode 1 and clobber
+    // the real ep1. Bail before any pattern fires.
+    if lower.contains("ncop") || lower.contains("nced") {
+        return None;
+    }
+
     // SxxExx pattern — most reliable.
     if let Some(caps) = RE_SXEX.captures(lower) {
         let s: i32 = caps.get(1)?.as_str().parse().ok()?;
@@ -187,6 +221,29 @@ pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
     if let Some(caps) = RE_EPISODE.captures(lower) {
         let e: i32 = caps.get(1)?.as_str().parse().ok()?;
         return Some((None, e));
+    }
+
+    // Bare-number-before-subtitle fallback. Shape:
+    // `<title> NN - <subtitle>.mkv` — first match wins (subtitle may
+    // contain its own ` <n> - ` run that should NOT shadow the real
+    // episode marker).
+    if let Some(caps) = RE_BARE_NUM_DASH.captures(lower) {
+        if let Some(m) = caps.get(1) {
+            if let Ok(e) = m.as_str().parse::<i32>() {
+                return Some((None, e));
+            }
+        }
+    }
+
+    // Bare-number-before-bracket fallback for space-delimited packs.
+    // Use the rightmost match so an earlier title token like
+    // `Show 99 (extra) 01` doesn't shadow the actual episode number.
+    if let Some(caps) = RE_BARE_NUM_BRACKET.captures_iter(lower).last() {
+        if let Some(m) = caps.get(1) {
+            if let Ok(e) = m.as_str().parse::<i32>() {
+                return Some((None, e));
+            }
+        }
     }
 
     None
@@ -246,5 +303,240 @@ fn format_size(bytes: u64) -> String {
     } else {
         let mb = bytes as f64 / (1024.0 * 1024.0);
         format!("{:.0} MiB", mb)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_episode_number;
+
+    // Fixtures here are real-world filenames captured verbatim from
+    // an actual library, lower-cased to match the parser's input. They
+    // are kept verbatim so we have genuine ground truth for what
+    // shapes the parser must handle — any divergence between these
+    // fixtures and what we produce in synthetic tests would be the
+    // silent regression hazard the no-fabricated-release-naming
+    // feedback exists to prevent.
+
+    fn parse(name: &str) -> Option<(Option<i32>, i32)> {
+        parse_episode_number(&name.to_lowercase())
+    }
+
+    // ── SxxExx (RE_SXEX) ─────────────────────────────────────────────
+
+    #[test]
+    fn sxxexx_dot_separated_full_title() {
+        // smol releases use dot-separated tokens.
+        assert_eq!(
+            parse("Whisper.Me.a.Love.Song.S01E06.REPACK.1080p.WEBRip.DDP2.0.x265-smol.mkv"),
+            Some((Some(1), 6))
+        );
+        assert_eq!(
+            parse("Nisekoi.False.Love.S02E11.1080p.BluRay.Opus2.0.x265-smol.mkv"),
+            Some((Some(2), 11))
+        );
+    }
+
+    #[test]
+    fn sxxexx_with_v2_suffix_after_episode() {
+        // S02E10v2 — the v2 must not corrupt the episode capture.
+        assert_eq!(parse("[Judas] Frieren - S02E10v2.mkv"), Some((Some(2), 10)));
+        assert_eq!(parse("[Judas] Fire Force - S03E18v2.mkv"), Some((Some(3), 18)));
+        assert_eq!(
+            parse("JUJUTSU.KAISEN.S03E03.v2.1080p.CR.WEBRip.DUAL.AUDIO.AV1-Sokudo.mkv"),
+            Some((Some(3), 3))
+        );
+    }
+
+    #[test]
+    fn sxxexx_minimal_bracketed_group() {
+        assert_eq!(parse("[Judas] Kaya-chan - S01E01.mkv"), Some((Some(1), 1)));
+    }
+
+    #[test]
+    fn sxxexx_dot_separated_with_long_subtitle() {
+        // VARYG-style: long descriptive sentence between SxxExx and quality.
+        assert_eq!(
+            parse(
+                "You.and.I.Are.Polar.Opposites.S01E05.Someone.Who.Thinks.and.Someone.Who.Doesnt.1080p.CR.WEB-DL.DUAL.AAC2.0.H.264-VARYG.mkv"
+            ),
+            Some((Some(1), 5))
+        );
+    }
+
+    #[test]
+    fn sxxexx_space_separated_with_quality_bracket() {
+        assert_eq!(
+            parse("Jujutsu Kaisen - S02E10 (BD 1080p HEVC) [Vodes].mkv"),
+            Some((Some(2), 10))
+        );
+        assert_eq!(
+            parse("[LostYears] Vinland Saga - S02E12 (WEB 1080p HEVC E-AC-3 AAC) [B413DFCD].mkv"),
+            Some((Some(2), 12))
+        );
+        assert_eq!(
+            parse("[LostYears] Vinland Saga - S02E13 (WEB 1080p HEVC AAC) [A6F924F6].mkv"),
+            Some((Some(2), 13))
+        );
+    }
+
+    // ── ` - NN ` dash-delimited (RE_DASH_EP) ─────────────────────────
+
+    #[test]
+    fn dash_ep_with_quality_and_hash_brackets() {
+        assert_eq!(
+            parse("[MTBB] Mob Psycho 100 S2 - 10 (BD 1080p) [BED02FC5].mkv"),
+            Some((None, 10))
+        );
+        assert_eq!(
+            parse("[Salieri] Jujutsu Kaisen S2 - 06 (1080p) (HDR) [Dual Audio].mkv"),
+            Some((None, 6))
+        );
+        assert_eq!(
+            parse("[Kaizoku] Jujutsu Kaisen - 35 (BD 1080p) [3311E835].mkv"),
+            Some((None, 35))
+        );
+        assert_eq!(
+            parse("[Kaizoku] Jujutsu Kaisen - 47 (BD 1080p) [3D93127E].mkv"),
+            Some((None, 47))
+        );
+    }
+
+    #[test]
+    fn dash_ep_with_square_quality_bracket() {
+        // sam / notFoxtrot use `[BD 1080p FLAC]` instead of `(...)`.
+        assert_eq!(
+            parse("[sam] Vinland Saga - 04 [BD 1080p FLAC] [22FE1988].mkv"),
+            Some((None, 4))
+        );
+        assert_eq!(
+            parse("[notFoxtrot] Vinland Saga - 05 [BD 1080p FLAC] [7F2FF84F].mkv"),
+            Some((None, 5))
+        );
+    }
+
+    #[test]
+    fn dash_ep_with_end_marker_after_number() {
+        // NanakoRaws appends ` END` to the final episode of a season.
+        assert_eq!(
+            parse("[NanakoRaws] Jujutsu Kaisen S2 - 23 END (1080p).mkv"),
+            Some((None, 23))
+        );
+    }
+
+    #[test]
+    fn dash_ep_with_v2_suffix_glued_to_number() {
+        // ` - 16v2 ` — version suffix is consumed by the trailing alt.
+        assert_eq!(
+            parse("[NanakoRaws] Jujutsu Kaisen S2 - 16v2 (1080p).mkv"),
+            Some((None, 16))
+        );
+    }
+
+    // ── Bare number before ` - subtitle` (RE_BARE_NUM_DASH) ──────────
+
+    #[test]
+    fn bare_number_before_dash_subtitle_no_group_prefix() {
+        // No group bracket, no leading ` - `, just `<title> NN - <subtitle>`.
+        // Returned None prior to RE_BARE_NUM_DASH.
+        assert_eq!(
+            parse("Koyomimonogatari 01 - Koyomi Stone.mkv"),
+            Some((None, 1))
+        );
+        assert_eq!(
+            parse("Owarimonogatari 2nd Season 03 - Hitagi Rendezvous, Part 1.mkv"),
+            Some((None, 3))
+        );
+        assert_eq!(
+            parse("Nisemonogatari 06 - Karen Bee, Part 6.mkv"),
+            Some((None, 6))
+        );
+    }
+
+    #[test]
+    fn sxxexx_with_subtitle_and_quality_brackets() {
+        // `[Group] Title - SxxExx - Episode Subtitle (quality) [hash].mkv`
+        // Two ` - ` delimiters, parenthesized quality, bracketed hash.
+        // Regression guard: RE_SXEX must win before the bare-number
+        // branches fire on the " - <subtitle>" portion.
+        assert_eq!(
+            parse("[smol] Monogatari - S07E05 - Owarimonogatari (BD 1080p HEVC Opus) [A89E97DA].mkv"),
+            Some((Some(7), 5))
+        );
+        assert_eq!(
+            parse("[smol] Monogatari - S07E14 - Owarimonogatari Second Season (Ge) (BD 1080p HEVC Opus) [EBAB5DDD].mkv"),
+            Some((Some(7), 14))
+        );
+    }
+
+    // ── "Episode N" (RE_EPISODE) ─────────────────────────────────────
+
+    #[test]
+    fn episode_word_prefix_with_three_digit_number() {
+        // Long-runner with no other tokens in the filename.
+        assert_eq!(parse("Episode 039.mkv"), Some((None, 39)));
+    }
+
+    // ── NCOP/NCED non-episodic guard ─────────────────────────────────
+
+    #[test]
+    fn nced_non_episode_returns_none() {
+        // Creditless ending. Without the NCOP/NCED guard, the
+        // bare-number-before-bracket fallback would otherwise parse
+        // ` 1 [` as episode 1 and clobber the real ep1 on import.
+        assert_eq!(
+            parse("[notFoxtrot] Vinland Saga - NCED 1 [BD 1080p FLAC] [CC708A2C].mkv"),
+            None
+        );
+    }
+
+    #[test]
+    fn ncop_non_episode_returns_none() {
+        assert_eq!(
+            parse("[notFoxtrot] Vinland Saga - NCOP 1 [BD 1080p FLAC] [300FAD69].mkv"),
+            None
+        );
+    }
+
+    // ── Non-episode files that have no number anywhere ───────────────
+
+    #[test]
+    fn ova_with_no_episode_number_returns_none() {
+        // A single OVA file with no episode marker. Today this returns
+        // None because no pattern matches, and that's the correct
+        // outcome — there's nothing to parse.
+        assert_eq!(
+            parse("[WBDP] Yahari Ore no Seishun Love Comedy wa Machigatteiru Zoku OVA [BD][1080p-AAC] [93937CE2].mkv"),
+            None
+        );
+    }
+
+    #[test]
+    fn pv_promo_video_returns_none() {
+        // Bare `PV.mkv` — no digits at all, nothing to parse.
+        assert_eq!(parse("PV.mkv"), None);
+    }
+
+    #[test]
+    fn bd_stream_file_with_only_zero_padded_index_returns_none() {
+        // Raw BD stream file from an untitled disc rip. The leading
+        // `00000` is a disc-side playlist index, not an episode
+        // number — both RE_BARE_NUM_DASH and RE_BARE_NUM_BRACKET
+        // require a delimiter after the digits, so this correctly
+        // falls through to None.
+        assert_eq!(parse("00000.m2ts"), None);
+    }
+
+    #[test]
+    fn folder_icon_with_arc_number_in_title_returns_none() {
+        // Hypothetical: if the folder-icon PNG had been served as
+        // media (it isn't — is_media_filename gates .png out), the
+        // `Arc 5 Sasuke` title token must NOT be mis-parsed as
+        // episode 5. Defensive regression guard for the bare-number
+        // branches.
+        assert_eq!(
+            parse("Naruto Arc 5 Sasuke Recovery Mission Arc Folder Icon.mkv"),
+            None
+        );
     }
 }

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -39,8 +39,15 @@ static SEL_VIEW_TITLE: LazyLock<Selector> = LazyLock::new(|| {
 });
 static SEL_VIEW_ROW: LazyLock<Selector> =
     LazyLock::new(|| Selector::parse("div.panel-body div.row").expect("SEL_VIEW_ROW parses"));
-static SEL_VIEW_COL: LazyLock<Selector> =
-    LazyLock::new(|| Selector::parse("div").expect("SEL_VIEW_COL parses"));
+// Target Nyaa's actual Bootstrap grid columns (`col-md-1`, `col-md-5`, etc.)
+// rather than every `<div>` in the row. The broader `div` selector also
+// descended into nested `<div>`s like embedded MediaInfo blocks, which
+// made the label/value pair-up (`while i + 1 < cols.len()` in
+// `parse_view_page`) drift and silently zero out seeder/leecher counts
+// on view pages that had any extra inner markup.
+static SEL_VIEW_COL: LazyLock<Selector> = LazyLock::new(|| {
+    Selector::parse("div[class*='col-md-']").expect("SEL_VIEW_COL parses")
+});
 static SEL_VIEW_MAGNET: LazyLock<Selector> = LazyLock::new(|| {
     Selector::parse("a.card-footer-item[href^='magnet:']").expect("SEL_VIEW_MAGNET parses")
 });

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -242,7 +242,6 @@ async fn import_torrent(
     grab: &grabbed_torrents::GrabbedTorrent,
     torrent_hash: &str,
     torrent_save_path: &str,
-    qbit_torrent_name: &str,
 ) -> Result<bool, String> {
     // Phase 2: look up per-file routing rows written by the auto-expand
     // path. A non-empty result means this grab was an auto-expanded
@@ -304,16 +303,22 @@ async fn import_torrent(
     // Unique series_ids that had at least one file successfully
     // imported — drives the per-series NFO/poster write after the loop.
     let mut touched_series: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
-    // Per-target-series (episode number, individual file size) pairs for
-    // every file we successfully landed. Replaces the
-    // `grab.episode_numbers`-based mark_completed at the end of the loop:
-    // bare batch grabs arrive here with an empty episode list on the
-    // parent grab row, but we've already parsed ep_num per file above so
-    // we can mark completed with the real list instead. The per-file
-    // size (not the total torrent size) is what the episode detail modal
-    // surfaces to the user — a batch torrent's aggregate size across ~12
-    // episodes is not a meaningful per-episode number.
-    let mut imported_eps_by_series: HashMap<i64, Vec<(i32, i64)>> = HashMap::new();
+    // Per-target-series tuple (episode number, individual file size,
+    // post-processed on-disk file name) for every file we successfully
+    // landed. Replaces the `grab.episode_numbers`-based mark_completed
+    // at the end of the loop: bare batch grabs arrive here with an
+    // empty episode list on the parent grab row, but we've already
+    // parsed ep_num per file above so we can mark completed with the
+    // real list instead.
+    //
+    // The per-file size feeds `mark_grab_history_completed`'s
+    // non-batch-only size-refine path (batch rows retain their whole-
+    // torrent total so the episode detail modal can show "from an
+    // X GiB batch"). The on-disk file name feeds the same function so
+    // each per-episode row carries the Sonarr-style renamed basename
+    // (e.g. `Jujutsu Kaisen - S01E06 - Hidden Inventory.mkv`) instead
+    // of the batch torrent's release title.
+    let mut imported_eps_by_series: HashMap<i64, Vec<(i32, i64, String)>> = HashMap::new();
     let mut imported_count = 0_usize;
 
     for (file_idx, file) in &video_files {
@@ -620,6 +625,7 @@ async fn import_torrent(
                         &grab.torrent_name,
                         "",
                         file.size,
+                        grab.is_batch,
                     )
                     .await
                     .map(|_| ())
@@ -673,10 +679,15 @@ async fn import_torrent(
                     }
                 }
 
+                let dest_basename = dest_video
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or(filename_only)
+                    .to_string();
                 imported_eps_by_series
                     .entry(target_series_id)
                     .or_default()
-                    .push((ep_num, file.size));
+                    .push((ep_num, file.size, dest_basename));
             }
             Err(e) => {
                 logger::error(
@@ -733,18 +744,21 @@ async fn import_torrent(
     // Two flips happen per episode: the quality-tag row (via
     // `mark_completed`) and the newest 'grabbed' history row (via
     // `mark_grab_history_completed`). The history flip stamps in the
-    // real qBit torrent name and the per-file size so the episode
-    // detail modal can show both in the history table.
+    // per-episode post-processed file name (Sonarr-style renamed
+    // basename) and — only for non-batch rows — refines size_bytes to
+    // the imported file's real size. Batch rows keep the whole-
+    // torrent total so the episode detail modal can report "this
+    // episode came from an X GiB batch".
     for (series_id, episodes) in &imported_eps_by_series {
-        let ep_nums: Vec<i32> = episodes.iter().map(|(n, _)| *n).collect();
+        let ep_nums: Vec<i32> = episodes.iter().map(|(n, _, _)| *n).collect();
         let _ = episode_tags::mark_completed(&state.db, *series_id, &ep_nums).await;
-        for (ep_num, size_bytes) in episodes {
+        for (ep_num, file_size, file_name) in episodes {
             let _ = episode_tags::mark_grab_history_completed(
                 &state.db,
                 *series_id,
                 *ep_num,
-                qbit_torrent_name,
-                *size_bytes,
+                file_name,
+                *file_size,
             )
             .await;
         }
@@ -866,7 +880,7 @@ pub async fn run_once(state: &AppState) {
             continue;
         }
 
-        match import_torrent(state, &cfg, grab, &torrent.hash, &torrent.save_path, &torrent.name).await {
+        match import_torrent(state, &cfg, grab, &torrent.hash, &torrent.save_path).await {
             Ok(true) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
@@ -1179,6 +1193,10 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
             let file_size = std::fs::metadata(&item.file_path)
                 .map(|m| m.len() as i64)
                 .unwrap_or(0);
+            // Externally-imported file — we're creating both the quality
+            // tag and the grab history row from thin air. `is_batch` is
+            // looked up above from the optional matching grabbed_torrents
+            // row; falls back to false for truly external files.
             let _ = episode_tags::record_grab(
                 &state.db,
                 item.series_id,
@@ -1187,6 +1205,7 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                 classify_title,
                 "",
                 file_size,
+                is_batch,
             )
             .await;
             let _ = episode_tags::mark_completed(
@@ -1195,16 +1214,19 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                 &[item.episode_number],
             )
             .await;
-            // Also flip the fresh grab history row to 'completed' with
-            // the actual file size. No qBit torrent name exists for
-            // externally-imported files — fall back to the classify
-            // title (same as release_title) so the modal shows
-            // something.
+            // Flip the fresh grab history row to 'completed' and stamp
+            // in the on-disk file basename for the episode detail modal.
+            let imported_basename = item
+                .file_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(classify_title)
+                .to_string();
             let _ = episode_tags::mark_grab_history_completed(
                 &state.db,
                 item.series_id,
                 item.episode_number,
-                classify_title,
+                &imported_basename,
                 file_size,
             )
             .await;

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -155,6 +155,14 @@ struct SeriesImportCtx {
     /// series-row-only shape.
     cached_detail: Option<crate::services::anilist::AnimeDetail>,
     runtime_minutes: Option<i32>,
+    /// Snapshot of `episode_quality_tags` for this series at import
+    /// start. Used by the per-file post-download reclassify path to
+    /// decide whether to UPDATE in place vs INSERT a new row, and to
+    /// log the prior source for diagnostics. Refreshed once per
+    /// series-ctx build — safe because within a single import pass
+    /// each episode is written at most once, so later files can't
+    /// depend on earlier files' writes landing in this map.
+    existing_tags: HashMap<i32, episode_tags::EpisodeQualityTag>,
 }
 
 /// Resolve the [`SeriesImportCtx`] for `series_id`: loads the series
@@ -216,6 +224,14 @@ async fn load_series_import_ctx(
         .map(|c| c.detail);
     let runtime_minutes = cached_detail.as_ref().and_then(|d| d.duration);
 
+    // Load the full `episode_quality_tags` snapshot once here instead
+    // of inside the per-file import loop. Previously this ran N times
+    // per batch (one fetch per file) even though each file only writes
+    // its own episode row and no inter-file read dependency exists.
+    let existing_tags = episode_tags::get_for_series(&state.db, series.id)
+        .await
+        .unwrap_or_default();
+
     Ok(SeriesImportCtx {
         series,
         folder_name,
@@ -224,6 +240,7 @@ async fn load_series_import_ctx(
         ep_meta,
         cached_detail,
         runtime_minutes,
+        existing_tags,
     })
 }
 
@@ -318,7 +335,13 @@ async fn import_torrent(
     // each per-episode row carries the Sonarr-style renamed basename
     // (e.g. `Jujutsu Kaisen - S01E06 - Hidden Inventory.mkv`) instead
     // of the batch torrent's release title.
-    let mut imported_eps_by_series: HashMap<i64, Vec<(i32, i64, String)>> = HashMap::new();
+    // BTreeMap for deterministic iteration order downstream — the
+    // post-loop `mark_completed` / `mark_grab_history_completed` pass
+    // runs in series_id ascending order every run, matching
+    // `touched_series`'s BTreeSet so log interleaving is stable and
+    // greppable. Functionally equivalent to HashMap; pure log hygiene.
+    let mut imported_eps_by_series: std::collections::BTreeMap<i64, Vec<(i32, i64, String)>> =
+        std::collections::BTreeMap::new();
     let mut imported_count = 0_usize;
 
     for (file_idx, file) in &video_files {
@@ -575,11 +598,10 @@ async fn import_torrent(
                 // Rows with manual_override = 1 are left alone by the DB
                 // helpers so user tags stick.
                 let series_root = Path::new(&cfg.media_root).join(&ctx.folder_name);
-                let existing_tags =
-                    episode_tags::get_for_series(&state.db, target_series_id)
-                        .await
-                        .unwrap_or_default();
-                let existing_row = existing_tags.get(&ep_num);
+                // Snapshot loaded once per series in `load_series_import_ctx`;
+                // see `SeriesImportCtx::existing_tags` for why refreshing
+                // per-file is unnecessary.
+                let existing_row = ctx.existing_tags.get(&ep_num);
                 let pre_source = existing_row.map(|t| t.source.clone()).unwrap_or_default();
                 let row_exists = existing_row.is_some();
                 let post = source::classify_post_download(

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -316,29 +316,32 @@ async fn import_torrent(
             .copied()
             .unwrap_or(grab.series_id);
 
-        if !series_ctx_cache.contains_key(&target_series_id) {
-            match load_series_import_ctx(state, cfg, target_series_id).await {
-                Ok(ctx) => {
-                    series_ctx_cache.insert(target_series_id, ctx);
-                }
-                Err(e) => {
-                    logger::error(
-                        &state.db,
-                        LogCategory::PostProcess,
-                        &format!(
-                            "Failed to load series context for id={}",
-                            target_series_id
-                        ),
-                        &e,
-                    )
-                    .await;
-                    continue;
+        // Can't use the clean `Entry::or_insert_with_async` pattern
+        // because the loader is async and `entry()` borrows the map
+        // across the await. Branching on the Entry variant keeps the
+        // hot path (cache hit) to a single lookup and only calls the
+        // loader on a cold miss.
+        let ctx = match series_ctx_cache.entry(target_series_id) {
+            std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                match load_series_import_ctx(state, cfg, target_series_id).await {
+                    Ok(ctx) => entry.insert(ctx),
+                    Err(e) => {
+                        logger::error(
+                            &state.db,
+                            LogCategory::PostProcess,
+                            &format!(
+                                "Failed to load series context for id={}",
+                                target_series_id
+                            ),
+                            &e,
+                        )
+                        .await;
+                        continue;
+                    }
                 }
             }
-        }
-        let ctx = series_ctx_cache
-            .get(&target_series_id)
-            .expect("ctx just inserted");
+        };
 
         let src: PathBuf = Path::new(&source_base).join(&file.name);
 

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -242,6 +242,7 @@ async fn import_torrent(
     grab: &grabbed_torrents::GrabbedTorrent,
     torrent_hash: &str,
     torrent_save_path: &str,
+    qbit_torrent_name: &str,
 ) -> Result<bool, String> {
     // Phase 2: look up per-file routing rows written by the auto-expand
     // path. A non-empty result means this grab was an auto-expanded
@@ -303,6 +304,16 @@ async fn import_torrent(
     // Unique series_ids that had at least one file successfully
     // imported — drives the per-series NFO/poster write after the loop.
     let mut touched_series: std::collections::BTreeSet<i64> = std::collections::BTreeSet::new();
+    // Per-target-series (episode number, individual file size) pairs for
+    // every file we successfully landed. Replaces the
+    // `grab.episode_numbers`-based mark_completed at the end of the loop:
+    // bare batch grabs arrive here with an empty episode list on the
+    // parent grab row, but we've already parsed ep_num per file above so
+    // we can mark completed with the real list instead. The per-file
+    // size (not the total torrent size) is what the episode detail modal
+    // surfaces to the user — a batch torrent's aggregate size across ~12
+    // episodes is not a meaningful per-episode number.
+    let mut imported_eps_by_series: HashMap<i64, Vec<(i32, i64)>> = HashMap::new();
     let mut imported_count = 0_usize;
 
     for (file_idx, file) in &video_files {
@@ -555,15 +566,17 @@ async fn import_torrent(
 
                 // Post-download re-classification (Layers 5 + 6). Runs ffprobe
                 // on the landed file and walks the series directory for BD
-                // artifacts, then updates episode_quality_tags in place.
+                // artifacts, then upserts episode_quality_tags.
                 // Rows with manual_override = 1 are left alone by the DB
-                // helper so user tags stick.
+                // helpers so user tags stick.
                 let series_root = Path::new(&cfg.media_root).join(&ctx.folder_name);
-                let pre_source = episode_tags::get_for_series(&state.db, ctx.series.id)
-                    .await
-                    .ok()
-                    .and_then(|m| m.get(&ep_num).map(|t| t.source.clone()))
-                    .unwrap_or_default();
+                let existing_tags =
+                    episode_tags::get_for_series(&state.db, target_series_id)
+                        .await
+                        .unwrap_or_default();
+                let existing_row = existing_tags.get(&ep_num);
+                let pre_source = existing_row.map(|t| t.source.clone()).unwrap_or_default();
+                let row_exists = existing_row.is_some();
                 let post = source::classify_post_download(
                     &state.db,
                     &dest_video,
@@ -577,19 +590,46 @@ async fn import_torrent(
                     grab.is_batch,
                 )
                 .await;
-                if let Err(e) = episode_tags::update_classification(
-                    &state.db,
-                    ctx.series.id,
-                    ep_num,
-                    &post,
-                )
-                .await
-                {
+                // Batch grabs often arrive here with no pre-existing tag
+                // row: the "Grab batch" dropdown and interactive batch
+                // paths skip `episode_tags::record_grab` because they
+                // don't know which episodes are in the pack until
+                // post-processing parses the filenames. `update_classification`
+                // is UPDATE-only, so in that case it would silently
+                // affect 0 rows and the episode stays UNKNOWN in the
+                // UI despite the classifier correctly identifying it.
+                // Branch on row existence: UPSERT via `record_grab`
+                // for the no-row case (same pattern
+                // `scan_library_for_unclassified` uses for externally
+                // imported files), UPDATE in-place via
+                // `update_classification` otherwise.
+                let persist_result = if row_exists {
+                    episode_tags::update_classification(
+                        &state.db,
+                        target_series_id,
+                        ep_num,
+                        &post,
+                    )
+                    .await
+                } else {
+                    episode_tags::record_grab(
+                        &state.db,
+                        target_series_id,
+                        ep_num,
+                        &post,
+                        &grab.torrent_name,
+                        "",
+                        file.size,
+                    )
+                    .await
+                    .map(|_| ())
+                };
+                if let Err(e) = persist_result {
                     logger::warn(
                         &state.db,
                         LogCategory::PostProcess,
                         &format!(
-                            "Post-download tag update failed for S{:02}E{:02}",
+                            "Post-download tag persist failed for S{:02}E{:02}",
                             season, ep_num
                         ),
                         &e.to_string(),
@@ -606,7 +646,12 @@ async fn import_torrent(
                             post.label(),
                             post.confidence
                         ),
-                        &format!("pre={}, post={}", pre_source, post.source.as_str()),
+                        &format!(
+                            "pre={}, post={}, row_existed={}",
+                            pre_source,
+                            post.source.as_str(),
+                            row_exists
+                        ),
                     )
                     .await;
                     // If the post-download classifier flipped into needs_review,
@@ -627,6 +672,11 @@ async fn import_torrent(
                         .await;
                     }
                 }
+
+                imported_eps_by_series
+                    .entry(target_series_id)
+                    .or_default()
+                    .push((ep_num, file.size));
             }
             Err(e) => {
                 logger::error(
@@ -670,26 +720,31 @@ async fn import_torrent(
     }
 
     // Flip episode tag rows from "grabbed" to "completed" per target
-    // series. For a routed batch each sibling route gets its own
-    // `mark_completed` call with the per-sibling episode numbers the
-    // auto-expand path wrote into the routes table; the legacy path
-    // falls through to the grab's parent series and episode list.
-    if routes.is_empty() {
-        let _ = episode_tags::mark_completed(
-            &state.db,
-            grab.series_id,
-            &grab.episode_numbers,
-        )
-        .await;
-    } else {
-        for route in &routes {
-            if route.episode_numbers.is_empty() {
-                continue;
-            }
-            let _ = episode_tags::mark_completed(
+    // series. Uses the accumulator populated during the per-file loop
+    // rather than `grab.episode_numbers` so three cases are handled
+    // uniformly:
+    //   - legacy single-episode grabs (ep list populated at grab time),
+    //   - bare batch grabs where `grab.episode_numbers` is empty and
+    //     the real list only exists on the landed filenames,
+    //   - Phase 2 routed batches where files are split across sibling
+    //     series (each sibling gets its own call keyed by
+    //     `target_series_id`).
+    //
+    // Two flips happen per episode: the quality-tag row (via
+    // `mark_completed`) and the newest 'grabbed' history row (via
+    // `mark_grab_history_completed`). The history flip stamps in the
+    // real qBit torrent name and the per-file size so the episode
+    // detail modal can show both in the history table.
+    for (series_id, episodes) in &imported_eps_by_series {
+        let ep_nums: Vec<i32> = episodes.iter().map(|(n, _)| *n).collect();
+        let _ = episode_tags::mark_completed(&state.db, *series_id, &ep_nums).await;
+        for (ep_num, size_bytes) in episodes {
+            let _ = episode_tags::mark_grab_history_completed(
                 &state.db,
-                route.series_id,
-                &route.episode_numbers,
+                *series_id,
+                *ep_num,
+                qbit_torrent_name,
+                *size_bytes,
             )
             .await;
         }
@@ -811,7 +866,7 @@ pub async fn run_once(state: &AppState) {
             continue;
         }
 
-        match import_torrent(state, &cfg, grab, &torrent.hash, &torrent.save_path).await {
+        match import_torrent(state, &cfg, grab, &torrent.hash, &torrent.save_path, &torrent.name).await {
             Ok(true) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
@@ -882,7 +937,19 @@ struct PendingClassification {
     series_root: std::path::PathBuf,
     file_path: std::path::PathBuf,
     episode_number: i32,
+    /// Sanitized on-disk filename. Used as a fallback title for L1
+    /// classification when `original_torrent_name` is empty (externally
+    /// imported files that Ryokan never grabbed).
     title: String,
+    /// Original torrent name from `grabbed_torrents`, if a Ryokan grab
+    /// exists for this episode. Passed to `classify_post_download` as
+    /// the L1 input when non-empty: the post-processing import step
+    /// sanitizes release tags out of filenames (e.g. "[SubsPlease] Foo
+    /// (1080p) [Batch]" becomes "Foo - S01E05 - Title.mkv"), so
+    /// classifying against the on-disk name yields `rule=empty` and
+    /// the episode shows as UNKNOWN forever. Looking up the original
+    /// grab lets us classify against the unsanitized release name.
+    original_torrent_name: String,
     /// True when an `episode_quality_tags` row already exists for this
     /// (series, episode) pair. Determines whether the persist step goes
     /// through `update_classification` (UPDATE) or `record_grab` +
@@ -957,14 +1024,12 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                 // Decide whether to (re-)classify this file.
                 //
                 // Skip when:
+                //  - `manual_override = 1`: the user explicitly pinned
+                //    this classification — never touch.
                 //  - a tag exists with a non-empty source that isn't
-                //    "unknown" — already confidently classified.
-                //  - the tag is flagged `needs_review` — user should
-                //    resolve it manually via the Needs Review queue;
-                //    we don't want to silently overwrite their pending
-                //    decision with another low-confidence result.
-                //  - the tag is `manual_override` — the user explicitly
-                //    pinned this classification.
+                //    "unknown". Already confidently classified. If such
+                //    a row is *also* flagged `needs_review`, we respect
+                //    that pending user decision and leave it alone.
                 //
                 // Pick up when:
                 //  - no tag exists yet (externally-imported file).
@@ -974,9 +1039,22 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                 //    the file exists now, so retry with the full
                 //    ffprobe/dir-walk pipeline. This is the background
                 //    self-healing path for rows that started as Unknown.
+                //
+                // Note: unknown rows are retried **even when
+                // `needs_review = 1`**. That used to trap stale bad
+                // classifications — a row that was classified
+                // against the sanitized post-import filename before
+                // the original-torrent-name lookup landed produces
+                // `rule=empty` and gets flagged for review, and the
+                // old guard then refused to retry it even after the
+                // bug was fixed. An unknown needs-review row carries
+                // no useful user decision to stomp on (the user
+                // resolves via `set_manual_override`, which sets
+                // `manual_override = 1` and clears `needs_review`),
+                // so retrying is safe.
                 let tag = existing.get(&file.episode_number);
                 if let Some(t) = tag {
-                    if t.manual_override || t.needs_review {
+                    if t.manual_override {
                         continue;
                     }
                     let src = t.source.trim();
@@ -992,13 +1070,49 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                     continue;
                 }
 
-                // Use the filename itself as the title — we don't have the
-                // original torrent name for externally-imported files.
+                // Use the sanitized on-disk filename as the fallback
+                // title. For Ryokan-grabbed files we'll override this
+                // with the original torrent name in the unlocked
+                // classify phase below so L1 sees the full release tag
+                // set instead of the tags-stripped post-import name.
                 let title = Path::new(&file.filename)
                     .file_name()
                     .and_then(|n| n.to_str())
                     .unwrap_or(&file.filename)
                     .to_string();
+
+                // Look up the grab that covers this episode so we can
+                // classify against the unsanitized torrent name. Done
+                // inside the lock because the enumeration phase needs
+                // the work list to be a consistent snapshot and the DB
+                // round-trip is cheap next to the ffprobe shell-out
+                // that runs in the unlocked phase below.
+                //
+                // First try the per-episode lookup. When that misses
+                // (old batch grabs recorded with `episode_numbers = []`
+                // before the grab-time episode-range fix, where
+                // `json_each` yields nothing), fall back to the most
+                // recent imported grab for the series as a whole:
+                // for a single-series batch that's by definition the
+                // grab these files came from. Both queries are cheap
+                // `LIMIT 1` lookups.
+                let original_torrent_name = match grabbed_torrents::find_imported_for_episode(
+                    &state.db,
+                    row.id,
+                    file.episode_number,
+                )
+                .await
+                .ok()
+                .and_then(|grabs| grabs.into_iter().next())
+                {
+                    Some(g) => g.torrent_name,
+                    None => grabbed_torrents::most_recent_imported_torrent_name_for_series(
+                        &state.db,
+                        row.id,
+                    )
+                    .await
+                    .unwrap_or_default(),
+                };
 
                 pending.push(PendingClassification {
                     series_id: row.id,
@@ -1009,6 +1123,7 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                     file_path,
                     episode_number: file.episode_number,
                     title,
+                    original_torrent_name,
                     row_exists: tag.is_some(),
                 });
             }
@@ -1021,17 +1136,22 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
     // slow part; doing them here instead of under the lock lets
     // `process_completed_downloads` keep running in parallel.
     for item in pending {
-        // Library scan path works against on-disk filenames, which may
-        // or may not match any original grab record. We look up the
-        // stored `is_batch` flag by torrent_name as a best effort —
-        // matches self-healed Unknown rows back to their original grab,
-        // defaults to `false` for externally-imported files that
-        // Ryokan never grabbed. Either way, L4 gets the most accurate
-        // signal available for this file.
+        // Prefer the original torrent name from `grabbed_torrents`
+        // (carries full release tags like "[SubsPlease] Foo (01-12)
+        // [BD 1080p]"), fall back to the sanitized on-disk filename
+        // for externally-imported files that Ryokan never grabbed.
+        // This is the difference between L1 producing useful
+        // evidence and producing `rule=empty` on a release that
+        // landed via post-processing's rename step.
+        let classify_title: &str = if !item.original_torrent_name.is_empty() {
+            &item.original_torrent_name
+        } else {
+            &item.title
+        };
         let is_batch = crate::models::grabbed_torrents::get_is_batch_by_name(
             &state.db,
             item.series_id,
-            &item.title,
+            classify_title,
         )
         .await
         .unwrap_or(false);
@@ -1039,7 +1159,7 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
             &state.db,
             &item.file_path,
             Some(&item.series_root),
-            &item.title,
+            classify_title,
             Some(SeriesContext {
                 status: &item.series_status,
                 season_year: item.series_season_year,
@@ -1055,19 +1175,37 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
         // release metadata to insert-or-upsert, then flip state to
         // 'completed' since the file is already on disk.
         if !item.row_exists {
+            // Best-effort single stat — failure just leaves size at 0.
+            let file_size = std::fs::metadata(&item.file_path)
+                .map(|m| m.len() as i64)
+                .unwrap_or(0);
             let _ = episode_tags::record_grab(
                 &state.db,
                 item.series_id,
                 item.episode_number,
                 &result,
-                &item.title,
+                classify_title,
                 "",
+                file_size,
             )
             .await;
             let _ = episode_tags::mark_completed(
                 &state.db,
                 item.series_id,
                 &[item.episode_number],
+            )
+            .await;
+            // Also flip the fresh grab history row to 'completed' with
+            // the actual file size. No qBit torrent name exists for
+            // externally-imported files — fall back to the classify
+            // title (same as release_title) so the modal shows
+            // something.
+            let _ = episode_tags::mark_grab_history_completed(
+                &state.db,
+                item.series_id,
+                item.episode_number,
+                classify_title,
+                file_size,
             )
             .await;
         } else {

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -270,10 +270,23 @@ async fn import_torrent(
         .await
         .unwrap_or_default();
 
-    // file_idx → target series_id, flattened from the routes table.
-    let routes_by_file: HashMap<usize, i64> = routes
+    // file_idx → (target series_id, episode_offset), flattened from
+    // the routes table. `episode_offset` is subtracted from each
+    // file's parsed episode number before the file is renamed /
+    // tagged so absolute-numbered batches (e.g. smol Monogatari
+    // S07E14 → Owari S2 E01 with offset 13) land under the correct
+    // arc-local episode number. Offset is 0 for siblings with arc-
+    // local numbering and for all legacy routes (via COALESCE in the
+    // model read).
+    let routes_by_file: HashMap<usize, (i64, i32)> = routes
         .iter()
-        .flat_map(|r| r.file_indices.iter().map(move |i| (*i, r.series_id)))
+        .flat_map(|r| {
+            let series_id = r.series_id;
+            let offset = r.episode_offset;
+            r.file_indices
+                .iter()
+                .map(move |i| (*i, (series_id, offset)))
+        })
         .collect();
 
     let qbit = state
@@ -350,10 +363,10 @@ async fn import_torrent(
         // grabs and for any completed video file whose index wasn't
         // covered by a route (e.g. extension mismatch between
         // `auto_search::is_media_filename` and [`is_video_file`]).
-        let target_series_id = routes_by_file
+        let (target_series_id, ep_offset) = routes_by_file
             .get(file_idx)
             .copied()
-            .unwrap_or(grab.series_id);
+            .unwrap_or((grab.series_id, 0));
 
         // Can't use the clean `Entry::or_insert_with_async` pattern
         // because the loader is async and `entry()` borrows the map
@@ -404,7 +417,7 @@ async fn import_torrent(
                 }
             });
 
-        let Some(ep_num) = ep_num else {
+        let Some(raw_ep_num) = ep_num else {
             logger::warn(
                 &state.db,
                 LogCategory::PostProcess,
@@ -414,6 +427,32 @@ async fn import_torrent(
             .await;
             continue;
         };
+
+        // Apply per-route episode_offset. For absolute-numbered
+        // continuation packs (smol Monogatari S07E14 → Owari S2 E01,
+        // NoobSubs JoJo E25 → Egypt-hen E01), the offset was computed
+        // at detection time as parent_cap so E14 - 13 = E01. A non-
+        // positive result means the route/file mismatch is bad (file
+        // landed on a sibling whose offset is larger than the file's
+        // own episode number) — log and skip rather than write a
+        // bogus E0 file.
+        let ep_num = raw_ep_num - ep_offset;
+        if ep_num <= 0 {
+            logger::warn(
+                &state.db,
+                LogCategory::PostProcess,
+                &format!(
+                    "Skipping '{}' — effective ep {} after offset {} is non-positive",
+                    filename_only, ep_num, ep_offset
+                ),
+                &format!(
+                    "series={}, raw_ep={}, ep_offset={}",
+                    ctx.series.title, raw_ep_num, ep_offset
+                ),
+            )
+            .await;
+            continue;
+        }
 
         let ep_title = ctx
             .ep_meta

--- a/src/services/qbit.rs
+++ b/src/services/qbit.rs
@@ -300,11 +300,14 @@ impl QbitClient {
         self.resume_torrent(&hash_lc).await?;
 
         // With a `.torrent` URL qBit has the file list within 1-3
-        // seconds; 60s is a generous ceiling. On timeout we give up
-        // on narrowing and let the full download proceed — the
-        // torrent is running, not stuck.
+        // seconds; 10s is a generous ceiling that keeps the HTTP
+        // handler responsive. On timeout we give up on narrowing and
+        // let the full download proceed — the torrent is running, not
+        // stuck. A longer wait here would block the Grab button in
+        // the UI for the full timeout, which is a worse UX than just
+        // downloading the whole pack when metadata is slow.
         let files = match self
-            .wait_for_metadata(&hash_lc, std::time::Duration::from_secs(60))
+            .wait_for_metadata(&hash_lc, std::time::Duration::from_secs(10))
             .await
         {
             Ok(files) => files,
@@ -365,9 +368,31 @@ impl QbitClient {
     }
 
     /// Get the files inside a specific torrent.
+    ///
+    /// qBit 5.x returns **HTTP 404 with a plain-text `"Not Found"` body**
+    /// for `/torrents/files?hash=X` while the torrent is still fetching
+    /// metadata — not an empty JSON array. `reqwest::Response::json()`
+    /// does not look at the status code, so calling it on a 404 body
+    /// hits the serde parser against `"Not Found"` and fails with
+    /// `"error decoding response body"`. We were then treating that as
+    /// a real error and burning the full 60s timeout in
+    /// [`wait_for_metadata`]'s retry loop even though the torrent was
+    /// just a couple seconds away from being ready.
+    ///
+    /// Returning `Ok(vec![])` on 404 lets the wait loop's "empty list →
+    /// retry" arm drive the poll, the same way it would for a
+    /// pre-5.x qBit that returns `[]` in the not-ready state.
     pub async fn get_torrent_files(&self, hash: &str) -> Result<Vec<TorrentFile>, String> {
         let endpoint = format!("/api/v2/torrents/files?hash={}", hash);
         let resp = self.do_get(&endpoint).await?;
+        if resp.status() == StatusCode::NOT_FOUND {
+            return Ok(Vec::new());
+        }
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("qbit torrent files fetch failed: {} {}", status, body.trim()));
+        }
         let files: Vec<TorrentFile> = resp
             .json()
             .await

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -564,6 +564,10 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
                     }),
                 ).await;
                 for ep_num in &ep_list {
+                    // RSS items don't carry size info in the feed — the
+                    // grab history row starts at 0 and gets filled in
+                    // with the actual imported file size by
+                    // post-processing.
                     let _ = episode_tags::record_grab(
                         &state.db,
                         cand.found.series.id,
@@ -571,6 +575,7 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
                         &classification,
                         &cand.item.title,
                         &cand.item.group,
+                        0,
                     ).await;
                 }
             }

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -567,7 +567,8 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
                     // RSS items don't carry size info in the feed — the
                     // grab history row starts at 0 and gets filled in
                     // with the actual imported file size by
-                    // post-processing.
+                    // post-processing. RSS feeds only surface individual
+                    // episode releases, so `is_batch=false` by definition.
                     let _ = episode_tags::record_grab(
                         &state.db,
                         cand.found.series.id,
@@ -576,6 +577,7 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
                         &cand.item.title,
                         &cand.item.group,
                         0,
+                        false,
                     ).await;
                 }
             }

--- a/src/services/source.rs
+++ b/src/services/source.rs
@@ -497,36 +497,56 @@ impl ClassificationResult {
         }
     }
 
-    /// Human-readable label for logs and UI.
+    /// Human-readable label for logs and UI. Sonarr-style `SOURCE-RES`
+    /// base with an optional space-separated BluRay sub-tier suffix:
+    /// `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEBDL-1080p`,
+    /// `WEBRip-1080p`, `WEB-1080p`, `HDTV-1080p`, `DVD-480p`, etc.
+    ///
+    /// Keeping the resolution adjacent to the source (rather than
+    /// appending it after the sub-tier) preserves parity with Sonarr's
+    /// quality definition names, which treat `<source>-<resolution>`
+    /// as the immutable key and bolt any Remux qualifier on afterward.
     ///
     /// Source rendering is variant-aware:
-    /// - `Source::Web` with a known `web_kind` displays as "WEB-DL" or
-    ///   "WEBRip" instead of bare "Web".
-    /// - `Source::BluRay` picks **one** sub-label, mutually exclusive:
-    ///   "BluRay BDMV" if `is_bdmv` (highest tier — full disc), else
-    ///   "BluRay Remux" if `is_remux` (lossless MKV extract), else plain
-    ///   "BluRay" (encoded).
+    /// - `Source::Web` with a known `web_kind` displays as "WEBDL" or
+    ///   "WEBRip" (Sonarr-style, no internal hyphen) instead of the
+    ///   bare "WEB" fallback.
+    /// - `Source::BluRay` always renders as `BD` with at most one
+    ///   trailing space-separated qualifier, mutually exclusive:
+    ///   ` RAW` if `is_bdmv` (highest tier — full disc), else
+    ///   ` Remux` if `is_remux` (lossless MKV extract), else no
+    ///   suffix (encoded).
     pub fn label(&self) -> String {
         let source_label: String = match self.source {
             Source::Unknown => String::new(),
-            Source::Web if self.web_kind != WebKind::Unknown => self.web_kind.as_str().to_string(),
-            Source::BluRay => {
-                if self.is_bdmv {
-                    "BluRay BDMV".to_string()
-                } else if self.is_remux {
-                    "BluRay Remux".to_string()
-                } else {
-                    "BluRay".to_string()
-                }
-            }
+            Source::Web => match self.web_kind {
+                WebKind::WebDl => "WEBDL".to_string(),
+                WebKind::WebRip => "WEBRip".to_string(),
+                WebKind::Unknown => "WEB".to_string(),
+            },
+            Source::BluRay => "BD".to_string(),
             other => other.as_str().to_string(),
         };
-        match (source_label.as_str(), self.resolution) {
+
+        // Base `SOURCE-RESOLUTION` (or just one of the two when the
+        // other is missing). BluRay sub-tier gets appended after.
+        let base = match (source_label.as_str(), self.resolution) {
             ("", Resolution::Unknown) => "Unknown".to_string(),
             (s, Resolution::Unknown) => s.to_string(),
             ("", r) => r.as_str().to_string(),
-            (s, r) => format!("{} {}", s, r.as_str()),
+            (s, r) => format!("{}-{}", s, r.as_str()),
+        };
+
+        if matches!(self.source, Source::BluRay) {
+            if self.is_bdmv {
+                return format!("{} RAW", base);
+            }
+            if self.is_remux {
+                return format!("{} Remux", base);
+            }
         }
+
+        base
     }
 }
 
@@ -1543,7 +1563,7 @@ mod tests {
         // BDMV wins even when both flags are set.
         let both = ClassificationResult { is_remux: true, is_bdmv: true, ..plain.clone() };
         assert_eq!(both.bluray_tier(), 2);
-        assert_eq!(both.label(), "BluRay BDMV 1080p");
+        assert_eq!(both.label(), "BD-1080p RAW");
     }
 
     #[test]
@@ -1561,8 +1581,8 @@ mod tests {
         };
         let webdl = ClassificationResult { web_kind: WebKind::WebDl, ..webrip.clone() };
         assert!(webdl.rank() > webrip.rank());
-        assert_eq!(webrip.label(), "WEBRip 1080p");
-        assert_eq!(webdl.label(), "WEB-DL 1080p");
+        assert_eq!(webrip.label(), "WEBRip-1080p");
+        assert_eq!(webdl.label(), "WEBDL-1080p");
     }
 
     #[test]

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -257,6 +257,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                             &incoming_classification,
                             &result.title,
                             &result.group,
+                            result.size_bytes,
                         )
                         .await;
                     }

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -258,6 +258,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                             &result.title,
                             &result.group,
                             result.size_bytes,
+                            result.is_batch,
                         )
                         .await;
                     }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -404,6 +404,8 @@ fieldset legend {
 
 /* --- Seed/leech counts --- */
 .seed-count { color: var(--green); font-family: var(--font-mono); font-weight: 600; }
+.leech-count { color: var(--red); font-family: var(--font-mono); font-weight: 600; }
+.peer-sep { color: var(--text-dim); font-family: var(--font-mono); }
 .leech-count { color: var(--red); font-family: var(--font-mono); }
 .dl-count { color: var(--text-dim); font-family: var(--font-mono); }
 
@@ -2936,10 +2938,11 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     background: var(--bg-elevated);
 }
 
-.interactive-search-table .col-score { width: 55px; text-align: center; }
-.interactive-search-table .col-grab  { width: 70px; text-align: right; }
-.interactive-search-table .col-size  { width: 80px; white-space: nowrap; }
-.interactive-search-table .col-seeds { width: 50px; text-align: right; }
+.interactive-search-table .col-score   { width: 55px; text-align: center; }
+.interactive-search-table .col-grab    { width: 70px; text-align: right; }
+.interactive-search-table .col-size    { width: 80px; white-space: nowrap; }
+.interactive-search-table .col-seeds   { width: 78px; text-align: right; white-space: nowrap; }
+.interactive-search-table .col-quality { width: 120px; white-space: nowrap; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
 
 .is-modal-scroll {
     overflow-y: auto;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -406,7 +406,6 @@ fieldset legend {
 .seed-count { color: var(--green); font-family: var(--font-mono); font-weight: 600; }
 .leech-count { color: var(--red); font-family: var(--font-mono); font-weight: 600; }
 .peer-sep { color: var(--text-dim); font-family: var(--font-mono); }
-.leech-count { color: var(--red); font-family: var(--font-mono); }
 .dl-count { color: var(--text-dim); font-family: var(--font-mono); }
 
 /* --- Load more --- */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2670,7 +2670,7 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 }
 
 .modal-ep {
-    max-width: 860px;
+    max-width: 1100px;
     width: 100%;
 }
 
@@ -2831,11 +2831,21 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 }
 
 /* --- Grab history table --- */
+.grab-history-scroll {
+    /* Past ~10 entries the modal would blow out vertically and the
+     * user reported clipped rows. Capping the scroll box at 320px
+     * comfortably fits ~10 rows and scrolls the rest. */
+    max-height: 320px;
+    overflow-y: auto;
+    margin-top: 4px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+}
+
 .grab-history-table {
     width: 100%;
     border-collapse: collapse;
     font-size: 12px;
-    margin-top: 4px;
 }
 
 .grab-history-table th {
@@ -2847,6 +2857,13 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     letter-spacing: 0.4px;
     color: var(--text-dim);
     border-bottom: 1px solid var(--border);
+    /* Sticky so the header stays put when the user scrolls past 10
+     * entries. Opaque background needed so rows scrolling beneath
+     * don't bleed through. */
+    background: var(--bg-elevated);
+    position: sticky;
+    top: 0;
+    z-index: 1;
 }
 
 .grab-history-table td {
@@ -2859,9 +2876,19 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     border-bottom: none;
 }
 
-.grab-state-grabbed { color: var(--green); font-weight: 600; }
-.grab-state-failed  { color: var(--red); font-weight: 600; }
-.grab-state-removed { color: var(--text-dim); font-weight: 600; }
+/* Release + Torrent Name cells ellipsize so wide columns don't blow the
+ * table out; full value shown via the tooltip. */
+.grab-history-table .grab-history-ellipsis {
+    max-width: 240px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.grab-state-grabbed   { color: var(--green); font-weight: 600; }
+.grab-state-completed { color: var(--accent); font-weight: 600; }
+.grab-state-failed    { color: var(--red); font-weight: 600; }
+.grab-state-removed   { color: var(--text-dim); font-weight: 600; }
 
 .btn-mark-failed {
     font-size: 11px;
@@ -2917,6 +2944,15 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .is-modal-scroll {
     overflow-y: auto;
     max-height: 480px;
+    /* Zero top/bottom padding so the sticky `<th>` header sits flush
+     * against the scroll container's top edge. With the inherited
+     * 20px padding from `.modal-body`, `position: sticky; top: 0`
+     * leaves a 20px gap above the header where scrolled rows bleed
+     * through (reported: "top bar isn't treated properly, results
+     * show above it"). Horizontal padding is preserved so the table
+     * still breathes from the modal edges. */
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 /* --- Delete file button in ep-detail --- */

--- a/templates/index.html
+++ b/templates/index.html
@@ -135,7 +135,12 @@ function searchAnilist() {
 
     fetch(`/api/anilist/search?q=${encodeURIComponent(q)}`)
         .then(r => {
-            if (!r.ok) throw new Error('Search failed');
+            if (!r.ok) {
+                return r.text().then(msg => {
+                    const trimmed = (msg || '').trim();
+                    throw new Error(trimmed || `Search failed (HTTP ${r.status})`);
+                });
+            }
             return r.json();
         })
         .then(results => {

--- a/templates/series.html
+++ b/templates/series.html
@@ -393,11 +393,11 @@
                 <label class="form-row">
                     <span class="form-label">Source</span>
                     <select id="override-source" class="folder-select">
-                        <option value="bluray_bdmv">BD-Raw (BDMV)</option>
+                        <option value="bluray_bdmv">BD-RAW</option>
                         <option value="bluray_remux">BD-Remux</option>
-                        <option value="bluray">BluRay</option>
-                        <option value="web_dl">WEB-DL</option>
-                        <option value="webrip">WEBRip</option>
+                        <option value="bluray">BD</option>
+                        <option value="web_dl">WEBDL</option>
+                        <option value="webrip">WEBRIP</option>
                         <option value="dvd">DVD</option>
                         <option value="hdtv">HDTV</option>
                         <option value="tv">TV</option>
@@ -567,6 +567,14 @@ function showEpisodeDetail(epNum, btn) {
     }
 }
 
+function formatBytes(bytes) {
+    if (!bytes || bytes <= 0) return '';
+    const gb = bytes / (1024 * 1024 * 1024);
+    if (gb >= 1) return gb.toFixed(1) + ' GiB';
+    const mb = bytes / (1024 * 1024);
+    return Math.round(mb) + ' MiB';
+}
+
 function renderGrabHistory(entries, epNum) {
     const el = document.getElementById('grab-history-body');
     if (!el) return;
@@ -574,20 +582,37 @@ function renderGrabHistory(entries, epNum) {
         el.textContent = 'No grab history.';
         return;
     }
-    let html = '<table class="grab-history-table"><thead><tr><th>Quality</th><th>Release</th><th>Group</th><th>Date</th><th>State</th><th></th></tr></thead><tbody>';
+    // Table lives inside a scroll container so history past 10 entries
+    // scrolls within the modal rather than blowing out modal height.
+    let html = '<div class="grab-history-scroll"><table class="grab-history-table"><thead><tr><th>Quality</th><th>Release</th><th>Torrent Name</th><th>Group</th><th>Size</th><th>Date</th><th>State</th><th></th></tr></thead><tbody>';
     for (const e of entries) {
-        const stateClass = e.state === 'failed' ? 'grab-state-failed' : e.state === 'removed' ? 'grab-state-removed' : 'grab-state-grabbed';
+        const stateClass = e.state === 'failed' ? 'grab-state-failed'
+            : e.state === 'removed' ? 'grab-state-removed'
+            : e.state === 'completed' ? 'grab-state-completed'
+            : 'grab-state-grabbed';
+        // Only active 'grabbed' rows can be manually failed — once
+        // post-processing flips to 'completed' the user should delete
+        // the file or trigger an upgrade instead.
         const canFail = e.state === 'grabbed';
+        // Torrent name column falls back to the release title when the
+        // grab never completed (pre-post-process rows, RSS items).
+        const torrentName = e.torrent_name && e.torrent_name.length ? e.torrent_name : e.release_title;
+        const sameAsRelease = torrentName === e.release_title;
+        const torrentCell = sameAsRelease
+            ? '<span style="color:var(--text-dim)">—</span>'
+            : escHtml(torrentName);
         html += `<tr>
             <td>${escHtml(e.quality_tag)}</td>
-            <td style="max-width:260px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="${escHtml(e.release_title)}">${escHtml(e.release_title)}</td>
+            <td class="grab-history-ellipsis" title="${escHtml(e.release_title)}">${escHtml(e.release_title)}</td>
+            <td class="grab-history-ellipsis" title="${escHtml(torrentName)}">${torrentCell}</td>
             <td>${escHtml(e.release_group)}</td>
+            <td style="white-space:nowrap;color:var(--text-dim)">${escHtml(formatBytes(e.size_bytes))}</td>
             <td style="white-space:nowrap;color:var(--text-dim)">${escHtml(e.grabbed_at)}</td>
             <td class="${stateClass}">${escHtml(e.state)}</td>
             <td>${canFail ? `<button class="btn-mark-failed" onclick="markEpisodeFailed(${e.id}, ${epNum}, this)">Mark Failed</button>` : ''}</td>
         </tr>`;
     }
-    html += '</tbody></table>';
+    html += '</tbody></table></div>';
     el.innerHTML = html;
 }
 
@@ -764,7 +789,8 @@ function grabInteractiveResult(epNum, idx, btn) {
             title: result.title,
             group: result.group,
             resolution: result.resolution,
-            info_hash: result.info_hash
+            info_hash: result.info_hash,
+            size_bytes: result.size_bytes || 0
         })
     })
     .then(async r => {
@@ -863,7 +889,8 @@ function grabInteractiveBatchResult(idx, btn) {
             title: result.title,
             group: result.group,
             resolution: result.resolution,
-            info_hash: result.info_hash
+            info_hash: result.info_hash,
+            size_bytes: result.size_bytes || 0
         })
     })
     .then(async r => {

--- a/templates/series.html
+++ b/templates/series.html
@@ -737,22 +737,45 @@ function escHtml(s) {
 // pure regex read of the title — no platform-tag tables, no group
 // heuristics, no description scraping — so what you see in the UI is
 // exactly what the filename says.
+//
+// Labels mirror the backend `ClassificationResult::label()` Sonarr-parity
+// scheme so the value shown in interactive search equals the value
+// persisted to `episode_tags` once the release is grabbed:
+//     BDMV/BDISO/BD-Raw → `BD-1080p RAW`  (raw disc image)
+//     Remux             → `BD-1080p Remux`
+//     BluRay/BDRip/BD   → `BD-1080p`      (re-encode)
+//     WEB-DL            → `WEBDL-1080p`
+//     WEB-Rip           → `WEBRip-1080p`
+// Note: BDRip is a re-encode and deliberately falls into the BluRay branch,
+// NOT the BDMV branch.
 function parseQualityFromTitle(title, resolution) {
     const t = String(title || '');
     let source = '';
-    if (/\b(BDMV|BD-?Raw|BD-?RIP\b|BDISO)\b/i.test(t))          source = 'BDMV';
-    else if (/\bRemux\b/i.test(t))                              source = 'BD-Remux';
-    else if (/\b(BluRay|Blu-?Ray|BDRip|BD|\.BD\.|\[BD\])\b/i.test(t)) source = 'BluRay';
-    else if (/\bWEB-?DL\b/i.test(t))                            source = 'WEBDL';
-    else if (/\bWEB-?Rip\b/i.test(t))                           source = 'WEBRip';
-    else if (/\bWEB\b/i.test(t))                                source = 'WEB';
-    else if (/\bHDTV\b/i.test(t))                               source = 'HDTV';
-    else if (/\bDVD(?:Rip)?\b/i.test(t))                        source = 'DVD';
+    let suffix = ''; // ' RAW' | ' Remux' | '' — appended after resolution
+    if (/\b(BDMV|BD-?Raw|BDISO)\b/i.test(t)) {
+        source = 'BD'; suffix = ' RAW';
+    } else if (/\bRemux\b/i.test(t)) {
+        source = 'BD'; suffix = ' Remux';
+    } else if (/\b(BluRay|Blu-?Ray|BDRip|BD|\.BD\.|\[BD\])\b/i.test(t)) {
+        source = 'BD';
+    } else if (/\bWEB-?DL\b/i.test(t)) {
+        source = 'WEBDL';
+    } else if (/\bWEB-?Rip\b/i.test(t)) {
+        source = 'WEBRip';
+    } else if (/\bWEB\b/i.test(t)) {
+        source = 'WEB';
+    } else if (/\bHDTV\b/i.test(t)) {
+        source = 'HDTV';
+    } else if (/\bDVD(?:Rip)?\b/i.test(t)) {
+        source = 'DVD';
+    }
     const res = String(resolution || '').trim();
-    if (source && res) return `${source}-${res}`;
-    if (source)        return source;
-    if (res)           return res;
-    return '—';
+    let base;
+    if (source && res) base = `${source}-${res}`;
+    else if (source)   base = source;
+    else if (res)      base = res;
+    else               return '—';
+    return base + suffix;
 }
 
 // Seeders in green, leechers in red, separated by a dim slash.

--- a/templates/series.html
+++ b/templates/series.html
@@ -545,7 +545,13 @@ function showEpisodeDetail(epNum, btn) {
         body.innerHTML =
             '<div class="ep-detail-two-col">' +
             '<div class="ep-detail-row ep-detail-full"><span class="ep-detail-label">File</span><span class="ep-detail-value ep-detail-path">' + escHtml(fullPath) + '</span></div>' +
-            (size ? '<div class="ep-detail-row"><span class="ep-detail-label">Size</span><span class="ep-detail-value">' + escHtml(size) + '</span></div>' : '') +
+            // The Size row starts with the on-disk file size and is
+            // patched in place by `renderGrabHistory` once the grab
+            // history loads: if the latest grab was a batch, the row is
+            // rewritten to show the whole-torrent total with a
+            // "(batch total)" hint. Always rendered (even when size is
+            // empty) so the batch-patch has a stable target to find.
+            '<div class="ep-detail-row"><span class="ep-detail-label">Size</span><span class="ep-detail-value ep-detail-size-value">' + escHtml(size || '—') + '</span></div>' +
             '</div>' +
             '<div class="ep-detail-row" id="grab-history-section" style="margin-top:16px"><span class="ep-detail-label">Grab History</span><div id="grab-history-body" style="margin-top:6px;color:var(--text-dim);font-size:12px">Loading…</div></div>';
     } else {
@@ -584,7 +590,7 @@ function renderGrabHistory(entries, epNum) {
     }
     // Table lives inside a scroll container so history past 10 entries
     // scrolls within the modal rather than blowing out modal height.
-    let html = '<div class="grab-history-scroll"><table class="grab-history-table"><thead><tr><th>Quality</th><th>Release</th><th>Torrent Name</th><th>Group</th><th>Size</th><th>Date</th><th>State</th><th></th></tr></thead><tbody>';
+    let html = '<div class="grab-history-scroll"><table class="grab-history-table"><thead><tr><th>Quality</th><th>Release</th><th>File Name</th><th>Group</th><th>Size</th><th>Date</th><th>State</th><th></th></tr></thead><tbody>';
     for (const e of entries) {
         const stateClass = e.state === 'failed' ? 'grab-state-failed'
             : e.state === 'removed' ? 'grab-state-removed'
@@ -594,19 +600,30 @@ function renderGrabHistory(entries, epNum) {
         // post-processing flips to 'completed' the user should delete
         // the file or trigger an upgrade instead.
         const canFail = e.state === 'grabbed';
-        // Torrent name column falls back to the release title when the
-        // grab never completed (pre-post-process rows, RSS items).
-        const torrentName = e.torrent_name && e.torrent_name.length ? e.torrent_name : e.release_title;
-        const sameAsRelease = torrentName === e.release_title;
-        const torrentCell = sameAsRelease
+        // File name column: shows the post-processed on-disk basename
+        // once post-processing lands the file. Before that it's still
+        // seeded with the release title, so hide the duplicate — the
+        // Release column already carries that.
+        const fileName = e.file_name && e.file_name.length ? e.file_name : e.release_title;
+        const sameAsRelease = fileName === e.release_title;
+        const fileCell = sameAsRelease
             ? '<span style="color:var(--text-dim)">—</span>'
-            : escHtml(torrentName);
+            : escHtml(fileName);
+        // Size column: for batch grabs it's the whole-torrent total
+        // (suffixed with a dim " (batch)" hint) so the user can tell
+        // it's a pack size rather than a per-episode size.
+        const sizeText = formatBytes(e.size_bytes);
+        const sizeCell = sizeText
+            ? (e.is_batch
+                ? escHtml(sizeText) + ' <span style="color:var(--text-dim);font-size:10px">(batch)</span>'
+                : escHtml(sizeText))
+            : '';
         html += `<tr>
             <td>${escHtml(e.quality_tag)}</td>
             <td class="grab-history-ellipsis" title="${escHtml(e.release_title)}">${escHtml(e.release_title)}</td>
-            <td class="grab-history-ellipsis" title="${escHtml(torrentName)}">${torrentCell}</td>
+            <td class="grab-history-ellipsis" title="${escHtml(fileName)}">${fileCell}</td>
             <td>${escHtml(e.release_group)}</td>
-            <td style="white-space:nowrap;color:var(--text-dim)">${escHtml(formatBytes(e.size_bytes))}</td>
+            <td style="white-space:nowrap;color:var(--text-dim)">${sizeCell}</td>
             <td style="white-space:nowrap;color:var(--text-dim)">${escHtml(e.grabbed_at)}</td>
             <td class="${stateClass}">${escHtml(e.state)}</td>
             <td>${canFail ? `<button class="btn-mark-failed" onclick="markEpisodeFailed(${e.id}, ${epNum}, this)">Mark Failed</button>` : ''}</td>
@@ -614,6 +631,22 @@ function renderGrabHistory(entries, epNum) {
     }
     html += '</tbody></table></div>';
     el.innerHTML = html;
+
+    // Task 24: the episode detail "Size" row above the grab history
+    // should reflect the batch total when the latest grab for this
+    // episode was a batch, not the per-file on-disk size. We only
+    // know this once history loads, so patch the row in-place after
+    // the table renders. Find the newest non-failed entry as the
+    // current source of truth — a 'completed' row wins over an older
+    // 'grabbed' row sitting behind a failed upgrade attempt.
+    const current = entries.find(function(e) { return e.state === 'completed' || e.state === 'grabbed'; });
+    if (current && current.is_batch && current.size_bytes > 0) {
+        const sizeValueEl = document.querySelector('#ep-detail-body .ep-detail-size-value');
+        if (sizeValueEl) {
+            sizeValueEl.innerHTML = escHtml(formatBytes(current.size_bytes))
+                + ' <span style="color:var(--text-dim);font-size:11px">(batch total)</span>';
+        }
+    }
 }
 
 function markEpisodeFailed(historyId, epNum, btn) {
@@ -698,6 +731,38 @@ function escHtml(s) {
     return d.innerHTML;
 }
 
+// Quick source detection from release title. The backend already carries
+// the canonical ClassificationResult, but the interactive-search payload
+// only exposes `resolution`. Per user preference the column here is a
+// pure regex read of the title — no platform-tag tables, no group
+// heuristics, no description scraping — so what you see in the UI is
+// exactly what the filename says.
+function parseQualityFromTitle(title, resolution) {
+    const t = String(title || '');
+    let source = '';
+    if (/\b(BDMV|BD-?Raw|BD-?RIP\b|BDISO)\b/i.test(t))          source = 'BDMV';
+    else if (/\bRemux\b/i.test(t))                              source = 'BD-Remux';
+    else if (/\b(BluRay|Blu-?Ray|BDRip|BD|\.BD\.|\[BD\])\b/i.test(t)) source = 'BluRay';
+    else if (/\bWEB-?DL\b/i.test(t))                            source = 'WEBDL';
+    else if (/\bWEB-?Rip\b/i.test(t))                           source = 'WEBRip';
+    else if (/\bWEB\b/i.test(t))                                source = 'WEB';
+    else if (/\bHDTV\b/i.test(t))                               source = 'HDTV';
+    else if (/\bDVD(?:Rip)?\b/i.test(t))                        source = 'DVD';
+    const res = String(resolution || '').trim();
+    if (source && res) return `${source}-${res}`;
+    if (source)        return source;
+    if (res)           return res;
+    return '—';
+}
+
+// Seeders in green, leechers in red, separated by a dim slash.
+// E.g., `32 / 5` where 32 is green and 5 is red.
+function renderPeers(seeders, leechers) {
+    const s = Number.isFinite(seeders) ? seeders : 0;
+    const l = Number.isFinite(leechers) ? leechers : 0;
+    return `<span class="seed-count">${s}</span><span class="peer-sep">/</span><span class="leech-count">${l}</span>`;
+}
+
 function searchBatchReleases(btn) {
     const status = document.getElementById('auto-search-status');
     setBusyButton(btn, true, 'Searching…');
@@ -757,7 +822,7 @@ function renderInteractiveResults(results, epNum) {
         body.innerHTML = '<div style="text-align:center;color:var(--text-dim);padding:32px">No results found.</div>';
         return;
     }
-    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
+    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
     results.forEach((r, idx) => {
         const batchTag = r.is_batch ? '<span class="tag tag-batch" style="margin-left:4px">batch</span>' : '';
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
@@ -766,8 +831,9 @@ function renderInteractiveResults(results, epNum) {
             <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
             <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
+            <td class="col-quality">${escHtml(parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>
-            <td class="col-seeds"><span class="seed-count">${r.seeders}</span></td>
+            <td class="col-seeds">${renderPeers(r.seeders, r.leechers)}</td>
             <td class="col-grab"><button class="btn-grab" data-idx="${idx}" onclick="grabInteractiveResult(${epNum}, ${idx}, this)">Grab</button></td>
         </tr>`;
     });
@@ -857,7 +923,7 @@ function renderInteractiveBatchResults(results) {
         body.innerHTML = '<div style="text-align:center;color:var(--text-dim);padding:32px">No batch releases found.</div>';
         return;
     }
-    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
+    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
     results.forEach((r, idx) => {
         const batchTag = r.is_batch ? '<span class="tag tag-batch" style="margin-left:4px">batch</span>' : '';
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
@@ -866,8 +932,9 @@ function renderInteractiveBatchResults(results) {
             <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
             <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
+            <td class="col-quality">${escHtml(parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>
-            <td class="col-seeds"><span class="seed-count">${r.seeders}</span></td>
+            <td class="col-seeds">${renderPeers(r.seeders, r.leechers)}</td>
             <td class="col-grab"><button class="btn-grab" data-idx="${idx}" onclick="grabInteractiveBatchResult(${idx}, this)">Grab</button></td>
         </tr>`;
     });
@@ -1522,12 +1589,18 @@ function pollDownloadProgress() {
                 const showingProgress = qualityCell.querySelector('.dl-progress-wrap') !== null;
 
                 if (item) {
-                    const pct = (item.progress * 100).toFixed(1);
-                    const isComplete = item.state.includes('UP') || item.state === 'uploading';
-                    if (!isComplete) {
-                        if (!qualityCell.dataset.originalHtml) {
-                            qualityCell.dataset.originalHtml = qualityCell.innerHTML;
-                        }
+                    if (!qualityCell.dataset.originalHtml) {
+                        qualityCell.dataset.originalHtml = qualityCell.innerHTML;
+                    }
+                    const isComplete = item.state.includes('UP') || item.state === 'uploading' || item.progress >= 1.0;
+                    if (isComplete) {
+                        // qBit has finished but post-processing hasn't imported
+                        // the release into the library yet. Show a full bar with
+                        // an "Importing..." label so the user isn't staring at a
+                        // stale 0.0% until the next post-processing tick.
+                        qualityCell.innerHTML = '<div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:100%"></div></div><span class="dl-progress-text">Importing…</span></div>';
+                    } else {
+                        const pct = (item.progress * 100).toFixed(1);
                         qualityCell.innerHTML = `<div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:${pct}%"></div></div><span class="dl-progress-text">${pct}%</span></div>`;
                     }
                 } else if (showingProgress) {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -141,7 +141,7 @@
                 <label for="preferred_source">Preferred Source</label>
                 <select name="preferred_source" id="preferred_source">
                     <option value="web" {% if config.preferred_source == "web" %}selected{% endif %}>WEB</option>
-                    <option value="bluray" {% if config.preferred_source == "bluray" %}selected{% endif %}>BluRay</option>
+                    <option value="bluray" {% if config.preferred_source == "bluray" %}selected{% endif %}>BD</option>
                     <option value="dvd" {% if config.preferred_source == "dvd" %}selected{% endif %}>DVD</option>
                 </select>
                 <span class="form-hint">The release source auto search ranks highest. Other sources still match but are deprioritized in scoring.</span>
@@ -160,12 +160,12 @@
                 <label for="cutoff_source">Cutoff Source</label>
                 <select name="cutoff_source" id="cutoff_source">
                     <option value="web" {% if config.cutoff_source == "web" %}selected{% endif %}>WEB</option>
-                    <option value="bluray" {% if config.cutoff_source == "bluray" %}selected{% endif %}>BluRay</option>
-                    <option value="bluray_remux" {% if config.cutoff_source == "bluray_remux" %}selected{% endif %}>BD Remux</option>
-                    <option value="bluray_bdmv" {% if config.cutoff_source == "bluray_bdmv" %}selected{% endif %}>BD RAW (BDMV)</option>
+                    <option value="bluray" {% if config.cutoff_source == "bluray" %}selected{% endif %}>BD</option>
+                    <option value="bluray_remux" {% if config.cutoff_source == "bluray_remux" %}selected{% endif %}>BD-Remux</option>
+                    <option value="bluray_bdmv" {% if config.cutoff_source == "bluray_bdmv" %}selected{% endif %}>BD-RAW</option>
                     <option value="dvd" {% if config.cutoff_source == "dvd" %}selected{% endif %}>DVD</option>
                 </select>
-                <span class="form-hint">Stop upgrading once the existing file reaches this source at or above the cutoff resolution. Should be ≥ preferred source. BD Remux and BD RAW require a matching sub-tier — plain BluRay encodes will stay upgradeable.</span>
+                <span class="form-hint">Stop upgrading once the existing file reaches this source at or above the cutoff resolution. Should be ≥ preferred source. BD-Remux and BD-RAW require a matching sub-tier — plain BD encodes will stay upgradeable.</span>
             </div>
             <div class="form-group">
                 <label for="cutoff_resolution">Cutoff Resolution</label>
@@ -184,7 +184,7 @@
                     <option value="prefer_bd" {% if config.finished_series_quality == "prefer_bd" %}selected{% endif %}>Prefer BD (fall back to WEB)</option>
                     <option value="bd_only" {% if config.finished_series_quality == "bd_only" %}selected{% endif %}>BD only (skip WEB)</option>
                 </select>
-                <span class="form-hint">For series marked "Finished" on AniList. "Prefer BD" searches for Bluray releases first, falling back to WEB if none found. "BD only" will skip WEB releases entirely.</span>
+                <span class="form-hint">For series marked "Finished" on AniList. "Prefer BD" searches for BD releases first, falling back to WEB if none found. "BD only" will skip WEB releases entirely.</span>
             </div>
             <div class="form-group">
                 <label>Audio Preference</label>
@@ -279,7 +279,7 @@
 <div class="settings-tab-panel active">
     <fieldset>
         <legend>Release Group Source Map</legend>
-        <p class="form-hint">Maps release groups to their known source. Used by Layer 3 of the classification pipeline when the filename alone doesn't carry source keywords (e.g. SubsPlease is WEB, VCB-Studio is BluRay). Seeded rows are restored on startup; user-edited rows are preserved.</p>
+        <p class="form-hint">Maps release groups to their known source. Used by Layer 3 of the classification pipeline when the filename alone doesn't carry source keywords (e.g. SubsPlease is WEB, VCB-Studio is BD). Seeded rows are restored on startup; user-edited rows are preserved.</p>
 
         {% if !suggestions.is_empty() %}
         <h3 class="settings-subheading">Suggested Mappings ({{ suggestions.len() }})</h3>
@@ -333,7 +333,7 @@
                 <label for="new_group_source">Source</label>
                 <select name="source" id="new_group_source">
                     <option value="web">WEB</option>
-                    <option value="bluray">BluRay</option>
+                    <option value="bluray">BD</option>
                     <option value="dvd">DVD</option>
                     <option value="hdtv">HDTV</option>
                     <option value="tv">TV</option>
@@ -536,7 +536,7 @@
             <h3>Bundled Defaults</h3>
         </div>
         <p class="cf-section-desc">
-            <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BluRay source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 and casual-group penalties) — existing names are skipped so repeat clicks are safe.
+            <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 and casual-group penalties) — existing names are skipped so repeat clicks are safe.
             <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file — use this after you've edited a default CF and want the original back. Manual and imported CFs are untouched.
         </p>
         <div class="settings-inline-actions">


### PR DESCRIPTION
## Context

PR #9 (`80fc05a feat: Phase 2 megapack auto-expand + SeaDex direct-fetch`) was merged into `main` prematurely during a fast-forward push to ship the GHCR/Docker workflow (`de9a3ed`, `d9c3ee3`). The review hadn't been addressed and **the changes only had minimal testing** — the unit test suite passed, but the end-to-end auto-expand flow against a real qBit + Nyaa + SeaDex stack hadn't been exercised before it landed on `main` and became `:latest`.

This PR:
1. Addresses all nine review items from PR #9's code review as follow-up commits on `dev`.
2. Establishes a test plan that must be completed before this merges to `main`, covering both the review fixes **and** the original PR #9 content that's currently running under-tested as `:latest`.

## Commits in this PR

- `6587ce4 fix: address PR #9 follow-up review items (1-9)`
- `3a3e24b fix: bump SeaDex cache TTL from 5m to 24h`

## Commits already on main but not end-to-end tested

These shipped with the premature merge. Unit tests passed; the test plan below is for the integration surface.

- `80fc05a feat: Phase 2 megapack auto-expand + SeaDex direct-fetch` — original PR #9 content
- `f465937 feat: Custom Formats settings UI polish` — touches the CF settings page
- `26d6346 fix: skip Phase 2 auto-expand when selective narrowing succeeded` — fix on top of 80fc05a

## Review items addressed (all from PR #9)

1. **`RE_ROMAN_PART`** — drop bare single-letter Romans (I, V, X) so "I Want to Eat Your Pancreas" doesn't trip the part-number extractor. Tests updated.
2. **`pick_by_part_number`** — docstring on the 1-part-per-episode assumption and the Rebuild of Evangelion 2.22 fallthrough.
3. **`SEL_VIEW_COL`** — tightened from `div` to `div[class*='col-md-']` so nested MediaInfo divs don't desync the label/value walk in `parse_view_page`.
4. **`auto_expand_library_from_pack` call sites** — both wrapped in `tokio::spawn` so HTTP handlers don't block up to ~60s on qBit metadata discovery.
5. **SeaDex in-memory cache** — 24-hour TTL keyed by `anilist_id`, wired into `fetch_seadex_payload`. SeaDex is curated on the order of days, not minutes, so a long TTL amortizes the cost down to ~1 lookup per target per day. Multi-target sweeps (JoJo S1–S5) go from ~5 × (1 + N) HTTP requests to one per target on the first sweep and zero on subsequent sweeps. `Ok(Some)`/`Ok(None)` cached; `Err` intentionally retries.
6. **`is_pack_candidate_relation`** — added `CHARACTER` / `OTHER` to the exclude list.
7. **`auto_expand_library_from_pack` metadata-wait warn** — now explicitly states the parent-series fallback in the message.
8. **`is_seadex_match`** — dropped the unnecessary `to_ascii_lowercase()` allocation; added a `debug_assert!` that callers pass lowercase hashes.
9. **`auto_expand_library_from_pack` split + tests** — outer fn handles the qBit metadata wait, inner `_with_files` is a pure fn taking a pre-fetched file list. Added an in-memory SQLite test module with two test cases covering the JoJo/Stardust Crusaders sibling + parent route split and the no-siblings no-op path.

## Test plan

### Review-fix items (new in this PR)

- [x] \`cargo test\` — 315 tests pass locally (run again in CI)
- [x] \`cargo clippy --tests\` — no new warnings introduced
- [x] Unit tests specifically:
  - [x] \`handlers::library::tests::auto_expand_routes_sibling_and_parent_files\`
  - [x] \`handlers::library::tests::auto_expand_noop_when_no_siblings_detected\`
  - [x] \`services::auto_search::tests::extract_part_number_drops_bare_roman_i_on_kizu_first_entry\`
  - [x] \`services::auto_search::tests::extract_part_number_rejects_bare_roman_on_english_pronoun\`
  - [x] \`services::nyaa::tests::parse_view_page_extracts_smol_pack_metadata\` (should still pass with tightened selector)

### Original PR #9 content (on main, integration surface not yet exercised)

- [x] **Phase 2 megapack auto-expand — JoJo-style franchise pack**
  - [x] Grab a JoJo S1-S3 megapack through interactive search on the Phase 1 entry (e.g. JoJo's Bizarre Adventure Part 1)
  - [x] Confirm sibling library entries get auto-added (Phantom Blood / Battle Tendency / Stardust Crusaders)
  - [x] Confirm \`grabbed_torrent_series\` has one route per sibling + one parent route
  - [x] Verify post-processing routes each file to the correct series folder under the media root
- [x] **Selective narrowing skip (from \`26d6346\`)**
  - [x] When selective narrowing filters a megapack down to one sibling, confirm auto-expand does NOT create ghost library rows for the other siblings
  - [x] When selective narrowing times out and falls back to full download, confirm auto-expand DOES run
- [x] **SeaDex direct-fetch**
  - [x] Pick a title with a known SeaDex entry whose Nyaa listing title does NOT overlap with AniList aliases (smol's \`Monogatari (Season 9)\` for Kizu Part 2 is the canonical case)
  - [x] Confirm the SeaDex-curated release shows up in interactive search even though the text query wouldn't find it
  - [x] Confirm the SeaDex boost is applied to the score
  - [x] Check logs for \`seadex: cache hit\` on a second sweep against the same target (item 5 verification — should fire any time within 24h of the first fetch)
- [x] **SeaDex cache cold-start**
  - [x] Restart the process and confirm \`seadex: fetching releases.moe entry\` fires on the next lookup (the cache is in-memory, so a restart is the force-refresh escape hatch). Long-TTL expiry isn't practical to verify without either temporarily shortening \`SEADEX_CACHE_TTL\` in a local build or waiting 24h.
- [x] **Failed SeaDex lookup doesn't poison the cache**
  - [x] Trigger an error path (offline, bad anilist_id, etc.) and confirm a retry on the next call still goes over the wire (Err is intentionally not cached)
- [x] **Relation filter (item 6)**
  - [x] Pick a title with \`CHARACTER\` or \`OTHER\` AniList relations and confirm they no longer get considered during sibling detection

### Custom Formats settings UI polish (\`f465937\`, also on main)

- [ ] Load \`/settings/custom-formats\`, verify the UI renders and edits save correctly
- [ ] Import/export a CF JSON round-trip
- [ ] Verify the trash-guides anime fixture still parses (\`custom_formats::tests::trash_anime_fixtures_all_parse\`)

## Deployment notes

- \`:latest\` on GHCR is currently built from the under-tested \`main\`. Don't promote anything to production until this PR merges and a new \`:latest\` build rolls out.
- \`:dev\` on GHCR is built from this branch and can be used for the test plan above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)