### PR TITLE
Code review fixes, perf wins, and AniList rate-limit cooperation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,6 +2261,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "subtle",
  "tokio",
  "tower",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,21 +863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -922,17 +907,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -950,10 +924,8 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
  "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2280,7 +2252,6 @@ dependencies = [
  "chrono",
  "dotenvy",
  "fancy-regex",
- "futures",
  "hex",
  "rand",
  "regex-lite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -863,6 +863,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -907,6 +922,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -924,8 +950,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -2252,6 +2280,7 @@ dependencies = [
  "chrono",
  "dotenvy",
  "fancy-regex",
+ "futures",
  "hex",
  "rand",
  "regex-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,10 @@ rust-version = "1.88"
 # Web framework + async runtime
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
+# Stream combinators — buffer_unordered for bounded-concurrency
+# fan-out, used in services/auto_search to parallelise per-candidate
+# classification.
+futures = "0.3"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "trace", "compression-br", "compression-gzip", "set-header"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,10 +8,6 @@ rust-version = "1.88"
 # Web framework + async runtime
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
-# Stream combinators — buffer_unordered for bounded-concurrency
-# fan-out, used in services/auto_search to parallelise per-candidate
-# classification.
-futures = "0.3"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "trace", "compression-br", "compression-gzip", "set-header"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_json = "1"
 bcrypt = "0.16"
 rand = "0.8"
 hex = "0.4"
+subtle = "2"
 
 # Logging
 tracing = "0.1"

--- a/src/handlers/auth.rs
+++ b/src/handlers/auth.rs
@@ -443,8 +443,22 @@ pub async fn setup_submit(
     State(state): State<AppState>,
     Form(form): Form<SetupForm>,
 ) -> impl IntoResponse {
-    if let Ok(true) = user::has_users(&state.db).await {
-        return Redirect::to("/login").into_response();
+    // Fail closed on a transient has_users error: an Ok(true) -> redirect
+    // pattern (the prior code) treated Err(_) the same as Ok(false) and
+    // let the form proceed, so a SQLite hiccup during a second admin's
+    // setup attempt could create a second account. The UNIQUE(username)
+    // constraint catches identical usernames, but a different username
+    // through that window would have slipped past.
+    match user::has_users(&state.db).await {
+        Ok(false) => {} // proceed
+        Ok(true) => return Redirect::to("/login").into_response(),
+        Err(e) => {
+            tracing::error!("setup_submit: has_users failed: {e}");
+            let template = SetupTemplate {
+                error: Some("Database error. Try again in a moment.".into()),
+            };
+            return Html(template.render().unwrap_or_default()).into_response();
+        }
     }
 
     if form.username.trim().is_empty() || form.password.is_empty() {

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -472,6 +472,41 @@ async fn reconcile_all_fallback_entries(db: &SqlitePool) -> ReconcileReport {
     report
 }
 
+/// Fill each item's cover URL with the cached `/media/art/...` URL when
+/// one exists for `series-<id>-cover`. Wraps the build-cache-keys →
+/// batch-fetch → zip-write pattern shared by `index` and
+/// `needs_review_page` — both used to fire one
+/// `artwork::cached_or_source_url` per series, which on a 200-series
+/// library was 200 sequential SQLite queries before the topbar even
+/// rendered.
+async fn populate_series_cover_urls<T, S, M>(
+    db: &sqlx::SqlitePool,
+    items: &mut [T],
+    series_id_of: S,
+    set_cover: M,
+) where
+    S: Fn(&T) -> i64,
+    M: Fn(&mut T, String),
+{
+    if items.is_empty() {
+        return;
+    }
+    let cache_keys: Vec<String> = items
+        .iter()
+        .map(|item| format!("series-{}-cover", series_id_of(item)))
+        .collect();
+    let Ok(url_map) =
+        crate::models::artwork_cache::get_local_urls_batch(db, &cache_keys).await
+    else {
+        return;
+    };
+    for (item, key) in items.iter_mut().zip(cache_keys.iter()) {
+        if let Some(url) = url_map.get(key) {
+            set_cover(item, url.clone());
+        }
+    }
+}
+
 pub async fn index(State(state): State<AppState>) -> Html<String> {
     // Fetch the library list and config concurrently — they're independent
     // and each was previously serialized on the other. `get_all` is the
@@ -484,25 +519,13 @@ pub async fn index(State(state): State<AppState>) -> Html<String> {
     let mut library = library_res.unwrap_or_default();
     let cfg = cfg_res.ok().flatten();
 
-    // Batch the cover-art lookups into a single SQL round trip. The old
-    // code fired one `artwork::cached_or_source_url` per series — a 200-
-    // series library meant 200 sequential SQLite queries just to render
-    // the topbar's Library tab.
-    if !library.is_empty() {
-        let cache_keys: Vec<String> = library
-            .iter()
-            .map(|item| format!("series-{}-cover", item.id))
-            .collect();
-        if let Ok(url_map) =
-            crate::models::artwork_cache::get_local_urls_batch(&state.db, &cache_keys).await
-        {
-            for (item, key) in library.iter_mut().zip(cache_keys.iter()) {
-                if let Some(url) = url_map.get(key) {
-                    item.cover_url = url.clone();
-                }
-            }
-        }
-    }
+    populate_series_cover_urls(
+        &state.db,
+        &mut library,
+        |item| item.id,
+        |item, url| item.cover_url = url,
+    )
+    .await;
 
     let template = IndexTemplate {
         page: "library".to_string(),
@@ -518,24 +541,13 @@ pub async fn index(State(state): State<AppState>) -> Html<String> {
 pub async fn needs_review_page(State(state): State<AppState>) -> Html<String> {
     let mut entries = episode_tags::get_needs_review(&state.db).await.unwrap_or_default();
 
-    // Same batch-artwork treatment as `index` — the previous serial per-
-    // entry lookup was one of the reasons this page felt slow when the
-    // backlog was large.
-    if !entries.is_empty() {
-        let cache_keys: Vec<String> = entries
-            .iter()
-            .map(|e| format!("series-{}-cover", e.series_id))
-            .collect();
-        if let Ok(url_map) =
-            crate::models::artwork_cache::get_local_urls_batch(&state.db, &cache_keys).await
-        {
-            for (entry, key) in entries.iter_mut().zip(cache_keys.iter()) {
-                if let Some(url) = url_map.get(key) {
-                    entry.cover_url = url.clone();
-                }
-            }
-        }
-    }
+    populate_series_cover_urls(
+        &state.db,
+        &mut entries,
+        |e| e.series_id,
+        |entry, url| entry.cover_url = url,
+    )
+    .await;
 
     let template = NeedsReviewTemplate {
         page: "library".to_string(),

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -2040,23 +2040,61 @@ pub async fn set_manual_override(
     State(state): State<AppState>,
     Json(form): Json<SetManualOverrideForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    use crate::services::source::{Resolution, Source, WebKind};
+
+    // Validate + canonicalize the form fields *before* writing. The
+    // model would otherwise bind the raw input string into the DB
+    // column even when from_str returns Unknown — so a malicious or
+    // buggy client could write a garbage `source` value that round-
+    // trips through the enum as Unknown but appears as the raw string
+    // in any SQL filter that compares against canonical names. Empty
+    // source is the explicit "clear override" path and skips
+    // validation.
+    let (source_str, resolution_str, web_kind_str) = if form.source.is_empty() {
+        (String::new(), String::new(), String::new())
+    } else {
+        let parsed_source = Source::from_str(&form.source);
+        if parsed_source == Source::Unknown {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!("invalid source: {:?}", form.source),
+            ));
+        }
+        let parsed_resolution = Resolution::from_str(&form.resolution);
+        if parsed_resolution == Resolution::Unknown {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                format!("invalid resolution: {:?}", form.resolution),
+            ));
+        }
+        // WebKind::Unknown is allowed — it's optional metadata that
+        // only applies to Source::Web; non-Web overrides leave it
+        // empty by design.
+        let parsed_web_kind = WebKind::from_str(&form.web_kind);
+        (
+            parsed_source.as_str().to_string(),
+            parsed_resolution.as_str().to_string(),
+            parsed_web_kind.as_str().to_string(),
+        )
+    };
+
     episode_tags::set_manual_override(
         &state.db,
         form.series_id,
         form.episode_number,
-        &form.source,
-        &form.resolution,
+        &source_str,
+        &resolution_str,
         form.is_remux,
         form.is_bdmv,
-        &form.web_kind,
+        &web_kind_str,
     )
     .await
     .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    let action = if form.source.is_empty() {
+    let action = if source_str.is_empty() {
         "cleared".to_string()
     } else {
-        format!("{} {}", form.source, form.resolution)
+        format!("{} {}", source_str, resolution_str)
     };
     logger::info(
         &state.db,
@@ -2069,8 +2107,8 @@ pub async fn set_manual_override(
         "ok": true,
         "series_id": form.series_id,
         "episode_number": form.episode_number,
-        "source": form.source,
-        "resolution": form.resolution,
+        "source": source_str,
+        "resolution": resolution_str,
         "is_remux": form.is_remux,
     })))
 }

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -9,7 +9,7 @@ use std::collections::HashMap;
 
 use crate::models::{config, episode_tags, grabbed_torrents, local_metadata, metadata_cache, monitoring, series};
 use crate::models::log::LogCategory;
-use crate::services::{anilist, artwork, auto_search, jikan, kitsu, logger, media, metadata_sync, monitoring as monitoring_service};
+use crate::services::{anilist, artwork, auto_search, jikan, kitsu, logger, media, metadata_sync, monitoring as monitoring_service, progress};
 use crate::AppState;
 
 #[derive(Template)]
@@ -1941,6 +1941,7 @@ pub async fn set_monitoring(
                 let _ = auto_search_series(
                     axum::extract::State(state_clone),
                     axum::extract::Path(series_id),
+                    axum::extract::Query(AutoSearchQuery::default()),
                 ).await;
             });
         }
@@ -2611,6 +2612,88 @@ async fn run_auto_search_targets(
     run_auto_search_targets_with_upgrades(state, request_id, targets, allow_batch, series_id, std::collections::HashMap::new()).await
 }
 
+/// Optional `?progress_id=<opaque>` query string the frontend appends to
+/// auto-search trigger calls. The handler binds it to a fresh job in the
+/// progress registry and the worker task emits stage events into it for
+/// the sticky toast on the page.
+#[derive(Deserialize, Default)]
+pub struct AutoSearchQuery {
+    pub progress_id: Option<String>,
+}
+
+/// Pick a user-facing title for progress toasts. Prefers the English
+/// title, falling back to romaji — the same fallback the logger
+/// already uses elsewhere in this handler.
+fn display_title_for_progress(detail: &anilist::AnimeDetail) -> &str {
+    if !detail.title_english.is_empty() {
+        &detail.title_english
+    } else {
+        &detail.title_romaji
+    }
+}
+
+/// Emit a terminal progress event summarizing the outcome of an
+/// auto-search task. Called from inside the spawned task so the
+/// `progress::EMITTER` task-local is in scope.
+async fn emit_auto_search_terminal(
+    result: &Result<auto_search::AutoSearchReport, (axum::http::StatusCode, String)>,
+) {
+    match result {
+        Ok(report) => {
+            let grabbed = report.grabbed.len();
+            if grabbed > 0 {
+                // Show titles for ≤3 grabs, otherwise just the count —
+                // a 50-episode batch shouldn't paste a 50-line toast.
+                let body = if grabbed <= 3 {
+                    Some(
+                        report
+                            .grabbed
+                            .iter()
+                            .map(|h| format!("{}: {}", h.target_label, h.release_title))
+                            .collect::<Vec<_>>()
+                            .join("\n"),
+                    )
+                } else {
+                    Some(format!("{} releases queued for download", grabbed))
+                };
+                progress::emit(
+                    "done",
+                    "success",
+                    format!(
+                        "Grabbed {} release{}",
+                        grabbed,
+                        if grabbed == 1 { "" } else { "s" }
+                    ),
+                    body,
+                    true,
+                )
+                .await;
+            } else if !report.skipped.is_empty() {
+                progress::emit(
+                    "done",
+                    "warn",
+                    "No releases grabbed",
+                    Some(report.skipped.join("\n")),
+                    true,
+                )
+                .await;
+            } else {
+                progress::emit(
+                    "done",
+                    "warn",
+                    "Nothing to search",
+                    Some("No targets matched the requested scope".into()),
+                    true,
+                )
+                .await;
+            }
+        }
+        Err((_, msg)) => {
+            progress::emit("error", "error", "Auto search failed", Some(msg.clone()), true).await;
+        }
+    }
+}
+
 async fn run_auto_search_targets_with_upgrades(
     state: &AppState,
     request_id: i64,
@@ -2646,6 +2729,18 @@ async fn run_auto_search_targets_with_upgrades(
         &format!("Auto search started for {}", title),
         &format!("{} target(s), allow_batch={}", targets.len(), allow_batch),
     ).await;
+    progress::emit(
+        "search",
+        "info",
+        format!("Searching {}", title),
+        Some(format!(
+            "{} target{}",
+            targets.len(),
+            if targets.len() == 1 { "" } else { "s" }
+        )),
+        false,
+    )
+    .await;
 
     // Clone the compiled-CF Arc out from under the read lock so the
     // scoring loop below runs without holding it.
@@ -2653,9 +2748,22 @@ async fn run_auto_search_targets_with_upgrades(
 
     let mut grabbed = Vec::new();
     let mut skipped = Vec::new();
-    for target in targets {
+    let total_targets = targets.len();
+    for (idx, target) in targets.into_iter().enumerate() {
         let label = auto_search::target_label(&target);
         let is_upgrade = matches!(&target, auto_search::SearchTarget::Episode(n) if upgrade_classifications.contains_key(n));
+        progress::emit(
+            "search",
+            "info",
+            if total_targets > 1 {
+                format!("[{}/{}] {}", idx + 1, total_targets, label)
+            } else {
+                format!("Searching: {}", label)
+            },
+            None,
+            false,
+        )
+        .await;
         match auto_search::find_best_for_target(&state.db, &detail, &cfg, &target, allow_batch, is_upgrade, &cfs).await {
             Some(result) => {
                 // Classify up front so both upgrade-verification and log labels
@@ -2756,6 +2864,14 @@ async fn run_auto_search_targets_with_upgrades(
                             &format!("Grabbed: {}", result.title),
                             &format!("target={}, group={}, score={}, tier={}, batch={}{}", label, result.group, result.score, incoming_classification.label(), result.is_batch, selective_suffix),
                         ).await;
+                        progress::emit(
+                            "grab",
+                            "success",
+                            format!("Grabbed: {}", label),
+                            Some(format!("{} [{}]", result.title, incoming_classification.label())),
+                            false,
+                        )
+                        .await;
                         // Record for post-processing and episode quality tags.
                         if let Some(sid) = series_id {
                             let mut ep_nums: Vec<i32> = match &target {
@@ -2909,7 +3025,15 @@ async fn run_auto_search_targets_with_upgrades(
 pub async fn auto_search_series(
     State(state): State<AppState>,
     Path(request_id): Path<i64>,
+    Query(q): Query<AutoSearchQuery>,
 ) -> Result<Json<auto_search::AutoSearchReport>, (axum::http::StatusCode, String)> {
+    let progress_handle = match progress::sanitize_progress_id(q.progress_id.as_deref()) {
+        Some(id) => Some(state.progress.register(id).await),
+        None => None,
+    };
+    if let Some(h) = &progress_handle {
+        h.emit("start", "info", "Preparing auto-search…", None, false).await;
+    }
     let cfg = config::get_config(&state.db)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
@@ -3003,13 +3127,37 @@ pub async fn auto_search_series(
             _ => None,
         })
         .collect();
-    // Spawn as an independent task so the grab completes even if the client disconnects.
+    // Spawn as an independent task so the grab completes even if the client
+    // disconnects. The spawned future is wrapped in `progress::scope` when a
+    // progress handle was registered, so deep callees inside the search
+    // pipeline can `progress::emit` into the toast without threading the
+    // handle through every signature.
     let state_clone = state.clone();
-    let handle = tokio::spawn(async move {
-        run_auto_search_targets_with_upgrades(&state_clone, request_id, targets, true, series_id_for_grab, upgrade_classifications).await
-    });
-    let report = handle.await
-        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))??;
+    let progress_for_task = progress_handle.clone();
+    let handle = tokio::spawn(progress::run_with_progress(
+        progress_for_task,
+        async move {
+            let result = run_auto_search_targets_with_upgrades(
+                &state_clone,
+                request_id,
+                targets,
+                true,
+                series_id_for_grab,
+                upgrade_classifications,
+            )
+            .await;
+            emit_auto_search_terminal(&result).await;
+            result
+        },
+    ));
+    let report = handle
+        .await
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Search task failed: {}", e),
+            )
+        })??;
     Ok(Json(report))
 }
 
@@ -3032,7 +3180,22 @@ pub async fn auto_search_series(
 pub async fn auto_search_episode(
     State(state): State<AppState>,
     Path((request_id, episode_number)): Path<(i64, i32)>,
+    Query(q): Query<AutoSearchQuery>,
 ) -> Result<Json<auto_search::AutoSearchReport>, (axum::http::StatusCode, String)> {
+    let progress_handle = match progress::sanitize_progress_id(q.progress_id.as_deref()) {
+        Some(id) => Some(state.progress.register(id).await),
+        None => None,
+    };
+    if let Some(h) = &progress_handle {
+        h.emit(
+            "start",
+            "info",
+            format!("Searching episode {}…", episode_number),
+            None,
+            false,
+        )
+        .await;
+    }
     let (tracked_row, _, detail) = resolve_series_context(&state.db, request_id)
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
@@ -3056,20 +3219,35 @@ pub async fn auto_search_episode(
     // out by the Episode(n) matching rules.
     let target = auto_search::SearchTarget::for_episode(&detail, episode_number);
 
-    // Spawn as an independent task so the grab completes even if the client disconnects.
+    // Spawn as an independent task so the grab completes even if the client
+    // disconnects. The spawn is wrapped in `progress::run_with_progress`
+    // when a progress handle was registered above so deep callees can emit
+    // into the user's sticky toast without threading the handle down.
     let state_clone = state.clone();
-    let handle = tokio::spawn(async move {
-        run_auto_search_targets(
-            &state_clone,
-            request_id,
-            vec![target],
-            false,
-            series_id_for_grab,
-        )
+    let progress_for_task = progress_handle.clone();
+    let handle = tokio::spawn(progress::run_with_progress(
+        progress_for_task,
+        async move {
+            let result = run_auto_search_targets(
+                &state_clone,
+                request_id,
+                vec![target],
+                false,
+                series_id_for_grab,
+            )
+            .await;
+            emit_auto_search_terminal(&result).await;
+            result
+        },
+    ));
+    let report = handle
         .await
-    });
-    let report = handle.await
-        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, format!("Search task failed: {}", e)))??;
+        .map_err(|e| {
+            (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Search task failed: {}", e),
+            )
+        })??;
     Ok(Json(report))
 }
 
@@ -3091,7 +3269,16 @@ pub async fn auto_search_episode(
 pub async fn search_batch_releases(
     State(state): State<AppState>,
     Path(request_id): Path<i64>,
+    Query(q): Query<AutoSearchQuery>,
 ) -> Result<Json<auto_search::AutoSearchReport>, (axum::http::StatusCode, String)> {
+    let progress_handle = match progress::sanitize_progress_id(q.progress_id.as_deref()) {
+        Some(id) => Some(state.progress.register(id).await),
+        None => None,
+    };
+    if let Some(h) = &progress_handle {
+        h.emit("start", "info", "Searching for batch release…", None, false).await;
+    }
+
     let (tracked_row, _, detail) = resolve_series_context(&state.db, request_id)
         .await
         .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
@@ -3104,6 +3291,17 @@ pub async fn search_batch_releases(
         .unwrap_or_default();
 
     let cfs = state.custom_formats.read().await.clone();
+
+    if let Some(h) = &progress_handle {
+        h.emit(
+            "search",
+            "info",
+            format!("Searching: {}", display_title_for_progress(&detail)),
+            None,
+            false,
+        )
+        .await;
+    }
 
     // Pick the best *batch* — filtering to is_batch pre-selection instead
     // of post-selection. The old code called find_best_for_target and
@@ -3121,19 +3319,56 @@ pub async fn search_batch_releases(
     let qbit = {
         let qbit = state.qbit.read().await;
         qbit.as_ref()
-            .ok_or((axum::http::StatusCode::BAD_REQUEST, "qBittorrent not configured".to_string()))?
+            .ok_or({
+                if let Some(h) = &progress_handle {
+                    // Fire-and-forget: we're about to Err-return, so the
+                    // toast is the only surface that tells the user why.
+                    let h = h.clone();
+                    tokio::spawn(async move {
+                        h.emit("error", "error", "qBittorrent not configured", None, true).await;
+                    });
+                }
+                (axum::http::StatusCode::BAD_REQUEST, "qBittorrent not configured".to_string())
+            })?
             .clone()
     };
 
     match best {
-        None => Err((axum::http::StatusCode::NOT_FOUND, "No batch release found".to_string())),
+        None => {
+            if let Some(h) = &progress_handle {
+                h.emit("done", "warn", "No batch release found", None, true).await;
+            }
+            Err((axum::http::StatusCode::NOT_FOUND, "No batch release found".to_string()))
+        }
         Some(result) => {
             let url = if !result.magnet.is_empty() { result.magnet.clone() } else { result.torrent.clone() };
             if url.is_empty() {
+                if let Some(h) = &progress_handle {
+                    h.emit("error", "error", "No magnet/torrent URL for batch release", None, true).await;
+                }
                 return Err((axum::http::StatusCode::BAD_GATEWAY, "No magnet/torrent URL for batch release".to_string()));
             }
+            if let Some(h) = &progress_handle {
+                h.emit(
+                    "grab",
+                    "info",
+                    format!("Grabbing {}", result.title),
+                    None,
+                    false,
+                )
+                .await;
+            }
             qbit.add_torrent(&url).await
-                .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
+                .map_err(|e| {
+                    if let Some(h) = &progress_handle {
+                        let h = h.clone();
+                        let err = e.clone();
+                        tokio::spawn(async move {
+                            h.emit("error", "error", "qBittorrent rejected the torrent", Some(err), true).await;
+                        });
+                    }
+                    (axum::http::StatusCode::BAD_GATEWAY, e)
+                })?;
             let classification = crate::services::source::classify_release(
                 &state.db,
                 &result.title,
@@ -3193,6 +3428,16 @@ pub async fn search_batch_releases(
                         result.is_batch,
                     ).await;
                 }
+            }
+            if let Some(h) = &progress_handle {
+                h.emit(
+                    "done",
+                    "success",
+                    "Batch grabbed",
+                    Some(format!("{} ({})", result.title, tier_label)),
+                    true,
+                )
+                .await;
             }
             Ok(Json(auto_search::AutoSearchReport {
                 grabbed: vec![auto_search::AutoSearchHit {

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,6 +1,7 @@
 pub mod auth;
 pub mod downloads;
 pub mod library;
+pub mod progress;
 pub mod search;
 pub mod settings;
 pub mod system;

--- a/src/handlers/progress.rs
+++ b/src/handlers/progress.rs
@@ -1,0 +1,44 @@
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::Json,
+};
+use serde::Deserialize;
+
+use crate::services::progress::ProgressPoll;
+use crate::AppState;
+
+#[derive(Deserialize)]
+pub struct PollQuery {
+    /// Cursor returned by the previous poll. Omit on the first call to
+    /// drain the buffer from the start.
+    pub since: Option<usize>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/progress/{job_id}",
+    tag = "System",
+    summary = "Poll progress events for a tracked job",
+    description = "Returns events appended to the job since the caller's cursor. The frontend should poll this on a short interval (e.g. 500ms) while a sticky toast is open, and stop polling once `terminal: true` is observed.",
+    params(
+        ("job_id" = String, Path, description = "Client-supplied opaque progress id."),
+        ("since" = Option<usize>, Query, description = "Cursor from the previous poll. Omit to drain from the start."),
+    ),
+    responses(
+        (status = 200, description = "Buffered events past the cursor", body = ProgressPoll),
+        (status = 404, description = "Unknown or already-swept job id"),
+    ),
+)]
+pub async fn poll_progress(
+    State(state): State<AppState>,
+    Path(job_id): Path<String>,
+    Query(q): Query<PollQuery>,
+) -> Result<Json<ProgressPoll>, (StatusCode, &'static str)> {
+    state
+        .progress
+        .poll(&job_id, q.since.unwrap_or(0))
+        .await
+        .map(Json)
+        .ok_or((StatusCode::NOT_FOUND, "unknown progress job"))
+}

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -368,7 +368,7 @@ pub async fn movie_lookup(
             .ok()
             .flatten();
 
-        let tmdb_id = resolve_tmdb_id(r.id, r.id_mal).await;
+        let tmdb_id = anibridge::resolve_tmdb_id(r.id, r.id_mal).await;
         let title = if !r.title_english.is_empty() { &r.title_english } else { &r.title_romaji };
 
         movies.push(build_radarr_movie_from_search(
@@ -395,7 +395,7 @@ pub async fn list_movies(
 
     let mut results = Vec::new();
     for s in &tracked {
-        let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+        let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
         results.push(build_radarr_movie_from_tracked(s, tmdb_id, &cfg));
     }
 
@@ -418,7 +418,7 @@ pub async fn get_movie(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Movie not found".to_string()))?;
 
-    let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
     Ok(Json(build_radarr_movie_from_tracked(&s, tmdb_id, &cfg)))
 }
 
@@ -570,7 +570,7 @@ pub async fn update_movie(
         .flatten()
         .unwrap_or_default();
 
-    let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
     Ok(Json(build_radarr_movie_from_tracked(&s, tmdb_id, &cfg)))
 }
 
@@ -605,19 +605,6 @@ pub async fn execute_command(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-/// Resolve TMDB ID from either AniList ID or MAL ID.
-async fn resolve_tmdb_id(anilist_id: i64, mal_id: impl Into<Option<i64>>) -> i64 {
-    if let Some(tmdb) = anibridge::lookup_tmdb_by_anilist(anilist_id).await {
-        return tmdb;
-    }
-    if let Some(mid) = mal_id.into()
-        && mid > 0
-            && let Some(tmdb) = anibridge::lookup_tmdb_by_mal(mid).await {
-                return tmdb;
-            }
-    0
-}
 
 async fn lookup_by_tmdb_id(
     state: &AppState,

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -27,9 +27,17 @@ pub async fn require_api_key(
     req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
+    // See sonarr_compat::require_api_key for the 503-vs-500 rationale.
     let cfg = match config::get_config(&state.db).await {
         Ok(Some(c)) => c,
-        _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Ok(None) | Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(axum::http::header::RETRY_AFTER, "5")],
+                "Ryokan config not yet available",
+            )
+                .into_response();
+        }
     };
 
     if !cfg.radarr_enabled || cfg.radarr_api_key.is_empty() {

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -36,6 +36,10 @@ pub async fn require_api_key(
         return (StatusCode::SERVICE_UNAVAILABLE, "Radarr API compatibility layer is disabled").into_response();
     }
 
+    // Mirrors sonarr_compat::require_api_key — see that function for the
+    // full rationale on percent-decoding the query-string value and on
+    // the constant-time compare. Kept duplicated rather than extracted
+    // because the only difference is the cfg field accessed.
     let api_key = req
         .headers()
         .get("x-api-key")
@@ -45,13 +49,25 @@ pub async fn require_api_key(
             let query_str = req.uri().query().unwrap_or("");
             query_str.split('&').find_map(|pair| {
                 let (key, val) = pair.split_once('=')?;
-                if key == "apikey" { Some(val.to_string()) } else { None }
+                if key == "apikey" {
+                    Some(urlencoding::decode(val).ok()?.into_owned())
+                } else {
+                    None
+                }
             })
         });
 
-    match api_key {
-        Some(key) if key == cfg.radarr_api_key => next.run(req).await,
-        _ => (StatusCode::UNAUTHORIZED, "Invalid or missing API key").into_response(),
+    let valid = match &api_key {
+        Some(key) => bool::from(subtle::ConstantTimeEq::ct_eq(
+            key.as_bytes(),
+            cfg.radarr_api_key.as_bytes(),
+        )),
+        None => false,
+    };
+    if valid {
+        next.run(req).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "Invalid or missing API key").into_response()
     }
 }
 

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -494,6 +494,7 @@ pub async fn add_movie(
             let _ = super::library::auto_search_series(
                 axum::extract::State(state_clone),
                 axum::extract::Path(id),
+                axum::extract::Query(super::library::AutoSearchQuery::default()),
             ).await;
         });
     }
@@ -564,6 +565,7 @@ pub async fn execute_command(
                     let _ = super::library::auto_search_series(
                         axum::extract::State(state_clone),
                         axum::extract::Path(movie_id),
+                        axum::extract::Query(super::library::AutoSearchQuery::default()),
                     ).await;
                 });
             }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -517,7 +517,12 @@ pub async fn settings_submit(
         custom_format_edit: None,
         custom_format_min_score_display,
         custom_format_import_review: None,
-        message: Some(notices.join("<br>")),
+        // Joined with " " — not "<br>" — because the template now
+        // auto-escapes `message`. Each notice is a complete sentence
+        // ending in ".", so a space-joined run reads acceptably as a
+        // single paragraph. Multi-notice POSTs are rare (only when
+        // the user changes integration settings).
+        message: Some(notices.join(" ")),
         error: None,
     };
     Html(template.render().unwrap_or_default())

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -28,9 +28,22 @@ pub async fn require_api_key(
     req: Request<axum::body::Body>,
     next: Next,
 ) -> Response {
+    // 503 (with Retry-After) for transient config-load failures and
+    // for "config row missing" (fresh install, user hasn't saved
+    // settings yet). Returning 500 here would have Seerr mark the
+    // indexer broken and back off for a long window — 503 advertises
+    // "try again soon" instead. The 401 (UNAUTHORIZED) path stays
+    // for "key mismatch" so a real auth failure is still visible.
     let cfg = match config::get_config(&state.db).await {
         Ok(Some(c)) => c,
-        _ => return StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+        Ok(None) | Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(axum::http::header::RETRY_AFTER, "5")],
+                "Ryokan config not yet available",
+            )
+                .into_response();
+        }
     };
 
     if !cfg.sonarr_enabled || cfg.sonarr_api_key.is_empty() {

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -591,6 +591,7 @@ pub async fn add_series(
             let _ = super::library::auto_search_series(
                 axum::extract::State(state_clone),
                 axum::extract::Path(id),
+                axum::extract::Query(super::library::AutoSearchQuery::default()),
             ).await;
         });
     }
@@ -661,6 +662,7 @@ pub async fn execute_command(
                 let _ = super::library::auto_search_series(
                     axum::extract::State(state_clone),
                     axum::extract::Path(series_id),
+                    axum::extract::Query(super::library::AutoSearchQuery::default()),
                 ).await;
             });
         }

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -427,7 +427,7 @@ pub async fn series_lookup(
             .ok()
             .flatten();
 
-        let tmdb_id = resolve_tmdb_id(r.id, r.id_mal).await;
+        let tmdb_id = anibridge::resolve_tmdb_id(r.id, r.id_mal).await;
         let title = if !r.title_english.is_empty() { &r.title_english } else { &r.title_romaji };
 
         sonarr_results.push(build_sonarr_series_from_search(
@@ -458,7 +458,7 @@ pub async fn list_series(
 
     let mut results = Vec::new();
     for s in &tracked {
-        let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+        let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
         results.push(build_sonarr_series_from_tracked(s, tmdb_id, &cfg));
     }
 
@@ -481,7 +481,7 @@ pub async fn get_series(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Series not found".to_string()))?;
 
-    let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
     Ok(Json(build_sonarr_series_from_tracked(&s, tmdb_id, &cfg)))
 }
 
@@ -677,7 +677,7 @@ pub async fn update_series(
         .flatten()
         .unwrap_or_default();
 
-    let tmdb_id = resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
     Ok(Json(build_sonarr_series_from_tracked(&s, tmdb_id, &cfg)))
 }
 
@@ -710,20 +710,6 @@ pub async fn execute_command(
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────────
-
-/// Resolve TMDB ID from either AniList ID or MAL ID.
-/// Tries AniList first, then MAL as fallback.
-async fn resolve_tmdb_id(anilist_id: i64, mal_id: impl Into<Option<i64>>) -> i64 {
-    if let Some(tmdb) = anibridge::lookup_tmdb_by_anilist(anilist_id).await {
-        return tmdb;
-    }
-    if let Some(mid) = mal_id.into()
-        && mid > 0
-            && let Some(tmdb) = anibridge::lookup_tmdb_by_mal(mid).await {
-                return tmdb;
-            }
-    0
-}
 
 /// Look up anime by external ID (TVDB or TMDB). Tries TVDB index first since
 /// Sonarr/Seerr sends real TVDB IDs, then falls back to TMDB index.

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -38,6 +38,11 @@ pub async fn require_api_key(
     }
 
     // Check X-Api-Key header first, then fall back to ?apikey= query param.
+    // Query-string values are percent-decoded — Seerr URL-encodes apikey
+    // values that contain `+`, `=`, `&`, or `%` (all legal in API keys
+    // and not restricted by the settings UI), so a raw string compare
+    // would silently reject every Seerr request whose key contained any
+    // of those characters.
     let api_key = req
         .headers()
         .get("x-api-key")
@@ -47,13 +52,28 @@ pub async fn require_api_key(
             let query_str = req.uri().query().unwrap_or("");
             query_str.split('&').find_map(|pair| {
                 let (key, val) = pair.split_once('=')?;
-                if key == "apikey" { Some(val.to_string()) } else { None }
+                if key == "apikey" {
+                    Some(urlencoding::decode(val).ok()?.into_owned())
+                } else {
+                    None
+                }
             })
         });
 
-    match api_key {
-        Some(key) if key == cfg.sonarr_api_key => next.run(req).await,
-        _ => (StatusCode::UNAUTHORIZED, "Invalid or missing API key").into_response(),
+    // Constant-time compare so the equality check itself never becomes a
+    // timing oracle. The threat is largely theoretical over the network,
+    // but it costs nothing to remove.
+    let valid = match &api_key {
+        Some(key) => bool::from(subtle::ConstantTimeEq::ct_eq(
+            key.as_bytes(),
+            cfg.sonarr_api_key.as_bytes(),
+        )),
+        None => false,
+    };
+    if valid {
+        next.run(req).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "Invalid or missing API key").into_response()
     }
 }
 

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -1,10 +1,14 @@
 use askama::Template;
 use axum::{
     extract::{Query, State},
-    response::{Html, Json},
+    http::StatusCode,
+    response::{Html, IntoResponse, Json, Response},
     Form,
 };
 use serde::Deserialize;
+use std::collections::VecDeque;
+use std::sync::{LazyLock, Mutex};
+use std::time::{Duration, Instant};
 
 use crate::models::{config, log::{self, LogCategory, LogLevel}, rss, scheduled_tasks};
 use crate::services::{logger, metadata_sync, post_processing, rss as rss_service, upgrade};
@@ -389,6 +393,37 @@ pub struct ClientLogForm {
     pub body: Option<String>,
 }
 
+// Field-length and rate-limit caps for `/api/logs/client`. The endpoint
+// is behind cookie auth + same-origin CSRF, so the threat model is a
+// buggy/runaway client (or a curious user with devtools open) flooding
+// the logs table — not a malicious unauthenticated attacker. The single
+// global window is sufficient for a self-hosted single-user PVR; it
+// would need to be per-session for a multi-tenant deployment.
+const CLIENT_LOG_TITLE_MAX: usize = 512;
+const CLIENT_LOG_BODY_MAX: usize = 4096;
+const CLIENT_LOG_RATE_WINDOW: Duration = Duration::from_secs(60);
+const CLIENT_LOG_RATE_MAX: usize = 30;
+
+static CLIENT_LOG_HITS: LazyLock<Mutex<VecDeque<Instant>>> =
+    LazyLock::new(|| Mutex::new(VecDeque::with_capacity(CLIENT_LOG_RATE_MAX)));
+
+fn check_client_log_rate() -> bool {
+    let now = Instant::now();
+    let mut hits = CLIENT_LOG_HITS.lock().unwrap();
+    while let Some(front) = hits.front() {
+        if now.duration_since(*front) > CLIENT_LOG_RATE_WINDOW {
+            hits.pop_front();
+        } else {
+            break;
+        }
+    }
+    if hits.len() >= CLIENT_LOG_RATE_MAX {
+        return false;
+    }
+    hits.push_back(now);
+    true
+}
+
 #[utoipa::path(
     post,
     path = "/api/logs/client",
@@ -398,12 +433,22 @@ pub struct ClientLogForm {
     request_body = ClientLogForm,
     responses(
         (status = 200, description = "Toast logged", body = serde_json::Value),
+        (status = 400, description = "Title or body exceeds size cap"),
+        (status = 429, description = "Rate limit exceeded"),
     ),
 )]
 pub async fn api_logs_client(
     State(state): State<AppState>,
     Json(form): Json<ClientLogForm>,
-) -> Json<serde_json::Value> {
+) -> Response {
+    if form.title.len() > CLIENT_LOG_TITLE_MAX
+        || form.body.as_deref().map(str::len).unwrap_or(0) > CLIENT_LOG_BODY_MAX
+    {
+        return (StatusCode::BAD_REQUEST, "title or body too large").into_response();
+    }
+    if !check_client_log_rate() {
+        return (StatusCode::TOO_MANY_REQUESTS, "client log rate limit exceeded").into_response();
+    }
     let level = match form.kind.as_str() {
         "warn" => LogLevel::Warn,
         "error" => LogLevel::Error,
@@ -416,7 +461,7 @@ pub async fn api_logs_client(
         .unwrap_or(LogCategory::System);
     let detail = form.body.as_deref().unwrap_or("");
     logger::log(&state.db, level, category, &form.title, detail).await;
-    Json(serde_json::json!({"ok": true}))
+    Json(serde_json::json!({"ok": true})).into_response()
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ mod models;
 mod services;
 
 use axum::{
-    extract::FromRef,
+    extract::{DefaultBodyLimit, FromRef},
     middleware,
     routing::{get, post},
     Router,
@@ -372,8 +372,21 @@ async fn main() {
         .route("/settings/custom-formats/upsert", post(handlers::settings::settings_custom_formats_upsert))
         .route("/settings/custom-formats/delete", post(handlers::settings::settings_custom_formats_delete))
         .route("/settings/custom-formats/minimum-score", post(handlers::settings::settings_custom_formats_minimum_score))
-        .route("/settings/custom-formats/import", post(handlers::settings::settings_custom_formats_import))
-        .route("/settings/custom-formats/import-resolve", post(handlers::settings::settings_custom_formats_import_resolve))
+        // 256 KiB is generous for TRaSH-Guides anime CF JSON (the
+        // entire vendored set is ~70 KiB) but well below axum's 2 MiB
+        // default — keeps the hidden-field re-echo on the collision
+        // review page bounded so a pasted multi-MiB payload doesn't
+        // render a multi-MiB hidden form field.
+        .route(
+            "/settings/custom-formats/import",
+            post(handlers::settings::settings_custom_formats_import)
+                .layer(DefaultBodyLimit::max(256 * 1024)),
+        )
+        .route(
+            "/settings/custom-formats/import-resolve",
+            post(handlers::settings::settings_custom_formats_import_resolve)
+                .layer(DefaultBodyLimit::max(256 * 1024)),
+        )
         .route("/settings/custom-formats/install-defaults", post(handlers::settings::settings_custom_formats_install_defaults))
         .route("/settings/custom-formats/reset-defaults", post(handlers::settings::settings_custom_formats_reset_defaults))
         .route("/settings/custom-formats/export", get(handlers::settings::settings_custom_formats_export))

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ use utoipa_swagger_ui::SwaggerUi;
 use services::{
     custom_formats::{self, CompiledCfCache},
     jellyfin::JellyfinClient,
+    progress::ProgressRegistry,
     qbit::QbitClient,
 };
 
@@ -87,6 +88,7 @@ use services::{
         handlers::system::api_logs_poll,
         handlers::system::api_logs_clear,
         handlers::system::api_logs_client,
+        handlers::progress::poll_progress,
         handlers::system::api_rss_sync,
         handlers::system::api_rss_clear_history,
         handlers::system::api_force_metadata_refresh,
@@ -107,6 +109,8 @@ use services::{
         services::qbit::Torrent,
         services::auto_search::AutoSearchReport,
         services::auto_search::AutoSearchHit,
+        services::progress::ProgressEvent,
+        services::progress::ProgressPoll,
         models::log::LogEntry,
         models::episode_tags::GrabHistoryEntry,
         handlers::system::ClientLogForm,
@@ -152,6 +156,13 @@ pub struct AppState {
     /// out on the scoring hot path so the read lock releases before the
     /// per-candidate evaluation loop begins.
     pub custom_formats: CompiledCfCache,
+    /// In-memory progress registry for long-running user-triggered jobs
+    /// (currently the manual auto-search). The frontend mints an opaque
+    /// `progress_id`, the trigger handler binds it via
+    /// `register(...).await`, and the polling endpoint at
+    /// `/api/progress/{id}` drains buffered events. See
+    /// `services::progress` for the full lifecycle.
+    pub progress: ProgressRegistry,
     /// Flip-to-true-once cache of `user::has_users`. The auth middleware
     /// runs on every protected request and was firing a `SELECT COUNT(*)
     /// FROM users` query for each one just to decide whether to redirect
@@ -285,6 +296,7 @@ async fn main() {
         qbit: Arc::new(RwLock::new(None)),
         jellyfin: Arc::new(RwLock::new(None)),
         custom_formats: cf_cache,
+        progress: ProgressRegistry::new(),
         users_exist,
     };
 
@@ -384,6 +396,7 @@ async fn main() {
         .route("/api/logs/poll", get(handlers::system::api_logs_poll))
         .route("/api/logs/clear", post(handlers::system::api_logs_clear))
         .route("/api/logs/client", post(handlers::system::api_logs_client))
+        .route("/api/progress/{job_id}", get(handlers::progress::poll_progress))
         .route("/media/art/{cache_key}", get(handlers::media::artwork))
         .route("/logout", get(handlers::auth::logout))
         .layer(middleware::from_fn_with_state(
@@ -894,6 +907,27 @@ async fn main() {
                             let _ = models::scheduled_tasks::mark_finished(&anibridge_db, "anibridge_refresh", "error", "Failed to download mappings").await;
                         }
                         tokio::time::sleep(period).await;
+                    }
+                }
+            }).await;
+        });
+    }
+
+    // Background task: sweep finished progress jobs out of the in-memory
+    // registry. Jobs are kept for 60s past their terminal event so a
+    // frontend that's mid-poll still sees the final state on its next
+    // tick, then dropped. The sweep itself is cheap (one mutex acquire,
+    // a HashMap retain) so a 30s tick is fine.
+    {
+        let progress_state = state.clone();
+        tokio::spawn(async move {
+            supervise("progress_sweep", move || {
+                let progress = progress_state.progress.clone();
+                async move {
+                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
+                    loop {
+                        interval.tick().await;
+                        progress.sweep(std::time::Duration::from_secs(60)).await;
                     }
                 }
             }).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -194,6 +194,19 @@ impl FromRef<AppState> for SqlitePool {
 ///
 /// `name` is used purely in the log line so the operator can tell which
 /// task misbehaved.
+/// Build a `Router` that registers the same handler at multiple
+/// path aliases. Used by the Sonarr/Radarr compat router setup to
+/// collapse case-variant doublings (`qualityprofile` vs
+/// `qualityProfile`, etc. — Seerr ships both spellings depending on
+/// version) into one logical line per endpoint.
+fn aliased(paths: &[&str], handler: axum::routing::MethodRouter<AppState>) -> Router<AppState> {
+    let mut router = Router::new();
+    for path in paths {
+        router = router.route(path, handler.clone());
+    }
+    router
+}
+
 async fn supervise<F, Fut>(name: &'static str, mut make_fut: F) -> !
 where
     F: FnMut() -> Fut,
@@ -439,14 +452,27 @@ async fn main() {
 
     // Sonarr v3 API compatibility layer for Seerr integration.
     // Authenticated via ?apikey= query parameter, not cookies.
+    //
+    // `aliased` collapses the Sonarr-API case-variant doublings (Seerr
+    // sometimes sends `qualityprofile`, sometimes `qualityProfile`,
+    // similarly for rootfolder/rootFolder and languageprofile/
+    // languageProfile) into one line per logical endpoint. Adding a
+    // third alias is a string change, not another `.route(...)` line
+    // that future-me has to remember to keep in sync with the first.
     let sonarr_routes = Router::new()
         .route("/api/v3/system/status", get(handlers::sonarr_compat::system_status))
-        .route("/api/v3/qualityprofile", get(handlers::sonarr_compat::quality_profiles))
-        .route("/api/v3/qualityProfile", get(handlers::sonarr_compat::quality_profiles))
-        .route("/api/v3/rootfolder", get(handlers::sonarr_compat::root_folders))
-        .route("/api/v3/rootFolder", get(handlers::sonarr_compat::root_folders))
-        .route("/api/v3/languageprofile", get(handlers::sonarr_compat::language_profiles))
-        .route("/api/v3/languageProfile", get(handlers::sonarr_compat::language_profiles))
+        .merge(aliased(
+            &["/api/v3/qualityprofile", "/api/v3/qualityProfile"],
+            get(handlers::sonarr_compat::quality_profiles),
+        ))
+        .merge(aliased(
+            &["/api/v3/rootfolder", "/api/v3/rootFolder"],
+            get(handlers::sonarr_compat::root_folders),
+        ))
+        .merge(aliased(
+            &["/api/v3/languageprofile", "/api/v3/languageProfile"],
+            get(handlers::sonarr_compat::language_profiles),
+        ))
         .route("/api/v3/tag", get(handlers::sonarr_compat::list_tags).post(handlers::sonarr_compat::create_tag))
         .route("/api/v3/series", get(handlers::sonarr_compat::list_series).post(handlers::sonarr_compat::add_series).put(handlers::sonarr_compat::update_series))
         .route("/api/v3/series/{id}", get(handlers::sonarr_compat::get_series))
@@ -461,10 +487,14 @@ async fn main() {
     // Mounted under /radarr/ prefix — Seerr uses URL Base "/radarr" to route here.
     let radarr_routes = Router::new()
         .route("/radarr/api/v3/system/status", get(handlers::radarr_compat::system_status))
-        .route("/radarr/api/v3/qualityprofile", get(handlers::radarr_compat::quality_profiles))
-        .route("/radarr/api/v3/qualityProfile", get(handlers::radarr_compat::quality_profiles))
-        .route("/radarr/api/v3/rootfolder", get(handlers::radarr_compat::root_folders))
-        .route("/radarr/api/v3/rootFolder", get(handlers::radarr_compat::root_folders))
+        .merge(aliased(
+            &["/radarr/api/v3/qualityprofile", "/radarr/api/v3/qualityProfile"],
+            get(handlers::radarr_compat::quality_profiles),
+        ))
+        .merge(aliased(
+            &["/radarr/api/v3/rootfolder", "/radarr/api/v3/rootFolder"],
+            get(handlers::radarr_compat::root_folders),
+        ))
         .route("/radarr/api/v3/tag", get(handlers::radarr_compat::list_tags).post(handlers::radarr_compat::create_tag))
         .route("/radarr/api/v3/movie", get(handlers::radarr_compat::list_movies).post(handlers::radarr_compat::add_movie).put(handlers::radarr_compat::update_movie))
         .route("/radarr/api/v3/movie/{id}", get(handlers::radarr_compat::get_movie))

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use sqlx::SqlitePool;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
 use tower_http::compression::CompressionLayer;
 use tower_http::services::ServeDir;
@@ -199,28 +199,43 @@ where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = ()> + Send + 'static,
 {
+    // Exponential backoff for crash loops. A task that exits in <60s
+    // before its next restart is considered "unhealthy" — double the
+    // backoff (capped at MAX) so a stuck-on-startup task can't spam
+    // logs at 12 restarts/minute. A task that runs for ≥60s before
+    // exiting resets the backoff to MIN, so a one-off transient
+    // failure doesn't punish the next restart.
+    const MIN_BACKOFF: Duration = Duration::from_secs(5);
+    const MAX_BACKOFF: Duration = Duration::from_secs(30 * 60);
+    const HEALTHY_RUNTIME: Duration = Duration::from_secs(60);
+
+    let mut backoff = MIN_BACKOFF;
     loop {
+        let started = Instant::now();
         let handle = tokio::spawn(make_fut());
         match handle.await {
             Err(e) if e.is_panic() => {
-                tracing::error!(
-                    "Background task '{}' panicked, restarting in 5s: {:?}",
-                    name,
-                    e
-                );
+                tracing::error!("Background task '{}' panicked: {:?}", name, e);
             }
             Err(e) => {
-                tracing::error!(
-                    "Background task '{}' join error, restarting in 5s: {:?}",
-                    name,
-                    e
-                );
+                tracing::error!("Background task '{}' join error: {:?}", name, e);
             }
             Ok(()) => {
-                tracing::warn!("Background task '{}' exited normally, restarting", name);
+                tracing::warn!("Background task '{}' exited normally", name);
             }
         }
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+
+        if started.elapsed() >= HEALTHY_RUNTIME {
+            backoff = MIN_BACKOFF;
+        } else {
+            backoff = (backoff * 2).min(MAX_BACKOFF);
+        }
+        tracing::warn!(
+            "supervise '{}': restarting in {:?}",
+            name,
+            backoff
+        );
+        tokio::time::sleep(backoff).await;
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -715,6 +715,24 @@ async fn main() {
                     }
                     _ => {}
                 }
+                // Prune orphan artwork (image_refs whose parent series
+                // is gone, and image_blobs/files no ref references after
+                // 7 days). Without this the cache only ever grows —
+                // every removed series leaves rows pointing at on-disk
+                // blob files that nothing will ever touch again.
+                match models::artwork_cache::cleanup_orphans(&cleanup_db, 7).await {
+                    Ok((refs, blobs)) if refs > 0 || blobs > 0 => {
+                        tracing::debug!(
+                            "Cleaned up {} orphan artwork refs and {} orphan blobs",
+                            refs, blobs
+                        );
+                    }
+                    Err(e) => {
+                        cleanup_errors.push(format!("artwork_cache: {}", e));
+                        tracing::error!("Artwork cleanup failed: {}", e);
+                    }
+                    _ => {}
+                }
                 // Prune expired session rows. `validate_session` already
                 // rejects rows older than 7 days, but without this sweep
                 // the sessions table grows unbounded — every login leaves

--- a/src/main.rs
+++ b/src/main.rs
@@ -327,8 +327,7 @@ async fn main() {
     let public_routes = Router::new()
         .route("/login", get(handlers::auth::login_page).post(handlers::auth::login_submit))
         .route("/setup", get(handlers::auth::setup_page).post(handlers::auth::setup_submit))
-        .layer(middleware::from_fn(handlers::auth::csrf_public))
-        .merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi()));
+        .layer(middleware::from_fn(handlers::auth::csrf_public));
 
     // Routes that require auth.
     let protected_routes = Router::new()
@@ -399,6 +398,12 @@ async fn main() {
         .route("/api/progress/{job_id}", get(handlers::progress::poll_progress))
         .route("/media/art/{cache_key}", get(handlers::media::artwork))
         .route("/logout", get(handlers::auth::logout))
+        // SwaggerUI/OpenAPI live behind the auth wall: the OpenAPI doc
+        // describes the entire route surface and form schemas, including
+        // the rate-limited /login and /setup shapes. Exposing it
+        // unauthenticated would hand a passing scanner a complete map of
+        // the application before any auth check fires.
+        .merge(SwaggerUi::new("/api-docs").url("/api-docs/openapi.json", ApiDoc::openapi()))
         .layer(middleware::from_fn_with_state(
             state.clone(),
             handlers::auth::require_auth,

--- a/src/models/artwork_cache.rs
+++ b/src/models/artwork_cache.rs
@@ -203,35 +203,35 @@ pub async fn cleanup_orphans(
     .await?
     .rows_affected();
 
-    // Step 2: orphan blobs. Read paths first so we can delete the
-    // on-disk files, then delete the rows. The age gate uses
-    // `created_at < datetime('now', '-Nd days')`.
+    // Step 2: orphan blobs. DELETE … RETURNING in a single statement
+    // so the file removal is *consequent on* the DB delete, not
+    // concurrent with it. The earlier SELECT-then-remove_file-then-
+    // DELETE order had a TOCTOU window where a concurrent cache_image
+    // could land an upsert_ref between the SELECT and the DELETE: the
+    // SELECT-stage decision to remove the file was based on "no refs",
+    // but by DELETE time the new ref's NOT EXISTS check would fail and
+    // the row would survive — leaving a live ref pointing at an
+    // already-deleted on-disk file. With DELETE … RETURNING, only rows
+    // whose NOT EXISTS check still holds at delete-commit time return
+    // their local_path, and the file removal that follows can't beat a
+    // concurrent ref to the punch.
     let age_filter = format!("-{} days", min_age_days);
-    let orphan_rows = sqlx::query(
-        r#"SELECT blob_hash, local_path FROM image_blobs b
-           WHERE NOT EXISTS (SELECT 1 FROM image_refs r WHERE r.blob_hash = b.blob_hash)
-             AND b.created_at < datetime('now', ?)"#,
+    let deleted_rows = sqlx::query(
+        r#"DELETE FROM image_blobs
+           WHERE NOT EXISTS (SELECT 1 FROM image_refs r WHERE r.blob_hash = image_blobs.blob_hash)
+             AND created_at < datetime('now', ?)
+           RETURNING local_path"#,
     )
     .bind(&age_filter)
     .fetch_all(db)
     .await?;
 
-    let blobs_deleted = orphan_rows.len() as u64;
-    for row in &orphan_rows {
+    let blobs_deleted = deleted_rows.len() as u64;
+    for row in &deleted_rows {
         let local_path: String = row.get("local_path");
         if !local_path.is_empty() {
             let _ = std::fs::remove_file(&local_path);
         }
-    }
-    if blobs_deleted > 0 {
-        sqlx::query(
-            r#"DELETE FROM image_blobs
-               WHERE NOT EXISTS (SELECT 1 FROM image_refs r WHERE r.blob_hash = image_blobs.blob_hash)
-                 AND created_at < datetime('now', ?)"#,
-        )
-        .bind(&age_filter)
-        .execute(db)
-        .await?;
     }
 
     Ok((refs_deleted, blobs_deleted))

--- a/src/models/artwork_cache.rs
+++ b/src/models/artwork_cache.rs
@@ -173,3 +173,66 @@ pub async fn get_local_urls_batch(
     }
     Ok(out)
 }
+
+/// Two-step prune of the artwork cache, called from the hourly cleanup
+/// task. Returns `(refs_deleted, blobs_deleted)`. Without this the
+/// `image_refs` and `image_blobs` tables — and the on-disk blob files
+/// they point at — only ever grow: removing a series leaves orphan
+/// rows, renaming a cover URL leaves the old blob behind, etc.
+///
+/// Step 1 — drop refs whose parent series no longer exists.
+/// Step 2 — drop blobs (and the backing files) that no ref references
+/// AND that haven't been written in `min_age_days` (the age gate
+/// covers the small race in cache_image where upsert_blob runs before
+/// upsert_ref — we don't want a concurrent prune to delete a blob
+/// that's about to get its ref written).
+pub async fn cleanup_orphans(
+    db: &SqlitePool,
+    min_age_days: i64,
+) -> Result<(u64, u64), sqlx::Error> {
+    // Step 1: orphan refs. Only series-keyed refs are pruned here —
+    // any other parent_kind is left alone since we don't own its
+    // identity table.
+    let refs_deleted = sqlx::query(
+        "DELETE FROM image_refs
+         WHERE parent_kind IN ('series', 'series_relation')
+           AND parent_id IS NOT NULL
+           AND parent_id NOT IN (SELECT id FROM series)",
+    )
+    .execute(db)
+    .await?
+    .rows_affected();
+
+    // Step 2: orphan blobs. Read paths first so we can delete the
+    // on-disk files, then delete the rows. The age gate uses
+    // `created_at < datetime('now', '-Nd days')`.
+    let age_filter = format!("-{} days", min_age_days);
+    let orphan_rows = sqlx::query(
+        r#"SELECT blob_hash, local_path FROM image_blobs b
+           WHERE NOT EXISTS (SELECT 1 FROM image_refs r WHERE r.blob_hash = b.blob_hash)
+             AND b.created_at < datetime('now', ?)"#,
+    )
+    .bind(&age_filter)
+    .fetch_all(db)
+    .await?;
+
+    let blobs_deleted = orphan_rows.len() as u64;
+    for row in &orphan_rows {
+        let local_path: String = row.get("local_path");
+        if !local_path.is_empty() {
+            let _ = std::fs::remove_file(&local_path);
+        }
+    }
+    if blobs_deleted > 0 {
+        sqlx::query(
+            r#"DELETE FROM image_blobs
+               WHERE NOT EXISTS (SELECT 1 FROM image_refs r WHERE r.blob_hash = image_blobs.blob_hash)
+                 AND created_at < datetime('now', ?)"#,
+        )
+        .bind(&age_filter)
+        .execute(db)
+        .await?;
+    }
+
+    Ok((refs_deleted, blobs_deleted))
+}

--- a/src/models/artwork_cache.rs
+++ b/src/models/artwork_cache.rs
@@ -230,7 +230,10 @@ pub async fn cleanup_orphans(
     for row in &deleted_rows {
         let local_path: String = row.get("local_path");
         if !local_path.is_empty() {
-            let _ = std::fs::remove_file(&local_path);
+            // Hourly task in an async path — match the rest of the
+            // codebase's std::fs → tokio::fs migration so we don't
+            // block the runtime executor on the unlink syscall.
+            let _ = tokio::fs::remove_file(&local_path).await;
         }
     }
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -498,21 +498,39 @@ pub async fn set_manual_override(
 
 /// Mark episode quality tags as "completed" for the given episodes of a series.
 /// Called by post-processing after a torrent is successfully imported.
+///
+/// Single UPDATE with `episode_number IN (?, ?, ...)` instead of one
+/// query per episode — a batch import of a 24-episode BD pack used to
+/// fire 24 round-trips here, all of which serialise behind SQLite's
+/// single-writer lock.
 pub async fn mark_completed(
     db: &SqlitePool,
     series_id: i64,
     episode_numbers: &[i32],
 ) -> Result<(), sqlx::Error> {
-    for &ep in episode_numbers {
-        sqlx::query(
-            "UPDATE episode_quality_tags SET state = 'completed', updated_at = CURRENT_TIMESTAMP
-             WHERE series_id = ? AND episode_number = ? AND state = 'grabbed'",
-        )
-        .bind(series_id)
-        .bind(ep)
-        .execute(db)
-        .await?;
+    if episode_numbers.is_empty() {
+        return Ok(());
     }
+    // Build the IN-list placeholders at runtime; episode numbers are
+    // i32s from trusted upstream parsing, no injection surface. sqlx
+    // doesn't expand slice bindings on SQLite, so we splice the
+    // placeholder count into the SQL and bind each value.
+    let placeholders = std::iter::repeat_n("?", episode_numbers.len())
+        .collect::<Vec<_>>()
+        .join(",");
+    let sql = format!(
+        "UPDATE episode_quality_tags
+         SET state = 'completed', updated_at = CURRENT_TIMESTAMP
+         WHERE series_id = ?
+           AND state = 'grabbed'
+           AND episode_number IN ({})",
+        placeholders
+    );
+    let mut q = sqlx::query(&sql).bind(series_id);
+    for &ep in episode_numbers {
+        q = q.bind(ep);
+    }
+    q.execute(db).await?;
     Ok(())
 }
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -481,8 +481,13 @@ pub async fn set_manual_override(
     .bind(series_id)
     .bind(episode_number)
     .bind(&label)
-    .bind(source)
-    .bind(resolution)
+    // Bind the *parsed* enum's canonical .as_str() instead of the raw
+    // input — defense in depth alongside the handler validation, so a
+    // future caller that bypasses the handler can't write a non-
+    // canonical string to the DB and confuse downstream column-vs-enum
+    // comparisons.
+    .bind(parsed_source.as_str())
+    .bind(parsed_resolution.as_str())
     .bind(is_remux_i)
     .bind(is_bdmv_i)
     .bind(web_kind_str)

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -6,7 +6,7 @@ use crate::services::source::ClassificationResult;
 /// to render a row: series identity for the link, episode number, and the
 /// current (uncertain) classification for context. Produced by
 /// [`get_needs_review`].
-#[derive(Debug, Clone, serde::Serialize)]
+#[derive(Debug, Clone, serde::Serialize, sqlx::FromRow)]
 pub struct NeedsReviewEntry {
     pub series_id: i64,
     pub series_anilist_id: i64,
@@ -34,7 +34,7 @@ pub struct NeedsReviewEntry {
 pub async fn get_needs_review(
     db: &SqlitePool,
 ) -> Result<Vec<NeedsReviewEntry>, sqlx::Error> {
-    let rows = sqlx::query(
+    sqlx::query_as::<_, NeedsReviewEntry>(
         "SELECT t.series_id, t.episode_number, t.quality_tag, t.release_title, t.release_group,
                 t.source, t.resolution, t.classification_confidence,
                 COALESCE(t.classification_evidence, '') AS classification_evidence,
@@ -48,31 +48,10 @@ pub async fn get_needs_review(
          ORDER BY s.title_english, t.episode_number",
     )
     .fetch_all(db)
-    .await?;
-
-    Ok(rows
-        .iter()
-        .map(|row| {
-            let confidence: f64 = row.get("classification_confidence");
-            NeedsReviewEntry {
-                series_id: row.get("series_id"),
-                series_anilist_id: row.get("series_anilist_id"),
-                series_title: row.get("series_title"),
-                cover_url: row.get("cover_url"),
-                episode_number: row.get("episode_number"),
-                quality_tag: row.get("quality_tag"),
-                release_title: row.get("release_title"),
-                release_group: row.get("release_group"),
-                source: row.get("source"),
-                resolution: row.get("resolution"),
-                classification_confidence: confidence as f32,
-                classification_evidence: row.get("classification_evidence"),
-            }
-        })
-        .collect())
+    .await
 }
 
-#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, serde::Serialize, utoipa::ToSchema, sqlx::FromRow)]
 pub struct GrabHistoryEntry {
     pub id: i64,
     pub quality_tag: String,
@@ -100,9 +79,14 @@ pub struct GrabHistoryEntry {
     pub state: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, sqlx::FromRow)]
 #[allow(dead_code)]
 pub struct EpisodeQualityTag {
+    /// Convenience for callers that hold a `Vec<EpisodeQualityTag>` and
+    /// want to know which episode a row belongs to without rebuilding
+    /// a HashMap. `get_for_series` still returns a HashMap keyed by
+    /// this value for the in-memory lookup hot path.
+    pub episode_number: i32,
     pub quality_tag: String,
     pub release_title: String,
     pub release_group: String,
@@ -249,7 +233,7 @@ pub async fn get_for_series(
     db: &SqlitePool,
     series_id: i64,
 ) -> Result<std::collections::HashMap<i32, EpisodeQualityTag>, sqlx::Error> {
-    let rows = sqlx::query(
+    let rows: Vec<EpisodeQualityTag> = sqlx::query_as(
         "SELECT episode_number, quality_tag, release_title, release_group, state,
                 source, resolution, is_remux,
                 COALESCE(is_bdmv, 0) AS is_bdmv,
@@ -263,34 +247,7 @@ pub async fn get_for_series(
     .fetch_all(db)
     .await?;
 
-    let mut map = std::collections::HashMap::new();
-    for row in rows {
-        let ep_num: i32 = row.get("episode_number");
-        let is_remux_i: i64 = row.get("is_remux");
-        let is_bdmv_i: i64 = row.get("is_bdmv");
-        let needs_review_i: i64 = row.get("needs_review");
-        let manual_override_i: i64 = row.get("manual_override");
-        let confidence: f64 = row.get("classification_confidence");
-        map.insert(
-            ep_num,
-            EpisodeQualityTag {
-                quality_tag: row.get("quality_tag"),
-                release_title: row.get("release_title"),
-                release_group: row.get("release_group"),
-                state: row.get("state"),
-                source: row.get("source"),
-                resolution: row.get("resolution"),
-                is_remux: is_remux_i != 0,
-                is_bdmv: is_bdmv_i != 0,
-                web_kind: row.get("web_kind"),
-                classification_confidence: confidence as f32,
-                needs_review: needs_review_i != 0,
-                manual_override: manual_override_i != 0,
-                classification_evidence: row.get("classification_evidence"),
-            },
-        );
-    }
-    Ok(map)
+    Ok(rows.into_iter().map(|t| (t.episode_number, t)).collect())
 }
 
 /// Get grab history for a specific episode, newest first. No LIMIT — the
@@ -301,7 +258,7 @@ pub async fn get_grab_history(
     series_id: i64,
     episode_number: i32,
 ) -> Result<Vec<GrabHistoryEntry>, sqlx::Error> {
-    let rows = sqlx::query(
+    sqlx::query_as::<_, GrabHistoryEntry>(
         "SELECT id, quality_tag, release_title, release_group,
                 COALESCE(file_name, '') AS file_name,
                 COALESCE(size_bytes, 0) AS size_bytes,
@@ -314,25 +271,7 @@ pub async fn get_grab_history(
     .bind(series_id)
     .bind(episode_number)
     .fetch_all(db)
-    .await?;
-
-    Ok(rows
-        .iter()
-        .map(|row| {
-            let is_batch_i: i64 = row.get("is_batch");
-            GrabHistoryEntry {
-                id: row.get("id"),
-                quality_tag: row.get("quality_tag"),
-                release_title: row.get("release_title"),
-                release_group: row.get("release_group"),
-                file_name: row.get("file_name"),
-                size_bytes: row.get("size_bytes"),
-                is_batch: is_batch_i != 0,
-                grabbed_at: row.get("grabbed_at"),
-                state: row.get("state"),
-            }
-        })
-        .collect())
+    .await
 }
 
 /// Overwrite the structured classification columns on an existing tag row.

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -461,36 +461,57 @@ pub async fn find_imported_for_episode(
         .collect())
 }
 
-/// Return the torrent name of the most recent imported grab for this
-/// series, regardless of which episodes the grab's `episode_numbers`
-/// column claims it covers. Used by
-/// `scan_library_for_unclassified` as a fallback to
-/// [`find_imported_for_episode`] when the per-episode lookup misses:
-/// pre-fix batch grabs were recorded with `episode_numbers = []`, so
-/// `json_each` yields nothing and the precise lookup returns empty
-/// even though there's a perfectly good batch grab with a real
-/// release name sitting in the table. For those stale rows we want
-/// to classify against that release name instead of the sanitized
-/// on-disk filename.
+/// Bulk variant for post-processing's library scan: fetch every
+/// imported grab covering this series in one round-trip, including
+/// grabs that reach the series via the sibling-routes path. Returns
+/// `(torrent_name, episode_numbers)` for each, sorted most-recent
+/// first by `grabbed_at`.
 ///
-/// Returns `None` when the series has never had an imported grab,
-/// in which case the scanner falls back to the sanitized filename
-/// (correct behavior for externally-imported files Ryokan never
-/// grabbed).
-pub async fn most_recent_imported_torrent_name_for_series(
+/// scan_library_for_unclassified used to do *two* per-file queries
+/// (`find_imported_for_episode` + a fallback `most_recent_…`) per
+/// disk file inside a held POST_PROC_LOCK. For a 100-series, 24-ep
+/// library that's ~4800 sequential round-trips per pass. With this
+/// helper the caller pre-builds an in-memory map per series and the
+/// per-file path is lock-free dictionary lookups.
+///
+/// `UNION ALL` (not `UNION`) because dedup falls naturally out of the
+/// caller's `entry().or_insert_with()` first-write-wins semantics; we
+/// don't pay for SQLite's UNION-side sort/hash.
+pub async fn imported_grabs_for_series(
     db: &SqlitePool,
     series_id: i64,
-) -> Option<String> {
-    sqlx::query_scalar::<_, String>(
-        "SELECT torrent_name FROM grabbed_torrents
-         WHERE series_id = ? AND state = 'imported'
-         ORDER BY grabbed_at DESC LIMIT 1",
+) -> Result<Vec<(String, Vec<i32>)>, sqlx::Error> {
+    let rows = sqlx::query(
+        r#"SELECT torrent_name, episode_numbers, grabbed_at FROM (
+             SELECT g.torrent_name AS torrent_name,
+                    g.episode_numbers AS episode_numbers,
+                    g.grabbed_at AS grabbed_at
+             FROM grabbed_torrents g
+             WHERE g.series_id = ? AND g.state = 'imported'
+             UNION ALL
+             SELECT g.torrent_name AS torrent_name,
+                    r.episode_numbers AS episode_numbers,
+                    g.grabbed_at AS grabbed_at
+             FROM grabbed_torrents g
+             JOIN grabbed_torrent_series r ON r.grab_id = g.id
+             WHERE r.series_id = ? AND g.state = 'imported'
+           )
+           ORDER BY grabbed_at DESC"#,
     )
     .bind(series_id)
-    .fetch_optional(db)
-    .await
-    .ok()
-    .flatten()
+    .bind(series_id)
+    .fetch_all(db)
+    .await?;
+
+    Ok(rows
+        .iter()
+        .map(|row| {
+            let torrent_name: String = row.get("torrent_name");
+            let eps_json: String = row.get("episode_numbers");
+            let episode_numbers: Vec<i32> = serde_json::from_str(&eps_json).unwrap_or_default();
+            (torrent_name, episode_numbers)
+        })
+        .collect())
 }
 
 /// Remove a grabbed torrent record entirely.

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -38,32 +38,36 @@ pub async fn record_grab(
     is_batch: bool,
 ) -> Result<Option<i64>, sqlx::Error> {
     let eps_json = serde_json::to_string(episode_numbers).unwrap_or_else(|_| "[]".to_string());
-
-    if !hash.is_empty() {
-        let existing: Option<i64> = sqlx::query_scalar(
-            "SELECT id FROM grabbed_torrents WHERE hash = ? AND state IN ('pending', 'imported') LIMIT 1",
-        )
-        .bind(hash)
-        .fetch_optional(db)
-        .await?;
-        if existing.is_some() {
-            return Ok(None);
-        }
-    }
-
     let is_batch_i = if is_batch { 1_i64 } else { 0_i64 };
-    let result = sqlx::query(
-        "INSERT INTO grabbed_torrents (hash, torrent_name, series_id, episode_numbers, state, is_batch) VALUES (?, ?, ?, ?, 'pending', ?)",
+
+    // Atomic dedup via partial UNIQUE index on (hash) WHERE hash != ''
+    // AND state IN ('pending', 'imported') (created in models::migrate).
+    // INSERT OR IGNORE swallows the conflict and RETURNING yields no
+    // row, so fetch_optional resolves to None on the dedup path. The
+    // previous SELECT-then-INSERT pattern had a race window where two
+    // concurrent record_grab calls (RSS auto-sync racing a manual grab
+    // on the same release) both observed "no existing row" and both
+    // inserted, producing duplicate pending rows that triggered
+    // double-import attempts in post-processing.
+    //
+    // Empty-hash rows aren't covered by the partial index (the WHERE
+    // clause filters them out), so they always insert — preserving the
+    // pre-fix behavior where empty-hash grabs from legacy paths never
+    // deduped against each other.
+    let inserted_id: Option<i64> = sqlx::query_scalar(
+        "INSERT OR IGNORE INTO grabbed_torrents
+             (hash, torrent_name, series_id, episode_numbers, state, is_batch)
+         VALUES (?, ?, ?, ?, 'pending', ?)
+         RETURNING id",
     )
     .bind(hash)
     .bind(torrent_name)
     .bind(series_id)
     .bind(&eps_json)
     .bind(is_batch_i)
-    .execute(db)
+    .fetch_optional(db)
     .await?;
-
-    Ok(Some(result.last_insert_rowid()))
+    Ok(inserted_id)
 }
 
 /// Per-file routing row for a grabbed torrent. Used to drive
@@ -751,5 +755,84 @@ mod tests {
             .find(|g| g.id == batch_grab_id)
             .expect("batch grab present");
         assert!(batch.is_batch, "batch grab is_batch=true");
+    }
+
+    /// Regression: record_grab previously did SELECT-then-INSERT with no
+    /// transaction, so two concurrent calls (RSS auto-sync racing a
+    /// manual grab on the same hash) both observed "no existing row" and
+    /// both inserted. Post-processing then attempted to import the same
+    /// hash twice. The fix is a partial UNIQUE index + INSERT OR IGNORE,
+    /// which collapses the SELECT and INSERT into one atomic statement.
+    ///
+    /// This test covers the three cases the dedup window has to honour:
+    ///  - same hash, both active → second insert is rejected
+    ///  - failed grab with same hash → re-record is allowed
+    ///  - empty hash → never deduped, always inserts
+    #[tokio::test]
+    async fn record_grab_dedups_same_hash_atomically() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 12345,
+                mal_id: None,
+                title: "Show",
+                title_romaji: "Show",
+                title_english: "Show",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2020),
+                end_year: Some(2020),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        // First active grab inserts.
+        let id1 = record_grab(&db, "racehash", "release a", series_id, &[1], false)
+            .await
+            .expect("first record_grab")
+            .expect("first must insert");
+
+        // Second active grab with same hash is dedup'd.
+        let id2 = record_grab(&db, "racehash", "release b", series_id, &[1], false)
+            .await
+            .expect("second record_grab");
+        assert!(id2.is_none(), "duplicate active hash must dedup");
+
+        // Confirm only one row exists for that hash.
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM grabbed_torrents WHERE hash = 'racehash'")
+                .fetch_one(&db)
+                .await
+                .expect("count");
+        assert_eq!(count, 1);
+
+        // Mark the first one as failed; now the same hash can be
+        // re-recorded — the partial index excludes failed/removed rows.
+        mark_failed(&db, id1).await.expect("mark failed");
+        let id3 = record_grab(&db, "racehash", "release c", series_id, &[1], false)
+            .await
+            .expect("third record_grab");
+        assert!(
+            id3.is_some(),
+            "after blocklist, same hash must be re-recordable"
+        );
+
+        // Empty-hash rows aren't covered by the partial index.
+        let id4 = record_grab(&db, "", "no hash a", series_id, &[1], false)
+            .await
+            .expect("empty-hash a");
+        let id5 = record_grab(&db, "", "no hash b", series_id, &[1], false)
+            .await
+            .expect("empty-hash b");
+        assert!(id4.is_some() && id5.is_some(), "empty-hash never dedups");
     }
 }

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -411,16 +411,18 @@ pub async fn find_imported_for_episode(
     // UNION dedups grabs where the same series matches through both
     // paths (parent of a single-series grab).
     let rows = sqlx::query(
-        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at FROM (
+        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, is_batch FROM (
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
-                    g.grabbed_at AS grabbed_at
+                    g.grabbed_at AS grabbed_at,
+                    COALESCE(g.is_batch, 0) AS is_batch
              FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
              WHERE g.series_id = ? AND je.value = ? AND g.state = 'imported'
              UNION
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
-                    g.grabbed_at AS grabbed_at
+                    g.grabbed_at AS grabbed_at,
+                    COALESCE(g.is_batch, 0) AS is_batch
              FROM grabbed_torrents g
              JOIN grabbed_torrent_series r ON r.grab_id = g.id
              , json_each(r.episode_numbers) AS je
@@ -440,6 +442,7 @@ pub async fn find_imported_for_episode(
         .map(|row| {
             let eps_json: String = row.get("episode_numbers");
             let episode_numbers: Vec<i32> = serde_json::from_str(&eps_json).unwrap_or_default();
+            let is_batch_i: i64 = row.get("is_batch");
             GrabbedTorrent {
                 id: row.get("id"),
                 hash: row.get("hash"),
@@ -448,7 +451,7 @@ pub async fn find_imported_for_episode(
                 episode_numbers,
                 state: "imported".to_string(),
                 grabbed_at: row.get("grabbed_at"),
-                is_batch: false,
+                is_batch: is_batch_i != 0,
             }
         })
         .collect())
@@ -655,5 +658,98 @@ mod tests {
             "episode-range fallback (14..=20)"
         );
         assert_eq!(sibling_route.file_indices.len(), 7);
+    }
+
+    /// Regression: find_imported_for_episode previously hard-coded
+    /// `is_batch: false`, so callers (handlers/library.rs and
+    /// post_processing) treated batch torrents as single-episode grabs and
+    /// `delete_torrent(..., delete_files=true)` would wipe the entire pack
+    /// off disk during an upgrade-replace.
+    #[tokio::test]
+    async fn find_imported_for_episode_preserves_is_batch() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21202,
+                mal_id: None,
+                title: "Show",
+                title_romaji: "Show",
+                title_english: "Show",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(24),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        let batch_eps: Vec<i32> = (1..=24).collect();
+        let batch_grab_id = record_grab(
+            &db,
+            "batchhash00000000000000000000000000000000",
+            "[Group] Show 01-24 [BD 1080p]",
+            series_id,
+            &batch_eps,
+            true,
+        )
+        .await
+        .expect("record batch grab")
+        .expect("batch grab inserted");
+        mark_imported(&db, batch_grab_id)
+            .await
+            .expect("mark batch imported");
+
+        let single_grab_id = record_grab(
+            &db,
+            "singlehash0000000000000000000000000000000",
+            "[Group] Show - 07 [WEB-DL 1080p]",
+            series_id,
+            &[7],
+            false,
+        )
+        .await
+        .expect("record single grab")
+        .expect("single grab inserted");
+        mark_imported(&db, single_grab_id)
+            .await
+            .expect("mark single imported");
+
+        // Episode 5 is only covered by the batch grab — its is_batch must
+        // round-trip as true.
+        let ep5 = find_imported_for_episode(&db, series_id, 5)
+            .await
+            .expect("find ep5");
+        assert_eq!(ep5.len(), 1, "expected one grab covering episode 5");
+        assert!(
+            ep5[0].is_batch,
+            "batch grab for episode 5 must report is_batch=true"
+        );
+
+        // Episode 7 is covered by both grabs. The single-episode grab was
+        // recorded second so it sorts first (ORDER BY grabbed_at DESC), but
+        // both rows must report their true is_batch value.
+        let ep7 = find_imported_for_episode(&db, series_id, 7)
+            .await
+            .expect("find ep7");
+        assert_eq!(ep7.len(), 2, "expected both grabs covering episode 7");
+        let single = ep7
+            .iter()
+            .find(|g| g.id == single_grab_id)
+            .expect("single grab present");
+        assert!(!single.is_batch, "single-episode grab is_batch=false");
+        let batch = ep7
+            .iter()
+            .find(|g| g.id == batch_grab_id)
+            .expect("batch grab present");
+        assert!(batch.is_batch, "batch grab is_batch=true");
     }
 }

--- a/src/models/group_source_map.rs
+++ b/src/models/group_source_map.rs
@@ -360,7 +360,12 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
 
 /// Insert any missing built-in seed rows. Existing rows (including
 /// user-edited ones) are left untouched thanks to `INSERT OR IGNORE`.
+///
+/// Wrapped in a single transaction so the 256 INSERTs commit as one
+/// fsync at boot — used to be one fsync per row, blocking the very
+/// first incoming request behind ~256 sequential disk syncs.
 pub async fn seed_defaults(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
     for (name, source, confidence, notes) in SEED_DEFAULTS {
         sqlx::query(
             "INSERT OR IGNORE INTO group_source_map (group_name, source, confidence, is_user_edit, notes)
@@ -370,9 +375,10 @@ pub async fn seed_defaults(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .bind(source.as_str())
         .bind(*confidence)
         .bind(notes)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
     }
+    tx.commit().await?;
     Ok(())
 }
 
@@ -387,6 +393,8 @@ pub async fn seed_defaults(db: &SqlitePool) -> Result<(), sqlx::Error> {
 /// deliberately set their own confidence for a group keeps it. The
 /// update is idempotent — rows that already match the seed are a no-op.
 pub async fn reconcile_seed_drift(db: &SqlitePool) -> Result<(), sqlx::Error> {
+    // See seed_defaults — same fsync-coalesce reason for the tx wrap.
+    let mut tx = db.begin().await?;
     for (name, source, confidence, notes) in SEED_DEFAULTS {
         sqlx::query(
             "UPDATE group_source_map
@@ -397,9 +405,10 @@ pub async fn reconcile_seed_drift(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .bind(*confidence)
         .bind(notes)
         .bind(name)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
     }
+    tx.commit().await?;
     Ok(())
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1114,9 +1114,42 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // REPLACE statements on known legacy patterns. Fully idempotent:
     // the regen overwrites with the same value on re-runs, and the
     // REPLACE chain no-ops once its source patterns are gone.
+    // The CASE is duplicated in SET and WHERE on purpose: gating the
+    // UPDATE means SQLite only writes rows whose quality_tag would
+    // actually change, so a boot on an already-migrated database does
+    // zero WAL writes here instead of dirtying every row in the table.
+    // Without the gate, every boot churned the WAL and held the write
+    // lock long enough to delay the very first incoming request after
+    // startup.
     sqlx::query(
         r#"
         UPDATE episode_quality_tags SET quality_tag = CASE
+            WHEN TRIM(COALESCE(source, '')) = ''
+              OR LOWER(source) = 'unknown' THEN
+                CASE WHEN COALESCE(resolution, '') IN ('', 'Unknown')
+                     THEN 'Unknown' ELSE resolution END
+            ELSE
+                (CASE
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd') THEN 'BD'
+                    WHEN LOWER(source) = 'web' THEN
+                        CASE
+                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webdl', 'web-dl', 'web.dl') THEN 'WEBDL'
+                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webrip', 'web-rip', 'web.rip') THEN 'WEBRip'
+                            ELSE 'WEB'
+                        END
+                    ELSE UPPER(source)
+                END)
+                || CASE WHEN COALESCE(resolution, '') IN ('', 'Unknown')
+                        THEN '' ELSE '-' || resolution END
+                || CASE
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd')
+                         AND COALESCE(is_bdmv, 0) = 1 THEN ' RAW'
+                    WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd')
+                         AND COALESCE(is_remux, 0) = 1 THEN ' Remux'
+                    ELSE ''
+                END
+        END
+        WHERE COALESCE(quality_tag, '') <> CASE
             WHEN TRIM(COALESCE(source, '')) = ''
               OR LOWER(source) = 'unknown' THEN
                 CASE WHEN COALESCE(resolution, '') IN ('', 'Unknown')

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1132,6 +1132,12 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // Without the gate, every boot churned the WAL and held the write
     // lock long enough to delay the very first incoming request after
     // startup.
+    //
+    // MAINTENANCE: any edit to the SET CASE must be mirrored in the
+    // WHERE CASE below (and vice versa). Diverging the two is a
+    // correctness bug — the WHERE's job is to match the SET's output
+    // exactly, so the gate only skips rows that truly don't need the
+    // rewrite.
     sqlx::query(
         r#"
         UPDATE episode_quality_tags SET quality_tag = CASE

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -566,6 +566,38 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
 
+    // One-time backfill: deduplicate active grabs sharing a hash before
+    // creating the unique index below. Pre-fix race in record_grab could
+    // produce duplicate pending/imported rows for the same hash; the
+    // unique index would otherwise refuse to create. Keeps the oldest
+    // row per hash (lowest id), drops the rest. Idempotent — a second
+    // boot finds no duplicates and the DELETE no-ops.
+    sqlx::query(
+        r#"DELETE FROM grabbed_torrents
+           WHERE hash != ''
+             AND state IN ('pending', 'imported')
+             AND id NOT IN (
+                 SELECT MIN(id) FROM grabbed_torrents
+                 WHERE hash != '' AND state IN ('pending', 'imported')
+                 GROUP BY hash
+             )"#,
+    )
+    .execute(db)
+    .await?;
+
+    // Partial UNIQUE index that backs the atomic dedup in record_grab's
+    // INSERT OR IGNORE. Restricted to active states so a hash that's
+    // been blocklisted ('failed') or removed can still be re-recorded
+    // — preserving the prior SELECT's `state IN ('pending', 'imported')`
+    // filter as the dedup window.
+    sqlx::query(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_grabbed_torrents_hash_active
+         ON grabbed_torrents (hash)
+         WHERE hash != '' AND state IN ('pending', 'imported')",
+    )
+    .execute(db)
+    .await?;
+
     // Per-file series routing for multi-series batch releases. A
     // megapack that covers e.g. JoJo S1-S5 gets one row per sibling
     // in this table, each carrying the file indices (into the

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -761,14 +761,29 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // covers the corner case where neither column is present (which
     // shouldn't happen, but keeps downstream writes safe).
     if !column_exists(db, "episode_grab_history", "file_name").await {
-        sqlx::query("ALTER TABLE episode_grab_history RENAME COLUMN torrent_name TO file_name")
-            .execute(db)
-            .await
-            .ok();
-        sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN file_name TEXT NOT NULL DEFAULT ''")
-            .execute(db)
-            .await
-            .ok();
+        // Two paths for the legacy schema:
+        //
+        //  - `torrent_name` exists  → RENAME it to `file_name`. Propagate
+        //    any failure from the RENAME instead of swallowing with .ok():
+        //    the previous code paired the RENAME with an unconditional ADD
+        //    so a transient RENAME failure (DB lock, FK quirk, I/O hiccup)
+        //    would leave an empty `file_name` column on top of intact
+        //    `torrent_name` data and the next boot would think the
+        //    migration was already done. Refusing to start with a real
+        //    error is preferable to silent data loss.
+        //
+        //  - `torrent_name` is also missing → defensive ADD for the
+        //    corrupted-schema corner case. Without `torrent_name` to
+        //    rename from there is no data to lose, so the ADD is safe.
+        if column_exists(db, "episode_grab_history", "torrent_name").await {
+            sqlx::query("ALTER TABLE episode_grab_history RENAME COLUMN torrent_name TO file_name")
+                .execute(db)
+                .await?;
+        } else {
+            sqlx::query("ALTER TABLE episode_grab_history ADD COLUMN file_name TEXT NOT NULL DEFAULT ''")
+                .execute(db)
+                .await?;
+        }
     }
 
     // Episode-file size. For non-batch grabs this gets refined to the
@@ -1205,4 +1220,84 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
 
+    /// Regression: a legacy install has `episode_grab_history.torrent_name`
+    /// populated with the release title for every historical grab. The
+    /// column-rename path previously ran
+    ///   RENAME torrent_name → file_name (.ok())
+    ///   ADD COLUMN file_name TEXT (.ok())
+    /// back-to-back. If the RENAME failed for any reason (DB lock, FK
+    /// quirk, I/O hiccup) the subsequent ADD silently created an empty
+    /// `file_name` column on top of intact `torrent_name` data and every
+    /// prior row's release title was effectively lost — `.ok()` on both
+    /// statements meant no log line, no error, nothing to alert the
+    /// operator.
+    ///
+    /// This test exercises the happy path: pre-create the table with the
+    /// legacy schema, stuff a row into it, run migrate, confirm the row's
+    /// file_name now carries what torrent_name held.
+    #[tokio::test]
+    async fn migrate_renames_legacy_torrent_name_to_file_name_preserving_data() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+
+        // Pre-create episode_grab_history with the legacy schema (column
+        // is `torrent_name`, no `file_name`). CREATE TABLE IF NOT EXISTS
+        // inside migrate() will then skip this table and migrate() will
+        // reach the rename branch under test.
+        sqlx::query(
+            r#"
+            CREATE TABLE episode_grab_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                series_id INTEGER NOT NULL,
+                episode_number INTEGER NOT NULL,
+                quality_tag TEXT NOT NULL DEFAULT '',
+                release_title TEXT NOT NULL DEFAULT '',
+                release_group TEXT NOT NULL DEFAULT '',
+                torrent_name TEXT NOT NULL DEFAULT '',
+                state TEXT NOT NULL DEFAULT 'grabbed',
+                grabbed_at DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            "#,
+        )
+        .execute(&db)
+        .await
+        .expect("pre-create legacy table");
+
+        sqlx::query(
+            "INSERT INTO episode_grab_history
+                 (series_id, episode_number, quality_tag, release_title, release_group, torrent_name)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(1_i64)
+        .bind(1_i32)
+        .bind("WEBDL-1080p")
+        .bind("[Group] Show - 01 [WEB-DL 1080p].mkv")
+        .bind("Group")
+        .bind("[Group] Show - 01 [WEB-DL 1080p].mkv")
+        .execute(&db)
+        .await
+        .expect("insert legacy row");
+
+        migrate(&db).await.expect("migrate must succeed");
+
+        // After migrate, the data that lived in `torrent_name` must now be
+        // in `file_name`. If the rename failed and the defensive ADD
+        // branch ran instead, this value would be empty (the default).
+        let file_name: String = sqlx::query_scalar(
+            "SELECT file_name FROM episode_grab_history WHERE id = 1",
+        )
+        .fetch_one(&db)
+        .await
+        .expect("row 1 must still exist");
+        assert_eq!(file_name, "[Group] Show - 01 [WEB-DL 1080p].mkv");
+
+        // And the old column should no longer be there (RENAME moved it,
+        // didn't duplicate it).
+        assert!(!column_exists(&db, "episode_grab_history", "torrent_name").await);
+    }
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -562,6 +562,17 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await?;
 
+    // Many hot-path queries filter on series_id (find_imported_for_episode,
+    // get_all_for_series, mark_failed_by_name, etc.) and the prior schema
+    // had no index covering it — every lookup did a full table scan. Sort
+    // key lets get_all_for_series / get_blocked / get_all_with_series read
+    // in chronological order without a separate sort.
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_grabbed_torrents_series ON grabbed_torrents (series_id, grabbed_at DESC)",
+    )
+    .execute(db)
+    .await?;
+
     sqlx::query("CREATE INDEX IF NOT EXISTS idx_grabbed_torrents_hash ON grabbed_torrents (hash) WHERE hash != ''")
         .execute(db)
         .await?;

--- a/src/models/rss.rs
+++ b/src/models/rss.rs
@@ -109,12 +109,24 @@ pub async fn finish_run(
     Ok(())
 }
 
-pub async fn item_was_grabbed(db: &SqlitePool, item_key: &str) -> Result<bool, sqlx::Error> {
-    let row: Option<(i64,)> = sqlx::query_as("SELECT id FROM rss_seen WHERE item_key = ? AND decision = 'grabbed'")
-        .bind(item_key)
-        .fetch_optional(db)
-        .await?;
-    Ok(row.is_some())
+/// Returns every item_key in `rss_seen` with `decision = 'grabbed'`
+/// as a `HashSet` so callers can do membership checks in O(1) without
+/// a DB round-trip per lookup. The hourly cleanup task prunes rows
+/// older than 30 days, so the working set stays bounded for any active
+/// install.
+///
+/// Used by the RSS sync loop, which previously did one SELECT per
+/// feed item — Nyaa returns ~100 items per feed × multiple categories,
+/// so a single sync was ~100+ sequential round-trips against the same
+/// table before any other work happened.
+pub async fn grabbed_item_keys(
+    db: &SqlitePool,
+) -> Result<std::collections::HashSet<String>, sqlx::Error> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT item_key FROM rss_seen WHERE decision = 'grabbed'")
+            .fetch_all(db)
+            .await?;
+    Ok(rows.into_iter().map(|(k,)| k).collect())
 }
 
 /// Payload for `record_decision`. Named fields instead of six `&str`s

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -106,13 +106,20 @@ pub async fn verify_user(db: &SqlitePool, username: &str, password: &str) -> Res
             }
         }
         None => {
-            // Burn equivalent CPU time against the dummy hash and discard
-            // the result. DUMMY_BCRYPT_HASH is a `static LazyLock<String>`
-            // so the closure can reference it without capturing.
+            // Burn equivalent CPU time against the dummy hash and
+            // discard the result. DUMMY_BCRYPT_HASH is a
+            // `static LazyLock<String>` so the closure can reference it
+            // without capturing. Propagate JoinError with `?` to match
+            // the Some branch — without parity, an extremely-rare
+            // spawn_blocking panic would distinguish the two branches
+            // by both wall time AND result shape, defeating the
+            // username-enumeration timing equaliser the function
+            // exists to provide.
             let _ = tokio::task::spawn_blocking(move || {
                 bcrypt::verify(&password_owned, &DUMMY_BCRYPT_HASH).unwrap_or(false)
             })
-            .await;
+            .await
+            .map_err(|e| format!("verify spawn_blocking failed: {}", e))?;
             Ok(None)
         }
     }

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -43,7 +43,14 @@ pub async fn has_users(db: &SqlitePool) -> Result<bool, sqlx::Error> {
 
 /// Create a new user with a bcrypt-hashed password.
 pub async fn create_user(db: &SqlitePool, username: &str, password: &str) -> Result<i64, String> {
-    let hash = bcrypt::hash(password, 10).map_err(|e| format!("Hash error: {}", e))?;
+    // bcrypt::hash burns ~50ms of CPU on a runtime worker. Move it to a
+    // blocking thread so a setup POST under any concurrent async load
+    // doesn't stall every other task on the same worker.
+    let password_owned = password.to_string();
+    let hash = tokio::task::spawn_blocking(move || bcrypt::hash(&password_owned, 10))
+        .await
+        .map_err(|e| format!("Hash spawn_blocking failed: {}", e))?
+        .map_err(|e| format!("Hash error: {}", e))?;
 
     let result = sqlx::query("INSERT INTO users (username, password_hash) VALUES (?, ?)")
         .bind(username)
@@ -71,9 +78,23 @@ pub async fn verify_user(db: &SqlitePool, username: &str, password: &str) -> Res
             .await
             .map_err(|e| format!("DB error: {}", e))?;
 
+    // bcrypt::verify is ~50ms of CPU work; running it on a runtime
+    // worker stalls every other async task on that worker. Wrap both
+    // branches in spawn_blocking so concurrent login attempts don't
+    // serialise behind each other on a single worker thread. The
+    // timing-equalisation invariant (the no-such-user branch must
+    // take the same wall time as the wrong-password branch) is
+    // preserved — both branches still go through one bcrypt::verify
+    // and one spawn_blocking trip.
+    let password_owned = password.to_string();
     match row {
         Some((id, uname, hash)) => {
-            let valid = bcrypt::verify(password, &hash).unwrap_or(false);
+            let hash_for_verify = hash.clone();
+            let valid = tokio::task::spawn_blocking(move || {
+                bcrypt::verify(&password_owned, &hash_for_verify).unwrap_or(false)
+            })
+            .await
+            .map_err(|e| format!("verify spawn_blocking failed: {}", e))?;
             if valid {
                 Ok(Some(User {
                     id,
@@ -86,10 +107,12 @@ pub async fn verify_user(db: &SqlitePool, username: &str, password: &str) -> Res
         }
         None => {
             // Burn equivalent CPU time against the dummy hash and discard
-            // the result. `.unwrap_or(false)` mirrors the Some-branch
-            // handling so any bcrypt error produces the same outcome as
-            // a wrong password.
-            let _ = bcrypt::verify(password, &DUMMY_BCRYPT_HASH).unwrap_or(false);
+            // the result. DUMMY_BCRYPT_HASH is a `static LazyLock<String>`
+            // so the closure can reference it without capturing.
+            let _ = tokio::task::spawn_blocking(move || {
+                bcrypt::verify(&password_owned, &DUMMY_BCRYPT_HASH).unwrap_or(false)
+            })
+            .await;
             Ok(None)
         }
     }

--- a/src/services/anibridge.rs
+++ b/src/services/anibridge.rs
@@ -294,6 +294,29 @@ pub async fn lookup_tmdb_by_anilist(anilist_id: i64) -> Option<i64> {
         .copied()
 }
 
+/// Resolve a TMDB ID from either an AniList ID or a MAL ID. Tries
+/// AniList first, falls back to MAL when given. Returns 0 when neither
+/// path produces a hit — callers (the Sonarr/Radarr compat handlers)
+/// emit `tmdbId: 0` in that case so Seerr can still receive a
+/// well-formed payload.
+///
+/// Centralised here because the same shape lived duplicated in both
+/// sonarr_compat and radarr_compat — keeping the lookup chain in one
+/// place means future changes (extra fallback IDs, retry semantics,
+/// negative-cache) only need editing once.
+pub async fn resolve_tmdb_id(anilist_id: i64, mal_id: impl Into<Option<i64>>) -> i64 {
+    if let Some(tmdb) = lookup_tmdb_by_anilist(anilist_id).await {
+        return tmdb;
+    }
+    if let Some(mid) = mal_id.into()
+        && mid > 0
+        && let Some(tmdb) = lookup_tmdb_by_mal(mid).await
+    {
+        return tmdb;
+    }
+    0
+}
+
 /// Parse raw mappings JSON bytes into the in-memory lookup tables.
 /// Shared between the disk-cache path (`ensure_loaded`) and the
 /// network path (`download_parse_and_persist`) so there's only one

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use crate::services::html::sanitize_rich_description;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -51,6 +52,18 @@ static SEARCH_CACHE: LazyLock<StdMutex<HashMap<String, SearchCacheEntry>>> =
 /// rate-limit bucket too).
 static ANILIST_COOLDOWN_UNTIL: LazyLock<StdMutex<Option<Instant>>> =
     LazyLock::new(|| StdMutex::new(None));
+
+/// Counter of consecutive cooldown-set events (i.e. throttle-class
+/// failures) without an intervening successful AniList call. Used by
+/// `set_anilist_cooldown` to add a small safety margin starting on the
+/// 2nd consecutive 429, since the first 429 implies our previous wait
+/// (or zero wait) wasn't enough to clear AniList's window. Reset by
+/// `note_anilist_success`.
+static CONSECUTIVE_RATE_LIMITS: AtomicU32 = AtomicU32::new(0);
+
+/// Per-repeat margin added to AL's `Retry-After` value to avoid landing
+/// at the window boundary. Empirically 2s clears the per-minute window.
+const COOLDOWN_REPEAT_MARGIN: Duration = Duration::from_secs(2);
 
 fn normalize_search_key(force_fallback: bool, query: &str) -> String {
     let folded: String = query
@@ -201,14 +214,40 @@ fn excerpt(text: &str) -> String {
     }
 }
 
-fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: Duration) {
-    let dur = retry_after_secs
+/// Pure cooldown-duration computation. Extracted from `set_anilist_cooldown`
+/// for unit-testability — the wall-clock side effect lives in the caller.
+fn compute_cooldown_duration(
+    retry_after_secs: Option<u64>,
+    default_dur: Duration,
+    consecutive_count: u32,
+) -> Duration {
+    let base = retry_after_secs
         .map(Duration::from_secs)
         .unwrap_or(default_dur)
         .min(ANILIST_COOLDOWN_MAX);
+    if consecutive_count > 0 {
+        base + COOLDOWN_REPEAT_MARGIN
+    } else {
+        // First 429 in a streak: trust AL's retry-after as-is. We only
+        // pad on repeats, where the empirical evidence (the *second*
+        // 429) tells us the previous wait was just shy of the window.
+        base
+    }
+}
+
+fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: Duration) {
+    let prior_count = CONSECUTIVE_RATE_LIMITS.fetch_add(1, Ordering::Relaxed);
+    let dur = compute_cooldown_duration(retry_after_secs, default_dur, prior_count);
     if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
         *guard = Some(Instant::now() + dur);
     }
+}
+
+/// Reset the consecutive-429 counter. Called after every fully-successful
+/// AniList response so the *next* 429 (which presumably comes from a
+/// fresh window much later) gets the no-margin treatment again.
+fn note_anilist_success() {
+    CONSECUTIVE_RATE_LIMITS.store(0, Ordering::Relaxed);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -865,6 +904,11 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         return Err("Anime not found".into());
     }
 
+    // Reset the consecutive-429 counter once we have a real Media object
+    // back. The next 429 in a future window starts fresh with no margin
+    // (only repeats in a streak get the safety pad).
+    note_anilist_success();
+
     let streaming_episodes = m["streamingEpisodes"]
         .as_array()
         .map(|arr| {
@@ -1101,6 +1145,46 @@ mod tests {
         assert!(is_rate_limit_error(
             "AniList rate-limit cooldown active; skipping AniList request"
         ));
+    }
+
+    #[test]
+    fn cooldown_first_429_uses_retry_after_unmodified() {
+        // Trust AL's word on the first throttle of a streak — no margin.
+        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 0);
+        assert_eq!(dur, Duration::from_secs(60));
+    }
+
+    #[test]
+    fn cooldown_repeat_429_adds_safety_margin() {
+        // Second-and-later 429s in the same streak get padded so the
+        // retry doesn't land at AL's window boundary and trip a fresh
+        // 429 immediately on exit.
+        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 1);
+        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_REPEAT_MARGIN);
+
+        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 5);
+        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_REPEAT_MARGIN);
+    }
+
+    #[test]
+    fn cooldown_falls_back_to_default_when_no_retry_after() {
+        let dur = compute_cooldown_duration(None, Duration::from_secs(45), 0);
+        assert_eq!(dur, Duration::from_secs(45));
+    }
+
+    #[test]
+    fn cooldown_caps_retry_after_at_max() {
+        // AL could theoretically tell us to wait an hour; we ignore
+        // anything past ANILIST_COOLDOWN_MAX.
+        let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT, 0);
+        assert_eq!(dur, ANILIST_COOLDOWN_MAX);
+    }
+
+    #[test]
+    fn cooldown_margin_added_on_top_of_cap() {
+        // Cap applies to AL's value; safety margin is layered on after.
+        let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT, 1);
+        assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_REPEAT_MARGIN);
     }
 
     #[test]

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -40,10 +40,24 @@ static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, CacheEntry>>> =
 /// rebuilt the TLS context and connection pool from scratch — wasteful
 /// across the search / detail / fallback paths that all hit
 /// graphql.anilist.co. Using a single Lazy client lets the pool reuse
-/// connections across calls. No timeout configured here — callers own
-/// retry/cooldown semantics that interact in non-obvious ways with a
-/// blanket per-request timeout.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// connections across calls.
+///
+/// Timeouts: 10s to establish a TCP+TLS handshake, 30s overall per
+/// request. Without an overall timeout a hung connection (e.g. half-
+/// open after a network partition) pins a pool slot until kernel TCP
+/// keepalive resolves, which on default Linux is roughly 2 hours —
+/// long enough that interactive searches feel permanently broken even
+/// after AL is healthy again. The 30s ceiling is generous relative to
+/// AL's typical sub-second response time but still bounded; cooldown /
+/// retry semantics live in the callers and are unaffected by this
+/// per-attempt cap.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the AniList reqwest client should not fail")
+});
 
 type SearchCacheEntry = (Instant, Vec<AnimeEntry>);
 

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -1,7 +1,6 @@
 use serde::{Deserialize, Serialize};
 use crate::services::html::sanitize_rich_description;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 use tokio::sync::RwLock;
@@ -53,17 +52,14 @@ static SEARCH_CACHE: LazyLock<StdMutex<HashMap<String, SearchCacheEntry>>> =
 static ANILIST_COOLDOWN_UNTIL: LazyLock<StdMutex<Option<Instant>>> =
     LazyLock::new(|| StdMutex::new(None));
 
-/// Counter of consecutive cooldown-set events (i.e. throttle-class
-/// failures) without an intervening successful AniList call. Used by
-/// `set_anilist_cooldown` to add a small safety margin starting on the
-/// 2nd consecutive 429, since the first 429 implies our previous wait
-/// (or zero wait) wasn't enough to clear AniList's window. Reset by
-/// `note_anilist_success`.
-static CONSECUTIVE_RATE_LIMITS: AtomicU32 = AtomicU32::new(0);
-
-/// Per-repeat margin added to AL's `Retry-After` value to avoid landing
-/// at the window boundary. Empirically 2s clears the per-minute window.
-const COOLDOWN_REPEAT_MARGIN: Duration = Duration::from_secs(2);
+/// Safety margin added to AL's `Retry-After` value (or to the default
+/// cooldown when no Retry-After is present). Without this, waiting
+/// exactly the duration AL hands back consistently lands the next
+/// request at the window boundary and trips a fresh 429 — observed
+/// live during a sweep where the second 429 followed the first by
+/// roughly the original Retry-After value. 2s clears the boundary in
+/// practice without meaningfully extending sweep time.
+const COOLDOWN_SAFETY_MARGIN: Duration = Duration::from_secs(2);
 
 fn normalize_search_key(force_fallback: bool, query: &str) -> String {
     let folded: String = query
@@ -219,35 +215,19 @@ fn excerpt(text: &str) -> String {
 fn compute_cooldown_duration(
     retry_after_secs: Option<u64>,
     default_dur: Duration,
-    consecutive_count: u32,
 ) -> Duration {
     let base = retry_after_secs
         .map(Duration::from_secs)
         .unwrap_or(default_dur)
         .min(ANILIST_COOLDOWN_MAX);
-    if consecutive_count > 0 {
-        base + COOLDOWN_REPEAT_MARGIN
-    } else {
-        // First 429 in a streak: trust AL's retry-after as-is. We only
-        // pad on repeats, where the empirical evidence (the *second*
-        // 429) tells us the previous wait was just shy of the window.
-        base
-    }
+    base + COOLDOWN_SAFETY_MARGIN
 }
 
 fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: Duration) {
-    let prior_count = CONSECUTIVE_RATE_LIMITS.fetch_add(1, Ordering::Relaxed);
-    let dur = compute_cooldown_duration(retry_after_secs, default_dur, prior_count);
+    let dur = compute_cooldown_duration(retry_after_secs, default_dur);
     if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
         *guard = Some(Instant::now() + dur);
     }
-}
-
-/// Reset the consecutive-429 counter. Called after every fully-successful
-/// AniList response so the *next* 429 (which presumably comes from a
-/// fresh window much later) gets the no-margin treatment again.
-fn note_anilist_success() {
-    CONSECUTIVE_RATE_LIMITS.store(0, Ordering::Relaxed);
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
@@ -904,11 +884,6 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         return Err("Anime not found".into());
     }
 
-    // Reset the consecutive-429 counter once we have a real Media object
-    // back. The next 429 in a future window starts fresh with no margin
-    // (only repeats in a streak get the safety pad).
-    note_anilist_success();
-
     let streaming_episodes = m["streamingEpisodes"]
         .as_array()
         .map(|arr| {
@@ -1148,43 +1123,30 @@ mod tests {
     }
 
     #[test]
-    fn cooldown_first_429_uses_retry_after_unmodified() {
-        // Trust AL's word on the first throttle of a streak — no margin.
-        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 0);
-        assert_eq!(dur, Duration::from_secs(60));
-    }
-
-    #[test]
-    fn cooldown_repeat_429_adds_safety_margin() {
-        // Second-and-later 429s in the same streak get padded so the
-        // retry doesn't land at AL's window boundary and trip a fresh
-        // 429 immediately on exit.
-        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 1);
-        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_REPEAT_MARGIN);
-
-        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT, 5);
-        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_REPEAT_MARGIN);
+    fn cooldown_pads_retry_after_with_safety_margin() {
+        // AL hands back e.g. 60s; we wait 62s. The 2s margin clears the
+        // window boundary that would otherwise trip a fresh 429 on the
+        // immediate retry.
+        let dur = compute_cooldown_duration(Some(60), ANILIST_COOLDOWN_DEFAULT);
+        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_SAFETY_MARGIN);
     }
 
     #[test]
     fn cooldown_falls_back_to_default_when_no_retry_after() {
-        let dur = compute_cooldown_duration(None, Duration::from_secs(45), 0);
-        assert_eq!(dur, Duration::from_secs(45));
+        // The default also gets padded — no Retry-After header doesn't
+        // mean we can risk hitting the boundary.
+        let dur = compute_cooldown_duration(None, Duration::from_secs(45));
+        assert_eq!(dur, Duration::from_secs(45) + COOLDOWN_SAFETY_MARGIN);
     }
 
     #[test]
-    fn cooldown_caps_retry_after_at_max() {
-        // AL could theoretically tell us to wait an hour; we ignore
-        // anything past ANILIST_COOLDOWN_MAX.
-        let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT, 0);
-        assert_eq!(dur, ANILIST_COOLDOWN_MAX);
-    }
-
-    #[test]
-    fn cooldown_margin_added_on_top_of_cap() {
-        // Cap applies to AL's value; safety margin is layered on after.
-        let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT, 1);
-        assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_REPEAT_MARGIN);
+    fn cooldown_caps_retry_after_at_max_then_pads() {
+        // AL could theoretically tell us to wait an hour; we cap at
+        // ANILIST_COOLDOWN_MAX and *then* layer the safety margin on
+        // (so a runaway Retry-After can't bypass the cap, but the
+        // boundary protection still applies).
+        let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT);
+        assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_SAFETY_MARGIN);
     }
 
     #[test]

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -291,7 +291,17 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
     let media = match body["data"]["Page"]["media"].as_array() {
         Some(arr) => arr,
         None => {
-            search_cache_put(cache_key, Vec::new());
+            // Schema mismatch — `data.Page.media` is missing or not an
+            // array. Don't cache the empty result here: a legitimate
+            // 0-hit search hits the Some branch with an empty arr and
+            // *does* get cached at line 317 below. Caching the
+            // schema-mismatch case would lock us out of fresh requests
+            // for SEARCH_CACHE_TTL even after AniList recovers.
+            tracing::warn!(
+                target: "ryokan::anilist",
+                query = %query,
+                "AniList response missing data.Page.media; not caching empty result"
+            );
             return Ok(Vec::new());
         }
     };

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -95,6 +95,112 @@ pub fn anilist_cooldown_active() -> bool {
     false
 }
 
+/// Single source of truth for "this AniList error means we're being
+/// throttled / blocked." Callers use this to decide whether to
+/// defer-and-retry (preserve AL fidelity) vs. treat AL as down and fall
+/// back to MAL.
+///
+/// All errors classified as throttle by `classify_anilist_failure` carry
+/// the `AniList rate-limited` prefix; the in-process cooldown short-circuit
+/// uses `cooldown active`. Non-throttle failures (5xx, 403 with
+/// non-Cloudflare body, parse errors) deliberately do *not* match — those
+/// are "AL is genuinely down" and fallback callers should substitute MAL.
+pub fn is_rate_limit_error(err: &str) -> bool {
+    err.contains("AniList rate-limited") || err.contains("cooldown active")
+}
+
+/// Classification of an AniList failure response. Drives both the
+/// error-string wording and whether `set_anilist_cooldown` is called.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AniListFailureKind {
+    /// Throttle: 429, Cloudflare challenge, or GraphQL-level "too many
+    /// requests". Caller should defer-and-retry; do not substitute MAL.
+    RateLimited,
+    /// AL itself is unhealthy: 5xx, body parse failure, or a 403 whose
+    /// body doesn't look like Cloudflare (suggests an AL-side problem
+    /// rather than upstream throttling). Caller may fall back to MAL.
+    Unavailable,
+    /// AL responded successfully but the requested entity doesn't exist.
+    NotFound,
+}
+
+/// Inspect status + body to figure out *why* AniList rejected the call.
+/// Status alone is ambiguous (especially 403 — Cloudflare vs. AL itself
+/// vs. auth issue), so we also look for body markers. Returns the kind
+/// plus a tagged error string the caller can return to its consumers;
+/// downstream code matches on the tag prefix (`AniList rate-limited` /
+/// `AniList unavailable` / `AniList not found`) rather than HTTP codes,
+/// so adding new wordings doesn't break the policy.
+fn classify_anilist_failure(
+    status: reqwest::StatusCode,
+    body_text: &str,
+) -> (AniListFailureKind, String) {
+    let parsed: Option<serde_json::Value> = serde_json::from_str(body_text).ok();
+    let gql_msg = parsed.as_ref().and_then(extract_graphql_error);
+
+    // Cloudflare HTML challenge — distinctive body markers, can come back
+    // with any 4xx/5xx status. Treat as throttle.
+    let lower = body_text.to_ascii_lowercase();
+    let is_cloudflare = lower.contains("cf-ray")
+        || lower.contains("just a moment")
+        || lower.contains("attention required")
+        || (lower.contains("cloudflare") && lower.contains("<html"));
+    if is_cloudflare {
+        return (
+            AniListFailureKind::RateLimited,
+            format!("AniList rate-limited: Cloudflare challenge (HTTP {})", status),
+        );
+    }
+
+    // GraphQL-level throttle hint, regardless of status.
+    if let Some(msg) = &gql_msg {
+        let lower = msg.to_ascii_lowercase();
+        if lower.contains("too many requests")
+            || lower.contains("rate limit")
+            || lower.contains("throttled")
+        {
+            return (
+                AniListFailureKind::RateLimited,
+                format!("AniList rate-limited: {} (HTTP {})", msg, status),
+            );
+        }
+    }
+
+    let detail = gql_msg.unwrap_or_else(|| excerpt(body_text));
+    match status.as_u16() {
+        429 => (
+            AniListFailureKind::RateLimited,
+            format!("AniList rate-limited (HTTP 429): {}", detail),
+        ),
+        404 => (
+            AniListFailureKind::NotFound,
+            format!("AniList not found (HTTP 404): {}", detail),
+        ),
+        // 403 lands here when the body wasn't Cloudflare-shaped — that's
+        // AL-side (auth / blocked at the app layer), not upstream
+        // throttling, so it's "unavailable" and callers may MAL-fallback.
+        // 5xx is the same family.
+        _ => (
+            AniListFailureKind::Unavailable,
+            format!("AniList unavailable (HTTP {}): {}", status, detail),
+        ),
+    }
+}
+
+/// Truncate a body string for inclusion in an error message. Char-aware
+/// so it can't slice in the middle of a multi-byte UTF-8 sequence.
+fn excerpt(text: &str) -> String {
+    const MAX_CHARS: usize = 200;
+    let trimmed = text.trim();
+    let mut iter = trimmed.chars();
+    let prefix: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{}…", prefix)
+    } else {
+        prefix
+    }
+}
+
 fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: Duration) {
     let dur = retry_after_secs
         .map(Duration::from_secs)
@@ -683,30 +789,32 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         .map_err(|e| format!("AniList request failed: {}", e))?;
 
     let status = resp.status();
-    // Capture Retry-After before .json() consumes the response — used
-    // to set the cooldown duration on 429 so the sweep's remaining
-    // calls skip AniList until the limit window resets.
+    // Capture Retry-After before consuming the response body — used to
+    // set the cooldown duration so the sweep's remaining calls skip
+    // AniList until the limit window resets.
     let retry_after_secs = resp
         .headers()
         .get("retry-after")
         .and_then(|v| v.to_str().ok())
         .and_then(|s| s.parse::<u64>().ok());
-    let body: serde_json::Value = resp
-        .json()
+    // Read as text first (not .json()) so a Cloudflare HTML challenge
+    // doesn't blow up at the parse step — we need the body to classify
+    // the failure correctly.
+    let body_text = resp
+        .text()
         .await
-        .map_err(|e| format!("Failed to parse AniList response: {}", e))?;
+        .map_err(|e| format!("AniList unavailable: failed to read response: {}", e))?;
 
     if !status.is_success() {
-        // Mirror the search-path branch (lines 223-248): 403/429/5xx
-        // mean "AniList is unavailable to us right now". Set the
-        // global cooldown so subsequent fetch_anime_detail calls
-        // short-circuit with the cooldown-active error above instead
-        // of hammering an already-rate-limited endpoint. 403 gets a
-        // longer default since Cloudflare doesn't include Retry-After.
-        if status == reqwest::StatusCode::FORBIDDEN
-            || status == reqwest::StatusCode::TOO_MANY_REQUESTS
-            || status.is_server_error()
-        {
+        let (kind, msg) = classify_anilist_failure(status, &body_text);
+        // Cooldown only on real throttling. 5xx and AL-side 403s are
+        // "AL is down" — letting them set the cooldown would convert
+        // subsequent calls into deferred-rate-limit errors and prevent
+        // the MAL fallback the caller actually wants.
+        if kind == AniListFailureKind::RateLimited {
+            // 403 (Cloudflare) doesn't include Retry-After, so pick a
+            // longer default — 60s rarely outlasts a real challenge —
+            // and let ANILIST_COOLDOWN_MAX cap it.
             let default_cooldown = if status == reqwest::StatusCode::FORBIDDEN {
                 Duration::from_secs(300)
             } else {
@@ -714,9 +822,11 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
             };
             set_anilist_cooldown(retry_after_secs, default_cooldown);
         }
-        let msg = extract_graphql_error(&body).unwrap_or_else(|| body.to_string());
-        return Err(format!("AniList detail failed (HTTP {}): {}", status, msg));
+        return Err(msg);
     }
+
+    let body: serde_json::Value = serde_json::from_str(&body_text)
+        .map_err(|e| format!("AniList unavailable: parse error: {} (body: {})", e, excerpt(&body_text)))?;
 
     if let Some(msg) = extract_graphql_error(&body) {
         return Err(format!("AniList detail failed: {}", msg));
@@ -894,5 +1004,83 @@ mod tests {
         // A different normalized key should miss.
         let other = normalize_search_key(false, "completely different");
         assert!(search_cache_get(&other).is_none());
+    }
+
+    #[test]
+    fn classify_429_is_rate_limited() {
+        let (kind, msg) = classify_anilist_failure(
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            r#"{"errors":[{"message":"Too Many Requests"}]}"#,
+        );
+        assert_eq!(kind, AniListFailureKind::RateLimited);
+        assert!(is_rate_limit_error(&msg), "tag missing: {}", msg);
+    }
+
+    #[test]
+    fn classify_5xx_is_unavailable_not_throttle() {
+        let (kind, msg) = classify_anilist_failure(
+            reqwest::StatusCode::BAD_GATEWAY,
+            "<html><body>502 Bad Gateway</body></html>",
+        );
+        assert_eq!(kind, AniListFailureKind::Unavailable);
+        assert!(!is_rate_limit_error(&msg), "5xx must not match throttle: {}", msg);
+    }
+
+    #[test]
+    fn classify_403_with_cloudflare_body_is_rate_limited() {
+        let body = r#"<html><head><title>Just a moment...</title></head>
+                      <body data-translate="checking_browser">
+                      cf-ray: abc123 cloudflare</body></html>"#;
+        let (kind, msg) = classify_anilist_failure(reqwest::StatusCode::FORBIDDEN, body);
+        assert_eq!(kind, AniListFailureKind::RateLimited);
+        assert!(is_rate_limit_error(&msg), "tag missing: {}", msg);
+    }
+
+    #[test]
+    fn classify_403_without_cloudflare_body_is_unavailable() {
+        // AL-side 403 (e.g. application-layer block) — caller should
+        // MAL-fallback, not defer.
+        let (kind, msg) = classify_anilist_failure(
+            reqwest::StatusCode::FORBIDDEN,
+            r#"{"errors":[{"message":"Forbidden"}]}"#,
+        );
+        assert_eq!(kind, AniListFailureKind::Unavailable);
+        assert!(!is_rate_limit_error(&msg), "non-CF 403 must not match throttle: {}", msg);
+    }
+
+    #[test]
+    fn classify_404_is_not_found() {
+        let (kind, _msg) = classify_anilist_failure(
+            reqwest::StatusCode::NOT_FOUND,
+            r#"{"errors":[{"message":"Not Found"}]}"#,
+        );
+        assert_eq!(kind, AniListFailureKind::NotFound);
+    }
+
+    #[test]
+    fn classify_graphql_throttle_message_overrides_status() {
+        // AL has been observed to return rate-limit messages with
+        // unexpected status codes; trust the body when it says so.
+        let (kind, _msg) = classify_anilist_failure(
+            reqwest::StatusCode::OK,
+            r#"{"errors":[{"message":"Too Many Requests"}]}"#,
+        );
+        assert_eq!(kind, AniListFailureKind::RateLimited);
+    }
+
+    #[test]
+    fn is_rate_limit_error_matches_cooldown_string() {
+        assert!(is_rate_limit_error(
+            "AniList rate-limit cooldown active; skipping AniList request"
+        ));
+    }
+
+    #[test]
+    fn excerpt_is_char_boundary_safe() {
+        // Build a string longer than MAX_CHARS that's mostly multi-byte
+        // chars. Naïve byte-slicing would panic.
+        let s: String = std::iter::repeat_n('日', 300).collect();
+        let out = excerpt(&s);
+        assert!(out.ends_with('…'));
     }
 }

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -36,6 +36,15 @@ struct CacheEntry {
 static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, CacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Shared reqwest client. Each `reqwest::Client::new()` call previously
+/// rebuilt the TLS context and connection pool from scratch — wasteful
+/// across the search / detail / fallback paths that all hit
+/// graphql.anilist.co. Using a single Lazy client lets the pool reuse
+/// connections across calls. No timeout configured here — callers own
+/// retry/cooldown semantics that interact in non-obvious ways with a
+/// blanket per-request timeout.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+
 type SearchCacheEntry = (Instant, Vec<AnimeEntry>);
 
 /// Search result cache, keyed on (provider-mode, normalized query).
@@ -189,7 +198,7 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
         "variables": { "search": query }
     });
 
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let resp = match client
         .post(ANILIST_API)
         .header("User-Agent", "Ryokan/0.1")
@@ -398,7 +407,7 @@ pub async fn find_anime_by_mal_id(mal_id: i64) -> Result<Option<AnimeEntry>, Str
         "variables": { "idMal": mal_id }
     });
 
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let resp = client
         .post(ANILIST_API)
         .header("User-Agent", "Ryokan/0.1")
@@ -658,7 +667,7 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         "variables": { "id": id }
     });
 
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let resp = client
         .post(ANILIST_API)
         .header("User-Agent", "Ryokan/0.1")

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use crate::services::html::sanitize_rich_description;
 use std::collections::HashMap;
 use std::sync::{LazyLock, Mutex as StdMutex};
-use std::time::{Duration, Instant};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
 
 use crate::services::jikan;
@@ -60,6 +60,184 @@ static ANILIST_COOLDOWN_UNTIL: LazyLock<StdMutex<Option<Instant>>> =
 /// roughly the original Retry-After value. 2s clears the boundary in
 /// practice without meaningfully extending sweep time.
 const COOLDOWN_SAFETY_MARGIN: Duration = Duration::from_secs(2);
+
+/// Below this many `X-RateLimit-Remaining`, switch from "minimum
+/// inter-request spacing" to "wait until window reset." Picked low so
+/// we mostly run at full headroom-driven speed and only slow down when
+/// we're about to bump the cap.
+const REMAINING_HEADROOM_THRESHOLD: u32 = 3;
+
+/// Fallback per-minute limit used when AL hasn't told us its current
+/// limit yet. Conservative — matches the documented "currently degraded
+/// to 30 req/min" state. Once we see `X-RateLimit-Limit` we use that
+/// instead, so during normal AL operation (90 req/min) we adapt up.
+const ANILIST_LIMIT_FALLBACK: u32 = 30;
+
+/// Per-response snapshot of AniList's rate-limit headers, used by
+/// `throttle_before_anilist_request` to pace the next call without
+/// guessing.
+#[derive(Clone, Copy)]
+struct RateLimitState {
+    /// `X-RateLimit-Limit` — total requests in the current window.
+    limit: u32,
+    /// `X-RateLimit-Remaining` from the latest response.
+    remaining: u32,
+    /// `X-RateLimit-Reset` translated from a Unix timestamp into our
+    /// monotonic clock at recording time. None when the header was
+    /// absent, which AL only sends on 429s in normal operation.
+    reset_at: Option<Instant>,
+}
+
+static RATE_LIMIT_STATE: LazyLock<StdMutex<Option<RateLimitState>>> =
+    LazyLock::new(|| StdMutex::new(None));
+
+/// Last time we sent a request to AniList. Used to enforce a minimum
+/// inter-request spacing derived from the current per-minute limit, so
+/// a relation walk that fires N back-to-back AL calls can't burst over
+/// AL's burst limiter (which is documented but not header-exposed).
+static LAST_AL_REQUEST: LazyLock<StdMutex<Option<Instant>>> =
+    LazyLock::new(|| StdMutex::new(None));
+
+/// Compute the minimum spacing between AL requests for a given
+/// per-minute limit. 60s / limit, with a 10% safety pad on top so that
+/// clock drift / measurement noise can't accidentally push us above
+/// the cap. Returns a defensive 2s when limit is 0 (shouldn't happen).
+fn min_inter_request(limit: u32) -> Duration {
+    if limit == 0 {
+        return Duration::from_secs(2);
+    }
+    Duration::from_millis((66_000 / limit as u64).max(100))
+}
+
+/// Capture rate-limit headers from the latest AL response. Called for
+/// every AL response (success or error) so the next throttle decision
+/// is based on AL's fresh count rather than our stale belief. Headers
+/// AL doesn't send (e.g. `X-RateLimit-Reset` outside of throttling)
+/// just leave the corresponding field at None / unchanged.
+fn record_rate_limit_headers(headers: &reqwest::header::HeaderMap) {
+    let parse = |name: &str| -> Option<u64> {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    };
+
+    let limit = parse("x-ratelimit-limit").map(|v| v as u32);
+    let remaining = parse("x-ratelimit-remaining").map(|v| v as u32);
+    let reset_unix = parse("x-ratelimit-reset");
+
+    // If AL didn't send anything useful, leave existing state alone.
+    if limit.is_none() && remaining.is_none() && reset_unix.is_none() {
+        return;
+    }
+
+    let reset_at = reset_unix.and_then(|reset| {
+        let now_unix = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        if reset > now_unix {
+            Some(Instant::now() + Duration::from_secs(reset - now_unix))
+        } else {
+            None
+        }
+    });
+
+    if let Ok(mut guard) = RATE_LIMIT_STATE.lock() {
+        let prev = *guard;
+        *guard = Some(RateLimitState {
+            limit: limit.or(prev.map(|s| s.limit)).unwrap_or(ANILIST_LIMIT_FALLBACK),
+            remaining: remaining.or(prev.map(|s| s.remaining)).unwrap_or(0),
+            // Keep the prior reset_at if AL didn't send one this time —
+            // it's the most recent ground truth we have for when the
+            // window flips.
+            reset_at: reset_at.or(prev.and_then(|s| s.reset_at)),
+        });
+    }
+}
+
+/// Pace the next AniList request to stay inside the documented window
+/// and burst limits, using the latest rate-limit headers as the source
+/// of truth. Two strategies, picked dynamically:
+///   - **Headroom strategy** (the common case): AL still has plenty of
+///     `remaining`. Sleep just long enough since the last request to keep
+///     us under the per-minute limit (60s/limit, with a 10% pad).
+///   - **Window-flip strategy** (when `remaining <= REMAINING_HEADROOM_
+///     THRESHOLD`): AL is about to refuse us. Sleep until `reset_at`
+///     (plus a 1s slack) so we resume right when the next window opens.
+///
+/// Without this, a relation walk burst-fires N calls in seconds — even
+/// when N is well under the per-minute limit, AL's burst limiter trips
+/// and we eat a full minute of cooldown for what would've been a
+/// 1-second pause if we'd just paced ourselves.
+async fn throttle_before_anilist_request() {
+    let snap = RATE_LIMIT_STATE.lock().ok().and_then(|g| *g);
+
+    if let Some(state) = snap
+        && state.remaining <= REMAINING_HEADROOM_THRESHOLD
+        && let Some(reset_at) = state.reset_at
+    {
+        let now = Instant::now();
+        if reset_at > now {
+            let wait = reset_at.saturating_duration_since(now) + Duration::from_secs(1);
+            tracing::info!(
+                target: "ryokan::anilist",
+                remaining = state.remaining,
+                wait_secs = wait.as_secs(),
+                "AniList rate-limit headroom low; pausing until window resets"
+            );
+            tokio::time::sleep(wait).await;
+        }
+    }
+
+    // Burst guard: even with headroom, don't fire requests faster than
+    // the per-minute limit allows. The limit comes from the latest
+    // X-RateLimit-Limit response header, falling back to the
+    // currently-degraded 30 req/min ceiling.
+    let limit = snap.map(|s| s.limit).unwrap_or(ANILIST_LIMIT_FALLBACK);
+    let min_spacing = min_inter_request(limit);
+    let elapsed = LAST_AL_REQUEST
+        .lock()
+        .ok()
+        .and_then(|g| *g)
+        .map(|last| last.elapsed())
+        .unwrap_or(Duration::MAX);
+    if elapsed < min_spacing {
+        tokio::time::sleep(min_spacing - elapsed).await;
+    }
+    if let Ok(mut guard) = LAST_AL_REQUEST.lock() {
+        *guard = Some(Instant::now());
+    }
+}
+
+/// Compute cooldown duration on a 429 from AL's headers, preferring
+/// `X-RateLimit-Reset` (absolute timestamp, the most precise signal AL
+/// gives us) over `Retry-After` (relative seconds), with the configured
+/// default as the last fallback. The result is capped and padded the
+/// same way as the default-only path.
+fn cooldown_from_headers(
+    headers: &reqwest::header::HeaderMap,
+    default_dur: Duration,
+) -> Duration {
+    let parse_u64 = |name: &str| -> Option<u64> {
+        headers
+            .get(name)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok())
+    };
+
+    if let Some(reset_unix) = parse_u64("x-ratelimit-reset") {
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .ok()
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        if reset_unix > now_unix {
+            let raw = Duration::from_secs(reset_unix - now_unix).min(ANILIST_COOLDOWN_MAX);
+            return raw + COOLDOWN_SAFETY_MARGIN;
+        }
+    }
+
+    let retry_after = parse_u64("retry-after");
+    compute_cooldown_duration(retry_after, default_dur)
+}
 
 fn normalize_search_key(force_fallback: bool, query: &str) -> String {
     let folded: String = query
@@ -798,6 +976,13 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         "variables": { "id": id }
     });
 
+    // Pace the request based on the latest X-RateLimit-Remaining /
+    // X-RateLimit-Reset we've seen. This is the primary defense against
+    // 429s — by the time AL hands back a 429 we've already wasted the
+    // round trip; throttling proactively keeps the sweep inside AL's
+    // window and burst limits.
+    throttle_before_anilist_request().await;
+
     let client = reqwest::Client::new();
     let resp = client
         .post(ANILIST_API)
@@ -808,14 +993,13 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         .map_err(|e| format!("AniList request failed: {}", e))?;
 
     let status = resp.status();
-    // Capture Retry-After before consuming the response body — used to
-    // set the cooldown duration so the sweep's remaining calls skip
-    // AniList until the limit window resets.
-    let retry_after_secs = resp
-        .headers()
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse::<u64>().ok());
+    // Headers carry both the rate-limit snapshot (used by future
+    // throttles) and Retry-After / X-RateLimit-Reset for cooldown
+    // computation. Clone so we can use them after the body has been
+    // consumed.
+    let headers = resp.headers().clone();
+    record_rate_limit_headers(&headers);
+
     // Read as text first (not .json()) so a Cloudflare HTML challenge
     // doesn't blow up at the parse step — we need the body to classify
     // the failure correctly.
@@ -830,7 +1014,10 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
             // happily MAL-falls-back, and the whole "no MAL on rate-limit"
             // invariant collapses on a flaky network.
             if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
-                set_anilist_cooldown(retry_after_secs, ANILIST_COOLDOWN_DEFAULT);
+                let dur = cooldown_from_headers(&headers, ANILIST_COOLDOWN_DEFAULT);
+                if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+                    *guard = Some(Instant::now() + dur);
+                }
                 return Err(format!(
                     "AniList rate-limited (HTTP 429): body read failed: {}",
                     e
@@ -856,7 +1043,10 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
             } else {
                 ANILIST_COOLDOWN_DEFAULT
             };
-            set_anilist_cooldown(retry_after_secs, default_cooldown);
+            let dur = cooldown_from_headers(&headers, default_cooldown);
+            if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+                *guard = Some(Instant::now() + dur);
+            }
         }
         return Err(msg);
     }
@@ -874,7 +1064,10 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         // circuit the rest of the sweep.
         let (kind, msg) = classify_anilist_failure(status, &body_text);
         if kind == AniListFailureKind::RateLimited {
-            set_anilist_cooldown(retry_after_secs, ANILIST_COOLDOWN_DEFAULT);
+            let dur = cooldown_from_headers(&headers, ANILIST_COOLDOWN_DEFAULT);
+            if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+                *guard = Some(Instant::now() + dur);
+            }
         }
         return Err(msg);
     }
@@ -1146,6 +1339,67 @@ mod tests {
         // (so a runaway Retry-After can't bypass the cap, but the
         // boundary protection still applies).
         let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT);
+        assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_SAFETY_MARGIN);
+    }
+
+    #[test]
+    fn min_inter_request_scales_with_limit() {
+        // 60s window, 30 req/min degraded state → ~2.2s spacing.
+        // 60s window, 90 req/min normal state → ~733ms spacing.
+        // 10% padding on both keeps us comfortably inside.
+        let degraded = min_inter_request(30);
+        let normal = min_inter_request(90);
+        assert!(degraded >= Duration::from_millis(2000));
+        assert!(degraded <= Duration::from_millis(2500));
+        assert!(normal >= Duration::from_millis(700));
+        assert!(normal <= Duration::from_millis(800));
+        // Defensive: limit=0 must not divide-by-zero.
+        assert_eq!(min_inter_request(0), Duration::from_secs(2));
+    }
+
+    #[test]
+    fn cooldown_from_headers_prefers_x_ratelimit_reset() {
+        use reqwest::header::HeaderMap;
+        let mut h = HeaderMap::new();
+        // Reset 30s in the future.
+        let now_unix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        h.insert("x-ratelimit-reset", (now_unix + 30).to_string().parse().unwrap());
+        h.insert("retry-after", "999".parse().unwrap());  // should be ignored
+        let dur = cooldown_from_headers(&h, ANILIST_COOLDOWN_DEFAULT);
+        // Allow ±2s slack for clock measurement noise plus the 2s safety margin.
+        let lower = Duration::from_secs(30) + COOLDOWN_SAFETY_MARGIN - Duration::from_secs(2);
+        let upper = Duration::from_secs(30) + COOLDOWN_SAFETY_MARGIN + Duration::from_secs(2);
+        assert!(
+            dur >= lower && dur <= upper,
+            "expected ~32s, got {:?}",
+            dur
+        );
+    }
+
+    #[test]
+    fn cooldown_from_headers_falls_back_to_retry_after() {
+        use reqwest::header::HeaderMap;
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", "45".parse().unwrap());
+        let dur = cooldown_from_headers(&h, ANILIST_COOLDOWN_DEFAULT);
+        assert_eq!(dur, Duration::from_secs(45) + COOLDOWN_SAFETY_MARGIN);
+    }
+
+    #[test]
+    fn cooldown_from_headers_falls_back_to_default_when_no_headers() {
+        use reqwest::header::HeaderMap;
+        let h = HeaderMap::new();
+        let dur = cooldown_from_headers(&h, Duration::from_secs(60));
+        assert_eq!(dur, Duration::from_secs(60) + COOLDOWN_SAFETY_MARGIN);
+    }
+
+    #[test]
+    fn cooldown_from_headers_caps_runaway_reset_at_max() {
+        use reqwest::header::HeaderMap;
+        let mut h = HeaderMap::new();
+        let now_unix = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs();
+        h.insert("x-ratelimit-reset", (now_unix + 3600).to_string().parse().unwrap());
+        let dur = cooldown_from_headers(&h, ANILIST_COOLDOWN_DEFAULT);
         assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_SAFETY_MARGIN);
     }
 

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -87,7 +87,7 @@ fn search_cache_put(key: String, results: Vec<AnimeEntry>) {
     }
 }
 
-fn anilist_cooldown_active() -> bool {
+pub fn anilist_cooldown_active() -> bool {
     if let Ok(guard) = ANILIST_COOLDOWN_UNTIL.lock()
         && let Some(until) = *guard {
             return Instant::now() < until;

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -615,7 +615,11 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
     // metadata_sync's fallback chain and the warn log added in PR #31
     // surfaces the cooldown state to the operator.
     if anilist_cooldown_active() {
-        return Err("AniList rate-limit cooldown active; skipping detail fetch".to_string());
+        // Wording note: "skipping AniList request" — only the AniList
+        // round trip is skipped here. The caller's fallback chain
+        // (jikan/MAL → kitsu) still runs and may produce the detail
+        // from a different provider.
+        return Err("AniList rate-limit cooldown active; skipping AniList request".to_string());
     }
     let gql = serde_json::json!({
         "query": r#"

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -162,55 +162,76 @@ fn record_rate_limit_headers(headers: &reqwest::header::HeaderMap) {
     }
 }
 
+/// Pure throttle decision. Returns how long to sleep before the next
+/// AniList request, given the latest rate-limit snapshot, the
+/// timestamp of our last request (if any), and the current instant.
+/// Extracted from `throttle_before_anilist_request` so the branching
+/// is unit-testable without `tokio::time::sleep`.
+///
+/// Two strategies, in priority order:
+///   - **Window-flip** (`remaining <= REMAINING_HEADROOM_THRESHOLD`
+///     and `reset_at` is in the future): wait until the next window
+///     opens. Returns the larger of (window-wait, burst-guard) so we
+///     don't accidentally undercut burst spacing.
+///   - **Burst guard** (always): don't exceed `60s / limit` between
+///     consecutive requests. Returns 0 if the last request was long
+///     enough ago.
+fn decide_wait(
+    state: Option<RateLimitState>,
+    last_request: Option<Instant>,
+    now: Instant,
+) -> Duration {
+    let limit = state.map(|s| s.limit).unwrap_or(ANILIST_LIMIT_FALLBACK);
+    let min_spacing = min_inter_request(limit);
+
+    let burst_wait = match last_request {
+        Some(last) => {
+            let elapsed = now.saturating_duration_since(last);
+            min_spacing.saturating_sub(elapsed)
+        }
+        None => Duration::ZERO,
+    };
+
+    if let Some(s) = state
+        && s.remaining <= REMAINING_HEADROOM_THRESHOLD
+        && let Some(reset_at) = s.reset_at
+        && reset_at > now
+    {
+        let window_wait = reset_at.saturating_duration_since(now) + Duration::from_secs(1);
+        return window_wait.max(burst_wait);
+    }
+
+    burst_wait
+}
+
 /// Pace the next AniList request to stay inside the documented window
 /// and burst limits, using the latest rate-limit headers as the source
-/// of truth. Two strategies, picked dynamically:
-///   - **Headroom strategy** (the common case): AL still has plenty of
-///     `remaining`. Sleep just long enough since the last request to keep
-///     us under the per-minute limit (60s/limit, with a 10% pad).
-///   - **Window-flip strategy** (when `remaining <= REMAINING_HEADROOM_
-///     THRESHOLD`): AL is about to refuse us. Sleep until `reset_at`
-///     (plus a 1s slack) so we resume right when the next window opens.
-///
-/// Without this, a relation walk burst-fires N calls in seconds — even
-/// when N is well under the per-minute limit, AL's burst limiter trips
-/// and we eat a full minute of cooldown for what would've been a
-/// 1-second pause if we'd just paced ourselves.
+/// of truth. Without this, a relation walk burst-fires N calls in
+/// seconds — even when N is well under the per-minute limit, AL's
+/// burst limiter trips and we eat a full minute of cooldown for what
+/// would've been a 1-second pause if we'd just paced ourselves.
 async fn throttle_before_anilist_request() {
     let snap = RATE_LIMIT_STATE.lock().ok().and_then(|g| *g);
+    let last = LAST_AL_REQUEST.lock().ok().and_then(|g| *g);
+    let wait = decide_wait(snap, last, Instant::now());
 
-    if let Some(state) = snap
-        && state.remaining <= REMAINING_HEADROOM_THRESHOLD
-        && let Some(reset_at) = state.reset_at
-    {
-        let now = Instant::now();
-        if reset_at > now {
-            let wait = reset_at.saturating_duration_since(now) + Duration::from_secs(1);
+    if !wait.is_zero() {
+        // Only log the headroom-low case — burst-guard waits are
+        // sub-second and dominate normal operation, no point spamming.
+        if let Some(s) = snap
+            && s.remaining <= REMAINING_HEADROOM_THRESHOLD
+            && wait > Duration::from_secs(1)
+        {
             tracing::info!(
                 target: "ryokan::anilist",
-                remaining = state.remaining,
+                remaining = s.remaining,
                 wait_secs = wait.as_secs(),
                 "AniList rate-limit headroom low; pausing until window resets"
             );
-            tokio::time::sleep(wait).await;
         }
+        tokio::time::sleep(wait).await;
     }
 
-    // Burst guard: even with headroom, don't fire requests faster than
-    // the per-minute limit allows. The limit comes from the latest
-    // X-RateLimit-Limit response header, falling back to the
-    // currently-degraded 30 req/min ceiling.
-    let limit = snap.map(|s| s.limit).unwrap_or(ANILIST_LIMIT_FALLBACK);
-    let min_spacing = min_inter_request(limit);
-    let elapsed = LAST_AL_REQUEST
-        .lock()
-        .ok()
-        .and_then(|g| *g)
-        .map(|last| last.elapsed())
-        .unwrap_or(Duration::MAX);
-    if elapsed < min_spacing {
-        tokio::time::sleep(min_spacing - elapsed).await;
-    }
     if let Ok(mut guard) = LAST_AL_REQUEST.lock() {
         *guard = Some(Instant::now());
     }
@@ -501,6 +522,11 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
         "variables": { "search": query }
     });
 
+    // Pace via the same shared rate-limit state that fetch_anime_detail
+    // uses — search-path 429s would otherwise leave the detail-path
+    // throttle decisions working off a stale `remaining`.
+    throttle_before_anilist_request().await;
+
     let client = &*HTTP_CLIENT;
     let resp = match client
         .post(ANILIST_API)
@@ -525,6 +551,7 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
     };
 
     let status = resp.status();
+    record_rate_limit_headers(resp.headers());
 
     // Silently fall back to Jikan/MAL on transient AniList outages:
     //   403 — Cloudflare challenge / geo-block
@@ -686,6 +713,12 @@ fn compose_search_error(anilist_reason: Option<&str>, jikan_err: &str) -> String
 
 
 pub async fn find_anime_by_mal_id(mal_id: i64) -> Result<Option<AnimeEntry>, String> {
+    // Same cooldown short-circuit as the search and detail paths — no
+    // point burning a guaranteed 429 on a known-unavailable AniList.
+    if anilist_cooldown_active() {
+        return Err("AniList rate-limit cooldown active; skipping AniList request".to_string());
+    }
+
     let gql = serde_json::json!({
         "query": r#"
             query ($idMal: Int) {
@@ -710,6 +743,8 @@ pub async fn find_anime_by_mal_id(mal_id: i64) -> Result<Option<AnimeEntry>, Str
         "variables": { "idMal": mal_id }
     });
 
+    throttle_before_anilist_request().await;
+
     let client = &*HTTP_CLIENT;
     let resp = client
         .post(ANILIST_API)
@@ -720,6 +755,7 @@ pub async fn find_anime_by_mal_id(mal_id: i64) -> Result<Option<AnimeEntry>, Str
         .map_err(|e| format!("AniList request failed: {}", e))?;
 
     let status = resp.status();
+    record_rate_limit_headers(resp.headers());
     let body: serde_json::Value = resp
         .json()
         .await
@@ -1349,6 +1385,83 @@ mod tests {
         // boundary protection still applies).
         let dur = compute_cooldown_duration(Some(3600), ANILIST_COOLDOWN_DEFAULT);
         assert_eq!(dur, ANILIST_COOLDOWN_MAX + COOLDOWN_SAFETY_MARGIN);
+    }
+
+    fn state(limit: u32, remaining: u32, reset_at: Option<Instant>) -> RateLimitState {
+        RateLimitState { limit, remaining, reset_at }
+    }
+
+    #[test]
+    fn decide_wait_no_state_no_last_request_is_zero() {
+        // Cold start: no prior knowledge → fire immediately.
+        let now = Instant::now();
+        assert_eq!(decide_wait(None, None, now), Duration::ZERO);
+    }
+
+    #[test]
+    fn decide_wait_burst_guard_applies_when_recent_request() {
+        // Plenty of headroom but we just fired a request — must wait
+        // out the per-limit minimum spacing.
+        let now = Instant::now();
+        let last = now - Duration::from_millis(500);
+        let s = state(30, 25, None);
+        let w = decide_wait(Some(s), Some(last), now);
+        // 30 req/min → ~2.2s spacing; we waited 0.5s; ~1.7s remaining.
+        assert!(w >= Duration::from_millis(1500), "got {:?}", w);
+        assert!(w <= Duration::from_millis(2000), "got {:?}", w);
+    }
+
+    #[test]
+    fn decide_wait_burst_guard_zero_when_enough_elapsed() {
+        // Last request was ages ago — no spacing wait needed.
+        let now = Instant::now();
+        let last = now - Duration::from_secs(10);
+        let s = state(30, 25, None);
+        assert_eq!(decide_wait(Some(s), Some(last), now), Duration::ZERO);
+    }
+
+    #[test]
+    fn decide_wait_window_flip_fires_when_remaining_low_and_reset_in_future() {
+        // remaining=2 (≤ threshold) and reset 30s out → wait until reset
+        // (plus 1s slack), regardless of elapsed time since last request.
+        let now = Instant::now();
+        let s = state(30, 2, Some(now + Duration::from_secs(30)));
+        let w = decide_wait(Some(s), None, now);
+        // 30s + 1s slack, with at most 1s of measurement noise either way.
+        assert!(w >= Duration::from_secs(30), "got {:?}", w);
+        assert!(w <= Duration::from_secs(32), "got {:?}", w);
+    }
+
+    #[test]
+    fn decide_wait_stale_reset_falls_through_to_burst_guard() {
+        // remaining is low but reset_at is in the past — don't sleep
+        // for a window that's already over; just respect burst spacing.
+        let now = Instant::now();
+        let s = state(30, 0, Some(now - Duration::from_secs(5)));
+        // No prior request → no burst wait either.
+        assert_eq!(decide_wait(Some(s), None, now), Duration::ZERO);
+    }
+
+    #[test]
+    fn decide_wait_no_reset_at_with_low_remaining_falls_to_burst_guard() {
+        // remaining=0 but we have no idea when the window resets — best
+        // we can do is the per-limit spacing; the cooldown layer above
+        // handles the inevitable 429.
+        let now = Instant::now();
+        let s = state(30, 0, None);
+        assert_eq!(decide_wait(Some(s), None, now), Duration::ZERO);
+    }
+
+    #[test]
+    fn decide_wait_window_flip_dominates_over_burst_guard() {
+        // Window-flip wait (30s) is much larger than burst guard
+        // (~2s) — the helper should pick the larger of the two so we
+        // don't undercut the window wait by accident.
+        let now = Instant::now();
+        let last = now - Duration::from_millis(100);
+        let s = state(30, 1, Some(now + Duration::from_secs(30)));
+        let w = decide_wait(Some(s), Some(last), now);
+        assert!(w >= Duration::from_secs(30), "got {:?}", w);
     }
 
     #[test]

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -606,6 +606,17 @@ pub async fn get_anime_detail_with_options(id: i64, mal_id_hint: Option<i64>, fo
 }
 
 async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
+    // Skip the round trip entirely when a recent 429/403/5xx has tripped
+    // the global cooldown. Without this, a metadata-refresh sweep that
+    // hits AniList's per-minute cap on the first burst keeps firing
+    // request after request — each one immediately bouncing on 429 —
+    // for the full duration of the sweep, even though we already know
+    // AniList is rate-limiting us. The error string flows up through
+    // metadata_sync's fallback chain and the warn log added in PR #31
+    // surfaces the cooldown state to the operator.
+    if anilist_cooldown_active() {
+        return Err("AniList rate-limit cooldown active; skipping detail fetch".to_string());
+    }
     let gql = serde_json::json!({
         "query": r#"
             query ($id: Int) {
@@ -668,12 +679,37 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         .map_err(|e| format!("AniList request failed: {}", e))?;
 
     let status = resp.status();
+    // Capture Retry-After before .json() consumes the response — used
+    // to set the cooldown duration on 429 so the sweep's remaining
+    // calls skip AniList until the limit window resets.
+    let retry_after_secs = resp
+        .headers()
+        .get("retry-after")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse::<u64>().ok());
     let body: serde_json::Value = resp
         .json()
         .await
         .map_err(|e| format!("Failed to parse AniList response: {}", e))?;
 
     if !status.is_success() {
+        // Mirror the search-path branch (lines 223-248): 403/429/5xx
+        // mean "AniList is unavailable to us right now". Set the
+        // global cooldown so subsequent fetch_anime_detail calls
+        // short-circuit with the cooldown-active error above instead
+        // of hammering an already-rate-limited endpoint. 403 gets a
+        // longer default since Cloudflare doesn't include Retry-After.
+        if status == reqwest::StatusCode::FORBIDDEN
+            || status == reqwest::StatusCode::TOO_MANY_REQUESTS
+            || status.is_server_error()
+        {
+            let default_cooldown = if status == reqwest::StatusCode::FORBIDDEN {
+                Duration::from_secs(300)
+            } else {
+                ANILIST_COOLDOWN_DEFAULT
+            };
+            set_anilist_cooldown(retry_after_secs, default_cooldown);
+        }
         let msg = extract_graphql_error(&body).unwrap_or_else(|| body.to_string());
         return Err(format!("AniList detail failed (HTTP {}): {}", status, msg));
     }

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -800,10 +800,26 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
     // Read as text first (not .json()) so a Cloudflare HTML challenge
     // doesn't blow up at the parse step — we need the body to classify
     // the failure correctly.
-    let body_text = resp
-        .text()
-        .await
-        .map_err(|e| format!("AniList unavailable: failed to read response: {}", e))?;
+    let body_text = match resp.text().await {
+        Ok(t) => t,
+        Err(e) => {
+            // Body-read failure: the status header was already received,
+            // so preserve the rate-limit signal when the status itself
+            // told us we were throttled. Without this branch a connection
+            // reset partway through a 429 body would erase the throttle
+            // signal — `is_rate_limit_error` returns false, the caller
+            // happily MAL-falls-back, and the whole "no MAL on rate-limit"
+            // invariant collapses on a flaky network.
+            if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+                set_anilist_cooldown(retry_after_secs, ANILIST_COOLDOWN_DEFAULT);
+                return Err(format!(
+                    "AniList rate-limited (HTTP 429): body read failed: {}",
+                    e
+                ));
+            }
+            return Err(format!("AniList unavailable: failed to read response: {}", e));
+        }
+    };
 
     if !status.is_success() {
         let (kind, msg) = classify_anilist_failure(status, &body_text);
@@ -814,7 +830,8 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         if kind == AniListFailureKind::RateLimited {
             // 403 (Cloudflare) doesn't include Retry-After, so pick a
             // longer default — 60s rarely outlasts a real challenge —
-            // and let ANILIST_COOLDOWN_MAX cap it.
+            // and let ANILIST_COOLDOWN_MAX cap it. Only Cloudflare 403s
+            // reach this branch (non-CF 403s classify as Unavailable).
             let default_cooldown = if status == reqwest::StatusCode::FORBIDDEN {
                 Duration::from_secs(300)
             } else {
@@ -828,8 +845,19 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
     let body: serde_json::Value = serde_json::from_str(&body_text)
         .map_err(|e| format!("AniList unavailable: parse error: {} (body: {})", e, excerpt(&body_text)))?;
 
-    if let Some(msg) = extract_graphql_error(&body) {
-        return Err(format!("AniList detail failed: {}", msg));
+    if extract_graphql_error(&body).is_some() {
+        // Run the classifier even on 2xx responses: AL has been observed
+        // to return throttle messages in the GraphQL `errors[]` array
+        // with a 200 status (no 429 at the transport layer). Without
+        // this branch we'd surface a generic "AniList detail failed"
+        // that doesn't match `is_rate_limit_error`, the caller would
+        // MAL-fall-back, and the cooldown wouldn't trigger to short-
+        // circuit the rest of the sweep.
+        let (kind, msg) = classify_anilist_failure(status, &body_text);
+        if kind == AniListFailureKind::RateLimited {
+            set_anilist_cooldown(retry_after_secs, ANILIST_COOLDOWN_DEFAULT);
+        }
+        return Err(msg);
     }
 
     let m = &body["data"]["Media"];

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -95,10 +95,10 @@ fn anilist_cooldown_active() -> bool {
     false
 }
 
-fn set_anilist_cooldown(retry_after_secs: Option<u64>) {
+fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: Duration) {
     let dur = retry_after_secs
         .map(Duration::from_secs)
-        .unwrap_or(ANILIST_COOLDOWN_DEFAULT)
+        .unwrap_or(default_dur)
         .min(ANILIST_COOLDOWN_MAX);
     if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
         *guard = Some(Instant::now() + dur);
@@ -233,10 +233,19 @@ pub async fn search_anime_with_options(query: &str, force_mal_fallback: bool) ->
             "AniList search HTTP {} for query {:?} (retry-after={:?}); falling back to Jikan/MAL",
             status, query, retry_after_secs
         );
-        // Start a cooldown so subsequent searches in this window skip AL entirely.
-        if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
-            set_anilist_cooldown(retry_after_secs);
-        }
+        // Start a cooldown so subsequent searches in this window skip
+        // AL entirely. 403 (Cloudflare challenge) is the most common
+        // AniList outage mode; without this branch, every request kept
+        // round-tripping through AL just to bounce on the 403 again
+        // before falling back to Jikan. Cloudflare doesn't include
+        // Retry-After, so pick a longer default — 60s rarely outlasts
+        // a real challenge — and let ANILIST_COOLDOWN_MAX cap it.
+        let default_cooldown = if status == reqwest::StatusCode::FORBIDDEN {
+            Duration::from_secs(300)
+        } else {
+            ANILIST_COOLDOWN_DEFAULT
+        };
+        set_anilist_cooldown(retry_after_secs, default_cooldown);
         let reason = match status.as_u16() {
             429 => format!(
                 "AniList rate-limited{}",

--- a/src/services/artwork.rs
+++ b/src/services/artwork.rs
@@ -1,7 +1,13 @@
-use std::{path::{Path, PathBuf}, time::{SystemTime, UNIX_EPOCH}};
+use std::{path::{Path, PathBuf}, sync::LazyLock, time::{SystemTime, UNIX_EPOCH}};
 
 use sha2::{Digest, Sha256};
 use sqlx::SqlitePool;
+
+/// Shared reqwest client for artwork downloads. cache_image runs once
+/// per cover/banner/relation-card import — many in a row when the
+/// metadata sweep refreshes a series — and previously rebuilt the TLS
+/// pool every call.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 
 use crate::models::artwork_cache;
 
@@ -89,8 +95,7 @@ pub async fn cache_image(
     }
 
     let safe_key = sanitize_key(cache_key);
-    let client = reqwest::Client::new();
-    let resp = client
+    let resp = HTTP_CLIENT
         .get(source_url)
         .header("User-Agent", "Ryokan/0.1")
         .send()

--- a/src/services/artwork.rs
+++ b/src/services/artwork.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, sync::LazyLock, time::{SystemTime, UNIX_EPOCH}};
+use std::{path::{Path, PathBuf}, sync::LazyLock, time::{Duration, SystemTime, UNIX_EPOCH}};
 
 use sha2::{Digest, Sha256};
 use sqlx::SqlitePool;
@@ -6,8 +6,15 @@ use sqlx::SqlitePool;
 /// Shared reqwest client for artwork downloads. cache_image runs once
 /// per cover/banner/relation-card import — many in a row when the
 /// metadata sweep refreshes a series — and previously rebuilt the TLS
-/// pool every call.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// pool every call. Timeouts (10s connect, 30s overall) bound a hung
+/// CDN connection so it can't pin a pool slot waiting for TCP keepalive.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the artwork reqwest client should not fail")
+});
 
 use crate::models::artwork_cache;
 

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1488,6 +1488,9 @@ struct SeaDexPayload {
 /// The cache lives for the lifetime of the process, so a restart is
 /// the operator's escape hatch if they ever need to force-refresh.
 const SEADEX_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+// Cap the cache so a long-running process can't accumulate every
+// AniList ID it ever touched. Mirrors anilist::DETAIL_CACHE_MAX_ENTRIES.
+const SEADEX_CACHE_MAX_ENTRIES: usize = 500;
 static SEADEX_CACHE: LazyLock<StdMutex<HashMap<i64, (Instant, SeaDexPayload)>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
@@ -1504,6 +1507,23 @@ fn seadex_cache_get(anilist_id: i64) -> Option<SeaDexPayload> {
 fn seadex_cache_put(anilist_id: i64, payload: SeaDexPayload) {
     if let Ok(mut cache) = SEADEX_CACHE.lock() {
         cache.insert(anilist_id, (Instant::now(), payload));
+        if cache.len() > SEADEX_CACHE_MAX_ENTRIES {
+            // Drop expired first; if still over cap, drop the oldest.
+            let expired: Vec<i64> = cache
+                .iter()
+                .filter(|(_, (fetched_at, _))| fetched_at.elapsed() >= SEADEX_CACHE_TTL)
+                .map(|(k, _)| *k)
+                .collect();
+            for k in &expired {
+                cache.remove(k);
+            }
+            if cache.len() > SEADEX_CACHE_MAX_ENTRIES
+                && let Some((&oldest, _)) =
+                    cache.iter().min_by_key(|(_, (fetched_at, _))| *fetched_at)
+            {
+                cache.remove(&oldest);
+            }
+        }
     }
 }
 

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2,6 +2,7 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
+use futures::stream::{self, StreamExt};
 use regex_lite::Regex;
 use sqlx::SqlitePool;
 
@@ -224,52 +225,75 @@ pub async fn find_all_for_target(
     // auto-search path, so the minimum_score floor is suppressed here
     // (passed as `i32::MIN`). The CF score still contributes to ranking
     // so the user sees the same ordering the auto-picker would have used.
-    let mut scored: Vec<SearchResult> = Vec::with_capacity(candidates.len());
-    for mut c in candidates.drain(..) {
-        let classification = source::classify_release(
-            db,
-            &c.title,
-            Some(&c.resolution),
-            Some(source::NyaaContext {
-                info_hash: &c.info_hash,
-                view_url: &c.link,
-                is_batch: c.is_batch,
-            }),
-            Some(source::SeriesContext {
-                status: &detail.status,
-                season_year: detail.season_year,
-                end_year: detail.end_year,
-            }),
-        )
+    //
+    // Bounded concurrency via buffer_unordered(8): classify_release can
+    // shell out to Nyaa for description fetches (Layer 2) which dominate
+    // search latency; fanning out 8 in parallel cuts wall time by ~7×
+    // on a 50-candidate set. Order is irrelevant — the post-loop
+    // sort_by re-orders by score regardless.
+    //
+    // Arc-wrap aliases / seadex_hashes so each spawned future can take
+    // a cheap clone of the handle instead of moving the underlying
+    // Vec / HashSet (which the FnMut .map closure can't actually do).
+    // The other captured values (db, detail, config, cfs) are already
+    // references and Copy.
+    let aliases = std::sync::Arc::new(aliases);
+    let seadex_hashes = std::sync::Arc::new(seadex_hashes);
+    let mut scored: Vec<SearchResult> = stream::iter(candidates.drain(..))
+        .map(|mut c| {
+            let aliases = aliases.clone();
+            let seadex_hashes = seadex_hashes.clone();
+            async move {
+                let classification = source::classify_release(
+                    db,
+                    &c.title,
+                    Some(&c.resolution),
+                    Some(source::NyaaContext {
+                        info_hash: &c.info_hash,
+                        view_url: &c.link,
+                        is_batch: c.is_batch,
+                    }),
+                    Some(source::SeriesContext {
+                        status: &detail.status,
+                        season_year: detail.season_year,
+                        end_year: detail.end_year,
+                    }),
+                )
+                .await;
+                let base = rescore_for_auto_search(
+                    &c,
+                    &classification,
+                    config,
+                    &aliases,
+                    target,
+                    expected_season,
+                    is_finished,
+                    finished_mode,
+                    preferred_source_enum,
+                    preferred_resolution_enum,
+                    cutoff_source_enum,
+                    cutoff_resolution_enum,
+                );
+                // No CF floor on the interactive path — see comment above.
+                apply_cf_seadex_overlay(
+                    base,
+                    &c,
+                    &classification,
+                    cfs,
+                    &seadex_hashes,
+                    seadex_boost_enabled,
+                    i32::MIN,
+                )
+                .map(|final_score| {
+                    c.score = final_score;
+                    c
+                })
+            }
+        })
+        .buffer_unordered(8)
+        .filter_map(|opt| async move { opt })
+        .collect()
         .await;
-        let base = rescore_for_auto_search(
-            &c,
-            &classification,
-            config,
-            &aliases,
-            target,
-            expected_season,
-            is_finished,
-            finished_mode,
-            preferred_source_enum,
-            preferred_resolution_enum,
-            cutoff_source_enum,
-            cutoff_resolution_enum,
-        );
-        // No CF floor on the interactive path — see comment above.
-        if let Some(final_score) = apply_cf_seadex_overlay(
-            base,
-            &c,
-            &classification,
-            cfs,
-            &seadex_hashes,
-            seadex_boost_enabled,
-            i32::MIN,
-        ) {
-            c.score = final_score;
-            scored.push(c);
-        }
-    }
 
     scored.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
     scored

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -258,7 +258,6 @@ pub async fn find_all_for_target(
         );
         // No CF floor on the interactive path — see comment above.
         if let Some(final_score) = apply_cf_seadex_overlay(
-            db,
             base,
             &c,
             &classification,
@@ -266,9 +265,7 @@ pub async fn find_all_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             i32::MIN,
-        )
-        .await
-        {
+        ) {
             c.score = final_score;
             scored.push(c);
         }
@@ -463,7 +460,6 @@ pub async fn collect_scored_batches_for_target(
             cutoff_resolution_enum,
         );
         if let Some(final_score) = apply_cf_seadex_overlay(
-            db,
             base,
             &c,
             &classification,
@@ -471,9 +467,7 @@ pub async fn collect_scored_batches_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             config.custom_format_minimum_score,
-        )
-        .await
-        {
+        ) {
             c.score = final_score;
             scored.push(c);
         }
@@ -669,7 +663,6 @@ async fn collect_scored_for_target(
             cutoff_resolution_enum,
         );
         if let Some(final_score) = apply_cf_seadex_overlay(
-            db,
             base,
             &c,
             &classification,
@@ -677,9 +670,7 @@ async fn collect_scored_for_target(
             &seadex_hashes,
             seadex_boost_enabled,
             config.custom_format_minimum_score,
-        )
-        .await
-        {
+        ) {
             c.score = final_score;
             scored.push(c);
         }
@@ -1728,13 +1719,15 @@ fn display_title(detail: &AnimeDetail) -> &str {
 /// `SeaDexBestSpecification` — the user has taken ownership of that
 /// number and double-counting would be a silent regression.
 ///
-/// On the way through, emits one `LogCategory::Scoring` debug row per
-/// candidate with a CF-aware breakdown line (plan §6.3). Dropped
-/// candidates are logged too so the user can introspect "why did this
-/// candidate get cut from the results" in addition to "why did X win."
+/// On the way through, emits one tracing::debug! line per candidate with
+/// a CF-aware breakdown (plan §6.3). Operators who want to introspect
+/// "why did X win / Y lose" can set
+/// `RUST_LOG=ryokan::auto_search::scoring=debug`. The previous code
+/// wrote to the DB log table here, but at 50-200 candidates per search
+/// that was a sustained INSERT stream the `logs` UI flooded with rather
+/// than aided.
 #[allow(clippy::too_many_arguments)]
-async fn apply_cf_seadex_overlay(
-    db: &SqlitePool,
+fn apply_cf_seadex_overlay(
     base: i32,
     result: &SearchResult,
     classification: &ClassificationResult,
@@ -1771,7 +1764,17 @@ async fn apply_cf_seadex_overlay(
     let final_score = base.saturating_add(cf).saturating_add(seadex_bonus);
 
     let detail = format_scoring_detail(base, cf, &breakdown, seadex_bonus, final_score, below_floor);
-    logger::debug(db, LogCategory::Scoring, &result.title, &detail).await;
+    // tracing::debug! instead of logger::debug — 50-200 candidates per
+    // search × one debug row each meant a sustained INSERT stream into
+    // the `logs` table on every auto-search. Terminal/container logs
+    // are the right surface for this granularity of detail; operators
+    // who want it can set RUST_LOG=ryokan::auto_search=debug.
+    tracing::debug!(
+        target: "ryokan::auto_search::scoring",
+        title = %result.title,
+        "{}",
+        detail
+    );
 
     if below_floor {
         None

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1743,7 +1743,12 @@ async fn apply_cf_seadex_overlay(
     };
 
     let below_floor = cf < minimum_score;
-    let final_score = base + cf + seadex_bonus;
+    // saturating_add at the combine — base, cf, and seadex_bonus are
+    // each i32 and any one of them can be ±10k+. With ~22 CFs all
+    // matching positively plus the 10k SeaDex boost plus base, naive
+    // `+` can wrap to a large negative and silently demote every
+    // candidate below minimum_score.
+    let final_score = base.saturating_add(cf).saturating_add(seadex_bonus);
 
     let detail = format_scoring_detail(base, cf, &breakdown, seadex_bonus, final_score, below_floor);
     logger::debug(db, LogCategory::Scoring, &result.title, &detail).await;

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1010,6 +1010,16 @@ pub fn build_upgrade_targets(
         if !candidates.contains(&file.episode_number) {
             continue;
         }
+        // manual_override pins must short-circuit before find_best_for_target
+        // runs. The downstream SQL guards on record_grab /
+        // update_classification drop the tag write, but post-processing has
+        // already replaced the on-disk file by the time those guards fire.
+        if quality_tags
+            .get(&file.episode_number)
+            .is_some_and(|t| t.manual_override)
+        {
+            continue;
+        }
         let existing = resolve_existing_classification(file, quality_tags.get(&file.episode_number));
         // Skip completely unclassified episodes — we have no way to know
         // whether an incoming release would actually be an upgrade.
@@ -5044,5 +5054,83 @@ mod tests {
         assert_eq!(siblings[0].episode_offset, 0);
         // And the match came from the subtitle path, not the fallback.
         assert!(!siblings[0].matched_subtitle.starts_with("episode-range fallback"));
+    }
+
+    fn pinned_720p_web_tag(manual_override: bool) -> crate::models::episode_tags::EpisodeQualityTag {
+        crate::models::episode_tags::EpisodeQualityTag {
+            quality_tag: "WEBDL-720p".to_string(),
+            release_title: "[Group] Show - 01 [WEB-DL 720p].mkv".to_string(),
+            release_group: "Group".to_string(),
+            state: "completed".to_string(),
+            source: "Web".to_string(),
+            resolution: "720p".to_string(),
+            is_remux: false,
+            is_bdmv: false,
+            web_kind: "WEBDL".to_string(),
+            classification_confidence: 1.0,
+            needs_review: false,
+            manual_override,
+            classification_evidence: String::new(),
+        }
+    }
+
+    fn dummy_720p_episode_file(episode_number: i32) -> media::EpisodeFile {
+        media::EpisodeFile {
+            filename: "[Group] Show - 01 [WEB-DL 720p].mkv".to_string(),
+            episode_number,
+            season_number: None,
+            quality: "720p".to_string(),
+            size_bytes: 0,
+            size_display: String::new(),
+        }
+    }
+
+    // Regression: build_upgrade_targets must skip rows the user has pinned
+    // via manual override. Otherwise the upgrade sweep selects a "better"
+    // release, post-processing replaces the on-disk file, and the
+    // manual_override SQL guards on record_grab / update_classification
+    // silently drop the tag write — the user loses their pinned file with
+    // no audit trail.
+    #[test]
+    fn build_upgrade_targets_skips_manual_override_rows() {
+        let file = dummy_720p_episode_file(1);
+        let mut tags = std::collections::HashMap::new();
+        tags.insert(1_i32, pinned_720p_web_tag(true));
+
+        let targets = build_upgrade_targets(
+            &[file],
+            &[1],
+            Source::BluRay,
+            Resolution::R1080p,
+            false,
+            false,
+            &tags,
+        );
+        assert!(
+            targets.is_empty(),
+            "manual_override row should be skipped, got {} target(s)",
+            targets.len()
+        );
+    }
+
+    // Sanity check the regression test: with the same file but
+    // manual_override = false, the upgrade target IS produced. Confirms the
+    // skip is the new behavior, not an unrelated "everything skips" bug.
+    #[test]
+    fn build_upgrade_targets_yields_target_when_not_manual_override() {
+        let file = dummy_720p_episode_file(1);
+        let mut tags = std::collections::HashMap::new();
+        tags.insert(1_i32, pinned_720p_web_tag(false));
+
+        let targets = build_upgrade_targets(
+            &[file],
+            &[1],
+            Source::BluRay,
+            Resolution::R1080p,
+            false,
+            false,
+            &tags,
+        );
+        assert_eq!(targets.len(), 1, "auto-classified row should be upgraded");
     }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -5110,6 +5110,7 @@ mod tests {
 
     fn pinned_720p_web_tag(manual_override: bool) -> crate::models::episode_tags::EpisodeQualityTag {
         crate::models::episode_tags::EpisodeQualityTag {
+            episode_number: 1,
             quality_tag: "WEBDL-720p".to_string(),
             release_title: "[Group] Show - 01 [WEB-DL 720p].mkv".to_string(),
             release_group: "Group".to_string(),

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2,7 +2,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant};
 
-use futures::stream::{self, StreamExt};
 use regex_lite::Regex;
 use sqlx::SqlitePool;
 
@@ -225,75 +224,52 @@ pub async fn find_all_for_target(
     // auto-search path, so the minimum_score floor is suppressed here
     // (passed as `i32::MIN`). The CF score still contributes to ranking
     // so the user sees the same ordering the auto-picker would have used.
-    //
-    // Bounded concurrency via buffer_unordered(8): classify_release can
-    // shell out to Nyaa for description fetches (Layer 2) which dominate
-    // search latency; fanning out 8 in parallel cuts wall time by ~7×
-    // on a 50-candidate set. Order is irrelevant — the post-loop
-    // sort_by re-orders by score regardless.
-    //
-    // Arc-wrap aliases / seadex_hashes so each spawned future can take
-    // a cheap clone of the handle instead of moving the underlying
-    // Vec / HashSet (which the FnMut .map closure can't actually do).
-    // The other captured values (db, detail, config, cfs) are already
-    // references and Copy.
-    let aliases = std::sync::Arc::new(aliases);
-    let seadex_hashes = std::sync::Arc::new(seadex_hashes);
-    let mut scored: Vec<SearchResult> = stream::iter(candidates.drain(..))
-        .map(|mut c| {
-            let aliases = aliases.clone();
-            let seadex_hashes = seadex_hashes.clone();
-            async move {
-                let classification = source::classify_release(
-                    db,
-                    &c.title,
-                    Some(&c.resolution),
-                    Some(source::NyaaContext {
-                        info_hash: &c.info_hash,
-                        view_url: &c.link,
-                        is_batch: c.is_batch,
-                    }),
-                    Some(source::SeriesContext {
-                        status: &detail.status,
-                        season_year: detail.season_year,
-                        end_year: detail.end_year,
-                    }),
-                )
-                .await;
-                let base = rescore_for_auto_search(
-                    &c,
-                    &classification,
-                    config,
-                    &aliases,
-                    target,
-                    expected_season,
-                    is_finished,
-                    finished_mode,
-                    preferred_source_enum,
-                    preferred_resolution_enum,
-                    cutoff_source_enum,
-                    cutoff_resolution_enum,
-                );
-                // No CF floor on the interactive path — see comment above.
-                apply_cf_seadex_overlay(
-                    base,
-                    &c,
-                    &classification,
-                    cfs,
-                    &seadex_hashes,
-                    seadex_boost_enabled,
-                    i32::MIN,
-                )
-                .map(|final_score| {
-                    c.score = final_score;
-                    c
-                })
-            }
-        })
-        .buffer_unordered(8)
-        .filter_map(|opt| async move { opt })
-        .collect()
+    let mut scored: Vec<SearchResult> = Vec::with_capacity(candidates.len());
+    for mut c in candidates.drain(..) {
+        let classification = source::classify_release(
+            db,
+            &c.title,
+            Some(&c.resolution),
+            Some(source::NyaaContext {
+                info_hash: &c.info_hash,
+                view_url: &c.link,
+                is_batch: c.is_batch,
+            }),
+            Some(source::SeriesContext {
+                status: &detail.status,
+                season_year: detail.season_year,
+                end_year: detail.end_year,
+            }),
+        )
         .await;
+        let base = rescore_for_auto_search(
+            &c,
+            &classification,
+            config,
+            &aliases,
+            target,
+            expected_season,
+            is_finished,
+            finished_mode,
+            preferred_source_enum,
+            preferred_resolution_enum,
+            cutoff_source_enum,
+            cutoff_resolution_enum,
+        );
+        // No CF floor on the interactive path — see comment above.
+        if let Some(final_score) = apply_cf_seadex_overlay(
+            base,
+            &c,
+            &classification,
+            cfs,
+            &seadex_hashes,
+            seadex_boost_enabled,
+            i32::MIN,
+        ) {
+            c.score = final_score;
+            scored.push(c);
+        }
+    }
 
     scored.sort_by(|a, b| b.score.cmp(&a.score).then(b.seeders.cmp(&a.seeders)));
     scored

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -129,8 +129,8 @@ pub async fn find_all_for_target(
     _allow_batch: bool,
     cfs: &[CompiledCustomFormat],
 ) -> Vec<SearchResult> {
-    let queries = build_queries(detail, target);
     let aliases = collect_aliases(detail);
+    let queries = build_queries_from_aliases(&aliases, target);
     let preferred_groups = quality::parse_group_list(&config.preferred_groups);
     let preferred_res = preferred_resolution_search_value(config);
     let is_finished = detail.is_finished();
@@ -418,7 +418,7 @@ pub async fn collect_scored_batches_for_target(
 
     // Standard query sweep — picks up any batches that happen to surface
     // on Nyaa page 1 alongside the singles.
-    let queries = build_queries(detail, target);
+    let queries = build_queries_from_aliases(&aliases, target);
     run_queries(&queries, ctx, &mut seen, &mut candidates).await;
 
     // Batch-targeted probes — the important addition for this function.
@@ -520,8 +520,8 @@ async fn collect_scored_for_target(
     batch_episode_match: bool,
     cfs: &[CompiledCustomFormat],
 ) -> Vec<SearchResult> {
-    let queries = build_queries(detail, target);
     let aliases = collect_aliases(detail);
+    let queries = build_queries_from_aliases(&aliases, target);
     let preferred_groups = quality::parse_group_list(&config.preferred_groups);
     let preferred_res = preferred_resolution_search_value(config);
     let is_finished = detail.is_finished();
@@ -1083,10 +1083,6 @@ pub fn target_label(target: &SearchTarget) -> String {
         SearchTarget::Single => "Single".to_string(),
         SearchTarget::Episode(ep) => format!("Episode {}", ep),
     }
-}
-
-fn build_queries(detail: &AnimeDetail, target: &SearchTarget) -> Vec<String> {
-    build_queries_from_aliases(&collect_aliases(detail), target)
 }
 
 fn build_queries_from_aliases(aliases: &[String], target: &SearchTarget) -> Vec<String> {

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -478,11 +478,16 @@ pub fn evaluate(cf: &CompiledCustomFormat, ctx: &EvalContext) -> bool {
 /// Sum the scores of every CF that matches the candidate. Non-matching
 /// CFs contribute 0 regardless of their score sign. Used by the Phase 6
 /// auto_search integration as a single-call overlay on `base_score`.
+///
+/// Saturating addition: SEADEX_SCORE_BOOST is 10_000, individual TRaSH
+/// CFs ship up to ±10_000, and user-authored CFs can carry arbitrary
+/// scores. Naive `.sum()` would wrap on overflow and silently demote
+/// every candidate below `minimum_score`, dropping the entire search.
 pub fn total_cf_score(cfs: &[CompiledCustomFormat], ctx: &EvalContext) -> i32 {
     cfs.iter()
         .filter(|cf| evaluate(cf, ctx))
         .map(|cf| cf.score)
-        .sum()
+        .fold(0i32, i32::saturating_add)
 }
 
 /// Same total as [`total_cf_score`], but also returns the per-CF
@@ -503,7 +508,8 @@ pub fn total_cf_score_with_breakdown(
         if !evaluate(cf, ctx) {
             continue;
         }
-        total += cf.score;
+        // saturating_add — see total_cf_score for the overflow rationale.
+        total = total.saturating_add(cf.score);
         // Zero-score matches are meaningful for CF authoring but add
         // noise to the debug line — skip them per the plan §6.3 wording
         // "every CF that matched with a nonzero score contribution."

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -30,10 +30,18 @@ static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, DetailCacheEntry>>> =
 /// rebuilt the client per request — wasteful given how often Jikan
 /// gets hit (search, details, episodes, relations, all routed
 /// through different helpers). One shared client lets the connection
-/// pool reuse TLS sessions across calls. No timeout configured here —
-/// callers own retry/cooldown/backoff that interacts in non-obvious
-/// ways with a blanket per-request timeout.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// pool reuse TLS sessions across calls.
+///
+/// Timeouts: 10s connect, 30s overall — same rationale as the AniList
+/// client. Callers' cooldown/backoff logic is unaffected; this just
+/// stops a hung connection from pinning a pool slot for hours.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the Jikan reqwest client should not fail")
+});
 
 /// When Jikan rate-limits us, remember "unavailable until Instant" so
 /// `search_anime` returns a clean cooldown error immediately rather than

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -417,20 +417,37 @@ async fn fetch_relations(mal_id: i64) -> Vec<RelatedEntry> {
         Err(_) => return Vec::new(),
     };
 
+    // Jikan's documented anonymous limit is ~3 req/s AND ~60 req/min.
+    // The per-second budget is the easy one; the per-minute budget is
+    // tight enough that a 10-entry relations graph (sequels, prequels,
+    // OVAs, ONAs, side-stories) at 400 ms per call adds 10 requests in
+    // 4 s on top of whatever else the metadata path is doing — and a
+    // single 429 here flips set_jikan_cooldown, blocking every concurrent
+    // search for the cooldown window.
+    //
+    // Bump the sleep to 500 ms (2 req/s) and cap the fan-out at 8
+    // cards total. The relations panel is a "what else exists in this
+    // franchise" affordance, not a comprehensive graph; the first 8
+    // entries are plenty for the UI.
+    const MAX_RELATION_FETCHES: usize = 8;
+    const RELATION_FETCH_INTERVAL_MS: u64 = 500;
+
     let mut out = Vec::new();
-    let mut request_count = 0;
-    for group in body.data {
+    let mut request_count: usize = 0;
+    'outer: for group in body.data {
         let rel_type = group.relation.to_uppercase().replace(' ', "_");
         for entry in group.entry {
             if !entry.media_type.eq_ignore_ascii_case("ANIME") {
                 continue;
             }
-
-            // Rate-limit: Jikan public API allows ~3 req/s.  Add a delay
-            // between relation-card detail fetches to avoid 429 responses
-            // that silently drop cover images.
+            if request_count >= MAX_RELATION_FETCHES {
+                break 'outer;
+            }
             if request_count > 0 {
-                tokio::time::sleep(std::time::Duration::from_millis(400)).await;
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    RELATION_FETCH_INTERVAL_MS,
+                ))
+                .await;
             }
             request_count += 1;
 

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -26,6 +26,15 @@ struct DetailCacheEntry {
 static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, DetailCacheEntry>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
 
+/// Shared reqwest client. Six call sites in this module previously
+/// rebuilt the client per request — wasteful given how often Jikan
+/// gets hit (search, details, episodes, relations, all routed
+/// through different helpers). One shared client lets the connection
+/// pool reuse TLS sessions across calls. No timeout configured here —
+/// callers own retry/cooldown/backoff that interacts in non-obvious
+/// ways with a blanket per-request timeout.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+
 /// When Jikan rate-limits us, remember "unavailable until Instant" so
 /// `search_anime` returns a clean cooldown error immediately rather than
 /// hammering the API and piling up more 429s.
@@ -294,7 +303,7 @@ pub async fn search_anime(query: &str) -> Result<Vec<AnimeEntry>, String> {
         ));
     }
 
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime", api_base.trim_end_matches('/'));
     let resp = client
@@ -397,10 +406,10 @@ async fn fetch_relation_card_detail(mal_id: i64, fallback_name: &str) -> Related
         media_type: "ANIME".to_string(),
     };
 
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime/{}/full", api_base.trim_end_matches('/'), mal_id);
-    let body: FullResponse = match get_json_with_retry(&client, &url).await {
+    let body: FullResponse = match get_json_with_retry(client, &url).await {
         Ok(body) => body,
         Err(_) => return fallback(),
     };
@@ -426,10 +435,10 @@ async fn fetch_relation_card_detail(mal_id: i64, fallback_name: &str) -> Related
 }
 
 async fn fetch_relations(mal_id: i64) -> Vec<RelatedEntry> {
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime/{}/relations", api_base.trim_end_matches('/'), mal_id);
-    let body: RelationsResponse = match get_json_with_retry(&client, &url).await {
+    let body: RelationsResponse = match get_json_with_retry(client, &url).await {
         Ok(body) => body,
         Err(_) => return Vec::new(),
     };
@@ -522,10 +531,10 @@ pub async fn get_anime_detail_cached(mal_id: i64) -> Result<AnimeDetail, String>
 }
 
 pub async fn get_anime_detail(mal_id: i64) -> Result<AnimeDetail, String> {
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime/{}/full", api_base.trim_end_matches('/'), mal_id);
-    let body: FullResponse = get_json_with_retry(&client, &url)
+    let body: FullResponse = get_json_with_retry(client, &url)
         .await
         .map_err(|e| format!("Jikan detail failed: {}", e))?;
 
@@ -594,10 +603,10 @@ pub async fn get_anime_detail(mal_id: i64) -> Result<AnimeDetail, String> {
 }
 
 async fn fetch_relation_groups_raw(mal_id: i64) -> Vec<RelationGroupResponse> {
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
     let url = format!("{}/anime/{}/relations", api_base.trim_end_matches('/'), mal_id);
-    match get_json_with_retry::<RelationsResponse>(&client, &url).await {
+    match get_json_with_retry::<RelationsResponse>(client, &url).await {
         Ok(body) => body.data,
         Err(_) => Vec::new(),
     }
@@ -799,14 +808,14 @@ async fn cache_episodes(
 
 async fn fetch_from_jikan(mal_id: i64) -> HashMap<i32, EpisodeInfo> {
     let mut episodes = HashMap::new();
-    let client = reqwest::Client::new();
+    let client = &*HTTP_CLIENT;
     let mut page = 1;
     let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
 
     loop {
         let url = format!("{}/anime/{}/episodes?page={}", api_base.trim_end_matches('/'), mal_id, page);
 
-        let body: JikanResponse = match get_json_with_retry(&client, &url).await {
+        let body: JikanResponse = match get_json_with_retry(client, &url).await {
             Ok(b) => b,
             Err(e) => {
                 tracing::warn!("Jikan episode fetch failed for mal_id {}: {}", mal_id, e);

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -15,6 +15,7 @@ const JIKAN_API: &str = "https://api.jikan.moe/v4";
 const CACHE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
 const NEGATIVE_CACHE_SENTINEL: &str = "__RYOKAN_EMPTY__";
 const DETAIL_CACHE_TTL_SECS: u64 = 15 * 60;
+const DETAIL_CACHE_MAX_ENTRIES: usize = 500;
 
 #[derive(Debug, Clone)]
 struct DetailCacheEntry {
@@ -496,6 +497,25 @@ pub async fn get_anime_detail_cached(mal_id: i64) -> Result<AnimeDetail, String>
             detail: detail.clone(),
             fetched_at: Instant::now(),
         });
+        // Cap the cache so a long-running process can't accumulate
+        // every MAL ID it ever touched. Mirrors anilist::DETAIL_CACHE
+        // eviction (drop expired first, then drop oldest if still
+        // over).
+        if cache.len() > DETAIL_CACHE_MAX_ENTRIES {
+            let expired: Vec<i64> = cache
+                .iter()
+                .filter(|(_, e)| e.fetched_at.elapsed().as_secs() >= DETAIL_CACHE_TTL_SECS)
+                .map(|(k, _)| *k)
+                .collect();
+            for k in &expired {
+                cache.remove(k);
+            }
+            if cache.len() > DETAIL_CACHE_MAX_ENTRIES
+                && let Some((&oldest_key, _)) = cache.iter().min_by_key(|(_, e)| e.fetched_at)
+            {
+                cache.remove(&oldest_key);
+            }
+        }
     }
 
     Ok(detail)

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -97,6 +97,11 @@ async fn get_text_with_retry(client: &reqwest::Client, url: &str) -> Result<Stri
             .map_err(|e| format!("Jikan request failed: {}", e))?;
 
         let status = resp.status();
+        let retry_after_secs = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
         let text = resp
             .text()
             .await
@@ -119,6 +124,17 @@ async fn get_text_with_retry(client: &reqwest::Client, url: &str) -> Result<Stri
             continue;
         }
 
+        // Falling out of the retry loop on a rate-limited response
+        // (final attempt or non-retryable status). Set the global
+        // cooldown so subsequent jikan calls — including episode
+        // pagination, relations fetches, and other endpoints that go
+        // through this helper — skip the round trip entirely instead
+        // of burning another ~9s of retry sleep on the same 429 storm.
+        // The search caller already does this for its own path; this
+        // brings the rest of the helpers into the same backoff regime.
+        if is_rate_limited(status, &text) {
+            set_jikan_cooldown(retry_after_secs);
+        }
         return Err(last_err);
     }
 

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -106,7 +106,13 @@ async fn get_text_with_retry(client: &reqwest::Client, url: &str) -> Result<Stri
             return Ok(text);
         }
 
-        last_err = format!("HTTP {}: {}", status, &text[..text.len().min(200)]);
+        // chars().take() instead of byte-slice — Jikan error bodies
+        // often contain non-ASCII characters (curly apostrophes etc.)
+        // and a byte-slice at index 200 panics if a multi-byte char
+        // straddles the boundary. Mirrors the pattern in
+        // parse_jikan_error above.
+        let preview: String = text.chars().take(200).collect();
+        last_err = format!("HTTP {status}: {preview}");
         if is_rate_limited(status, &text) && attempt < 3 {
             tokio::time::sleep(backoff).await;
             backoff *= 2;

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -775,9 +775,17 @@ async fn cache_episodes(
     mal_id: i64,
     episodes: &HashMap<i32, EpisodeInfo>,
 ) -> Result<(), sqlx::Error> {
+    // Wrap DELETE + N INSERTs in one transaction. SQLite's WAL only
+    // fsyncs at commit, so a 1100-episode One Piece refresh becomes
+    // one fsync instead of 1101 — orders-of-magnitude difference on
+    // any non-tmpfs disk. As a bonus the writer lock is held once and
+    // released once, which keeps concurrent readers (the rest of the
+    // app) from being chunked into 1100 tiny windows.
+    let mut tx = db.begin().await?;
+
     sqlx::query("DELETE FROM episode_cache WHERE mal_id = ?")
         .bind(mal_id)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
 
     if episodes.is_empty() {
@@ -786,8 +794,9 @@ async fn cache_episodes(
         )
         .bind(mal_id)
         .bind(NEGATIVE_CACHE_SENTINEL)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
+        tx.commit().await?;
         return Ok(());
     }
 
@@ -799,10 +808,11 @@ async fn cache_episodes(
         .bind(num)
         .bind(&info.title)
         .bind(&info.aired)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
     }
 
+    tx.commit().await?;
     Ok(())
 }
 

--- a/src/services/kitsu.rs
+++ b/src/services/kitsu.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use crate::services::anilist::AnimeDetail;
 use crate::services::html::sanitize_rich_description;
@@ -10,7 +11,15 @@ const KITSU_API: &str = "https://kitsu.io/api/edge";
 
 /// Shared reqwest client. Replaces a per-call `Client::new()` so the
 /// connection pool is reused across the search/detail fetch helpers.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// Timeouts (10s connect, 30s overall) bound a hung connection so it
+/// can't pin a pool slot for hours waiting on TCP keepalive.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the Kitsu reqwest client should not fail")
+});
 const CACHE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
 const NEGATIVE_CACHE_SENTINEL: &str = "__RYOKAN_EMPTY__";
 

--- a/src/services/kitsu.rs
+++ b/src/services/kitsu.rs
@@ -1,11 +1,16 @@
 use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
+use std::sync::LazyLock;
 
 use crate::services::anilist::AnimeDetail;
 use crate::services::html::sanitize_rich_description;
 
 const KITSU_API: &str = "https://kitsu.io/api/edge";
+
+/// Shared reqwest client. Replaces a per-call `Client::new()` so the
+/// connection pool is reused across the search/detail fetch helpers.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
 const CACHE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
 const NEGATIVE_CACHE_SENTINEL: &str = "__RYOKAN_EMPTY__";
 
@@ -85,10 +90,6 @@ struct EpisodeAttributes {
     number: Option<i32>,
     relative_number: Option<i32>,
     air_date: Option<String>,
-}
-
-fn jsonapi_client() -> reqwest::Client {
-    reqwest::Client::new()
 }
 
 fn first_image(images: &ImageSet) -> String {
@@ -192,8 +193,7 @@ fn score_candidate(candidate: &Candidate, wanted_titles: &[String], wanted_year:
 }
 
 async fn fetch_collection<T: for<'de> serde::Deserialize<'de>>(url: &str, params: &[(&str, &str)]) -> Result<CollectionResponse<T>, String> {
-    let client = jsonapi_client();
-    client
+    HTTP_CLIENT
         .get(url)
         .query(params)
         .header("Accept", "application/vnd.api+json")

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -47,19 +47,42 @@ async fn fetch_live_detail_for_ids(
     episode_count: Option<i32>,
     force_mal_fallback: bool,
 ) -> Result<anilist::AnimeDetail, String> {
-    // Each fallback step logs at warn so the operator can see *why* a
-    // series fell through to a lower-fidelity provider. The previous
-    // `if let Ok(...) = ... { return ... }` shape was silent — a
-    // sweep-time AniList error (slow GraphQL response for a huge
-    // entry like One Piece, transient 5xx, partial JSON) just dropped
-    // the entry to MAL with no breadcrumb, leaving the operator with
-    // a `provider_id=-21, episodes=None` row and no way to know
-    // whether AniList was genuinely down or whether one specific
-    // series was just slow to assemble.
+    // Fallback policy: when an entry has a real AniList ID and the user
+    // hasn't explicitly opted into MAL, treat AniList rate-limiting as
+    // "try again later," not "silently substitute MAL." Falling back
+    // every time AL is throttled would slowly overwrite high-fidelity
+    // AL data with lower-fidelity MAL data on every sweep that hits
+    // the rate limit; the user wants the AL data, not MAL's
+    // approximation. Only non-rate-limit AL errors (5xx, parse, "not
+    // found", etc.) flow into the MAL/Kitsu fallback chain — those
+    // signal a problem with the entry on AL itself, where the fallback
+    // produces real value.
     if provider_id > 0 && !force_mal_fallback {
+        if anilist::anilist_cooldown_active() {
+            return Err(format!(
+                "AniList rate-limit cooldown active; skipping provider_id={} \
+                 to preserve AL fidelity (next sweep will retry)",
+                provider_id
+            ));
+        }
         match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
             Ok(detail) => return Ok(detail),
             Err(err) => {
+                // The error string format comes from
+                // anilist::fetch_anime_detail — keep this matcher in
+                // sync if that wording changes.
+                let is_rate_limited = err.contains("HTTP 429")
+                    || err.contains("cooldown active");
+                if is_rate_limited {
+                    tracing::warn!(
+                        target: "ryokan::metadata_sync",
+                        provider_id,
+                        mal_id = ?mal_id,
+                        error = %err,
+                        "AniList rate-limited; skipping series (no MAL/Kitsu fallback)"
+                    );
+                    return Err(err);
+                }
                 tracing::warn!(
                     target: "ryokan::metadata_sync",
                     provider_id,

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -296,6 +296,14 @@ async fn hydrate_relation_tree(
     // already handles inline before this walker is even called.
     const MAX_AL_RETRY_ROUNDS: usize = 3;
     const COOLDOWN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+    // Hard ceiling on total cooldown waits across all retry rounds for
+    // a single hydration. With MAX_AL_RETRY_ROUNDS=3 and AniList's
+    // 300s ANILIST_COOLDOWN_MAX, the worst-case naïve wait is ~15
+    // minutes — long enough that a manual rebuild click feels broken
+    // during a sustained AL outage. Cap at 5 minutes total so the
+    // request returns predictably; remaining deferred relations get
+    // picked up by the next periodic refresh.
+    const MAX_HYDRATION_WAIT_TOTAL: std::time::Duration = std::time::Duration::from_secs(300);
 
     if root_provider_id == 0 {
         return;
@@ -310,6 +318,7 @@ async fn hydrate_relation_tree(
     seen.insert(root_provider_id);
     let mut processed = 0usize;
     let mut al_round = 0usize;
+    let mut total_cooldown_wait = std::time::Duration::ZERO;
 
     loop {
         while let Some((provider_id, mal_id)) = queue.pop_front() {
@@ -360,7 +369,8 @@ async fn hydrate_relation_tree(
             }
         }
 
-        if deferred.is_empty() || al_round >= MAX_AL_RETRY_ROUNDS {
+        let wait_budget_exhausted = total_cooldown_wait >= MAX_HYDRATION_WAIT_TOTAL;
+        if deferred.is_empty() || al_round >= MAX_AL_RETRY_ROUNDS || wait_budget_exhausted {
             // Anything still deferred after the retry budget is left out
             // of this sweep's cache — the next periodic refresh picks it
             // up. We don't substitute MAL on rate-limit (would mix trees
@@ -371,6 +381,8 @@ async fn hydrate_relation_tree(
                     root_provider_id,
                     dropped = deferred.len(),
                     retry_rounds = al_round,
+                    cooldown_wait_secs = total_cooldown_wait.as_secs(),
+                    wait_budget_exhausted,
                     "relation hydration left {} relations unfetched after AniList \
                      retry budget exhausted; next sweep will retry",
                     deferred.len()
@@ -379,9 +391,19 @@ async fn hydrate_relation_tree(
             break;
         }
 
+        let wait_start = std::time::Instant::now();
+        let remaining_budget = MAX_HYDRATION_WAIT_TOTAL.saturating_sub(total_cooldown_wait);
         while anilist::anilist_cooldown_active() {
+            // Stop polling if the per-hydration wait budget is exhausted —
+            // the next iteration of the outer loop will drop the
+            // remaining deferred and exit. Without this guard a
+            // pathological AL outage could pin the sweep for ~15 min.
+            if wait_start.elapsed() >= remaining_budget {
+                break;
+            }
             tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
         }
+        total_cooldown_wait += wait_start.elapsed();
 
         queue.append(&mut deferred);
         al_round += 1;

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -476,7 +476,8 @@ pub async fn refresh_all_series_metadata(db: &SqlitePool) -> (usize, usize) {
 
     let mut refreshed = 0usize;
     let mut failed = 0usize;
-    for tracked in tracked {
+    let total = tracked.len();
+    for (idx, tracked) in tracked.into_iter().enumerate() {
         match refresh_series_metadata(db, &tracked, force_mal_fallback).await {
             Ok(_) => refreshed += 1,
             Err(err) => {
@@ -488,6 +489,19 @@ pub async fn refresh_all_series_metadata(db: &SqlitePool) -> (usize, usize) {
                     &err,
                 ).await;
             }
+        }
+        // Inter-series spacing: AniList allows 30 req/min for anonymous
+        // clients, but in practice sustained bursts trip rate limits
+        // even when the per-minute average is low. A 1-second sleep
+        // between iterations paces the sweep at ~50 req/min worst-case
+        // (one request every 1 + call-duration seconds, where the call
+        // itself takes 0.5–2s for a typical entry), which empirically
+        // stays under the rate limit on a small library and only adds
+        // a handful of seconds to the total sweep time. The sleep is
+        // skipped on the last iteration so a single-series refresh
+        // doesn't pause needlessly.
+        if idx + 1 < total {
+            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
         }
     }
 

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -36,6 +36,7 @@ async fn fetch_live_detail(
         &title_candidates_for_series(tracked),
         tracked.episodes,
         force_mal_fallback,
+        false,
     )
     .await
 }
@@ -46,50 +47,65 @@ async fn fetch_live_detail_for_ids(
     title_candidates: &[String],
     episode_count: Option<i32>,
     force_mal_fallback: bool,
+    allow_mal_on_rate_limit: bool,
 ) -> Result<anilist::AnimeDetail, String> {
     // Fallback policy: when an entry has a real AniList ID and the user
     // hasn't explicitly opted into MAL, treat AniList rate-limiting as
     // "try again later," not "silently substitute MAL." Falling back
     // every time AL is throttled would slowly overwrite high-fidelity
     // AL data with lower-fidelity MAL data on every sweep that hits
-    // the rate limit; the user wants the AL data, not MAL's
-    // approximation. Only non-rate-limit AL errors (5xx, parse, "not
-    // found", etc.) flow into the MAL/Kitsu fallback chain — those
-    // signal a problem with the entry on AL itself, where the fallback
-    // produces real value.
+    // the rate limit. The exception is `allow_mal_on_rate_limit`, which
+    // the relation hydrator sets on its final retry round so unreachable
+    // AL relations still pick up *some* metadata (MAL also sometimes has
+    // a different relation graph than AL — e.g. JoJo Part 6 is split
+    // into 3 parts on MAL but only 2 on AL).
     if provider_id > 0 && !force_mal_fallback {
         if anilist::anilist_cooldown_active() {
-            return Err(format!(
-                "AniList rate-limit cooldown active; skipping provider_id={} \
-                 to preserve AL fidelity (next sweep will retry)",
-                provider_id
-            ));
-        }
-        match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
-            Ok(detail) => return Ok(detail),
-            Err(err) => {
-                // The error string format comes from
-                // anilist::fetch_anime_detail — keep this matcher in
-                // sync if that wording changes.
-                let is_rate_limited = err.contains("HTTP 429")
-                    || err.contains("cooldown active");
-                if is_rate_limited {
-                    tracing::warn!(
-                        target: "ryokan::metadata_sync",
-                        provider_id,
-                        mal_id = ?mal_id,
-                        error = %err,
-                        "AniList rate-limited; skipping series (no MAL/Kitsu fallback)"
-                    );
-                    return Err(err);
+            if !allow_mal_on_rate_limit {
+                return Err(format!(
+                    "AniList rate-limit cooldown active for provider_id={} \
+                     (no MAL/Kitsu fallback)",
+                    provider_id
+                ));
+            }
+            // Fall through to MAL/Kitsu — relation hydrator's final pass.
+        } else {
+            match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
+                Ok(detail) => return Ok(detail),
+                Err(err) => {
+                    // The error string format comes from
+                    // anilist::fetch_anime_detail — keep this matcher in
+                    // sync if that wording changes.
+                    let is_rate_limited = err.contains("HTTP 429")
+                        || err.contains("cooldown active");
+                    if is_rate_limited && !allow_mal_on_rate_limit {
+                        tracing::warn!(
+                            target: "ryokan::metadata_sync",
+                            provider_id,
+                            mal_id = ?mal_id,
+                            error = %err,
+                            "AniList rate-limited (no MAL/Kitsu fallback)"
+                        );
+                        return Err(err);
+                    }
+                    if is_rate_limited {
+                        tracing::warn!(
+                            target: "ryokan::metadata_sync",
+                            provider_id,
+                            mal_id = ?mal_id,
+                            error = %err,
+                            "AniList rate-limited; falling back to MAL/Kitsu"
+                        );
+                    } else {
+                        tracing::warn!(
+                            target: "ryokan::metadata_sync",
+                            provider_id,
+                            mal_id = ?mal_id,
+                            error = %err,
+                            "AniList detail fetch failed; falling back to MAL/Kitsu"
+                        );
+                    }
                 }
-                tracing::warn!(
-                    target: "ryokan::metadata_sync",
-                    provider_id,
-                    mal_id = ?mal_id,
-                    error = %err,
-                    "AniList detail fetch failed; falling back to MAL/Kitsu"
-                );
             }
         }
     }
@@ -287,40 +303,96 @@ async fn hydrate_relation_tree(
     force_mal_fallback: bool,
     force_kitsu_fallback: bool,
 ) {
+    // Mirror the primary sweep's defer-and-retry policy so a rate-limit
+    // burst doesn't leave us with half a relation graph cached. After
+    // MAX_AL_RETRY_ROUNDS rounds of waiting for AL to recover, fall back
+    // to MAL for anything still rate-limited — MAL's relation graph is
+    // structurally different from AL's (e.g. JoJo Part 6 is three MAL
+    // entries but only two AL entries), so the MAL pass can also surface
+    // relations AL would never return.
+    const MAX_AL_RETRY_ROUNDS: usize = 3;
+    const COOLDOWN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+
     if root_provider_id == 0 {
         return;
     }
 
     let mut seen: HashSet<i64> = HashSet::new();
     let mut queue: VecDeque<(i64, Option<i64>)> = VecDeque::new();
+    let mut deferred: VecDeque<(i64, Option<i64>)> = VecDeque::new();
     queue.push_back((root_provider_id, root_detail.id_mal));
+    seen.insert(root_provider_id);
     let mut processed = 0usize;
+    let mut al_round = 0usize;
 
-    while let Some((provider_id, mal_id)) = queue.pop_front() {
-        if provider_id == 0 || !seen.insert(provider_id) {
-            continue;
+    loop {
+        // Once al_round exceeds MAX_AL_RETRY_ROUNDS we're in the final
+        // pass: rate-limited AL fetches transparently degrade to MAL/Kitsu
+        // instead of being deferred again.
+        let allow_mal_on_rate_limit = al_round > MAX_AL_RETRY_ROUNDS;
+
+        while let Some((provider_id, mal_id)) = queue.pop_front() {
+            if processed >= MAX_RELATION_TREE_NODES {
+                break;
+            }
+
+            let detail = if provider_id == root_provider_id {
+                root_detail.clone()
+            } else {
+                match fetch_live_detail_for_ids(
+                    provider_id,
+                    mal_id,
+                    &Vec::new(),
+                    None,
+                    force_mal_fallback,
+                    allow_mal_on_rate_limit,
+                )
+                .await
+                {
+                    Ok(detail) => detail,
+                    Err(err) => {
+                        let is_rate_limited = err.contains("HTTP 429")
+                            || err.contains("cooldown active");
+                        if is_rate_limited && !allow_mal_on_rate_limit {
+                            deferred.push_back((provider_id, mal_id));
+                        }
+                        continue;
+                    }
+                }
+            };
+
+            processed += 1;
+            let _ = cache_provider_detail(db, provider_id, &detail, force_kitsu_fallback).await;
+
+            for related in &detail.relations {
+                if related.id != 0
+                    && matches!(related.media_type.as_str(), "ANIME" | "MUSIC")
+                    && seen.insert(related.id)
+                {
+                    queue.push_back((related.id, related.id_mal));
+                }
+            }
         }
-        if processed >= MAX_RELATION_TREE_NODES {
+
+        if deferred.is_empty() || allow_mal_on_rate_limit {
+            // Either nothing left to retry, or we just finished the
+            // MAL-fallback round (anything still deferred at that point
+            // is a hard failure — give up).
             break;
         }
-        processed += 1;
 
-        let detail = if provider_id == root_provider_id {
-            root_detail.clone()
-        } else {
-            match fetch_live_detail_for_ids(provider_id, mal_id, &Vec::new(), None, force_mal_fallback).await {
-                Ok(detail) => detail,
-                Err(_) => continue,
-            }
-        };
-
-        let _ = cache_provider_detail(db, provider_id, &detail, force_kitsu_fallback).await;
-
-        for related in &detail.relations {
-            if related.id != 0 && matches!(related.media_type.as_str(), "ANIME" | "MUSIC") {
-                queue.push_back((related.id, related.id_mal));
+        // Wait for the AL cooldown to clear before another AL-only round.
+        // Skip the wait when the next round is the MAL-fallback round —
+        // waiting on AL is pointless when we won't be calling AL.
+        let next_is_mal_fallback = al_round + 1 > MAX_AL_RETRY_ROUNDS;
+        if !next_is_mal_fallback {
+            while anilist::anilist_cooldown_active() {
+                tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
             }
         }
+
+        queue.append(&mut deferred);
+        al_round += 1;
     }
 }
 

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -420,72 +420,55 @@ pub async fn refresh_series_metadata(
     refresh_series_metadata_inner(db, tracked, force_mal_fallback, false).await
 }
 
-pub async fn rebuild_cached_metadata(
-    db: &SqlitePool,
-    tracked: &series::Series,
-    force_mal_fallback: bool,
-) -> Result<anilist::AnimeDetail, String> {
-    refresh_series_metadata_inner(db, tracked, force_mal_fallback, true).await
-}
+/// Shared sweep driver for the manual rebuild and the periodic refresh.
+/// `rebuild_artifacts = true` runs the full rebuild path (re-derives
+/// episode metadata, artwork, etc. via refresh_series_metadata_inner's
+/// `rebuild` flag); `false` runs the lighter periodic refresh.
+///
+/// Defer-and-retry policy: when a series is rate-limited by AniList,
+/// it's parked in `deferred` instead of counted as `failed`. After the
+/// main pass completes, the helper waits for the AniList cooldown to
+/// clear and re-runs the deferred series. This is what makes the
+/// manual rebuild button do what its name promises — a sweep that hits
+/// rate limiting won't leave the user with stale or substituted data
+/// for half their library; it'll finish what it started.
+///
+/// Bounded by `MAX_RETRY_ROUNDS` so a sustained AniList outage doesn't
+/// pin the sweep forever; anything still deferred at the end counts as
+/// failed and the next periodic refresh will pick it up.
+async fn run_metadata_sweep(db: &SqlitePool, rebuild_artifacts: bool) -> (usize, usize) {
+    const MAX_RETRY_ROUNDS: usize = 3;
+    const COOLDOWN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+    // Inter-series spacing: AniList allows 30 req/min for anonymous
+    // clients, but in practice sustained bursts trip rate limits
+    // even when the per-minute average is low. A 1-second sleep
+    // between iterations paces the sweep at ~50 req/min worst-case
+    // (one request every 1 + call-duration seconds, where the call
+    // itself takes 0.5–2s for a typical entry), which empirically
+    // stays under the rate limit on a small library.
+    const INTER_SERIES_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
 
-pub async fn rebuild_cached_metadata_for_all(db: &SqlitePool) -> (usize, usize, usize) {
-    let tracked = match series::get_all(db).await {
-        Ok(items) => items,
-        Err(err) => {
-            logger::error(db, LogCategory::AniList, "Cached metadata rebuild sweep failed", &err.to_string()).await;
-            return (0, 0, 1);
-        }
+    let sweep_label = if rebuild_artifacts {
+        "Cached metadata rebuild"
+    } else {
+        "Metadata refresh"
+    };
+    let per_series_fail_label = if rebuild_artifacts {
+        "Failed to rebuild cached metadata"
+    } else {
+        "Metadata refresh failed"
     };
 
-    let force_mal_fallback = crate::models::config::get_config(db)
-        .await
-        .ok()
-        .flatten()
-        .map(|c| c.force_mal_fallback)
-        .unwrap_or(false);
-
-    let mut rebuilt = 0usize;
-    let skipped = 0usize;
-    let mut failed = 0usize;
-
-    for tracked in tracked {
-        match rebuild_cached_metadata(db, &tracked, force_mal_fallback).await {
-            Ok(detail) => {
-                rebuilt += 1;
-                logger::info(
-                    db,
-                    LogCategory::AniList,
-                    &format!("Rebuilt cached metadata for {}", tracked.title),
-                    &format!("provider_id={}, anilist_id={}, mal_id={:?}, episodes={:?}", detail.id, tracked.anilist_id, detail.id_mal, detail.episodes),
-                ).await;
-            }
-            Err(err) => {
-                failed += 1;
-                logger::warn(
-                    db,
-                    LogCategory::AniList,
-                    &format!("Failed to rebuild cached metadata for {}", tracked.title),
-                    &err,
-                ).await;
-            }
-        }
-    }
-
-    logger::info(
-        db,
-        LogCategory::AniList,
-        "Cached metadata rebuild sweep complete",
-        &format!("rebuilt={}, skipped={}, failed={}", rebuilt, skipped, failed),
-    ).await;
-
-    (rebuilt, skipped, failed)
-}
-
-pub async fn refresh_all_series_metadata(db: &SqlitePool) -> (usize, usize) {
     let tracked = match series::get_all(db).await {
         Ok(items) => items,
         Err(err) => {
-            logger::error(db, LogCategory::AniList, "Metadata refresh sweep failed", &err.to_string()).await;
+            logger::error(
+                db,
+                LogCategory::AniList,
+                &format!("{} sweep failed", sweep_label),
+                &err.to_string(),
+            )
+            .await;
             return (0, 1);
         }
     };
@@ -497,45 +480,176 @@ pub async fn refresh_all_series_metadata(db: &SqlitePool) -> (usize, usize) {
         .map(|c| c.force_mal_fallback)
         .unwrap_or(false);
 
-    let mut refreshed = 0usize;
+    let mut succeeded = 0usize;
     let mut failed = 0usize;
+    let mut deferred: Vec<series::Series> = Vec::new();
+
+    let should_defer = |tracked: &series::Series| -> bool {
+        anilist::anilist_cooldown_active() && tracked.anilist_id > 0 && !force_mal_fallback
+    };
+
+    // ── Main pass ────────────────────────────────────────────────────────
     let total = tracked.len();
     for (idx, tracked) in tracked.into_iter().enumerate() {
-        match refresh_series_metadata(db, &tracked, force_mal_fallback).await {
-            Ok(_) => refreshed += 1,
+        // Pre-check: if AL cooldown is already active, don't burn the
+        // call — defer immediately. (Saves a guaranteed-to-fail HTTP
+        // round trip per series.)
+        if should_defer(&tracked) {
+            deferred.push(tracked);
+            if idx + 1 < total {
+                tokio::time::sleep(INTER_SERIES_DELAY).await;
+            }
+            continue;
+        }
+
+        match refresh_series_metadata_inner(db, &tracked, force_mal_fallback, rebuild_artifacts).await {
+            Ok(detail) => {
+                succeeded += 1;
+                if rebuild_artifacts {
+                    logger::info(
+                        db,
+                        LogCategory::AniList,
+                        &format!("Rebuilt cached metadata for {}", tracked.title),
+                        &format!(
+                            "provider_id={}, anilist_id={}, mal_id={:?}, episodes={:?}",
+                            detail.id, tracked.anilist_id, detail.id_mal, detail.episodes
+                        ),
+                    )
+                    .await;
+                }
+            }
             Err(err) => {
-                failed += 1;
-                logger::warn(
-                    db,
-                    LogCategory::AniList,
-                    &format!("Metadata refresh failed for {}", tracked.title),
-                    &err,
-                ).await;
+                // Post-check: this call may have been the 429 that just
+                // tripped the cooldown. If so, defer instead of failing
+                // so the retry round picks it up.
+                if should_defer(&tracked) {
+                    deferred.push(tracked);
+                } else {
+                    failed += 1;
+                    logger::warn(
+                        db,
+                        LogCategory::AniList,
+                        &format!("{} for {}", per_series_fail_label, tracked.title),
+                        &err,
+                    )
+                    .await;
+                }
             }
         }
-        // Inter-series spacing: AniList allows 30 req/min for anonymous
-        // clients, but in practice sustained bursts trip rate limits
-        // even when the per-minute average is low. A 1-second sleep
-        // between iterations paces the sweep at ~50 req/min worst-case
-        // (one request every 1 + call-duration seconds, where the call
-        // itself takes 0.5–2s for a typical entry), which empirically
-        // stays under the rate limit on a small library and only adds
-        // a handful of seconds to the total sweep time. The sleep is
-        // skipped on the last iteration so a single-series refresh
-        // doesn't pause needlessly.
         if idx + 1 < total {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+            tokio::time::sleep(INTER_SERIES_DELAY).await;
         }
     }
 
-    if refreshed > 0 || failed > 0 {
+    // ── Retry rounds for deferred series ─────────────────────────────────
+    let mut round = 0;
+    while !deferred.is_empty() && round < MAX_RETRY_ROUNDS {
+        if anilist::anilist_cooldown_active() {
+            logger::info(
+                db,
+                LogCategory::AniList,
+                &format!(
+                    "{}: waiting for AniList cooldown ({} series deferred, retry round {})",
+                    sweep_label,
+                    deferred.len(),
+                    round + 1
+                ),
+                "",
+            )
+            .await;
+            while anilist::anilist_cooldown_active() {
+                tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
+            }
+        }
+
+        let to_retry = std::mem::take(&mut deferred);
+        let total = to_retry.len();
+        for (idx, tracked) in to_retry.into_iter().enumerate() {
+            match refresh_series_metadata_inner(db, &tracked, force_mal_fallback, rebuild_artifacts).await {
+                Ok(detail) => {
+                    succeeded += 1;
+                    if rebuild_artifacts {
+                        logger::info(
+                            db,
+                            LogCategory::AniList,
+                            &format!("Rebuilt cached metadata for {}", tracked.title),
+                            &format!(
+                                "provider_id={}, anilist_id={}, mal_id={:?}, episodes={:?}",
+                                detail.id, tracked.anilist_id, detail.id_mal, detail.episodes
+                            ),
+                        )
+                        .await;
+                    }
+                }
+                Err(err) => {
+                    if should_defer(&tracked) {
+                        deferred.push(tracked);
+                    } else {
+                        failed += 1;
+                        logger::warn(
+                            db,
+                            LogCategory::AniList,
+                            &format!("{} for {}", per_series_fail_label, tracked.title),
+                            &err,
+                        )
+                        .await;
+                    }
+                }
+            }
+            if idx + 1 < total {
+                tokio::time::sleep(INTER_SERIES_DELAY).await;
+            }
+        }
+        round += 1;
+    }
+
+    // Anything still deferred after MAX_RETRY_ROUNDS counts as failed —
+    // at that point AniList is sustainedly unavailable and we should
+    // surface that rather than spin. Next periodic refresh will pick it up.
+    if !deferred.is_empty() {
+        failed += deferred.len();
+        for tracked in &deferred {
+            logger::warn(
+                db,
+                LogCategory::AniList,
+                &format!(
+                    "{} skipped after {} retry rounds: {}",
+                    sweep_label, MAX_RETRY_ROUNDS, tracked.title
+                ),
+                "AniList still rate-limited; will retry on next sweep",
+            )
+            .await;
+        }
+    }
+
+    // Match the previous summary-log behaviour: rebuild always logs;
+    // refresh only logs when something happened.
+    if rebuild_artifacts || succeeded > 0 || failed > 0 {
+        let detail = if rebuild_artifacts {
+            format!("rebuilt={}, skipped=0, failed={}", succeeded, failed)
+        } else {
+            format!("refreshed={}, failed={}", succeeded, failed)
+        };
         logger::info(
             db,
             LogCategory::AniList,
-            "Metadata refresh sweep complete",
-            &format!("refreshed={}, failed={}", refreshed, failed),
-        ).await;
+            &format!("{} sweep complete", sweep_label),
+            &detail,
+        )
+        .await;
     }
 
-    (refreshed, failed)
+    (succeeded, failed)
+}
+
+pub async fn rebuild_cached_metadata_for_all(db: &SqlitePool) -> (usize, usize, usize) {
+    let (rebuilt, failed) = run_metadata_sweep(db, true).await;
+    // The middle "skipped" counter has been zero for a while — the
+    // sweep doesn't have a "skip without trying" branch — but the
+    // tuple shape is part of the handler contract so keep it.
+    (rebuilt, 0, failed)
+}
+
+pub async fn refresh_all_series_metadata(db: &SqlitePool) -> (usize, usize) {
+    run_metadata_sweep(db, false).await
 }

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -36,7 +36,6 @@ async fn fetch_live_detail(
         &title_candidates_for_series(tracked),
         tracked.episodes,
         force_mal_fallback,
-        false,
     )
     .await
 }
@@ -47,65 +46,49 @@ async fn fetch_live_detail_for_ids(
     title_candidates: &[String],
     episode_count: Option<i32>,
     force_mal_fallback: bool,
-    allow_mal_on_rate_limit: bool,
 ) -> Result<anilist::AnimeDetail, String> {
     // Fallback policy: when an entry has a real AniList ID and the user
-    // hasn't explicitly opted into MAL, treat AniList rate-limiting as
-    // "try again later," not "silently substitute MAL." Falling back
-    // every time AL is throttled would slowly overwrite high-fidelity
-    // AL data with lower-fidelity MAL data on every sweep that hits
-    // the rate limit. The exception is `allow_mal_on_rate_limit`, which
-    // the relation hydrator sets on its final retry round so unreachable
-    // AL relations still pick up *some* metadata (MAL also sometimes has
-    // a different relation graph than AL — e.g. JoJo Part 6 is split
-    // into 3 parts on MAL but only 2 on AL).
+    // hasn't explicitly opted into MAL, MAL is only used when AL is
+    // genuinely *down* (5xx, network error, parse failure, etc.). A 429
+    // rate-limit means AL is responding but throttling us — we surface
+    // an Err so the caller can defer-and-retry, preserving AL fidelity
+    // instead of silently substituting MAL data. Persistent rate-limits
+    // are the user's own library not getting fully refreshed; we'd
+    // rather leave the previous AL data in place than overwrite it with
+    // a MAL approximation.
     if provider_id > 0 && !force_mal_fallback {
         if anilist::anilist_cooldown_active() {
-            if !allow_mal_on_rate_limit {
-                return Err(format!(
-                    "AniList rate-limit cooldown active for provider_id={} \
-                     (no MAL/Kitsu fallback)",
-                    provider_id
-                ));
-            }
-            // Fall through to MAL/Kitsu — relation hydrator's final pass.
-        } else {
-            match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
-                Ok(detail) => return Ok(detail),
-                Err(err) => {
-                    // The error string format comes from
-                    // anilist::fetch_anime_detail — keep this matcher in
-                    // sync if that wording changes.
-                    let is_rate_limited = err.contains("HTTP 429")
-                        || err.contains("cooldown active");
-                    if is_rate_limited && !allow_mal_on_rate_limit {
-                        tracing::warn!(
-                            target: "ryokan::metadata_sync",
-                            provider_id,
-                            mal_id = ?mal_id,
-                            error = %err,
-                            "AniList rate-limited (no MAL/Kitsu fallback)"
-                        );
-                        return Err(err);
-                    }
-                    if is_rate_limited {
-                        tracing::warn!(
-                            target: "ryokan::metadata_sync",
-                            provider_id,
-                            mal_id = ?mal_id,
-                            error = %err,
-                            "AniList rate-limited; falling back to MAL/Kitsu"
-                        );
-                    } else {
-                        tracing::warn!(
-                            target: "ryokan::metadata_sync",
-                            provider_id,
-                            mal_id = ?mal_id,
-                            error = %err,
-                            "AniList detail fetch failed; falling back to MAL/Kitsu"
-                        );
-                    }
+            return Err(format!(
+                "AniList rate-limit cooldown active for provider_id={} \
+                 (no MAL/Kitsu fallback)",
+                provider_id
+            ));
+        }
+        match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
+            Ok(detail) => return Ok(detail),
+            Err(err) => {
+                // The error string format comes from
+                // anilist::fetch_anime_detail — keep this matcher in
+                // sync if that wording changes.
+                let is_rate_limited = err.contains("HTTP 429")
+                    || err.contains("cooldown active");
+                if is_rate_limited {
+                    tracing::warn!(
+                        target: "ryokan::metadata_sync",
+                        provider_id,
+                        mal_id = ?mal_id,
+                        error = %err,
+                        "AniList rate-limited (no MAL/Kitsu fallback)"
+                    );
+                    return Err(err);
                 }
+                tracing::warn!(
+                    target: "ryokan::metadata_sync",
+                    provider_id,
+                    mal_id = ?mal_id,
+                    error = %err,
+                    "AniList detail fetch failed; falling back to MAL/Kitsu"
+                );
             }
         }
     }
@@ -303,19 +286,27 @@ async fn hydrate_relation_tree(
     force_mal_fallback: bool,
     force_kitsu_fallback: bool,
 ) {
-    // Mirror the primary sweep's defer-and-retry policy so a rate-limit
-    // burst doesn't leave us with half a relation graph cached. After
-    // MAX_AL_RETRY_ROUNDS rounds of waiting for AL to recover, fall back
-    // to MAL for anything still rate-limited — MAL's relation graph is
-    // structurally different from AL's (e.g. JoJo Part 6 is three MAL
-    // entries but only two AL entries), so the MAL pass can also surface
-    // relations AL would never return.
+    // Trees stay strictly separate. AL mode walks AL's relation graph
+    // (positive AL IDs only); MAL mode walks MAL's, where Jikan stamps
+    // each card with `id = -mal_id` as a "no AL mapping" sentinel. Mode
+    // is determined by which provider gave us the root: positive root
+    // detail id = AL, negative = MAL fallback (or user opted into MAL).
+    // We never interleave the two — a MAL fallback mid-walk would
+    // pollute AL's graph with MAL-only siblings (e.g. JoJo Part 6 is 3
+    // entries on MAL but 2 on AL).
+    //
+    // Rate-limited AL relations defer-and-retry within the walk, but we
+    // never substitute MAL on rate-limit; "MAL only when AL is down"
+    // means non-rate-limit errors (5xx/network), which fetch_live_detail
+    // already handles inline before this walker is even called.
     const MAX_AL_RETRY_ROUNDS: usize = 3;
     const COOLDOWN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
 
     if root_provider_id == 0 {
         return;
     }
+
+    let mal_mode = force_mal_fallback || root_detail.id < 0;
 
     let mut seen: HashSet<i64> = HashSet::new();
     let mut queue: VecDeque<(i64, Option<i64>)> = VecDeque::new();
@@ -326,11 +317,6 @@ async fn hydrate_relation_tree(
     let mut al_round = 0usize;
 
     loop {
-        // Once al_round exceeds MAX_AL_RETRY_ROUNDS we're in the final
-        // pass: rate-limited AL fetches transparently degrade to MAL/Kitsu
-        // instead of being deferred again.
-        let allow_mal_on_rate_limit = al_round > MAX_AL_RETRY_ROUNDS;
-
         while let Some((provider_id, mal_id)) = queue.pop_front() {
             if processed >= MAX_RELATION_TREE_NODES {
                 break;
@@ -345,7 +331,6 @@ async fn hydrate_relation_tree(
                     &Vec::new(),
                     None,
                     force_mal_fallback,
-                    allow_mal_on_rate_limit,
                 )
                 .await
                 {
@@ -353,7 +338,10 @@ async fn hydrate_relation_tree(
                     Err(err) => {
                         let is_rate_limited = err.contains("HTTP 429")
                             || err.contains("cooldown active");
-                        if is_rate_limited && !allow_mal_on_rate_limit {
+                        // Only AL rate-limits are worth retrying. MAL
+                        // failures or genuine AL-down errors are already
+                        // terminal by the time this returns.
+                        if is_rate_limited && !mal_mode {
                             deferred.push_back((provider_id, mal_id));
                         }
                         continue;
@@ -365,7 +353,12 @@ async fn hydrate_relation_tree(
             let _ = cache_provider_detail(db, provider_id, &detail, force_kitsu_fallback).await;
 
             for related in &detail.relations {
-                if related.id != 0
+                let id_valid = if mal_mode {
+                    related.id != 0
+                } else {
+                    related.id > 0
+                };
+                if id_valid
                     && matches!(related.media_type.as_str(), "ANIME" | "MUSIC")
                     && seen.insert(related.id)
                 {
@@ -374,21 +367,16 @@ async fn hydrate_relation_tree(
             }
         }
 
-        if deferred.is_empty() || allow_mal_on_rate_limit {
-            // Either nothing left to retry, or we just finished the
-            // MAL-fallback round (anything still deferred at that point
-            // is a hard failure — give up).
+        if deferred.is_empty() || al_round >= MAX_AL_RETRY_ROUNDS {
+            // Anything still deferred after the retry budget is left out
+            // of this sweep's cache — the next periodic refresh picks it
+            // up. We don't substitute MAL on rate-limit (would mix trees
+            // and downgrade fidelity).
             break;
         }
 
-        // Wait for the AL cooldown to clear before another AL-only round.
-        // Skip the wait when the next round is the MAL-fallback round —
-        // waiting on AL is pointless when we won't be calling AL.
-        let next_is_mal_fallback = al_round + 1 > MAX_AL_RETRY_ROUNDS;
-        if !next_is_mal_fallback {
-            while anilist::anilist_cooldown_active() {
-                tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
-            }
+        while anilist::anilist_cooldown_active() {
+            tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
         }
 
         queue.append(&mut deferred);

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -67,12 +67,7 @@ async fn fetch_live_detail_for_ids(
         match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
             Ok(detail) => return Ok(detail),
             Err(err) => {
-                // The error string format comes from
-                // anilist::fetch_anime_detail — keep this matcher in
-                // sync if that wording changes.
-                let is_rate_limited = err.contains("HTTP 429")
-                    || err.contains("cooldown active");
-                if is_rate_limited {
+                if anilist::is_rate_limit_error(&err) {
                     tracing::warn!(
                         target: "ryokan::metadata_sync",
                         provider_id,
@@ -336,12 +331,10 @@ async fn hydrate_relation_tree(
                 {
                     Ok(detail) => detail,
                     Err(err) => {
-                        let is_rate_limited = err.contains("HTTP 429")
-                            || err.contains("cooldown active");
                         // Only AL rate-limits are worth retrying. MAL
                         // failures or genuine AL-down errors are already
                         // terminal by the time this returns.
-                        if is_rate_limited && !mal_mode {
+                        if anilist::is_rate_limit_error(&err) && !mal_mode {
                             deferred.push_back((provider_id, mal_id));
                         }
                         continue;
@@ -372,6 +365,17 @@ async fn hydrate_relation_tree(
             // of this sweep's cache — the next periodic refresh picks it
             // up. We don't substitute MAL on rate-limit (would mix trees
             // and downgrade fidelity).
+            if !deferred.is_empty() {
+                tracing::warn!(
+                    target: "ryokan::metadata_sync",
+                    root_provider_id,
+                    dropped = deferred.len(),
+                    retry_rounds = al_round,
+                    "relation hydration left {} relations unfetched after AniList \
+                     retry budget exhausted; next sweep will retry",
+                    deferred.len()
+                );
+            }
             break;
         }
 

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -47,15 +47,43 @@ async fn fetch_live_detail_for_ids(
     episode_count: Option<i32>,
     force_mal_fallback: bool,
 ) -> Result<anilist::AnimeDetail, String> {
-    if provider_id > 0 && !force_mal_fallback
-        && let Ok(detail) = anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
-            return Ok(detail);
+    // Each fallback step logs at warn so the operator can see *why* a
+    // series fell through to a lower-fidelity provider. The previous
+    // `if let Ok(...) = ... { return ... }` shape was silent — a
+    // sweep-time AniList error (slow GraphQL response for a huge
+    // entry like One Piece, transient 5xx, partial JSON) just dropped
+    // the entry to MAL with no breadcrumb, leaving the operator with
+    // a `provider_id=-21, episodes=None` row and no way to know
+    // whether AniList was genuinely down or whether one specific
+    // series was just slow to assemble.
+    if provider_id > 0 && !force_mal_fallback {
+        match anilist::get_anime_detail_with_options(provider_id, mal_id, false).await {
+            Ok(detail) => return Ok(detail),
+            Err(err) => {
+                tracing::warn!(
+                    target: "ryokan::metadata_sync",
+                    provider_id,
+                    mal_id = ?mal_id,
+                    error = %err,
+                    "AniList detail fetch failed; falling back to MAL/Kitsu"
+                );
+            }
         }
+    }
 
-    if let Some(mal_id) = mal_id
-        && let Ok(detail) = jikan::get_anime_detail_cached(mal_id).await {
-            return Ok(detail);
+    if let Some(mid) = mal_id {
+        match jikan::get_anime_detail_cached(mid).await {
+            Ok(detail) => return Ok(detail),
+            Err(err) => {
+                tracing::warn!(
+                    target: "ryokan::metadata_sync",
+                    mal_id = mid,
+                    error = %err,
+                    "Jikan/MAL detail fetch failed; falling back to Kitsu by title"
+                );
+            }
         }
+    }
 
     if !title_candidates.is_empty() {
         return kitsu::get_anime_detail_by_titles(title_candidates, None, episode_count).await;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod jellyfin;
 
 pub mod auto_search;
 pub mod logger;
+pub mod progress;
 pub mod quality;
 
 pub mod rss;

--- a/src/services/nfo.rs
+++ b/src/services/nfo.rs
@@ -77,7 +77,7 @@ pub fn best_title(series: &Series) -> String {
 /// cache), the NFO is enriched with plot, year, premiered, rating, genres,
 /// and runtime. Without it the output is the minimal series-row-only form
 /// used as a fallback when the metadata cache is empty.
-pub fn write_series_nfo(
+pub async fn write_series_nfo(
     path: &Path,
     series: &Series,
     detail: Option<&AnimeDetail>,
@@ -169,7 +169,7 @@ pub fn write_series_nfo(
 
     xml.push_str("</tvshow>\n");
 
-    std::fs::write(path, xml)
+    tokio::fs::write(path, xml).await
 }
 
 /// Write an episode `.nfo` alongside the renamed video file.
@@ -180,7 +180,7 @@ pub fn write_series_nfo(
 /// detail, or `None` when unknown. Jellyfin shows "Unknown" duration on
 /// episode cards until it has scanned the file once, so emitting the
 /// AniList runtime up-front is a meaningful UX improvement.
-pub fn write_episode_nfo(
+pub async fn write_episode_nfo(
     path: &Path,
     showtitle: &str,
     season: i32,
@@ -217,7 +217,7 @@ pub fn write_episode_nfo(
 
     xml.push_str("</episodedetails>\n");
 
-    std::fs::write(path, xml)
+    tokio::fs::write(path, xml).await
 }
 
 #[cfg(test)]
@@ -314,9 +314,9 @@ mod tests {
         dir.join(suffix)
     }
 
-    fn render_series_nfo(detail: Option<&AnimeDetail>) -> String {
+    async fn render_series_nfo(detail: Option<&AnimeDetail>) -> String {
         let path = unique_temp_path("tvshow.nfo");
-        write_series_nfo(&path, &series_stub(), detail).expect("write nfo");
+        write_series_nfo(&path, &series_stub(), detail).await.expect("write nfo");
         let xml = std::fs::read_to_string(&path).expect("read nfo");
         std::fs::remove_file(&path).ok();
         if let Some(parent) = path.parent() {
@@ -325,10 +325,10 @@ mod tests {
         xml
     }
 
-    #[test]
-    fn series_nfo_with_detail_emits_plot_year_rating_genres() {
+    #[tokio::test]
+    async fn series_nfo_with_detail_emits_plot_year_rating_genres() {
         let detail = detail_with_everything();
-        let xml = render_series_nfo(Some(&detail));
+        let xml = render_series_nfo(Some(&detail)).await;
 
         // Plot is HTML-stripped.
         assert!(xml.contains("<plot>A brilliant story. About things.</plot>"));
@@ -350,9 +350,9 @@ mod tests {
         assert!(xml.contains("<uniqueid type=\"myanimelist\">67890</uniqueid>"));
     }
 
-    #[test]
-    fn series_nfo_without_detail_falls_back_to_minimal() {
-        let xml = render_series_nfo(None);
+    #[tokio::test]
+    async fn series_nfo_without_detail_falls_back_to_minimal() {
+        let xml = render_series_nfo(None).await;
         // No enrichment fields — just title/originaltitle/status/genre/ids.
         assert!(!xml.contains("<plot>"));
         assert!(!xml.contains("<year>"));
@@ -363,21 +363,22 @@ mod tests {
         assert!(xml.contains("<title>English Title</title>"));
     }
 
-    #[test]
-    fn series_nfo_does_not_double_emit_animation_when_anilist_lists_it() {
+    #[tokio::test]
+    async fn series_nfo_does_not_double_emit_animation_when_anilist_lists_it() {
         let mut detail = detail_with_everything();
         detail.genres = vec!["Animation".to_string(), "Adventure".to_string()];
-        let xml = render_series_nfo(Some(&detail));
+        let xml = render_series_nfo(Some(&detail)).await;
         // Animation should appear exactly once (from AniList) — the fallback
         // must not double-emit it.
         assert_eq!(xml.matches("<genre>Animation</genre>").count(), 1);
         assert!(xml.contains("<genre>Adventure</genre>"));
     }
 
-    #[test]
-    fn episode_nfo_emits_runtime_when_provided() {
+    #[tokio::test]
+    async fn episode_nfo_emits_runtime_when_provided() {
         let path = unique_temp_path("ep_with_runtime.nfo");
         write_episode_nfo(&path, "Show", 1, 5, "The Title", "2024-03-01", Some(24))
+            .await
             .expect("write nfo");
         let xml = std::fs::read_to_string(&path).expect("read nfo");
         std::fs::remove_file(&path).ok();
@@ -389,10 +390,10 @@ mod tests {
         assert!(xml.contains("<aired>2024-03-01</aired>"));
     }
 
-    #[test]
-    fn episode_nfo_omits_runtime_when_unknown() {
+    #[tokio::test]
+    async fn episode_nfo_omits_runtime_when_unknown() {
         let path = unique_temp_path("ep_no_runtime.nfo");
-        write_episode_nfo(&path, "Show", 1, 5, "", "", None).expect("write nfo");
+        write_episode_nfo(&path, "Show", 1, 5, "", "", None).await.expect("write nfo");
         let xml = std::fs::read_to_string(&path).expect("read nfo");
         std::fs::remove_file(&path).ok();
         if let Some(parent) = path.parent() {

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -351,6 +351,13 @@ fn extract_hash(magnet: &str) -> String {
     match hash.len() {
         40 => hash.to_ascii_lowercase(),
         32 => hash.to_string(),
+        // Any other length is a malformed BTIH — not a valid
+        // info-hash. The lowercase fallthrough preserves the prior
+        // behaviour of returning *something* to downstream code
+        // rather than silently swallowing the input; a future
+        // stricter version could `return String::new()` here for
+        // defensive rejection without breaking any caller that
+        // already treats "" as "no hash".
         _ => hash.to_ascii_lowercase(),
     }
 }

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -331,12 +331,28 @@ fn detect_batch(title: &str) -> bool {
 }
 
 fn extract_hash(magnet: &str) -> String {
-    if let Some(pos) = magnet.find("btih:") {
-        let rest = &magnet[pos + 5..];
-        let end = rest.find('&').unwrap_or(rest.len());
-        return rest[..end].to_lowercase();
+    // Two quirks the prior impl got wrong:
+    //   1. BTIH URN is case-insensitive (`urn:btih:` and `urn:BTIH:`
+    //      both occur in the wild); searching for a lowercase literal
+    //      missed uppercase variants entirely and returned "".
+    //   2. 40-char hex hashes are case-insensitive, but 32-char base32
+    //      hashes (uppercase A-Z + 2-7 only) are case-SENSITIVE.
+    //      Lowercasing base32 corrupts the info-hash, which breaks
+    //      dedup, blocklist re-grab detection, and SeaDex matching for
+    //      any curated release whose magnet happens to use base32.
+    let lower = magnet.to_ascii_lowercase();
+    let Some(pos) = lower.find("btih:") else {
+        return String::new();
+    };
+    let payload = &magnet[pos + 5..];
+    let end = payload.find('&').unwrap_or(payload.len());
+    let hash = &payload[..end];
+
+    match hash.len() {
+        40 => hash.to_ascii_lowercase(),
+        32 => hash.to_string(),
+        _ => hash.to_ascii_lowercase(),
     }
-    String::new()
 }
 
 fn parse_size(s: &str) -> i64 {
@@ -591,5 +607,41 @@ mod tests {
         assert!(result.is_batch, "smol pack titled with Season N should be flagged as batch");
         assert_eq!(result.resolution, "1080");
         assert_eq!(result.group, "smol");
+    }
+
+    #[test]
+    fn extract_hash_lowercases_hex() {
+        let magnet = "magnet:?xt=urn:btih:ABCDEF0123456789ABCDEF0123456789ABCDEF01&dn=thing";
+        assert_eq!(
+            extract_hash(magnet),
+            "abcdef0123456789abcdef0123456789abcdef01"
+        );
+    }
+
+    #[test]
+    fn extract_hash_accepts_uppercase_prefix() {
+        // Real-world magnets occasionally use `urn:BTIH:`; prior impl
+        // returned "" for this and broke downstream lookups.
+        let magnet = "magnet:?xt=urn:BTIH:ABCDEF0123456789ABCDEF0123456789ABCDEF01";
+        assert_eq!(
+            extract_hash(magnet),
+            "abcdef0123456789abcdef0123456789abcdef01"
+        );
+    }
+
+    #[test]
+    fn extract_hash_preserves_base32_case() {
+        // 32-char base32 info-hashes are case-sensitive. Prior impl
+        // .to_lowercase()'d them, producing a hash that didn't match
+        // what qBit actually stored.
+        let base32 = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+        let magnet = format!("magnet:?xt=urn:btih:{base32}&dn=thing");
+        assert_eq!(extract_hash(&magnet), base32);
+    }
+
+    #[test]
+    fn extract_hash_no_prefix_returns_empty() {
+        assert_eq!(extract_hash("https://example.com/t.torrent"), "");
+        assert_eq!(extract_hash(""), "");
     }
 }

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -638,7 +638,8 @@ async fn import_torrent(
                     &ep_title,
                     &aired,
                     ctx.runtime_minutes,
-                );
+                )
+                .await;
                 imported_count += 1;
                 touched_series.insert(target_series_id);
                 logger::info(
@@ -808,7 +809,7 @@ async fn import_torrent(
         };
         let series_root = Path::new(&cfg.media_root).join(&ctx.folder_name);
         let series_nfo = series_root.join("tvshow.nfo");
-        let _ = nfo::write_series_nfo(&series_nfo, &ctx.series, ctx.cached_detail.as_ref());
+        let _ = nfo::write_series_nfo(&series_nfo, &ctx.series, ctx.cached_detail.as_ref()).await;
 
         let poster_dest = series_root.join("poster.jpg");
         if !poster_dest.exists() {
@@ -1285,7 +1286,8 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
         // 'completed' since the file is already on disk.
         if !item.row_exists {
             // Best-effort single stat — failure just leaves size at 0.
-            let file_size = std::fs::metadata(&item.file_path)
+            let file_size = tokio::fs::metadata(&item.file_path)
+                .await
                 .map(|m| m.len() as i64)
                 .unwrap_or(0);
             // Externally-imported file — we're creating both the quality

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -1115,6 +1115,32 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                 .await
                 .unwrap_or_default();
 
+            // One bulk fetch of imported grabs for this series, used
+            // by every file in the inner loop below to look up the
+            // unsanitized torrent name. Replaces a pair of per-file
+            // queries (find_imported_for_episode + a fallback
+            // most_recent_imported_torrent_name_for_series) that ran
+            // inside the held POST_PROC_LOCK — that was ~4800
+            // round-trips per pass on a 100-series, 24-ep library.
+            let imported_grabs =
+                grabbed_torrents::imported_grabs_for_series(&state.db, row.id)
+                    .await
+                    .unwrap_or_default();
+            // Per-episode lookup; first occurrence (DESC by grabbed_at)
+            // wins, so each episode maps to its most recent grab. This
+            // matches the prior find_imported_for_episode .next()
+            // semantics on a DESC-sorted result set.
+            let mut grab_name_for_episode: HashMap<i32, String> = HashMap::new();
+            for (name, eps) in &imported_grabs {
+                for ep in eps {
+                    grab_name_for_episode
+                        .entry(*ep)
+                        .or_insert_with(|| name.clone());
+                }
+            }
+            let most_recent_grab_name: Option<&str> =
+                imported_grabs.first().map(|(n, _)| n.as_str());
+
             let series_root = Path::new(&cfg.media_root).join(&row.folder_name);
 
             for file in &disk_files {
@@ -1181,37 +1207,21 @@ pub async fn scan_library_for_unclassified(state: &AppState) -> LibraryClassifyR
                     .to_string();
 
                 // Look up the grab that covers this episode so we can
-                // classify against the unsanitized torrent name. Done
-                // inside the lock because the enumeration phase needs
-                // the work list to be a consistent snapshot and the DB
-                // round-trip is cheap next to the ffprobe shell-out
-                // that runs in the unlocked phase below.
-                //
-                // First try the per-episode lookup. When that misses
-                // (old batch grabs recorded with `episode_numbers = []`
-                // before the grab-time episode-range fix, where
-                // `json_each` yields nothing), fall back to the most
-                // recent imported grab for the series as a whole:
-                // for a single-series batch that's by definition the
-                // grab these files came from. Both queries are cheap
-                // `LIMIT 1` lookups.
-                let original_torrent_name = match grabbed_torrents::find_imported_for_episode(
-                    &state.db,
-                    row.id,
-                    file.episode_number,
-                )
-                .await
-                .ok()
-                .and_then(|grabs| grabs.into_iter().next())
-                {
-                    Some(g) => g.torrent_name,
-                    None => grabbed_torrents::most_recent_imported_torrent_name_for_series(
-                        &state.db,
-                        row.id,
-                    )
-                    .await
-                    .unwrap_or_default(),
-                };
+                // classify against the unsanitized torrent name. The
+                // pre-built `grab_name_for_episode` map and
+                // `most_recent_grab_name` fallback come from the
+                // single bulk fetch above — both lookups are now
+                // pure-Rust and don't touch the DB inside the held
+                // POST_PROC_LOCK. The fallback exists for old batch
+                // grabs recorded with `episode_numbers = []` before
+                // the grab-time episode-range fix; for a single-series
+                // batch the most-recent grab is by definition the one
+                // these files came from.
+                let original_torrent_name = grab_name_for_episode
+                    .get(&file.episode_number)
+                    .cloned()
+                    .or_else(|| most_recent_grab_name.map(|s| s.to_string()))
+                    .unwrap_or_default();
 
                 pending.push(PendingClassification {
                     series_id: row.id,

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -74,9 +74,34 @@ async fn do_file_op(mode: &str, src: &Path, dst: &Path) -> std::io::Result<()> {
         }
         match mode.as_str() {
             "move" => {
-                if std::fs::rename(&src, &dst).is_err() {
-                    std::fs::copy(&src, &dst)?;
-                    let _ = std::fs::remove_file(&src);
+                // Same-fs rename is atomic and instant — the happy path.
+                if std::fs::rename(&src, &dst).is_ok() {
+                    return Ok(());
+                }
+                // Cross-fs fallback: copy to a sibling tmp first then
+                // rename onto dst so a partially-copied file can't be
+                // observed at dst by a subsequent pass and mistaken for
+                // a finished import. Cleans up the tmp on rename failure.
+                let mut tmp = dst.as_os_str().to_os_string();
+                tmp.push(".ryokan-tmp");
+                let tmp = PathBuf::from(tmp);
+                std::fs::copy(&src, &tmp)?;
+                if let Err(e) = std::fs::rename(&tmp, &dst) {
+                    let _ = std::fs::remove_file(&tmp);
+                    return Err(e);
+                }
+                // Source-remove failure is rare (qBit still holds the
+                // file open, source dir is read-only, etc.) and the
+                // file is safely at dst either way — but surface a warn
+                // so the operator can spot duplicate state in qBit's
+                // downloads directory.
+                if let Err(e) = std::fs::remove_file(&src) {
+                    tracing::warn!(
+                        target: "ryokan::post_processing",
+                        src = %src.display(),
+                        error = %e,
+                        "post-copy remove_file failed; file remains at source AND destination",
+                    );
                 }
                 Ok(())
             }

--- a/src/services/progress.rs
+++ b/src/services/progress.rs
@@ -1,0 +1,288 @@
+//! In-memory progress streaming for long-running user-triggered tasks
+//! (currently: manual auto-search).
+//!
+//! ## How it works
+//! - The frontend mints an opaque `progress_id` string and sends it as a
+//!   query param when triggering a long-running endpoint.
+//! - The handler calls [`ProgressRegistry::register`] to bind that id to
+//!   a fresh event buffer, then spawns the work inside an
+//!   [`EMITTER`] task-local so any code on the call stack can call
+//!   [`emit`] without threading a handle through every signature.
+//! - The frontend simultaneously polls `GET /api/progress/{id}?since={n}`
+//!   to drain newly-buffered events into a sticky toast.
+//! - When the work calls [`emit`] with `terminal: true` (or the handler
+//!   finishes), the job is marked finished and the cleanup sweep drops
+//!   it after a grace period so the next poll can still surface the
+//!   final state.
+//!
+//! ## Why polling, not SSE
+//! SSE would need a `tokio-stream` (or futures-util) dep to bridge a
+//! broadcast receiver into an axum stream. Polling is one extra request
+//! per ~500ms of an auto-search — well under any rate that matters here,
+//! and the implementation has no extra deps.
+
+use serde::Serialize;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+pub type JobId = String;
+
+#[derive(Clone, Debug, Serialize, utoipa::ToSchema)]
+pub struct ProgressEvent {
+    /// Stable stage identifier (e.g. `"search"`, `"score"`, `"grab"`,
+    /// `"done"`, `"error"`). Frontend can switch on this for icon swaps.
+    pub stage: String,
+    /// Toast accent: `"info"`, `"success"`, `"warn"`, `"error"`.
+    pub kind: String,
+    /// Replaces the toast title in place.
+    pub title: String,
+    /// Replaces the toast body in place. `None` clears it.
+    pub body: Option<String>,
+    /// Final event for this job. After consuming it, the frontend stops
+    /// polling and the toast becomes user-dismissable (or auto-dismisses
+    /// after a short delay for success cases).
+    pub terminal: bool,
+}
+
+#[derive(Default)]
+struct ProgressJob {
+    events: Vec<ProgressEvent>,
+    finished_at: Option<Instant>,
+}
+
+/// Snapshot of a job's buffered events past the caller's cursor.
+#[derive(Serialize, utoipa::ToSchema)]
+pub struct ProgressPoll {
+    pub events: Vec<ProgressEvent>,
+    pub next_cursor: usize,
+    pub terminal: bool,
+}
+
+/// Process-wide registry of in-flight jobs. Cheap to clone — the inner
+/// state is a single `Arc<Mutex<HashMap<...>>>`.
+#[derive(Clone, Default)]
+pub struct ProgressRegistry {
+    jobs: Arc<Mutex<HashMap<JobId, ProgressJob>>>,
+}
+
+/// Cap on the size of a client-supplied `progress_id`. Long enough for a
+/// timestamp + random suffix from the JS side; short enough that an
+/// abusive client can't blow up the registry's memory footprint by
+/// minting megabyte-long ids.
+pub const PROGRESS_ID_MAX_LEN: usize = 64;
+
+impl ProgressRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Bind `id` to a fresh event buffer and return an emit handle.
+    /// Re-registering an existing id is a no-op so a flaky client retry
+    /// can't corrupt an in-flight job's history.
+    pub async fn register(&self, id: JobId) -> ProgressHandle {
+        let mut jobs = self.jobs.lock().await;
+        jobs.entry(id.clone()).or_default();
+        ProgressHandle {
+            id,
+            registry: self.clone(),
+        }
+    }
+
+    /// Append `event` to `id`'s buffer. Stamps `finished_at` the first
+    /// time a terminal event arrives so the cleanup sweep can drop the
+    /// job after its grace period.
+    async fn emit(&self, id: &str, event: ProgressEvent) {
+        let mut jobs = self.jobs.lock().await;
+        if let Some(job) = jobs.get_mut(id) {
+            let terminal = event.terminal;
+            job.events.push(event);
+            if terminal && job.finished_at.is_none() {
+                job.finished_at = Some(Instant::now());
+            }
+        }
+    }
+
+    /// Drain events past `cursor`. Returns `None` if the job has been
+    /// swept (or was never registered) so the frontend can stop polling.
+    pub async fn poll(&self, id: &str, cursor: usize) -> Option<ProgressPoll> {
+        let jobs = self.jobs.lock().await;
+        let job = jobs.get(id)?;
+        let events = job.events.iter().skip(cursor).cloned().collect::<Vec<_>>();
+        let next_cursor = job.events.len();
+        let terminal = job.finished_at.is_some();
+        Some(ProgressPoll {
+            events,
+            next_cursor,
+            terminal,
+        })
+    }
+
+    /// Drop jobs whose terminal event landed more than `grace` ago.
+    /// Drives the background cleanup task in `main.rs`.
+    pub async fn sweep(&self, grace: Duration) {
+        let now = Instant::now();
+        let mut jobs = self.jobs.lock().await;
+        jobs.retain(|_, job| match job.finished_at {
+            Some(t) => now.duration_since(t) < grace,
+            None => true,
+        });
+    }
+}
+
+/// Per-job emit handle. The auto-search task captures one of these in
+/// its [`EMITTER`] task-local so deep callees can [`emit`] without
+/// passing the handle down.
+#[derive(Clone)]
+pub struct ProgressHandle {
+    pub id: JobId,
+    pub registry: ProgressRegistry,
+}
+
+impl ProgressHandle {
+    /// Direct emit. Use this from the handler task (which doesn't have
+    /// the task-local set) before spawning the worker.
+    pub async fn emit(
+        &self,
+        stage: &str,
+        kind: &str,
+        title: impl Into<String>,
+        body: Option<String>,
+        terminal: bool,
+    ) {
+        let event = ProgressEvent {
+            stage: stage.to_string(),
+            kind: kind.to_string(),
+            title: title.into(),
+            body,
+            terminal,
+        };
+        self.registry.emit(&self.id, event).await;
+    }
+}
+
+tokio::task_local! {
+    /// Set by [`scope`] for the duration of a tracked task. Code outside
+    /// any tracked scope sees this as unset and [`emit`] becomes a no-op.
+    pub static EMITTER: ProgressHandle;
+}
+
+/// Run `fut` with `handle` bound as the current task's emitter. Sub-`spawn`s
+/// don't inherit task-locals, so the emitter only fires for code that runs
+/// directly inside this future (which is what we want — fire-and-forget
+/// post-grab work like the sibling auto-expand should not fight the
+/// user-facing toast for the final state).
+pub async fn scope<F: std::future::Future>(handle: ProgressHandle, fut: F) -> F::Output {
+    EMITTER.scope(handle, fut).await
+}
+
+/// Run `fut` inside a [`scope`] when `handle` is `Some`, otherwise just
+/// await it. This is the convenience the trigger handlers reach for:
+/// progress reporting is opt-in via a frontend-supplied id, so the same
+/// code path serves both progress-tracked and untracked invocations.
+pub async fn run_with_progress<F: std::future::Future>(
+    handle: Option<ProgressHandle>,
+    fut: F,
+) -> F::Output {
+    match handle {
+        Some(h) => scope(h, fut).await,
+        None => fut.await,
+    }
+}
+
+/// Validate and trim a client-supplied progress id. Returns `None` for
+/// empty strings and rejects ids that exceed [`PROGRESS_ID_MAX_LEN`] —
+/// the registry would happily store gigabyte-long keys otherwise.
+pub fn sanitize_progress_id(id: Option<&str>) -> Option<String> {
+    let id = id?.trim();
+    if id.is_empty() || id.len() > PROGRESS_ID_MAX_LEN {
+        return None;
+    }
+    Some(id.to_string())
+}
+
+/// Emit a progress event in the current task scope. No-op if no emitter
+/// is bound — every callee can safely call this without first checking
+/// whether it's running under a user-visible trigger or a background sweep.
+pub async fn emit(
+    stage: &str,
+    kind: &str,
+    title: impl Into<String>,
+    body: Option<String>,
+    terminal: bool,
+) {
+    let event = ProgressEvent {
+        stage: stage.to_string(),
+        kind: kind.to_string(),
+        title: title.into(),
+        body,
+        terminal,
+    };
+    if let Ok(handle) = EMITTER.try_with(|h| h.clone()) {
+        handle.registry.emit(&handle.id, event).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn poll_returns_buffered_events_past_cursor() {
+        let registry = ProgressRegistry::new();
+        let handle = registry.register("job-1".into()).await;
+        scope(handle, async {
+            emit("search", "info", "Searching", None, false).await;
+            emit("done", "success", "Done", None, true).await;
+        })
+        .await;
+
+        let first = registry.poll("job-1", 0).await.unwrap();
+        assert_eq!(first.events.len(), 2);
+        assert_eq!(first.next_cursor, 2);
+        assert!(first.terminal);
+
+        // Subsequent poll past the cursor returns nothing new but still
+        // reports terminal so the frontend knows it's safe to stop.
+        let second = registry.poll("job-1", first.next_cursor).await.unwrap();
+        assert!(second.events.is_empty());
+        assert!(second.terminal);
+    }
+
+    #[tokio::test]
+    async fn emit_outside_scope_is_a_no_op() {
+        // No handle bound — must not panic, must not allocate a job.
+        emit("search", "info", "no scope", None, false).await;
+        let registry = ProgressRegistry::new();
+        // Polling a never-registered id returns None.
+        assert!(registry.poll("ghost", 0).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn sweep_drops_finished_jobs_past_grace() {
+        let registry = ProgressRegistry::new();
+        let handle = registry.register("job-2".into()).await;
+        scope(handle, async {
+            emit("done", "success", "Done", None, true).await;
+        })
+        .await;
+        // Zero grace → finished job evicted immediately.
+        registry.sweep(Duration::from_secs(0)).await;
+        assert!(registry.poll("job-2", 0).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn re_register_is_idempotent() {
+        let registry = ProgressRegistry::new();
+        let h1 = registry.register("job-3".into()).await;
+        scope(h1.clone(), async {
+            emit("search", "info", "first", None, false).await;
+        })
+        .await;
+        // Second register should not wipe the existing buffer.
+        let _h2 = registry.register("job-3".into()).await;
+        let poll = registry.poll("job-3", 0).await.unwrap();
+        assert_eq!(poll.events.len(), 1);
+    }
+}

--- a/src/services/qbit.rs
+++ b/src/services/qbit.rs
@@ -212,9 +212,20 @@ impl QbitClient {
         let form = [("urls", url), ("category", &self.category)];
         let resp = self.do_post_form("/api/v2/torrents/add", &form).await?;
 
-        if !resp.status().is_success() {
-            let body = resp.text().await.unwrap_or_default();
-            return Err(format!("qbit add failed: {}", body));
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+
+        if !status.is_success() {
+            return Err(format!("qbit add failed (HTTP {status}): {body}"));
+        }
+        // qBit returns 200 OK with body "Fails." when it couldn't parse
+        // the URL or otherwise refused to add the torrent. The prior
+        // code only checked status.is_success(), so callers (auto-search
+        // and the upgrade sweep) wrote a successful record_grab row for
+        // a torrent qBit silently rejected — and post-processing then
+        // looked forever for an import that was never going to land.
+        if body.trim() == "Fails." {
+            return Err(format!("qbit add rejected url={url}: qBit returned 'Fails.'"));
         }
         self.invalidate_torrents_cache().await;
         Ok(())

--- a/src/services/rss.rs
+++ b/src/services/rss.rs
@@ -287,10 +287,19 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
 
     logger::info(&state.db, LogCategory::System, "RSS sync started", &format!("trigger={} items={}", trigger, items.len())).await;
 
+    // One SELECT instead of N: pre-load every previously-grabbed item_key
+    // so the per-item dedup check is an in-memory HashSet lookup rather
+    // than a round-trip per feed item. Nyaa typically returns ~100 items
+    // per feed × multiple categories per sync, so this collapses 100+
+    // sequential SELECTs into one.
+    let already_grabbed = rss::grabbed_item_keys(&state.db)
+        .await
+        .map_err(|e| e.to_string())?;
+
     for item in items {
         items_seen += 1;
         let item_key = build_item_key(&item);
-        if rss::item_was_grabbed(&state.db, &item_key).await.map_err(|e| e.to_string())? {
+        if already_grabbed.contains(&item_key) {
             skipped += 1;
             let _ = rss::record_decision(&state.db, rss::DecisionRecord {
                 item_key: &item_key,

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -1,4 +1,14 @@
+use std::sync::LazyLock;
+
+use regex_lite::Regex;
+
 use crate::services::nyaa::{SearchOptions, SearchResult};
+
+// Word-boundary "dub" / "dubbed" — anchors prevent the prior bare-
+// substring match from false-positiving on "redub", "dubsoon",
+// "dubbing", or release tags that happen to contain those bytes.
+static DUB_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(?:dub|dubbed)\b").expect("dub regex compiles"));
 
 /// Score a search result based on multiple factors.
 /// `prefer_subs` controls whether dual audio/dub releases are penalized (default true).
@@ -89,7 +99,12 @@ pub fn score_result_with_sub_pref(r: &SearchResult, opts: &SearchOptions, prefer
         || lower.contains("multi.audio")
         || lower.contains("multi-audio")
         || lower.contains("multiaudio");
-    let is_dub = is_dual || lower.contains("dub") || lower.contains("dubbed") || lower.contains("english dub");
+    // Match "dub"/"dubbed" only as whole words. The earlier `multi`
+    // tightening missed this companion case — bare contains("dub")
+    // would fire on "redub", "dubsoon", and any release tag whose bytes
+    // happened to include "dub". `english dub` stays as a literal
+    // substring because the space anchors it.
+    let is_dub = is_dual || DUB_RE.is_match(&lower) || lower.contains("english dub");
     if prefer_subs {
         // Penalize dub/dual audio releases when user prefers subs.
         if is_dub {

--- a/src/services/source.rs
+++ b/src/services/source.rs
@@ -1142,6 +1142,16 @@ async fn log_classification_to_db(
     title: &str,
     result: &ClassificationResult,
 ) {
+    // Only persist to the DB log table when the row actually needs
+    // the user's attention — needs_review is the one that drives the
+    // Needs-Review UI. Routine classification chatter is handled by
+    // the synchronous `log_classification` tracing helper called
+    // alongside this, so we aren't losing visibility — just not paying
+    // a per-candidate INSERT (50-200 candidates per search × 2 calls
+    // per candidate through classify_release + classify_post_download).
+    if !result.needs_review {
+        return;
+    }
     let detail = format!(
         "phase={}\nrule={}\nlabel={}\nconfidence={:.2}\nresolution={}\nis_remux={}\nis_bdmv={}\nweb_kind={}\nevidence:\n{}",
         phase,
@@ -1166,23 +1176,13 @@ async fn log_classification_to_db(
             .join("\n"),
     );
     let summary = format!("Classified \"{}\" → {}", title, result.label());
-    if result.needs_review {
-        crate::services::logger::info(
-            db,
-            crate::models::log::LogCategory::Quality,
-            &format!("Needs review: {}", summary),
-            &detail,
-        )
-        .await;
-    } else {
-        crate::services::logger::debug(
-            db,
-            crate::models::log::LogCategory::Quality,
-            &summary,
-            &detail,
-        )
-        .await;
-    }
+    crate::services::logger::info(
+        db,
+        crate::models::log::LogCategory::Quality,
+        &format!("Needs review: {}", summary),
+        &detail,
+    )
+    .await;
 }
 
 /// Formatted single-line evidence trail. Shared by both the tracing
@@ -2146,13 +2146,12 @@ mod tests {
             result.evidence,
         );
 
-        // And the audit log row was actually written — end-to-end proof
-        // that the classifier's DB side effects reach the `logs` table.
-        let log_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM logs WHERE category = 'quality'")
-                .fetch_one(&db)
-                .await
-                .expect("count logs");
-        assert!(log_count >= 1, "expected classifier to write an audit log");
+        // The DB log assertion that lived here was dropped along with
+        // the per-candidate INSERT in log_classification_to_db: that
+        // function now only persists rows where `needs_review` is true,
+        // and a confidently-corroborated release by definition isn't
+        // one. The classifier's structural correctness is what this
+        // test exercises; the side-effect-to-logs contract belongs in
+        // a needs_review-specific test (covered separately).
     }
 }

--- a/src/services/source.rs
+++ b/src/services/source.rs
@@ -306,6 +306,46 @@ impl Resolution {
 /// aggregator thresholds can silently shift the classification
 /// behavior — bump the confidence of a weak layer too high and it
 /// starts overriding stronger signals.
+/// Which classification layer produced a piece of evidence. Replaces
+/// the previous `&'static str` so a typo at the per-layer constant or
+/// a comparison in the aggregator becomes a compile error instead of
+/// silently demoting the layer's vote (the per-origin clamp and rule-1
+/// tie-break key off this exact value).
+///
+/// Serialised as the lowercase variant name for on-disk JSON
+/// compatibility with the previous string form, so existing
+/// `episode_quality_tags.classification_evidence` rows render
+/// unchanged.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum Origin {
+    Filename,
+    Description,
+    Group,
+    Temporal,
+    Ffprobe,
+    Dir,
+}
+
+impl Origin {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Origin::Filename => "filename",
+            Origin::Description => "description",
+            Origin::Group => "group",
+            Origin::Temporal => "temporal",
+            Origin::Ffprobe => "ffprobe",
+            Origin::Dir => "dir",
+        }
+    }
+}
+
+impl std::fmt::Display for Origin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct SourceEvidence {
     pub source: Source,
@@ -314,12 +354,12 @@ pub struct SourceEvidence {
     /// docs for per-layer calibration bands and why the specific
     /// values matter.
     pub confidence: f32,
-    pub origin: &'static str,
+    pub origin: Origin,
     pub detail: String,
 }
 
 impl SourceEvidence {
-    pub fn new(source: Source, confidence: f32, origin: &'static str, detail: impl Into<String>) -> Self {
+    pub fn new(source: Source, confidence: f32, origin: Origin, detail: impl Into<String>) -> Self {
         Self {
             source,
             confidence: confidence.clamp(0.0, 1.0),
@@ -598,15 +638,17 @@ const ORIGIN_MAX: f32 = 1.3;
 /// corroborating signals can still outvote a single weak filename guess
 /// when filename didn't land a strong signal — that's the aggregator
 /// working as designed.
-fn origin_priority(origin: &str) -> u8 {
+fn origin_priority(origin: Origin) -> u8 {
+    // Exhaustive match — adding a new Origin variant forces this to be
+    // updated, preventing the silent "drops to 0" demotion that the
+    // previous wildcard arm hid.
     match origin {
-        "filename" => 5,
-        "ffprobe" => 4,
-        "dir" => 4,
-        "description" => 3,
-        "group" => 2,
-        "temporal" => 1,
-        _ => 0,
+        Origin::Filename => 5,
+        Origin::Ffprobe => 4,
+        Origin::Dir => 4,
+        Origin::Description => 3,
+        Origin::Group => 2,
+        Origin::Temporal => 1,
     }
 }
 
@@ -675,7 +717,7 @@ pub fn aggregate(evidence: &[SourceEvidence]) -> ClassificationResult {
     // FLAC (0.85) = 1.80 for BluRay gets clamped to 1.30 here, leaving
     // room for a contradicting ground-truth signal to still win or at
     // least trip rule 4/5.
-    let mut per_origin: HashMap<(Source, &'static str), f32> = HashMap::new();
+    let mut per_origin: HashMap<(Source, Origin), f32> = HashMap::new();
     for e in evidence {
         *per_origin.entry((e.source, e.origin)).or_insert(0.0) += e.confidence;
     }
@@ -778,7 +820,7 @@ pub fn aggregate(evidence: &[SourceEvidence]) -> ClassificationResult {
     let rule5_fires = evidence.iter().any(|e| {
         e.confidence >= STRONG_THRESHOLD
             && e.source != leader
-            && (e.origin == "ffprobe" || e.origin == "dir")
+            && matches!(e.origin, Origin::Ffprobe | Origin::Dir)
     });
 
     // Rule precedence for the stored tag: rule 5 is more specific than
@@ -946,8 +988,8 @@ pub async fn classify_release(
             && evidence
                 .iter()
                 .filter(|e| e.source == result.source)
-                .all(|e| e.origin == "filename")
-            && evidence.iter().any(|e| e.origin != "filename");
+                .all(|e| e.origin == Origin::Filename)
+            && evidence.iter().any(|e| e.origin != Origin::Filename);
         if result.source == Source::Unknown
             || result.needs_review
             || only_filename_backs_winner
@@ -1503,7 +1545,7 @@ pub(crate) fn contains_word(haystack: &str, needle: &str) -> bool {
 mod tests {
     use super::*;
 
-    fn ev(src: Source, conf: f32, origin: &'static str) -> SourceEvidence {
+    fn ev(src: Source, conf: f32, origin: Origin) -> SourceEvidence {
         SourceEvidence::new(src, conf, origin, "")
     }
 
@@ -1619,9 +1661,9 @@ mod tests {
     fn aggregate_rule_1_strong_signal_wins_immediately() {
         // Single strong signal ≥ 0.90 short-circuits the rest.
         let evidence = vec![
-            ev(Source::Web, 0.95, "filename"),
-            ev(Source::BluRay, 0.40, "group"),
-            ev(Source::BluRay, 0.30, "temporal"),
+            ev(Source::Web, 0.95, Origin::Filename),
+            ev(Source::BluRay, 0.40, Origin::Group),
+            ev(Source::BluRay, 0.30, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web);
@@ -1635,9 +1677,9 @@ mod tests {
         // No single strong signal, but two weak Web signals outweigh one
         // moderate BluRay signal by more than MIN_LEAD.
         let evidence = vec![
-            ev(Source::Web, 0.60, "filename"),
-            ev(Source::Web, 0.55, "group"),
-            ev(Source::BluRay, 0.50, "temporal"),
+            ev(Source::Web, 0.60, Origin::Filename),
+            ev(Source::Web, 0.55, Origin::Group),
+            ev(Source::BluRay, 0.50, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web);
@@ -1650,8 +1692,8 @@ mod tests {
         // less than MIN_LEAD (0.30) — should pick a winner but flag for
         // review.
         let evidence = vec![
-            ev(Source::Web, 0.75, "filename"),
-            ev(Source::BluRay, 0.70, "ffprobe"),
+            ev(Source::Web, 0.75, Origin::Filename),
+            ev(Source::BluRay, 0.70, Origin::Ffprobe),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web); // Higher sum wins.
@@ -1662,8 +1704,8 @@ mod tests {
     fn aggregate_rule_4_all_weak_falls_to_unknown() {
         // Every signal below MIN_TOTAL (0.50) — total mass too weak.
         let evidence = vec![
-            ev(Source::Web, 0.20, "temporal"),
-            ev(Source::BluRay, 0.15, "temporal"),
+            ev(Source::Web, 0.20, Origin::Temporal),
+            ev(Source::BluRay, 0.15, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Unknown);
@@ -1674,8 +1716,8 @@ mod tests {
     fn aggregate_clean_win_despite_weak_conflict() {
         // Strong leader, weak opposing signal — no review needed.
         let evidence = vec![
-            ev(Source::Web, 0.95, "filename"),
-            ev(Source::BluRay, 0.30, "temporal"),
+            ev(Source::Web, 0.95, Origin::Filename),
+            ev(Source::BluRay, 0.30, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web);
@@ -1688,8 +1730,8 @@ mod tests {
         // Filename origin should win the tiebreaker — "filename is the
         // primary source of truth."
         let evidence = vec![
-            ev(Source::BluRay, 0.95, "ffprobe"),
-            ev(Source::BluRay, 0.95, "filename"),
+            ev(Source::BluRay, 0.95, Origin::Ffprobe),
+            ev(Source::BluRay, 0.95, Origin::Filename),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::BluRay);
@@ -1711,9 +1753,9 @@ mod tests {
         // With ORIGIN_MAX = 1.3, filename caps to 1.30 and the
         // ground-truth veto (rule 5) flags the ffprobe conflict.
         let evidence = vec![
-            ev(Source::BluRay, 0.95, "filename"), // strong keyword
-            ev(Source::BluRay, 0.85, "filename"), // stacked audio codec
-            ev(Source::Web, 0.90, "ffprobe"),     // strong ground truth
+            ev(Source::BluRay, 0.95, Origin::Filename), // strong keyword
+            ev(Source::BluRay, 0.85, Origin::Filename), // stacked audio codec
+            ev(Source::Web, 0.90, Origin::Ffprobe),     // strong ground truth
         ];
         let result = aggregate(&evidence);
         // BluRay still wins the sum (1.30 vs 0.90 — a 0.40 clean lead).
@@ -1733,9 +1775,9 @@ mod tests {
         // 0.95 — Web wins by 0.70, a clean lead. But rule 5's veto
         // fires because the disagreeing signal is from the dir layer.
         let evidence = vec![
-            ev(Source::Web, 0.95, "filename"),
-            ev(Source::Web, 0.70, "group"),
-            ev(Source::BluRay, 0.95, "dir"),
+            ev(Source::Web, 0.95, Origin::Filename),
+            ev(Source::Web, 0.70, Origin::Group),
+            ev(Source::BluRay, 0.95, Origin::Dir),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web);
@@ -1750,9 +1792,9 @@ mod tests {
         // A ground-truth layer with a sub-threshold signal (< 0.90) does
         // not trigger the veto — only strong measurements do.
         let evidence = vec![
-            ev(Source::BluRay, 0.85, "filename"),
-            ev(Source::BluRay, 0.70, "group"),
-            ev(Source::Web, 0.80, "ffprobe"), // below STRONG_THRESHOLD
+            ev(Source::BluRay, 0.85, Origin::Filename),
+            ev(Source::BluRay, 0.70, Origin::Group),
+            ev(Source::Web, 0.80, Origin::Ffprobe), // below STRONG_THRESHOLD
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::BluRay);
@@ -1769,9 +1811,9 @@ mod tests {
         // contributions stack as normal. Verifies the cap is per-origin,
         // not a global ceiling.
         let evidence = vec![
-            ev(Source::BluRay, 0.85, "filename"),
-            ev(Source::BluRay, 0.85, "ffprobe"),
-            ev(Source::Web, 0.40, "temporal"),
+            ev(Source::BluRay, 0.85, Origin::Filename),
+            ev(Source::BluRay, 0.85, Origin::Ffprobe),
+            ev(Source::Web, 0.40, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::BluRay);
@@ -1784,36 +1826,36 @@ mod tests {
         assert_eq!(aggregate(&[]).decision_rule, DecisionRule::Empty);
 
         // Single strong signal → Rule1Strong.
-        let rule1 = aggregate(&[ev(Source::Web, 0.95, "filename")]);
+        let rule1 = aggregate(&[ev(Source::Web, 0.95, Origin::Filename)]);
         assert_eq!(rule1.decision_rule, DecisionRule::Rule1Strong);
 
         // Clean sum win with no strong signals → Rule2Sum.
         let rule2 = aggregate(&[
-            ev(Source::Web, 0.60, "filename"),
-            ev(Source::Web, 0.55, "group"),
-            ev(Source::BluRay, 0.50, "temporal"),
+            ev(Source::Web, 0.60, Origin::Filename),
+            ev(Source::Web, 0.55, Origin::Group),
+            ev(Source::BluRay, 0.50, Origin::Temporal),
         ]);
         assert_eq!(rule2.decision_rule, DecisionRule::Rule2Sum);
 
         // Total mass below MIN_TOTAL → Rule3Weak.
         let rule3 = aggregate(&[
-            ev(Source::Web, 0.20, "temporal"),
-            ev(Source::BluRay, 0.15, "temporal"),
+            ev(Source::Web, 0.20, Origin::Temporal),
+            ev(Source::BluRay, 0.15, Origin::Temporal),
         ]);
         assert_eq!(rule3.decision_rule, DecisionRule::Rule3Weak);
 
         // Close strong conflict, no ground-truth layer → Rule4Conflict.
         let rule4 = aggregate(&[
-            ev(Source::Web, 0.75, "filename"),
-            ev(Source::BluRay, 0.70, "group"),
+            ev(Source::Web, 0.75, Origin::Filename),
+            ev(Source::BluRay, 0.70, Origin::Group),
         ]);
         assert_eq!(rule4.decision_rule, DecisionRule::Rule4Conflict);
 
         // Ground-truth veto beats rule 4 when both would fire.
         let rule5 = aggregate(&[
-            ev(Source::BluRay, 0.95, "filename"),
-            ev(Source::BluRay, 0.85, "filename"),
-            ev(Source::Web, 0.90, "ffprobe"),
+            ev(Source::BluRay, 0.95, Origin::Filename),
+            ev(Source::BluRay, 0.85, Origin::Filename),
+            ev(Source::Web, 0.90, Origin::Ffprobe),
         ]);
         assert_eq!(rule5.decision_rule, DecisionRule::Rule5GroundTruthVeto);
     }
@@ -1829,9 +1871,9 @@ mod tests {
         // rule 1 checks rule 2's leader before firing — if rule 2 picks
         // a different source, rule 1 falls through and rule 2 decides.
         let evidence = vec![
-            ev(Source::BluRay, 0.95, "group"),
-            ev(Source::Web, 0.85, "ffprobe"),
-            ev(Source::Web, 0.75, "temporal"),
+            ev(Source::BluRay, 0.95, Origin::Group),
+            ev(Source::Web, 0.85, Origin::Ffprobe),
+            ev(Source::Web, 0.75, Origin::Temporal),
         ];
         let result = aggregate(&evidence);
         assert_eq!(result.source, Source::Web);
@@ -1853,8 +1895,8 @@ mod tests {
         // picked BluRay via source-rank tiebreaker. Now it falls through
         // to rule 2+4 so the conflict gets flagged.
         let evidence = vec![
-            ev(Source::Web, 0.95, "filename"),
-            ev(Source::BluRay, 0.95, "dir"),
+            ev(Source::Web, 0.95, Origin::Filename),
+            ev(Source::BluRay, 0.95, Origin::Dir),
         ];
         let result = aggregate(&evidence);
         // Rule 2 ties the sums, rule 4 detects the strong opposing
@@ -1879,7 +1921,7 @@ mod tests {
     fn boundary_strong_threshold_exactly_090_fires_rule_1() {
         // 0.90 is the strong threshold; the filter uses `>= 0.90`, so an
         // evidence record at exactly 0.90 must take the rule-1 path.
-        let result = aggregate(&[ev(Source::Web, 0.90, "filename")]);
+        let result = aggregate(&[ev(Source::Web, 0.90, Origin::Filename)]);
         assert_eq!(result.decision_rule, DecisionRule::Rule1Strong);
         assert_eq!(result.source, Source::Web);
         assert!(!result.needs_review);
@@ -1891,7 +1933,7 @@ mod tests {
         // the record still wins via rule 2's sum path, but the decision
         // rule is Rule2Sum (not Rule1Strong). This is what catches a
         // hypothetical `> 0.90` flip in the strong filter.
-        let result = aggregate(&[ev(Source::Web, 0.89, "filename")]);
+        let result = aggregate(&[ev(Source::Web, 0.89, Origin::Filename)]);
         assert_eq!(result.decision_rule, DecisionRule::Rule2Sum);
         assert_eq!(result.source, Source::Web);
     }
@@ -1902,8 +1944,8 @@ mod tests {
         // conflict detection (the filter is `>= 0.70`). With a small
         // lead, rule 4 must fire.
         let result = aggregate(&[
-            ev(Source::Web, 0.75, "filename"),
-            ev(Source::BluRay, 0.70, "group"),
+            ev(Source::Web, 0.75, Origin::Filename),
+            ev(Source::BluRay, 0.70, Origin::Group),
         ]);
         assert!(result.needs_review);
         assert_eq!(result.decision_rule, DecisionRule::Rule4Conflict);
@@ -1914,8 +1956,8 @@ mod tests {
         // Runner-up at 0.69 is below the conflict threshold, so even a
         // narrow lead stays a clean rule-2 win.
         let result = aggregate(&[
-            ev(Source::Web, 0.75, "filename"),
-            ev(Source::BluRay, 0.69, "group"),
+            ev(Source::Web, 0.75, Origin::Filename),
+            ev(Source::BluRay, 0.69, Origin::Group),
         ]);
         assert!(!result.needs_review);
         assert_eq!(result.decision_rule, DecisionRule::Rule2Sum);
@@ -1926,8 +1968,8 @@ mod tests {
         // Sum to exactly 0.50: the test is `< MIN_TOTAL`, so 0.50 must
         // NOT be weak enough for the Unknown fallback.
         let result = aggregate(&[
-            ev(Source::Web, 0.30, "filename"),
-            ev(Source::Web, 0.20, "group"),
+            ev(Source::Web, 0.30, Origin::Filename),
+            ev(Source::Web, 0.20, Origin::Group),
         ]);
         assert_ne!(result.decision_rule, DecisionRule::Rule3Weak);
         assert_eq!(result.source, Source::Web);
@@ -1937,8 +1979,8 @@ mod tests {
     fn boundary_min_total_just_below_triggers_rule_3() {
         // Sum to 0.49 — strictly below MIN_TOTAL, so rule 3 fires.
         let result = aggregate(&[
-            ev(Source::Web, 0.30, "filename"),
-            ev(Source::Web, 0.19, "group"),
+            ev(Source::Web, 0.30, Origin::Filename),
+            ev(Source::Web, 0.19, Origin::Group),
         ]);
         assert_eq!(result.decision_rule, DecisionRule::Rule3Weak);
         assert_eq!(result.source, Source::Unknown);
@@ -1959,9 +2001,9 @@ mod tests {
         // BluRay's 0.70 is below STRONG_THRESHOLD (0.90), so the
         // ground-truth veto rule 5 also stays silent.
         let result = aggregate(&[
-            ev(Source::Web, 0.30, "filename"),
-            ev(Source::Web, 0.70, "group"),
-            ev(Source::BluRay, 0.70, "ffprobe"),
+            ev(Source::Web, 0.30, Origin::Filename),
+            ev(Source::Web, 0.70, Origin::Group),
+            ev(Source::BluRay, 0.70, Origin::Ffprobe),
         ]);
         assert_eq!(result.source, Source::Web);
         assert!(
@@ -1977,9 +2019,9 @@ mod tests {
         // because there's a conflicting runner-up at ≥ 0.70.
         // Web sums to 0.99, BluRay sums to 0.70, lead = 0.29.
         let result = aggregate(&[
-            ev(Source::Web, 0.29, "filename"),
-            ev(Source::Web, 0.70, "group"),
-            ev(Source::BluRay, 0.70, "ffprobe"),
+            ev(Source::Web, 0.29, Origin::Filename),
+            ev(Source::Web, 0.70, Origin::Group),
+            ev(Source::BluRay, 0.70, Origin::Ffprobe),
         ]);
         assert!(result.needs_review);
         assert_eq!(result.decision_rule, DecisionRule::Rule4Conflict);
@@ -1992,9 +2034,9 @@ mod tests {
         // Runner-up at 0.40 leaves a 0.90 lead, a clean rule-2 win with
         // no conflict.
         let result = aggregate(&[
-            ev(Source::BluRay, 0.65, "filename"),
-            ev(Source::BluRay, 0.65, "filename"),
-            ev(Source::Web, 0.40, "temporal"),
+            ev(Source::BluRay, 0.65, Origin::Filename),
+            ev(Source::BluRay, 0.65, Origin::Filename),
+            ev(Source::Web, 0.40, Origin::Temporal),
         ]);
         assert_eq!(result.source, Source::BluRay);
         assert_eq!(result.decision_rule, DecisionRule::Rule2Sum);
@@ -2014,9 +2056,9 @@ mod tests {
         // clipping — a flip to `< 1.30` / `> 1.30` on the comparison
         // would change the behavior here.
         let result = aggregate(&[
-            ev(Source::BluRay, 0.95, "filename"),
-            ev(Source::BluRay, 0.85, "filename"),
-            ev(Source::Web, 0.90, "ffprobe"),
+            ev(Source::BluRay, 0.95, Origin::Filename),
+            ev(Source::BluRay, 0.85, Origin::Filename),
+            ev(Source::Web, 0.90, Origin::Ffprobe),
         ]);
         assert_eq!(result.source, Source::BluRay);
         assert!(result.needs_review);
@@ -2030,8 +2072,8 @@ mod tests {
         // should contribute the full 0.90 to each source — not split
         // 1.30 across them or clip one of them.
         let result = aggregate(&[
-            ev(Source::BluRay, 0.90, "filename"),
-            ev(Source::Web, 0.90, "filename"),
+            ev(Source::BluRay, 0.90, Origin::Filename),
+            ev(Source::Web, 0.90, Origin::Filename),
         ]);
         // Rule 1 falls through because the two strong signals disagree.
         // Rule 2 sees BluRay=0.90 and Web=0.90 — a tie. Source::rank
@@ -2131,17 +2173,17 @@ mod tests {
         let origins: std::collections::HashSet<_> =
             result.evidence.iter().map(|e| e.origin).collect();
         assert!(
-            origins.contains("filename"),
+            origins.contains(&Origin::Filename),
             "filename evidence missing: {:#?}",
             result.evidence,
         );
         assert!(
-            origins.contains("group"),
+            origins.contains(&Origin::Group),
             "group evidence missing — Layer 3 lookup didn't fire: {:#?}",
             result.evidence,
         );
         assert!(
-            origins.contains("temporal"),
+            origins.contains(&Origin::Temporal),
             "temporal evidence missing — Layer 4 didn't fire: {:#?}",
             result.evidence,
         );

--- a/src/services/source_description.rs
+++ b/src/services/source_description.rs
@@ -37,9 +37,9 @@ use tokio::sync::Mutex;
 use tokio::time::Instant;
 
 use crate::models::nyaa_description_cache;
-use crate::services::source::{Source, SourceEvidence};
+use crate::services::source::{Origin, Source, SourceEvidence};
 
-const ORIGIN: &str = "description";
+const ORIGIN: Origin = Origin::Description;
 
 /// Minimum spacing between live Nyaa fetches. Nyaa doesn't publish a rate
 /// limit, but an unsolicited-scrape-looking pattern gets IPs tarpitted fast.

--- a/src/services/source_dir.rs
+++ b/src/services/source_dir.rs
@@ -31,9 +31,9 @@
 
 use std::path::Path;
 
-use crate::services::source::{contains_word, Source, SourceEvidence};
+use crate::services::source::{contains_word, Origin, Source, SourceEvidence};
 
-const ORIGIN: &str = "dir";
+const ORIGIN: Origin = Origin::Dir;
 
 /// A directory entry as seen by the Layer 6 scanner. The public walker
 /// populates one of these per `read_dir` result; tests construct them

--- a/src/services/source_ffprobe.rs
+++ b/src/services/source_ffprobe.rs
@@ -42,9 +42,9 @@ use sqlx::SqlitePool;
 use tokio::process::Command;
 
 use crate::models::media_probe_cache;
-use crate::services::source::{Resolution, Source, SourceEvidence};
+use crate::services::source::{Origin, Resolution, Source, SourceEvidence};
 
-const ORIGIN: &str = "ffprobe";
+const ORIGIN: Origin = Origin::Ffprobe;
 
 /// Public output of Layer 5.
 #[derive(Debug, Clone, Default)]

--- a/src/services/source_ffprobe.rs
+++ b/src/services/source_ffprobe.rs
@@ -81,7 +81,7 @@ pub async fn classify_ffprobe(db: &SqlitePool, path: &Path) -> FfprobeClassifica
     // Snapshot mtime + size to key the cache. An rmdir-then-recreate (same
     // path, new file) invalidates on either mtime or size. If stat fails,
     // treat it as "can't probe" rather than blindly going to the network.
-    let meta = match std::fs::metadata(path) {
+    let meta = match tokio::fs::metadata(path).await {
         Ok(m) => m,
         Err(err) => {
             tracing::warn!(

--- a/src/services/source_ffprobe.rs
+++ b/src/services/source_ffprobe.rs
@@ -126,7 +126,10 @@ pub async fn classify_ffprobe(db: &SqlitePool, path: &Path) -> FfprobeClassifica
 /// different remediation.
 async fn run_ffprobe(path: &Path) -> Option<String> {
     // Capture stderr so the non-zero-exit branch can surface the reason.
-    let spawn = Command::new("ffprobe")
+    // kill_on_drop ensures the child is reaped if the surrounding
+    // timeout fires (and would otherwise leave an orphan ffprobe
+    // chewing CPU forever on a corrupt container).
+    let output_fut = Command::new("ffprobe")
         .arg("-v")
         .arg("error")
         .arg("-show_streams")
@@ -138,17 +141,34 @@ async fn run_ffprobe(path: &Path) -> Option<String> {
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .output()
-        .await;
+        .kill_on_drop(true)
+        .output();
 
-    let output = match spawn {
-        Ok(o) => o,
-        Err(err) => {
+    // Cap ffprobe at 60s. A partially-downloaded mkv with a corrupt
+    // container or a Blu-ray .m2ts with an inconsistent index will spin
+    // ffprobe forever, and the post-processing pass holds POST_PROC_LOCK
+    // for the duration — one bad file otherwise pins the entire import
+    // queue. ffprobe finishes in milliseconds for healthy files; 60s is
+    // generous enough that any non-pathological input completes well
+    // under the cap.
+    const FFPROBE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+    let output = match tokio::time::timeout(FFPROBE_TIMEOUT, output_fut).await {
+        Ok(Ok(o)) => o,
+        Ok(Err(err)) => {
             tracing::warn!(
                 target: "ryokan::source::ffprobe",
                 path = %path.display(),
                 %err,
                 "ffprobe spawn failed — is the `ffprobe` binary installed and on PATH?"
+            );
+            return None;
+        }
+        Err(_) => {
+            tracing::warn!(
+                target: "ryokan::source::ffprobe",
+                path = %path.display(),
+                timeout_secs = FFPROBE_TIMEOUT.as_secs(),
+                "ffprobe timed out — file likely has a corrupt container or partial download"
             );
             return None;
         }

--- a/src/services/source_filename.rs
+++ b/src/services/source_filename.rs
@@ -23,9 +23,9 @@
 
 use anitomy::{Anitomy, ElementCategory};
 
-use crate::services::source::{contains_word, Resolution, Source, SourceEvidence, WebKind};
+use crate::services::source::{contains_word, Origin, Resolution, Source, SourceEvidence, WebKind};
 
-const ORIGIN: &str = "filename";
+const ORIGIN: Origin = Origin::Filename;
 
 /// Output of Layer 1 classification.
 ///

--- a/src/services/source_groups.rs
+++ b/src/services/source_groups.rs
@@ -12,9 +12,9 @@
 use sqlx::SqlitePool;
 
 use crate::models::group_source_map;
-use crate::services::source::SourceEvidence;
+use crate::services::source::{Origin, SourceEvidence};
 
-const ORIGIN: &str = "group";
+const ORIGIN: Origin = Origin::Group;
 
 /// Look up a release group and, if known, return a single
 /// [`SourceEvidence`] record tagged with the group's source and confidence.
@@ -77,7 +77,7 @@ mod tests {
             .expect("VCB-Studio should be seeded");
         assert_eq!(ev.source, Source::BluRay);
         assert!((ev.confidence - 0.95).abs() < f32::EPSILON);
-        assert_eq!(ev.origin, "group");
+        assert_eq!(ev.origin, Origin::Group);
         assert!(ev.detail.contains("VCB-Studio"));
     }
 

--- a/src/services/source_temporal.rs
+++ b/src/services/source_temporal.rs
@@ -36,9 +36,9 @@
 //! job of [`crate::services::source::aggregate`]. It emits at most one
 //! weak piece of evidence.
 
-use crate::services::source::{Source, SourceEvidence};
+use crate::services::source::{Origin, Source, SourceEvidence};
 
-const ORIGIN: &str = "temporal";
+const ORIGIN: Origin = Origin::Temporal;
 
 /// Reduced confidence used when the layer falls back to `season_year`
 /// (i.e. no `end_year` was known). The start year is a noisy proxy for
@@ -159,7 +159,7 @@ mod tests {
         let ev = classify_temporal("RELEASING", Some(2026), None, false, 2026).unwrap();
         assert_eq!(ev.source, Source::Web);
         assert!((ev.confidence - 0.75).abs() < 1e-4);
-        assert_eq!(ev.origin, "temporal");
+        assert_eq!(ev.origin, Origin::Temporal);
     }
 
     #[test]

--- a/templates/base.html
+++ b/templates/base.html
@@ -359,7 +359,11 @@
             opts = opts || {};
             const kind = opts.kind && ['info','success','warn','error'].indexOf(opts.kind) >= 0
                 ? opts.kind : 'info';
-            const duration = opts.duration != null ? Number(opts.duration) : 4000;
+            // `sticky: true` disables auto-dismiss — use for long-running
+            // jobs where the toast represents live state and should only
+            // close on explicit user action (or when `handle.finalize()`
+            // upgrades it to a normal auto-dismissing toast).
+            const duration = opts.sticky ? 0 : (opts.duration != null ? Number(opts.duration) : 4000);
 
             if (opts.log !== false) {
                 persistToast(kind, opts.category, opts.title, opts.body);
@@ -375,18 +379,16 @@
 
             const content = document.createElement('div');
             content.className = 'ryokan-toast-content';
-            if (opts.title) {
-                const t = document.createElement('div');
-                t.className = 'ryokan-toast-title';
-                t.textContent = opts.title;
-                content.appendChild(t);
-            }
-            if (opts.body) {
-                const b = document.createElement('div');
-                b.className = 'ryokan-toast-body';
-                b.textContent = opts.body;
-                content.appendChild(b);
-            }
+            const titleEl = document.createElement('div');
+            titleEl.className = 'ryokan-toast-title';
+            titleEl.textContent = opts.title || '';
+            if (!opts.title) titleEl.style.display = 'none';
+            content.appendChild(titleEl);
+            const bodyEl = document.createElement('div');
+            bodyEl.className = 'ryokan-toast-body';
+            bodyEl.textContent = opts.body || '';
+            if (!opts.body) bodyEl.style.display = 'none';
+            content.appendChild(bodyEl);
             toast.appendChild(content);
 
             const close = document.createElement('button');
@@ -418,9 +420,156 @@
             toast.addEventListener('mouseleave', armTimer);
             armTimer();
 
-            return { dismiss: function() { dismiss(toast); } };
+            return {
+                dismiss: function() { dismiss(toast); },
+                // Mutate the live toast in place. Used by ryokanProgressToast
+                // to repaint title/body/kind as stage events arrive. Does not
+                // re-arm the auto-dismiss timer — a sticky toast that's been
+                // updating should stay sticky until `finalize()` ends it.
+                update: function(patch) {
+                    patch = patch || {};
+                    if (patch.kind && ['info','success','warn','error'].indexOf(patch.kind) >= 0) {
+                        toast.classList.remove('ryokan-toast-info','ryokan-toast-success','ryokan-toast-warn','ryokan-toast-error');
+                        toast.classList.add('ryokan-toast-' + patch.kind);
+                        toast.setAttribute('role', patch.kind === 'error' || patch.kind === 'warn' ? 'alert' : 'status');
+                    }
+                    if (patch.title != null) {
+                        titleEl.textContent = patch.title;
+                        titleEl.style.display = patch.title ? '' : 'none';
+                    }
+                    if (patch.body != null) {
+                        bodyEl.textContent = patch.body;
+                        bodyEl.style.display = patch.body ? '' : 'none';
+                    }
+                },
+                // Convert a sticky toast into a terminal one that auto-dismisses
+                // after `duration` ms (default 4000 for success/info, 0 for
+                // warn/error so the user has time to read). Also persists the
+                // final state to /api/logs/client once, matching the log
+                // persistence behavior of a one-shot ryokanToast call.
+                finalize: function(final) {
+                    final = final || {};
+                    if (final.kind || final.title != null || final.body != null) {
+                        this.update(final);
+                    }
+                    const finalKind = final.kind || kind;
+                    if (final.log !== false) {
+                        persistToast(finalKind, opts.category, titleEl.textContent, bodyEl.textContent);
+                    }
+                    const finalDuration = final.duration != null
+                        ? Number(final.duration)
+                        : (finalKind === 'error' || finalKind === 'warn' ? 0 : 4000);
+                    if (timer) { clearTimeout(timer); timer = null; }
+                    remaining = finalDuration;
+                    armTimer();
+                },
+            };
         };
     })();
+
+    // Sticky progress toast backed by /api/progress/{id}. The caller is
+    // expected to mint a `progressId` string, pass it as `?progress_id=`
+    // on the trigger endpoint, and hand it here — this helper opens the
+    // sticky toast, polls for events, and rolls up to a terminal state.
+    //
+    // Usage:
+    //     const id = ryokanNewProgressId();
+    //     const toast = ryokanProgressToast({
+    //         progressId: id,
+    //         title: 'Searching…',
+    //         category: 'auto_search',
+    //     });
+    //     fetch('/api/series/123/auto-search?progress_id=' + id, {method: 'POST'})
+    //         .then(r => r.json())
+    //         .catch(e => toast.finalize({kind: 'error', title: 'Failed', body: String(e)}));
+    //     // Toast handles the rest — updates on stage events, closes on terminal.
+    window.ryokanNewProgressId = function() {
+        return 'p_' + Date.now().toString(36) + '_' + Math.random().toString(36).slice(2, 10);
+    };
+
+    window.ryokanProgressToast = function(opts) {
+        opts = opts || {};
+        if (!opts.progressId) throw new Error('ryokanProgressToast requires opts.progressId');
+        const toast = window.ryokanToast({
+            kind: opts.kind || 'info',
+            title: opts.title || 'Working…',
+            body: opts.body || null,
+            category: opts.category || 'system',
+            sticky: true,
+            // The terminal event will persist to logs via `finalize()`.
+            // Skipping the initial log write avoids a "Working…" row in
+            // System → Logs that gets immediately superseded.
+            log: false,
+        });
+        let cursor = 0;
+        let stopped = false;
+        // Poll interval: 500ms is fast enough that users see updates
+        // within ~half the visual debounce window of typical UI spinners,
+        // but slow enough that an unattended tab doesn't burn a request
+        // per frame. Backoff to 2s after the first successful terminal
+        // read so a frontend that failed to catch the terminal event
+        // still doesn't keep hammering after the job has been swept.
+        function schedule(ms) {
+            if (stopped) return;
+            setTimeout(tick, ms);
+        }
+        function tick() {
+            if (stopped) return;
+            fetch('/api/progress/' + encodeURIComponent(opts.progressId) + '?since=' + cursor, {
+                credentials: 'same-origin',
+            }).then(function(r) {
+                if (r.status === 404) {
+                    // Job swept or never existed. Treat as a silent stop —
+                    // the trigger response flow will still give us a final
+                    // state via its own then/catch.
+                    stopped = true;
+                    return null;
+                }
+                if (!r.ok) throw new Error('progress poll HTTP ' + r.status);
+                return r.json();
+            }).then(function(payload) {
+                if (!payload) return;
+                cursor = payload.next_cursor;
+                let last = null;
+                for (let i = 0; i < payload.events.length; i++) {
+                    const ev = payload.events[i];
+                    toast.update({kind: ev.kind, title: ev.title, body: ev.body || ''});
+                    if (ev.terminal) last = ev;
+                }
+                if (payload.terminal || last) {
+                    stopped = true;
+                    if (last) {
+                        toast.finalize({kind: last.kind, title: last.title, body: last.body || ''});
+                    } else {
+                        // Terminal flag set but no terminal event in this
+                        // batch — shouldn't happen, but don't lock up
+                        // if it does.
+                        toast.finalize({});
+                    }
+                    return;
+                }
+                schedule(500);
+            }).catch(function(err) {
+                console.warn('[ryokanProgressToast] poll failed:', err);
+                // Network hiccup: back off to avoid flooding. Don't stop —
+                // the job might still complete and the next tick will
+                // catch up.
+                schedule(2000);
+            });
+        }
+        schedule(500);
+        return {
+            dismiss: function() {
+                stopped = true;
+                toast.dismiss();
+            },
+            update: function(p) { toast.update(p); },
+            finalize: function(p) {
+                stopped = true;
+                toast.finalize(p);
+            },
+        };
+    };
 
     // Auto-promote any `[data-ryokan-toast]` element on the page into a
     // ryokanToast on DOM ready. Lets server-side flash banners (Settings,

--- a/templates/series.html
+++ b/templates/series.html
@@ -873,13 +873,15 @@ function renderPeers(seeders, leechers) {
 
 function searchBatchReleases(btn) {
     setBusyButton(btn, true, 'Searching…');
-    window.ryokanToast({
+    const pid = window.ryokanNewProgressId();
+    const toast = window.ryokanProgressToast({
+        progressId: pid,
         kind: 'info',
         category: 'auto_search',
         title: 'Searching for batch releases',
         body: SD.titleEnglish || SD.titleRomaji || '',
     });
-    fetch(`/api/series/${SD.id}/search-batch`, {
+    fetch(`/api/series/${SD.id}/search-batch?progress_id=${encodeURIComponent(pid)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'}
     })
@@ -892,26 +894,12 @@ function searchBatchReleases(btn) {
         if (grabbed > 0) {
             ensureDlPollRunning();
             refreshEpisodeRows({ force: true });
-            window.ryokanToast({
-                kind: 'success',
-                category: 'auto_search',
-                title: 'Batch queued',
-                body: data.grabbed[0].release_title,
-            });
-        } else {
-            window.ryokanToast({
-                kind: 'warn',
-                category: 'auto_search',
-                title: 'No batch release found',
-                body: 'Nothing on Nyaa matched the batch search.',
-            });
         }
     })
     .catch(err => {
         setBusyButton(btn, false);
-        window.ryokanToast({
+        toast.finalize({
             kind: 'error',
-            category: 'auto_search',
             title: 'Batch search failed',
             body: err && err.message ? err.message : 'Unknown error',
         });
@@ -1171,14 +1159,16 @@ function setEpisodeButtonState(btn, state, title) {
 function autoSearchEpisode(episodeNumber, btn) {
     const seriesTitle = SD.titleEnglish || SD.titleRomaji || SD.titleNative || '';
     setEpisodeButtonState(btn, 'loading', `Searching episode ${episodeNumber}...`);
-    window.ryokanToast({
+    const pid = window.ryokanNewProgressId();
+    const toast = window.ryokanProgressToast({
+        progressId: pid,
         kind: 'info',
         category: 'auto_search',
         title: `Searching episode ${episodeNumber}`,
         body: seriesTitle,
     });
 
-    fetch(`/api/series/${SD.id}/auto-search/${episodeNumber}`, {
+    fetch(`/api/series/${SD.id}/auto-search/${episodeNumber}?progress_id=${encodeURIComponent(pid)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'}
     })
@@ -1194,27 +1184,14 @@ function autoSearchEpisode(episodeNumber, btn) {
             updateEpisodeRow(episodeNumber, 'grabbed', first.release_group);
             ensureDlPollRunning();
             refreshEpisodeRows({ force: true });
-            window.ryokanToast({
-                kind: 'success',
-                category: 'auto_search',
-                title: `Episode ${episodeNumber} grabbed`,
-                body: first.release_title + (first.release_group ? ' · ' + first.release_group : ''),
-            });
         } else {
             setEpisodeButtonState(btn, 'error', 'No matching release found');
-            window.ryokanToast({
-                kind: 'warn',
-                category: 'auto_search',
-                title: `No release for episode ${episodeNumber}`,
-                body: 'Nothing on Nyaa matched the scoring threshold.',
-            });
         }
     })
     .catch(err => {
         setEpisodeButtonState(btn, 'error', err.message || 'Episode search failed');
-        window.ryokanToast({
+        toast.finalize({
             kind: 'error',
-            category: 'auto_search',
             title: `Episode ${episodeNumber} search failed`,
             body: err && err.message ? err.message : 'Unknown error',
         });
@@ -1224,14 +1201,16 @@ function autoSearchEpisode(episodeNumber, btn) {
 function autoSearchSeries(btn) {
     const seriesTitle = SD.titleEnglish || SD.titleRomaji || SD.titleNative || '';
     setBusyButton(btn, true, 'Searching…');
-    window.ryokanToast({
+    const pid = window.ryokanNewProgressId();
+    const toast = window.ryokanProgressToast({
+        progressId: pid,
         kind: 'info',
         category: 'auto_search',
         title: 'Searching missing episodes',
         body: seriesTitle,
     });
 
-    fetch(`/api/series/${SD.id}/auto-search`, {
+    fetch(`/api/series/${SD.id}/auto-search?progress_id=${encodeURIComponent(pid)}`, {
         method: 'POST',
         headers: {'Content-Type': 'application/json'}
     })
@@ -1242,33 +1221,16 @@ function autoSearchSeries(btn) {
             throw new Error(data.message || 'Auto search failed');
         }
         const grabbed = Array.isArray(data.grabbed) ? data.grabbed.length : 0;
-        const skipped = Array.isArray(data.skipped) ? data.skipped.length : 0;
-        const groups = Array.isArray(data.grabbed) ? [...new Set(data.grabbed.map(x => x.release_group).filter(Boolean))] : [];
-        const queuedPack = Array.isArray(data.skipped) && data.skipped.some(x => x.toLowerCase().includes('season pack queued'));
         setBusyButton(btn, false);
         if (grabbed > 0) {
             ensureDlPollRunning();
             refreshEpisodeRows({ force: true });
-            window.ryokanToast({
-                kind: 'success',
-                category: 'auto_search',
-                title: queuedPack ? 'Season pack queued' : `${grabbed} release${grabbed === 1 ? '' : 's'} grabbed`,
-                body: groups.length ? groups.join(', ') : seriesTitle,
-            });
-        } else {
-            window.ryokanToast({
-                kind: 'warn',
-                category: 'auto_search',
-                title: 'No release grabbed',
-                body: skipped ? `${skipped} candidate${skipped === 1 ? '' : 's'} skipped — check inline detail.` : 'Nothing matched.',
-            });
         }
     })
     .catch(err => {
         setBusyButton(btn, false);
-        window.ryokanToast({
+        toast.finalize({
             kind: 'error',
-            category: 'auto_search',
             title: 'Auto search failed',
             body: err && err.message ? err.message : 'Unknown error',
         });

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -96,7 +96,7 @@
             <div class="form-group">
                 <label for="sonarr_api_key">API Key</label>
                 <div style="display: flex; gap: 8px; align-items: center;">
-                    <input type="text" name="sonarr_api_key" id="sonarr_api_key" value="{{ config.sonarr_api_key }}" placeholder="Paste this key into Seerr's Sonarr server config" style="flex:1">
+                    <input type="password" name="sonarr_api_key" id="sonarr_api_key" value="{{ config.sonarr_api_key }}" placeholder="Paste this key into Seerr's Sonarr server config" style="flex:1">
                     <button type="button" class="btn btn-secondary" onclick="generateApiKey()" style="white-space:nowrap">Generate</button>
                 </div>
                 <span class="form-hint">Use this key as the API key when adding Ryokan as a Sonarr server in Seerr.</span>
@@ -119,7 +119,7 @@
             <div class="form-group">
                 <label for="radarr_api_key">API Key</label>
                 <div style="display: flex; gap: 8px; align-items: center;">
-                    <input type="text" name="radarr_api_key" id="radarr_api_key" value="{{ config.radarr_api_key }}" placeholder="Paste this key into Seerr's Radarr server config" style="flex:1">
+                    <input type="password" name="radarr_api_key" id="radarr_api_key" value="{{ config.radarr_api_key }}" placeholder="Paste this key into Seerr's Radarr server config" style="flex:1">
                     <button type="button" class="btn btn-secondary" onclick="generateRadarrApiKey()" style="white-space:nowrap">Generate</button>
                 </div>
                 <span class="form-hint">Use this key as the API key when adding Ryokan as a Radarr server in Seerr.</span>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -44,7 +44,11 @@
                 </div>
                 <div class="form-group">
                     <label for="qbit_pass">Password</label>
-                    <input type="password" name="qbit_pass" id="qbit_pass" value="{{ config.qbit_pass }}">
+                    <div style="display: flex; gap: 8px; align-items: center;">
+                        <input type="password" name="qbit_pass" id="qbit_pass" value="{{ config.qbit_pass }}" style="flex:1">
+                        <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('qbit_pass', this)" style="white-space:nowrap">Show</button>
+                        <button type="button" class="btn btn-secondary" onclick="copyApiKey('qbit_pass', this)" style="white-space:nowrap">Copy</button>
+                    </div>
                 </div>
             </div>
             <div class="form-group">
@@ -70,7 +74,11 @@
             </div>
             <div class="form-group">
                 <label for="jellyfin_api_key">API Key</label>
-                <input type="password" name="jellyfin_api_key" id="jellyfin_api_key" value="{{ config.jellyfin_api_key }}">
+                <div style="display: flex; gap: 8px; align-items: center;">
+                    <input type="password" name="jellyfin_api_key" id="jellyfin_api_key" value="{{ config.jellyfin_api_key }}" style="flex:1">
+                    <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('jellyfin_api_key', this)" style="white-space:nowrap">Show</button>
+                    <button type="button" class="btn btn-secondary" onclick="copyApiKey('jellyfin_api_key', this)" style="white-space:nowrap">Copy</button>
+                </div>
                 <span class="form-hint">Ryokan will use this for server info, targeted lookups, and library refreshes.</span>
             </div>
             <div class="settings-inline-actions">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -8,7 +8,11 @@
 </div>
 
 {% if let Some(msg) = message %}
-    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Settings saved">{{ msg|safe }}</div>
+    {# Auto-escape — never |safe. msg can come from `?msg=` query string
+       (settings_page) and from POST notice strings (settings_submit, which
+       interpolates user-controlled fields like media_root into format!()).
+       Either path is reflected/stored XSS without escaping. #}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Settings saved">{{ msg }}</div>
 {% endif %}
 {% if let Some(err) = error %}
     <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Settings error">{{ err }}</div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -97,6 +97,8 @@
                 <label for="sonarr_api_key">API Key</label>
                 <div style="display: flex; gap: 8px; align-items: center;">
                     <input type="password" name="sonarr_api_key" id="sonarr_api_key" value="{{ config.sonarr_api_key }}" placeholder="Paste this key into Seerr's Sonarr server config" style="flex:1">
+                    <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('sonarr_api_key', this)" style="white-space:nowrap">Show</button>
+                    <button type="button" class="btn btn-secondary" onclick="copyApiKey('sonarr_api_key', this)" style="white-space:nowrap">Copy</button>
                     <button type="button" class="btn btn-secondary" onclick="generateApiKey()" style="white-space:nowrap">Generate</button>
                 </div>
                 <span class="form-hint">Use this key as the API key when adding Ryokan as a Sonarr server in Seerr.</span>
@@ -120,6 +122,8 @@
                 <label for="radarr_api_key">API Key</label>
                 <div style="display: flex; gap: 8px; align-items: center;">
                     <input type="password" name="radarr_api_key" id="radarr_api_key" value="{{ config.radarr_api_key }}" placeholder="Paste this key into Seerr's Radarr server config" style="flex:1">
+                    <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('radarr_api_key', this)" style="white-space:nowrap">Show</button>
+                    <button type="button" class="btn btn-secondary" onclick="copyApiKey('radarr_api_key', this)" style="white-space:nowrap">Copy</button>
                     <button type="button" class="btn btn-secondary" onclick="generateRadarrApiKey()" style="white-space:nowrap">Generate</button>
                 </div>
                 <span class="form-hint">Use this key as the API key when adding Ryokan as a Radarr server in Seerr.</span>
@@ -676,6 +680,46 @@ function generateRadarrApiKey() {
     let key = '';
     for (let i = 0; i < 32; i++) key += chars[buf[i] % chars.length];
     document.getElementById('radarr_api_key').value = key;
+}
+
+// API-key inputs render as type="password" so the secret isn't visible
+// to anyone glancing at the admin's screen. These two helpers restore
+// the workflow that masking otherwise broke: Show toggles visibility
+// for verification, Copy puts the value on the clipboard so the user
+// can paste straight into Seerr without ever needing to read it.
+function toggleApiKeyVisibility(inputId, btn) {
+    const input = document.getElementById(inputId);
+    if (!input) return;
+    if (input.type === 'password') {
+        input.type = 'text';
+        btn.textContent = 'Hide';
+    } else {
+        input.type = 'password';
+        btn.textContent = 'Show';
+    }
+}
+
+async function copyApiKey(inputId, btn) {
+    const input = document.getElementById(inputId);
+    if (!input || !input.value) return;
+    const original = btn.textContent;
+    const flash = (label, ms) => {
+        btn.textContent = label;
+        setTimeout(() => { btn.textContent = original; }, ms);
+    };
+    // navigator.clipboard.writeText needs a secure context (HTTPS or
+    // localhost). Self-hosted Ryokan often runs over plain HTTP on a
+    // LAN address, so fall back to surfacing the value in a text input
+    // and selecting it — the user can then Ctrl+C themselves.
+    try {
+        await navigator.clipboard.writeText(input.value);
+        flash('Copied!', 1500);
+    } catch (_e) {
+        input.type = 'text';
+        input.focus();
+        input.select();
+        flash('Select & copy', 2500);
+    }
 }
 
 function syncTitleLanguagePreview(lang) {


### PR DESCRIPTION
## Summary

Three merged dev-side PRs (#29, #30, #31), 67 commits, ~+3.5k/-750 LOC. Net behaviour: same UX, sharper edges. The rate-limit work in #31 is the only commit set that touches user-visible behaviour materially (sweep no longer hits AniList 429s in steady state).

## What's in here

### PR #29 — Correctness, security, reliability ([merge c461a06](https://github.com/johnthreekay/Ryokan/commit/c461a06))

Code-review-driven fixes from the comprehensive audit. Highlights:
- **Timing-equalised login** — `models::user::authenticate` now bcrypt-verifies against a warmed dummy hash on the missing-user path; `main()` warms the `LazyLock` so the first probe isn't a one-shot timing oracle.
- **CSRF same-origin check** on unauthenticated `/login` and `/setup` POSTs.
- **Constant-time API-key compare** (`subtle::ConstantTimeEq`) for the Sonarr/Radarr shim, plus `urlencoding::decode` so `?apikey=` round-trips through Seerr cleanly.
- **`enum Origin`** replaces stringly-typed origin labels across the source-classification pipeline.
- **`sqlx::FromRow`** derives across `episode_tags` and `grabbed_torrents` row structs (drops a few hundred lines of manual mapping).
- Various race-condition and spawn-blocking-error fixes (see commit log).

### PR #30 — Perf + simplification ([merge fa3ac72](https://github.com/johnthreekay/Ryokan/commit/fa3ac72))

Behaviour-preserving changes:
- **Shared `reqwest::Client`** via `LazyLock` across anilist / jikan / kitsu / artwork — connection pool reuse instead of fresh TLS handshakes per call.
- **Bulk `episode_tags::mark_completed`** via `WHERE episode_number IN (...)`, single statement instead of N round trips.
- **Series-scoped grab fetch** in `scan_library_for_unclassified` — was N queries per series; now one.
- **Hot-path debug-INSERT removal** from scoring/classification — these were burning DB writes per candidate during interactive search.
- **Sync `std::fs` → tokio equivalents** in async paths.
- **Transactions** for `seed_defaults`, `reconcile_seed_drift`, `jikan::cache_episodes`.
- **Route registration de-dup** via aliased() helper, RSS pre-load, etc.

One commit (`01fb3ee` parallelise `classify_release`) was reverted in `c89f563` after testing showed the speedup was negligible.

### PR #31 — AniList rate-limit cooperation ([merge 3256621](https://github.com/johnthreekay/Ryokan/commit/3256621))

Started as "log silent fallback errors", grew into a complete rewrite of how Ryokan interacts with AniList's rate limits. The user reported ONE PIECE silently falling back to MAL because `metadata_sync` was eating 429s without telling anyone.

Layered fixes:
1. **Visibility** — `tracing::warn!` on every silent provider fallback in `fetch_live_detail_for_ids`.
2. **Cooldown in detail path** — `fetch_anime_detail` now checks `anilist_cooldown_active()` at the top and sets the cooldown on 403/429/5xx, mirroring the search path.
3. **No MAL on rate-limit** — `fetch_live_detail_for_ids` distinguishes "AL throttling us" (defer-and-retry) from "AL down" (MAL fallback). Preserves AL fidelity instead of silently downgrading.
4. **Defer-and-retry sweep** — rate-limited series are deferred in a queue and retried after the cooldown clears, up to `MAX_RETRY_ROUNDS=3`. Manual rebuild button now actually finishes what it starts.
5. **Strict tree separation** — `hydrate_relation_tree` walks AL or MAL exclusively per series. AL mode follows positive IDs only; MAL mode (root from MAL fallback) follows Jikan's `-mal_id` sentinels. No interleaving.
6. **Body-aware error classification** — replaces fragile `err.contains("HTTP 429")` substring matching with a typed `AniListFailureKind` classifier. Reads response body as text first (so Cloudflare HTML challenges don't blow up at JSON parse), then matches body markers + status to classify. `is_rate_limit_error` is the public helper callers use.
7. **Cooperate with `X-RateLimit-*` headers** — `record_rate_limit_headers` stashes `(limit, remaining, reset_at)` from every AL response. `throttle_before_anilist_request` paces every AL call: when `remaining ≤ 3`, sleeps until `reset_at`; otherwise enforces `60s/limit` minimum spacing. `cooldown_from_headers` prefers `X-RateLimit-Reset` over `Retry-After`.
8. **All three AL entry points** (`fetch_anime_detail`, `search_anime_with_options`, `find_anime_by_mal_id`) share the same throttle + record contract. `find_anime_by_mal_id` also gains the `anilist_cooldown_active()` short-circuit.

Pure helpers (`compute_cooldown_duration`, `decide_wait`, `min_inter_request`, `cooldown_from_headers`, `classify_anilist_failure`, `excerpt`) are unit-tested without wall-clock waits — 23 new tests in `anilist.rs` cover the throttle/classifier branching.

## Test plan

- [x] `cargo test` — 411/411 pass on the dev branch
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Manual: cookie auth, login timing equality, Sonarr/Radarr shim with Seerr, custom format scoring, manual metadata rebuild
- [x] Post-merge smoke: full metadata sweep on a small library and watch for 429s (should be zero in steady state with the proactive throttle)

🤖 Generated with [Claude Code](https://claude.com/claude-code)