### PR TITLE
PR #32 review followups: HTTP timeouts, hydration deadline, async unlink

### DIFF
--- a/src/models/artwork_cache.rs
+++ b/src/models/artwork_cache.rs
@@ -230,7 +230,10 @@ pub async fn cleanup_orphans(
     for row in &deleted_rows {
         let local_path: String = row.get("local_path");
         if !local_path.is_empty() {
-            let _ = std::fs::remove_file(&local_path);
+            // Hourly task in an async path — match the rest of the
+            // codebase's std::fs → tokio::fs migration so we don't
+            // block the runtime executor on the unlink syscall.
+            let _ = tokio::fs::remove_file(&local_path).await;
         }
     }
 

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -40,10 +40,24 @@ static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, CacheEntry>>> =
 /// rebuilt the TLS context and connection pool from scratch — wasteful
 /// across the search / detail / fallback paths that all hit
 /// graphql.anilist.co. Using a single Lazy client lets the pool reuse
-/// connections across calls. No timeout configured here — callers own
-/// retry/cooldown semantics that interact in non-obvious ways with a
-/// blanket per-request timeout.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// connections across calls.
+///
+/// Timeouts: 10s to establish a TCP+TLS handshake, 30s overall per
+/// request. Without an overall timeout a hung connection (e.g. half-
+/// open after a network partition) pins a pool slot until kernel TCP
+/// keepalive resolves, which on default Linux is roughly 2 hours —
+/// long enough that interactive searches feel permanently broken even
+/// after AL is healthy again. The 30s ceiling is generous relative to
+/// AL's typical sub-second response time but still bounded; cooldown /
+/// retry semantics live in the callers and are unaffected by this
+/// per-attempt cap.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the AniList reqwest client should not fail")
+});
 
 type SearchCacheEntry = (Instant, Vec<AnimeEntry>);
 

--- a/src/services/artwork.rs
+++ b/src/services/artwork.rs
@@ -1,4 +1,4 @@
-use std::{path::{Path, PathBuf}, sync::LazyLock, time::{SystemTime, UNIX_EPOCH}};
+use std::{path::{Path, PathBuf}, sync::LazyLock, time::{Duration, SystemTime, UNIX_EPOCH}};
 
 use sha2::{Digest, Sha256};
 use sqlx::SqlitePool;
@@ -6,8 +6,15 @@ use sqlx::SqlitePool;
 /// Shared reqwest client for artwork downloads. cache_image runs once
 /// per cover/banner/relation-card import — many in a row when the
 /// metadata sweep refreshes a series — and previously rebuilt the TLS
-/// pool every call.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// pool every call. Timeouts (10s connect, 30s overall) bound a hung
+/// CDN connection so it can't pin a pool slot waiting for TCP keepalive.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the artwork reqwest client should not fail")
+});
 
 use crate::models::artwork_cache;
 

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -30,10 +30,18 @@ static DETAIL_CACHE: LazyLock<RwLock<HashMap<i64, DetailCacheEntry>>> =
 /// rebuilt the client per request — wasteful given how often Jikan
 /// gets hit (search, details, episodes, relations, all routed
 /// through different helpers). One shared client lets the connection
-/// pool reuse TLS sessions across calls. No timeout configured here —
-/// callers own retry/cooldown/backoff that interacts in non-obvious
-/// ways with a blanket per-request timeout.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// pool reuse TLS sessions across calls.
+///
+/// Timeouts: 10s connect, 30s overall — same rationale as the AniList
+/// client. Callers' cooldown/backoff logic is unaffected; this just
+/// stops a hung connection from pinning a pool slot for hours.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the Jikan reqwest client should not fail")
+});
 
 /// When Jikan rate-limits us, remember "unavailable until Instant" so
 /// `search_anime` returns a clean cooldown error immediately rather than

--- a/src/services/kitsu.rs
+++ b/src/services/kitsu.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 use std::collections::{HashMap, HashSet};
 use std::sync::LazyLock;
+use std::time::Duration;
 
 use crate::services::anilist::AnimeDetail;
 use crate::services::html::sanitize_rich_description;
@@ -10,7 +11,15 @@ const KITSU_API: &str = "https://kitsu.io/api/edge";
 
 /// Shared reqwest client. Replaces a per-call `Client::new()` so the
 /// connection pool is reused across the search/detail fetch helpers.
-static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(reqwest::Client::new);
+/// Timeouts (10s connect, 30s overall) bound a hung connection so it
+/// can't pin a pool slot for hours waiting on TCP keepalive.
+static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .connect_timeout(Duration::from_secs(10))
+        .timeout(Duration::from_secs(30))
+        .build()
+        .expect("building the Kitsu reqwest client should not fail")
+});
 const CACHE_TTL_SECS: i64 = 7 * 24 * 60 * 60;
 const NEGATIVE_CACHE_SENTINEL: &str = "__RYOKAN_EMPTY__";
 

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -296,6 +296,14 @@ async fn hydrate_relation_tree(
     // already handles inline before this walker is even called.
     const MAX_AL_RETRY_ROUNDS: usize = 3;
     const COOLDOWN_POLL_INTERVAL: std::time::Duration = std::time::Duration::from_secs(5);
+    // Hard ceiling on total cooldown waits across all retry rounds for
+    // a single hydration. With MAX_AL_RETRY_ROUNDS=3 and AniList's
+    // 300s ANILIST_COOLDOWN_MAX, the worst-case naïve wait is ~15
+    // minutes — long enough that a manual rebuild click feels broken
+    // during a sustained AL outage. Cap at 5 minutes total so the
+    // request returns predictably; remaining deferred relations get
+    // picked up by the next periodic refresh.
+    const MAX_HYDRATION_WAIT_TOTAL: std::time::Duration = std::time::Duration::from_secs(300);
 
     if root_provider_id == 0 {
         return;
@@ -310,6 +318,7 @@ async fn hydrate_relation_tree(
     seen.insert(root_provider_id);
     let mut processed = 0usize;
     let mut al_round = 0usize;
+    let mut total_cooldown_wait = std::time::Duration::ZERO;
 
     loop {
         while let Some((provider_id, mal_id)) = queue.pop_front() {
@@ -360,7 +369,8 @@ async fn hydrate_relation_tree(
             }
         }
 
-        if deferred.is_empty() || al_round >= MAX_AL_RETRY_ROUNDS {
+        let wait_budget_exhausted = total_cooldown_wait >= MAX_HYDRATION_WAIT_TOTAL;
+        if deferred.is_empty() || al_round >= MAX_AL_RETRY_ROUNDS || wait_budget_exhausted {
             // Anything still deferred after the retry budget is left out
             // of this sweep's cache — the next periodic refresh picks it
             // up. We don't substitute MAL on rate-limit (would mix trees
@@ -371,6 +381,8 @@ async fn hydrate_relation_tree(
                     root_provider_id,
                     dropped = deferred.len(),
                     retry_rounds = al_round,
+                    cooldown_wait_secs = total_cooldown_wait.as_secs(),
+                    wait_budget_exhausted,
                     "relation hydration left {} relations unfetched after AniList \
                      retry budget exhausted; next sweep will retry",
                     deferred.len()
@@ -379,9 +391,19 @@ async fn hydrate_relation_tree(
             break;
         }
 
+        let wait_start = std::time::Instant::now();
+        let remaining_budget = MAX_HYDRATION_WAIT_TOTAL.saturating_sub(total_cooldown_wait);
         while anilist::anilist_cooldown_active() {
+            // Stop polling if the per-hydration wait budget is exhausted —
+            // the next iteration of the outer loop will drop the
+            // remaining deferred and exit. Without this guard a
+            // pathological AL outage could pin the sweep for ~15 min.
+            if wait_start.elapsed() >= remaining_budget {
+                break;
+            }
             tokio::time::sleep(COOLDOWN_POLL_INTERVAL).await;
         }
+        total_cooldown_wait += wait_start.elapsed();
 
         queue.append(&mut deferred);
         al_round += 1;


### PR DESCRIPTION
## Summary

Three small followups from the [PR #32 review](https://github.com/johnthreekay/Ryokan/pull/32). Merging this into `dev` updates PR #32 in place.

1. **`cleanup_orphans`: `tokio::fs::remove_file`** — slipped through PR #30's sync-fs → tokio-fs migration. Hourly task, small N, but trivially fixable.
2. **`HTTP_CLIENT` timeouts** — added `connect_timeout(10s)` + `timeout(30s)` to the four bare `reqwest::Client::new()` clients (anilist, jikan, kitsu, artwork). Without these, a hung TCP connection pins a pool slot until kernel keepalive (~2h on default Linux). Cooldown / retry semantics in callers are unaffected.
3. **`hydrate_relation_tree` per-hydration deadline** — `MAX_HYDRATION_WAIT_TOTAL = 300s` caps total cooldown waits across all retry rounds. Previous worst case during a sustained AL outage was 3 rounds × 300s = ~15 min for a single rebuild click; now bounded at 5 min. Remaining deferred relations get picked up by the next periodic refresh.

## Test plan

- [x] `cargo test` — 411/411 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] Smoke: nothing user-visible changed; existing rebuild test from PR #32 covers the happy path

🤖 Generated with [Claude Code](https://claude.com/claude-code)