### PR TITLE
fix: self-heal artwork cache rows with stale local_path

### DIFF
--- a/src/models/artwork_cache.rs
+++ b/src/models/artwork_cache.rs
@@ -34,13 +34,19 @@ pub async fn upsert_blob(
     Ok(())
 }
 
-pub async fn has_blob(db: &SqlitePool, blob_hash: &str) -> Result<bool, sqlx::Error> {
-    let row = sqlx::query(r#"SELECT 1 FROM image_blobs WHERE blob_hash = ?"#)
+/// Returns the `local_path` stored for a given blob hash, or `None` if no
+/// such blob row exists. Callers use this both as an existence check and
+/// to verify the on-disk file is still where the DB says it is — older
+/// builds wrote relative paths to this column, which break when the
+/// runtime CWD changes. See `services::artwork::cache_image` for the
+/// self-heal path.
+pub async fn get_blob_path(db: &SqlitePool, blob_hash: &str) -> Result<Option<String>, sqlx::Error> {
+    let row = sqlx::query(r#"SELECT local_path FROM image_blobs WHERE blob_hash = ?"#)
         .bind(blob_hash)
         .fetch_optional(db)
         .await?;
 
-    Ok(row.is_some())
+    Ok(row.map(|r| r.get::<String, _>("local_path")))
 }
 
 /// Payload for `upsert_ref`. Named fields so callers can't swap the

--- a/src/services/artwork.rs
+++ b/src/services/artwork.rs
@@ -24,9 +24,17 @@ fn blob_filename(blob_hash: &str, content_type: &str, source_url: &str) -> Strin
 }
 
 pub fn media_cache_dir() -> PathBuf {
-    std::env::var("RYOKAN_MEDIA_CACHE_DIR")
+    let base = std::env::var("RYOKAN_MEDIA_CACHE_DIR")
         .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("data/cache/artwork"))
+        .unwrap_or_else(|_| PathBuf::from("data/cache/artwork"));
+    // Always store absolute paths. Older builds wrote the relative
+    // default ("data/cache/artwork/blobs/<hash>.jpg") straight into
+    // image_blobs.local_path; those rows then break whenever the
+    // process CWD changes (e.g. a Docker image that later adds
+    // WORKDIR or sets RYOKAN_MEDIA_CACHE_DIR). Canonicalizing here
+    // means every new write records an absolute path regardless of
+    // how the env is configured.
+    std::path::absolute(&base).unwrap_or(base)
 }
 
 pub fn local_url(cache_key: &str, last_write: i64) -> String {
@@ -105,13 +113,24 @@ pub async fn cache_image(
     let dir = media_cache_dir().join("blobs");
     std::fs::create_dir_all(&dir).map_err(|e| format!("create artwork dir failed: {}", e))?;
 
-    let blob_exists = artwork_cache::has_blob(db, &blob_hash)
+    // Check whether we already have a row for this hash, and if so whether
+    // the on-disk file is still where the DB says it is. `has_blob` used to
+    // only return a bool; that meant a row with a stale relative path (or
+    // a blob file that had been deleted out from under us) would short-
+    // circuit the write forever, because the ref row would get refreshed
+    // while the broken blob row sat untouched. Self-heal: if the stored
+    // path is missing, rewrite the file to the current (absolute) path
+    // and upsert_blob so image_blobs is updated in place.
+    let existing_path = artwork_cache::get_blob_path(db, &blob_hash)
         .await
         .map_err(|e| e.to_string())?;
 
-    if blob_exists {
-        // Blob already exists; only refresh the lightweight reference row below.
-    } else {
+    let file_is_live = existing_path
+        .as_deref()
+        .map(|p| std::path::Path::new(p).is_file())
+        .unwrap_or(false);
+
+    if !file_is_live {
         let filename = blob_filename(&blob_hash, &content_type, source_url);
         let path = dir.join(&filename);
         if !path.exists() {


### PR DESCRIPTION
## Summary

- `media_cache_dir()` now always returns an absolute path via `std::path::absolute`, so blob writes are CWD-independent regardless of how `RYOKAN_MEDIA_CACHE_DIR` is configured.
- `cache_image()` verifies the on-disk file is still live before short-circuiting. If the stored `local_path` is missing or stale, it rewrites the blob to the current absolute path and refreshes `image_blobs` in place — the next metadata refresh self-heals every affected series.

## Why

Targets users upgrading from **older Docker builds** that predate `ENV RYOKAN_MEDIA_CACHE_DIR=/data/cache/artwork`. Back then `media_cache_dir()` fell through to the relative default `data/cache/artwork`, and `image_blobs.local_path` was stored verbatim — e.g. `data/cache/artwork/blobs/<hash>.jpg`. Those rows break the moment the process CWD changes (the current image resolves them against `/app`, but the real blob is now under `/data`), and `load_bytes` silently 404s.

The System → Rebuild metadata cache button couldn't fix it either: `cache_image` short-circuited on `has_blob` (DB-only check) and never touched the stale row. This PR makes that path self-healing.

## Test plan

- [x] `cargo check` clean
- [x] `cargo test` — 375/375 pass
- [x] `cargo clippy` — no new warnings in touched files
- [x] Deploy new image to an instance with stale rows, hit System → Rebuild metadata cache, confirm `image_blobs.local_path` rows get rewritten to absolute paths and broken covers load

🤖 Generated with [Claude Code](https://claude.com/claude-code)