### PR TITLE
PR 2: #11 CF page UX rework + #20 mobile layout pass

### DIFF
--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -154,6 +154,7 @@ pub struct ImportReviewView {
     pub payload: String,
     pub collisions: Vec<ImportCollision>,
     pub entries: Vec<ImportPreviewEntry>,
+    pub has_invalid: bool,
 }
 
 fn min_score_display(score: i32) -> String {
@@ -1223,6 +1224,7 @@ pub async fn settings_custom_formats_import(
             payload: payload.to_string(),
             collisions,
             entries: preview,
+            has_invalid,
         };
         let template = build_settings_template(
             &state,

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -134,12 +134,26 @@ pub struct ImportCollision {
     pub name: String,
 }
 
+/// One row of the import preview panel (#11.3). Status is one of
+/// `"new"` / `"collision"` / `"invalid"`; `error` is populated for the
+/// `"invalid"` case so the UI can surface the parse reason inline.
+/// `specs_count` renders as "N specs" next to the name.
+pub struct ImportPreviewEntry {
+    pub name: String,
+    pub score: i32,
+    pub specs_count: usize,
+    pub status: String,
+    pub error: Option<String>,
+}
+
 /// View model for the import review block. Holds the original payload
 /// (echoed back into a hidden field so the resolve handler can re-parse
-/// it) plus the list of collisions the user needs to act on.
+/// it) plus the full entries list (for the preview panel) and the
+/// collisions subset (for the resolve form).
 pub struct ImportReviewView {
     pub payload: String,
     pub collisions: Vec<ImportCollision>,
+    pub entries: Vec<ImportPreviewEntry>,
 }
 
 fn min_score_display(score: i32) -> String {
@@ -1145,10 +1159,13 @@ pub async fn settings_custom_formats_import(
         .map(|r| (r.name, r.id))
         .collect();
 
-    // Scan for collisions before touching the database. If any exist,
-    // render the review page inline — the user picks a decision per
-    // conflict and submits the resolve form.
+    // Scan every entry up-front: classify as new / collision / invalid.
+    // collisions[] feeds the existing resolve form; preview[] feeds the
+    // #11.3 preview panel that shows all rows with status badges so the
+    // user can see what they're about to import before picking actions
+    // per-collision.
     let mut collisions: Vec<ImportCollision> = Vec::new();
+    let mut preview: Vec<ImportPreviewEntry> = Vec::with_capacity(entries.len());
     for (idx, entry) in entries.iter().enumerate() {
         let name = entry
             .get("name")
@@ -1156,18 +1173,56 @@ pub async fn settings_custom_formats_import(
             .unwrap_or("")
             .trim()
             .to_string();
-        if !name.is_empty() && existing_by_name.contains_key(&name) {
-            collisions.push(ImportCollision { index: idx, name });
+        let score = entry
+            .get("score")
+            .and_then(|v| v.as_i64())
+            .unwrap_or(0) as i32;
+        let specs_count = entry
+            .get("specifications")
+            .and_then(|v| v.as_array())
+            .map(|a| a.len())
+            .unwrap_or(0);
+        // Dry-run compile so parse/regex errors surface in the preview
+        // with their actual message. The real import loop below re-runs
+        // the compile for the "apply" step — fine, compile is cheap.
+        let compile_err = cf_service::compile_from_json(&entry.to_string(), score, 0).err();
+        let (status, error) = if let Some(e) = compile_err.as_ref() {
+            ("invalid".to_string(), Some(e.clone()))
+        } else if name.is_empty() {
+            (
+                "invalid".to_string(),
+                Some("CF is missing a non-empty `name` field.".to_string()),
+            )
+        } else if existing_by_name.contains_key(&name) {
+            ("collision".to_string(), None)
+        } else {
+            ("new".to_string(), None)
+        };
+        if status == "collision" {
+            collisions.push(ImportCollision {
+                index: idx,
+                name: name.clone(),
+            });
         }
+        preview.push(ImportPreviewEntry {
+            name,
+            score,
+            specs_count,
+            status,
+            error,
+        });
     }
 
-    if !collisions.is_empty() {
-        // Re-render the settings page with the review block populated.
-        // The original payload rides along in a hidden form field so the
-        // resolve handler can re-parse it without server-side state.
+    // Only re-render inline when there's something for the user to act
+    // on — a collision (pick skip/overwrite/rename) or an invalid entry
+    // (fix and re-paste). If every entry is cleanly "new", fall through
+    // to the silent-apply branch below as before.
+    let has_invalid = preview.iter().any(|p| p.status == "invalid");
+    if !collisions.is_empty() || has_invalid {
         let review = ImportReviewView {
             payload: payload.to_string(),
             collisions,
+            entries: preview,
         };
         let template = build_settings_template(
             &state,

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -14,14 +14,68 @@ use crate::services::{
 };
 use crate::AppState;
 
-/// View-model wrapper rendered on the Custom Formats tab. Pairs each
-/// stored CF row with its parsed spec count (or parse error), so the
-/// table can surface "3 specs" next to well-formed rows and a red
-/// "parse error: ..." marker next to ones the user needs to fix.
+/// View-model wrapper rendered on the Custom Formats tab. Surfaces
+/// parse errors (so the user can spot broken CFs without tailing logs)
+/// and carries the per-spec label list used by the card-grid UI to
+/// render condition pills.
 pub struct CustomFormatView {
     pub row: cf_model::CustomFormatRow,
-    pub specs_count: usize,
     pub parse_error: Option<String>,
+    /// Sonarr-style condition pills shown on the CF card. Extracted
+    /// directly from the row's JSON `specifications[]` array (the
+    /// compiled form drops the per-spec `name` field, which is exactly
+    /// what the pill needs to render). Empty for parse-error rows; the
+    /// template uses `.len()` for the count display too.
+    pub spec_labels: Vec<SpecLabelView>,
+}
+
+pub struct SpecLabelView {
+    pub name: String,
+    pub implementation: String,
+    pub negate: bool,
+    pub required: bool,
+}
+
+/// Extract the per-spec labels used by CF card pills. Pulls
+/// `name`/`implementation`/`negate`/`required` straight out of the
+/// JSON — the compiled form at this layer already dropped the `name`
+/// field, so re-parsing as a loose `Value` is the simplest path.
+/// Returns an empty vec on any parse failure; the caller already
+/// surfaces the parse error via `parse_error`.
+fn extract_spec_labels(json: &str) -> Vec<SpecLabelView> {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(json) else {
+        return Vec::new();
+    };
+    let specs = match value.get("specifications").and_then(|v| v.as_array()) {
+        Some(arr) => arr,
+        None => return Vec::new(),
+    };
+    specs
+        .iter()
+        .map(|s| {
+            let name = s
+                .get("name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let implementation = s
+                .get("implementation")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let negate = s.get("negate").and_then(|v| v.as_bool()).unwrap_or(false);
+            let required = s
+                .get("required")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(false);
+            SpecLabelView {
+                name,
+                implementation,
+                negate,
+                required,
+            }
+        })
+        .collect()
 }
 
 /// View-model wrapper rendered when the Custom Formats tab is in edit
@@ -175,15 +229,16 @@ async fn load_custom_formats_view(db: &sqlx::SqlitePool) -> Vec<CustomFormatView
     let rows = cf_model::list_with_scores(db).await.unwrap_or_default();
     rows.into_iter()
         .map(|row| {
+            let spec_labels = extract_spec_labels(&row.json);
             match cf_service::compile_from_json(&row.json, row.score as i32, row.id) {
-                Ok(cf) => CustomFormatView {
-                    specs_count: cf.specs.len(),
+                Ok(_) => CustomFormatView {
                     parse_error: None,
+                    spec_labels,
                     row,
                 },
                 Err(e) => CustomFormatView {
-                    specs_count: 0,
                     parse_error: Some(e),
+                    spec_labels,
                     row,
                 },
             }

--- a/src/handlers/settings.rs
+++ b/src/handlers/settings.rs
@@ -1694,6 +1694,12 @@ pub struct CfExportQuery {
     /// `"sonarr-safe"` triggers the Sonarr-safe branch; anything else
     /// (or absent) falls through to the default Ryokan-compatible mode.
     mode: Option<String>,
+    /// Comma-separated row IDs to include. `None` or empty string =
+    /// export all rows (backwards-compatible with curl-based scripts
+    /// that just call `/settings/custom-formats/export`). Non-numeric
+    /// tokens are skipped silently. #11.4 — the UI populates this
+    /// from the per-CF checkbox list; unchecked CFs drop out here.
+    ids: Option<String>,
 }
 
 /// Normalize a parsed CF import payload into a flat list of per-CF
@@ -1780,6 +1786,20 @@ pub async fn settings_custom_formats_export(
         .map(|s| s.eq_ignore_ascii_case("sonarr-safe"))
         .unwrap_or(false);
 
+    // #11.4 — parse the `ids` query into an optional allow-set. None
+    // means "export all" (legacy behaviour). Empty / unparseable tokens
+    // are silently dropped; an `ids` value containing only garbage ends
+    // up filtering to zero rows, which produces a `[]` export — honest.
+    let id_filter: Option<std::collections::HashSet<i64>> = query
+        .ids
+        .as_deref()
+        .filter(|s| !s.trim().is_empty())
+        .map(|s| {
+            s.split(',')
+                .filter_map(|tok| tok.trim().parse::<i64>().ok())
+                .collect()
+        });
+
     let rows = cf_model::list_with_scores(&state.db)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
@@ -1791,6 +1811,11 @@ pub async fn settings_custom_formats_export(
     let mut out: Vec<serde_json::Value> = Vec::with_capacity(rows.len());
     let mut dropped_for_sonarr: Vec<String> = Vec::new();
     for row in rows {
+        if let Some(ref allow) = id_filter {
+            if !allow.contains(&row.id) {
+                continue;
+            }
+        }
         match serde_json::from_str::<serde_json::Value>(&row.json) {
             Ok(mut v) => {
                 // In Sonarr-safe mode, drop the whole CF if any spec

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -229,8 +229,6 @@ body {
         word-break: normal;
         margin-top: 4px;
     }
-    .log-expand-hint { display: none; }
-    .log-row-has-detail { cursor: default; }
 
     /* Series detail: strip the outer season-section card on phone so
      * the rounded-border container doesn't nest around the already-
@@ -3641,22 +3639,6 @@ input[type="file"]::file-selector-button:hover {
     max-width: 100%;
 }
 
-/* Chevron indicator so rows with hidden detail look tappable. Rotates
- * 180° when the row is expanded. Only visible on rows carrying the
- * `log-row-has-detail` class (rows without detail have nothing to
- * expand and don't get an onclick handler either). */
-.log-expand-hint {
-    display: inline-block;
-    margin-left: 6px;
-    color: var(--text-dim);
-    font-size: 10px;
-    transition: transform 0.15s ease;
-    vertical-align: middle;
-}
-.log-row.log-row-expanded .log-expand-hint {
-    transform: rotate(180deg);
-}
-
 /* Log Level Badges */
 .log-badge {
     display: inline-block;
@@ -3700,21 +3682,12 @@ input[type="file"]::file-selector-button:hover {
     background: rgba(203, 166, 247, 0.04);
 }
 
-/* Expand the wrapped detail on hover (desktop) OR on tap via the
- * `log-row-expanded` class toggled by the delegated click handler in
- * system.html's log script (mobile — :hover doesn't fire on touch). */
-.log-row:hover .log-detail,
-.log-row.log-row-expanded .log-detail {
+/* Expand the wrapped detail on hover (desktop only — touch targets
+ * get fully wrapped detail via the phone-width override). */
+.log-row:hover .log-detail {
     white-space: normal;
     word-break: break-word;
 }
-.log-row.log-row-expanded {
-    background: rgba(203, 166, 247, 0.04);
-}
-/* Only log rows carrying detail get an onclick + interactive cursor.
- * Rows without detail have nothing to expand, so tapping them doing
- * nothing was the previous confusing behavior — hide the affordance. */
-.log-row-has-detail { cursor: pointer; }
 
 /* RSS */
 .rss-panel {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2155,14 +2155,19 @@ fieldset legend {
         white-space: nowrap;
     }
     .tag-quality { padding: 1px 5px; font-size: 9px; }
-    .ep-col-actions {
+    /* Two-class selector so this wins over the later `.ep-col-actions`
+     * desktop rule (width: 84px; white-space: nowrap) that would
+     * otherwise pin the cell to 84px inside its full-width grid slot
+     * and push the buttons left. */
+    .episode-table .ep-col-actions {
         grid-area: actions;
         width: auto;
         text-align: right;
         padding-top: 6px;
         white-space: normal;
+        justify-self: stretch;
     }
-    .ep-col-actions .icon-btn {
+    .episode-table .ep-col-actions .icon-btn {
         display: inline-flex;
         min-width: 40px;
         min-height: 40px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,6 +59,13 @@ body {
         /* Padding so the fixed bottom tab bar (56px tall + safe-area
          * inset for iOS home indicator) doesn't overlap page content. */
         padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
+        /* Safety net: anything that somehow ends up wider than the
+         * viewport (e.g. long CF JSON in an edit textarea, a wide
+         * table that escaped its scroll wrapper) gets clipped
+         * instead of forcing the whole page to h-scroll. The
+         * expected-to-scroll elements (`.rss-table-wrap`,
+         * `.system-tabs`) each manage their own overflow-x: auto. */
+        overflow-x: hidden;
     }
     input[type="text"],
     input[type="search"],
@@ -70,6 +77,30 @@ body {
     select,
     textarea {
         font-size: 16px;
+    }
+    /* Forms fill their parent on mobile. Without this, `<input>` keeps
+     * its user-agent default width (~173px for 20ch) and wanders out
+     * of its fieldset instead of filling the column. `max-width: 100%`
+     * belt-and-suspenders against inline-style widths. */
+    .form-group input,
+    .form-group select,
+    .form-group textarea,
+    .settings-form input,
+    .settings-form select,
+    .settings-form textarea {
+        width: 100%;
+        max-width: 100%;
+        box-sizing: border-box;
+    }
+    /* Fieldset padding is 24px on desktop; shrink on phone so the
+     * input grid has more usable horizontal space. */
+    fieldset {
+        padding: 16px;
+    }
+    /* Content container padding tightens from 24px to 14px side-padding
+     * so forms don't get squeezed on both sides. */
+    .content {
+        padding: 24px 14px calc(80px + env(safe-area-inset-bottom, 0px));
     }
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2296,34 +2296,48 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     font-weight: 500;
 }
 
-/* #11.5 — two-column Defaults & Threshold panel. Bundled set (install/
- * reset buttons) on the left, Minimum Score input on the right. Stacks
- * below --bp-tablet (reused when #20 lands). */
-.cf-defaults-grid {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
-    gap: 20px;
-}
-@media (max-width: 760px) {
-    .cf-defaults-grid {
-        grid-template-columns: 1fr;
-    }
-}
-.cf-defaults-col {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-}
+/* #11.5 — Defaults & Threshold vertical stack. Two subsections
+ * (Bundled defaults + Minimum score) share one card, separated by
+ * the subtitle + paragraph rhythm. The 2-column grid attempt read
+ * as an orphan floating block for Min Score; stacking is cleaner. */
 .cf-defaults-subtitle {
-    font-size: 12px;
+    font-size: 13px;
     font-weight: 600;
-    color: var(--text-dim);
+    color: var(--text-bright);
     text-transform: uppercase;
     letter-spacing: 0.5px;
-    margin: 0;
+    margin: 0 0 10px;
 }
 .cf-min-score-form {
     margin: 0;
+}
+/* Score-floor input + inline Save button. max-width so the number
+ * field doesn't stretch across the whole card at desktop widths. */
+.cf-min-score-group {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    max-width: 360px;
+    margin: 0;
+}
+.cf-min-score-group input[type="number"] {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.cf-min-score-group .btn {
+    flex-shrink: 0;
+}
+
+/* #11.1 modal — the CF editor form wraps BOTH .modal-body and
+ * .modal-footer, so the .modal's flex-column rule can't keep the footer
+ * stuck at the bottom without the form itself being a flex child too.
+ * Without this, long textareas push the footer past the modal's
+ * max-height: 80vh and the Save/Cancel buttons clip. (#11.1 follow-up) */
+.cf-editor-form {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-height: 0;
 }
 
 /* #11.4 — Export selector card. Mode radio row, per-CF checkbox list,
@@ -2460,6 +2474,39 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     padding: 4px 8px;
     border-radius: 4px;
     margin-top: 4px;
+}
+
+/* Style the native file input so the "Choose File" button isn't a
+ * white OS-default block on the dark theme. Can't style the button
+ * directly (browser UA shadow DOM), but we can style the input's
+ * ::file-selector-button pseudo-element which both Chromium and
+ * Firefox expose. The rest of the input is the selected-file text
+ * that sits next to the button. */
+input[type="file"] {
+    background: var(--bg-elevated);
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 6px 10px;
+    font-size: 13px;
+    max-width: 100%;
+}
+input[type="file"]::file-selector-button {
+    background: var(--bg-card);
+    color: var(--text-bright);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 4px 12px;
+    margin-right: 10px;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+input[type="file"]::file-selector-button:hover {
+    background: var(--bg-elevated);
+    border-color: var(--border-accent);
+    color: var(--accent);
 }
 
 /* #11.1 — Sonarr-style CF card grid (full-width flex-wrap of ~300px
@@ -2727,10 +2774,14 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
    reused, but CF rows have a badge column that needs a bit more room
    and the actions column should align its buttons cleanly. */
 .cf-table .cf-name { font-weight: 600; color: var(--text-bright); }
-.cf-table .cf-score { font-variant-numeric: tabular-nums; }
-.cf-table .cf-score-positive { color: var(--green); }
-.cf-table .cf-score-negative { color: var(--red); }
-.cf-table .cf-score-zero { color: var(--text-dim); }
+/* Score coloring. Applies wherever a `.cf-score` element also carries a
+ * positive/negative/zero modifier — the CF card grid (#11.1), the
+ * export selector row (#11.4), the import preview (#11.3), and the
+ * legacy .cf-table if it ever returns. */
+.cf-score { font-variant-numeric: tabular-nums; }
+.cf-score-positive { color: var(--green); }
+.cf-score-negative { color: var(--red); }
+.cf-score-zero { color: var(--text-dim); }
 
 .cf-origin-badge {
     display: inline-block;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1896,10 +1896,49 @@ fieldset legend {
     .detail-banner { height: 160px; margin-bottom: -40px; }
     .ep-filename { max-width: 180px; }
     .ep-col-size { display: none; }
-    .ep-col-aired { display: none; }
     .folder-row { flex-wrap: wrap; }
     .folder-select { max-width: none; width: 100%; }
     .season-header { padding: 12px 14px; }
+
+    /* #20 commit 6 — Episode table collapse on phone. Each row
+     * becomes a card: status icon + episode number + title on top,
+     * then quality badge, then the action buttons on the last row.
+     * thead hides, size/aired columns already hid above; the
+     * monitor button moves into the card's top-right corner. */
+    .episode-table,
+    .episode-table tbody,
+    .episode-table tr,
+    .episode-table td {
+        display: block;
+        width: 100%;
+    }
+    .episode-table thead {
+        display: none;
+    }
+    .episode-table tbody tr {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 10px 12px;
+        margin-bottom: 8px;
+        display: grid;
+        grid-template-columns: auto auto 1fr auto;
+        grid-template-areas:
+            "status num title monitor"
+            "quality quality quality quality"
+            "actions actions actions actions";
+        gap: 6px 8px;
+        align-items: center;
+    }
+    .episode-table tbody tr:last-child { border: 1px solid var(--border); }
+    .episode-table td { border: none !important; padding: 0; }
+    .ep-col-status { grid-area: status; width: auto; }
+    .ep-col-num { grid-area: num; width: auto; text-align: left; }
+    .ep-col-title { grid-area: title; min-width: 0; overflow-wrap: anywhere; }
+    .ep-col-monitor { grid-area: monitor; width: auto; }
+    .ep-col-aired { display: none; }
+    .ep-col-quality { grid-area: quality; width: auto; text-align: left; }
+    .ep-col-actions { grid-area: actions; width: auto; text-align: left; display: flex; flex-wrap: wrap; gap: 6px; padding-top: 6px; border-top: 1px solid var(--border); margin-top: 2px; }
 }
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2102,45 +2102,39 @@ fieldset legend {
     .folder-select { max-width: none; width: 100%; }
     .season-header { padding: 12px 14px; }
 
-    /* #20 commit 6 — Episode table collapse on phone. Each row
-     * becomes a card: status icon + episode number + title on top,
-     * then quality badge, then the action buttons on the last row.
-     * thead hides, size/aired columns already hid above; the
-     * monitor button moves into the card's top-right corner. */
-    .episode-table,
-    .episode-table tbody,
-    .episode-table tr,
-    .episode-table td {
-        display: block;
-        width: 100%;
-    }
-    .episode-table thead {
-        display: none;
-    }
-    .episode-table tbody tr {
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 10px 12px;
-        margin-bottom: 8px;
-        display: grid;
-        grid-template-columns: auto auto 1fr auto;
-        grid-template-areas:
-            "status num title monitor"
-            "quality quality quality quality"
-            "actions actions actions actions";
-        gap: 6px 8px;
-        align-items: center;
-    }
-    .episode-table tbody tr:last-child { border: 1px solid var(--border); }
-    .episode-table td { border: none !important; padding: 0; }
-    .ep-col-status { grid-area: status; width: auto; }
-    .ep-col-num { grid-area: num; width: auto; text-align: left; }
-    .ep-col-title { grid-area: title; min-width: 0; overflow-wrap: anywhere; }
-    .ep-col-monitor { grid-area: monitor; width: auto; }
+    /* #20 — Episode table on phone. Previous pass collapsed rows into
+     * stacked cards, but the user preferred the desktop table shape.
+     * Keep the <table> layout and just tighten it: hide aired+size,
+     * shrink padding/fonts, let quality badges size naturally, and
+     * allow action icons to wrap within their cell so the row height
+     * grows instead of the row overflowing. */
+    .episode-table { font-size: 12px; }
+    .episode-table thead th { padding: 6px 4px; font-size: 10px; }
+    .episode-table td { padding: 6px 4px; vertical-align: middle; }
     .ep-col-aired { display: none; }
-    .ep-col-quality { grid-area: quality; width: auto; text-align: left; }
-    .ep-col-actions { grid-area: actions; width: auto; text-align: left; display: flex; flex-wrap: wrap; gap: 6px; padding-top: 6px; border-top: 1px solid var(--border); margin-top: 2px; }
+    .ep-col-size { display: none; }
+    .ep-col-status { width: 24px; }
+    .ep-col-num { width: 28px; }
+    .ep-col-monitor { width: auto; }
+    .ep-col-title { min-width: 0; overflow-wrap: anywhere; }
+    .ep-filename { max-width: 140px; }
+    .ep-col-quality { width: auto; min-width: 0; text-align: center; }
+    .tag-quality { padding: 1px 5px; font-size: 9px; }
+    .ep-col-actions {
+        width: auto;
+        white-space: normal;
+        text-align: right;
+    }
+    .ep-col-actions .icon-btn {
+        display: inline-flex;
+        min-width: 34px;
+        min-height: 34px;
+        width: 34px;
+        height: 34px;
+        padding: 0;
+        margin: 2px;
+    }
+    .ep-mon-btn { padding: 3px 8px; min-height: 28px; font-size: 11px; }
 }
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -359,6 +359,14 @@ body {
     .mobile-tab.active:hover {
         color: var(--accent);
     }
+    /* Keyboard focus ring — fires only for keyboard users via
+     * `:focus-visible`, so touch taps don't leave a stuck focus
+     * outline on the previously-tapped tab. */
+    .mobile-tab:focus-visible {
+        outline: 2px solid var(--accent);
+        outline-offset: -2px;
+        border-radius: 4px;
+    }
 }
 
 /* --- Content --- */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -810,6 +810,27 @@ fieldset legend {
     flex: 1;
 }
 
+/* #20 commit 8 — Full-screen modals on phone. Below --bp-phone the
+ * modal-backdrop padding drops to 0 and the modal fills the viewport
+ * edge-to-edge. Improves tap targets and avoids the fiddly
+ * floating-card feel on small screens. Applies to the shared
+ * .modal / .modal-backdrop primitives so ryokanConfirm / ryokanAlert
+ * / ryokanPrompt and the CF editor modal all pick it up
+ * automatically. */
+@media (max-width: 640px) {
+    .modal-backdrop {
+        padding: 0;
+    }
+    .modal {
+        max-width: none;
+        width: 100%;
+        height: 100%;
+        max-height: 100vh;
+        border-radius: 0;
+        border: none;
+    }
+}
+
 .modal-header .btn-icon {
     background: var(--bg-elevated);
     border: 1px solid var(--border);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2326,6 +2326,63 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     margin: 0;
 }
 
+/* #11.4 — Export selector card. Mode radio row, per-CF checkbox list,
+ * and a pair of action buttons. The checkbox list is vertically scrollable
+ * when many CFs are installed. */
+.cf-export-mode-row {
+    display: flex;
+    gap: 18px;
+    margin-bottom: 14px;
+}
+.cf-export-mode {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    color: var(--text);
+    cursor: pointer;
+}
+.cf-export-selector {
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    background: var(--bg-elevated);
+}
+.cf-export-selector-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    gap: 12px;
+    flex-wrap: wrap;
+}
+.cf-export-list {
+    max-height: 280px;
+    overflow-y: auto;
+    padding: 8px 14px;
+}
+.cf-export-check {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 0;
+    font-size: 13px;
+    cursor: pointer;
+}
+.cf-export-check:hover {
+    color: var(--text-bright);
+}
+.cf-export-check-name {
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+}
+.cf-export-check-score {
+    flex-shrink: 0;
+    font-weight: 600;
+    font-size: 12px;
+}
+
 /* #11.1 — Sonarr-style CF card grid (full-width flex-wrap of ~300px
  * cards). Replaced the earlier two-pane table layout because compressing
  * a list into 490px made names wrap ugly and the + Delete button clip.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -565,6 +565,18 @@ fieldset legend {
     grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
     gap: 20px;
 }
+/* #20 — Tighter minimum below --bp-phone so 375px-wide viewports
+ * (iPhone SE and friends) show two posters per row with healthy
+ * spacing. At 160px min, a 375px viewport drops to a single
+ * column; at 120px min, it cleanly fits 2. Gap also tightens from
+ * 20px → 12px so the reduced poster width isn't dominated by the
+ * gap itself. */
+@media (max-width: 640px) {
+    .library-grid {
+        grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+        gap: 12px;
+    }
+}
 
 .series-card {
     display: block;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2311,10 +2311,13 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .cf-min-score-form {
     margin: 0;
 }
-/* Score-floor input + inline Save button. max-width so the number
- * field doesn't stretch across the whole card at desktop widths. */
+/* Score-floor input + inline Save button. Explicit `flex-direction:
+ * row` overrides `.form-group`'s default `column` so the two children
+ * sit side-by-side; without it the Save button wraps below the input
+ * which reads as two separate controls. */
 .cf-min-score-group {
     display: flex;
+    flex-direction: row;
     gap: 8px;
     align-items: center;
     max-width: 360px;
@@ -2474,6 +2477,68 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     padding: 4px 8px;
     border-radius: 4px;
     margin-top: 4px;
+}
+
+/* Dark-theme styling for native form widgets that otherwise render as
+ * OS-default white controls on the CF tab: radios (Export mode
+ * picker), number input spin buttons (Min Score), and the file-picker
+ * button (Import). Kept scoped to the .settings-form / .cf-section
+ * context so this doesn't accidentally restyle unrelated inputs
+ * elsewhere in the app. */
+
+/* Radios — used by the #11.4 export-mode picker. Native radios render
+ * as a white circle with a white dot; custom appearance: none lets us
+ * draw a dark-theme version with the accent color for the selected
+ * state, matching the existing checkbox treatment. */
+.cf-section input[type="radio"],
+.settings-form input[type="radio"] {
+    appearance: none;
+    -webkit-appearance: none;
+    width: 16px;
+    height: 16px;
+    border: 2px solid var(--border-accent);
+    border-radius: 50%;
+    background: var(--bg);
+    margin: 0;
+    cursor: pointer;
+    position: relative;
+    display: inline-grid;
+    place-items: center;
+    flex-shrink: 0;
+    vertical-align: middle;
+    transition: border-color 0.15s, background 0.15s;
+}
+.cf-section input[type="radio"]:checked,
+.settings-form input[type="radio"]:checked {
+    border-color: var(--accent);
+    background: var(--bg);
+}
+.cf-section input[type="radio"]:checked::after,
+.settings-form input[type="radio"]:checked::after {
+    content: "";
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+}
+
+/* Number input spin arrows — the <input type="number"> spinner UI is
+ * browser-default white on Chromium/WebKit. Hide the spinner entirely;
+ * the user can still type or arrow-key the value. The Min Score field
+ * (and the CF Score field in the edit modal) are both happier without
+ * spinner chrome. Firefox-specific hides via appearance: textfield. */
+.cf-section input[type="number"],
+.settings-form input[type="number"] {
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+.cf-section input[type="number"]::-webkit-outer-spin-button,
+.cf-section input[type="number"]::-webkit-inner-spin-button,
+.settings-form input[type="number"]::-webkit-outer-spin-button,
+.settings-form input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    appearance: none;
+    margin: 0;
 }
 
 /* Style the native file input so the "Choose File" button isn't a
@@ -2775,7 +2840,7 @@ input[type="file"]::file-selector-button:hover {
    and the actions column should align its buttons cleanly. */
 .cf-table .cf-name { font-weight: 600; color: var(--text-bright); }
 /* Score coloring. Applies wherever a `.cf-score` element also carries a
- * positive/negative/zero modifier — the CF card grid (#11.1), the
+ * positive/negative/zero modifier: the CF card grid (#11.1), the
  * export selector row (#11.4), the import preview (#11.3), and the
  * legacy .cf-table if it ever returns. */
 .cf-score { font-variant-numeric: tabular-nums; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2296,91 +2296,171 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     font-weight: 500;
 }
 
-/* #11.1 — Two-pane CF layout (list on the left, editor on the right).
- * Proportions: 1fr list + 1.2fr editor so the editor's textarea gets
- * enough width without starving the list name column. Collapses to a
- * single column below 1080px because the editor form becomes unusable
- * at narrower widths; the full mobile treatment lands in #20. */
-.cf-panes {
-    display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
-    gap: 20px;
-    align-items: start;
-    margin-bottom: 20px;
-}
-@media (max-width: 1080px) {
-    .cf-panes {
-        grid-template-columns: 1fr;
-    }
-}
-.cf-pane-list,
-.cf-pane-editor {
-    margin-bottom: 0;
-}
-/* Header pill + "+ New" button live on the same right-aligned row so the
- * list header reads as "Title | count • new-button". */
-.cf-list-header-actions {
-    display: inline-flex;
-    align-items: center;
-    gap: 8px;
-}
+/* #11.1 — Sonarr-style CF card grid (full-width flex-wrap of ~300px
+ * cards). Replaced the earlier two-pane table layout because compressing
+ * a list into 490px made names wrap ugly and the + Delete button clip.
+ * Each card is a clickable tile that deep-links to ?edit_id=N; the
+ * editor form still lives below the grid (modal-ified in stage 2). */
 .cf-list-filter {
     margin-bottom: 14px;
     width: 100%;
+    max-width: 520px;
 }
-/* Soft cap on the list pane height so a 28-entry default set doesn't
- * push the editor pane off-screen. The editor is the thing the user is
- * actively typing in; the list stays scrollable. */
-.cf-list-scroll {
-    max-height: 560px;
-    overflow-y: auto;
-    border-top: 1px solid var(--border);
+.cf-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 14px;
 }
-.cf-list-scroll .group-source-table {
-    margin-top: 0;
-    border-top: none;
+.cf-card {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    transition: border-color 0.15s, background 0.15s;
+    min-height: 120px;
 }
-/* Sticky header so scrolling through the list keeps the column labels
- * visible. Requires the table to live inside .cf-list-scroll (which
- * establishes the scroll container). */
-.cf-list-scroll .group-source-table thead {
-    position: sticky;
-    top: 0;
-    background: var(--bg-card);
-    z-index: 1;
+.cf-card:hover {
+    border-color: var(--border-accent);
+    background: var(--bg);
 }
-.cf-row-link {
+.cf-card-selected {
+    border-color: var(--accent);
+    background: rgba(203, 166, 247, 0.06);
+}
+.cf-card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px 16px;
     color: inherit;
     text-decoration: none;
+    flex: 1 1 auto;
+}
+.cf-card-header {
     display: flex;
-    align-items: center;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 8px;
+}
+.cf-card-title-row {
+    display: flex;
+    align-items: flex-start;
     gap: 8px;
     min-width: 0;
-}
-.cf-row-link:hover {
-    color: var(--accent);
-}
-.cf-row-name {
-    overflow-wrap: anywhere;
     flex: 1 1 auto;
-    min-width: 0;
 }
-.cf-row-spec-count {
-    color: var(--text-dim);
-    font-size: 11px;
-    font-weight: 400;
-    white-space: nowrap;
-    flex-shrink: 0;
+/* Nudge the origin dot down slightly so it sits on the x-height of the
+ * name's first line instead of clinging to the cap height. Only matters
+ * when the name wraps to 2+ lines — otherwise the center-vs-baseline
+ * difference is imperceptible. */
+.cf-card-title-row .cf-origin-dot {
+    margin-top: 6px;
 }
-.cf-row-selected {
-    background: rgba(203, 166, 247, 0.08);
+.cf-card-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-bright);
+    margin: 0;
+    overflow-wrap: anywhere;
+    line-height: 1.35;
 }
-.cf-row-selected .cf-name {
+.cf-card-selected .cf-card-name {
     color: var(--accent);
 }
-/* Origin indicator as a colored dot inline with the name so the list pane
- * doesn't need a standalone Source column at tablet widths. Hover shows the
- * full label via the title attribute. */
+.cf-card-score {
+    font-size: 13px;
+    font-weight: 600;
+    flex-shrink: 0;
+    white-space: nowrap;
+}
+.cf-card-pills {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-top: auto;
+}
+/* Condition pill shape mirrors Sonarr's Labels: default grey, green
+ * when `required`, red when `negate`. One pill per spec; the title
+ * attribute carries the implementation type for hover inspection. */
+.cf-pill {
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 2px 8px;
+    border-radius: 999px;
+    background: var(--bg);
+    color: var(--text-dim);
+    border: 1px solid var(--border);
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.cf-pill-required {
+    background: rgba(140, 204, 151, 0.12);
+    color: #8ccc97;
+    border-color: rgba(140, 204, 151, 0.3);
+}
+.cf-pill-negate {
+    background: rgba(220, 70, 70, 0.12);
+    color: #e06b6b;
+    border-color: rgba(220, 70, 70, 0.3);
+}
+.cf-pill-error {
+    background: rgba(220, 70, 70, 0.2);
+    color: #e06b6b;
+    border-color: rgba(220, 70, 70, 0.4);
+}
+.cf-pill-muted {
+    font-style: italic;
+    opacity: 0.7;
+}
+/* Delete sits in the top-right corner, revealed on card hover so the
+ * grid doesn't scream "× × × ×" to the eye at rest. */
+.cf-card-actions {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    opacity: 0;
+    transition: opacity 0.15s;
+}
+.cf-card:hover .cf-card-actions,
+.cf-card:focus-within .cf-card-actions {
+    opacity: 1;
+}
+/* Trailing "+ Add" tile — same dimensions as a CF card but dashed border
+ * and centered label so it reads as a create affordance, not a real
+ * entry. */
+.cf-card-add {
+    border-style: dashed;
+    align-items: center;
+    justify-content: center;
+    color: var(--text-dim);
+    text-decoration: none;
+    padding: 14px 16px;
+    text-align: center;
+    cursor: pointer;
+}
+.cf-card-add:hover {
+    color: var(--accent);
+    border-color: var(--accent);
+    background: rgba(203, 166, 247, 0.04);
+}
+.cf-card-add-icon {
+    font-size: 28px;
+    font-weight: 300;
+    line-height: 1;
+    margin-bottom: 6px;
+}
+.cf-card-add-label {
+    font-size: 13px;
+    font-weight: 500;
+}
+/* Origin indicator: colored dot inline with the card name. Filter still
+ * matches on origin via data-cf-origin so removing the dedicated column
+ * doesn't hurt discoverability. */
 .cf-origin-dot {
     width: 8px;
     height: 8px;
@@ -2392,38 +2472,26 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .cf-origin-dot-defaults { background: var(--accent); }
 .cf-origin-dot-import { background: #8ccc97; }
 .cf-origin-dot-manual { background: var(--text-dim); }
-
-/* Tighten Score + Delete action columns so the Name column keeps as much
- * width as possible inside the ~490px list pane. */
-.cf-list-score-col {
-    width: 64px;
-    text-align: right;
-    white-space: nowrap;
-}
-.cf-list-action-col {
-    width: 36px;
-    text-align: right;
-    padding-right: 8px !important;
-}
-/* Icon-only danger button (the × for Delete). Matches the btn-danger
- * color scheme at a tighter footprint. */
+/* Icon-only danger button (× for Delete). Kept from the earlier
+ * tightening commit — used here on the absolutely-positioned card
+ * action stack so the × isn't in the primary click path. */
 .btn-icon-danger {
-    width: 28px;
-    height: 28px;
+    width: 26px;
+    height: 26px;
     padding: 0;
     border-radius: 6px;
     border: 1px solid transparent;
-    background: transparent;
+    background: var(--bg-card);
     color: var(--text-dim);
-    font-size: 18px;
+    font-size: 16px;
     line-height: 1;
     cursor: pointer;
     transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .btn-icon-danger:hover {
-    background: rgba(220, 70, 70, 0.12);
+    background: rgba(220, 70, 70, 0.15);
     color: #e06b6b;
-    border-color: rgba(220, 70, 70, 0.3);
+    border-color: rgba(220, 70, 70, 0.35);
 }
 
 /* Trash-Guides description callout shown above the edit form when the

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3452,6 +3452,69 @@ input[type="file"]::file-selector-button:hover {
     color: var(--green);
 }
 
+/* #20 — Collapse .rss-table rows into stacked "cards" on phone
+ * viewports. Used by the downloads page (queue / history / blocklist)
+ * plus the System RSS decisions and Scheduled Tasks tables. Rather
+ * than dual markup — which would triple the template work for six+
+ * tables — we reshape the existing rows via display: block. The
+ * tradeoff: accessibility tree loses the table semantics at phone
+ * widths; acceptable because the data is still per-row and the
+ * desktop/tablet path keeps the real table.
+ *
+ * Each <tr> becomes a padded card; each <td> becomes a row inside
+ * that card with the first column (usually the name) bolded, and
+ * the action column pushed to a footer row with horizontal flex. */
+@media (max-width: 640px) {
+    .rss-table,
+    .rss-table tbody,
+    .rss-table tr,
+    .rss-table td {
+        display: block;
+        width: 100%;
+    }
+    .rss-table thead {
+        display: none;
+    }
+    .rss-table-wrap {
+        overflow-x: visible;
+    }
+    .rss-table tr {
+        background: var(--bg-card);
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+        padding: 12px 14px;
+        margin-bottom: 10px;
+    }
+    .rss-table td {
+        border: none !important;
+        padding: 3px 0;
+        font-size: 13px;
+    }
+    .rss-table td:first-child {
+        font-weight: 500;
+        color: var(--text-bright);
+        padding: 0 0 8px;
+        border-bottom: 1px solid var(--border) !important;
+        margin-bottom: 8px;
+    }
+    /* Action columns (buttons) sit on their own row flex-wrapped so
+     * play/pause/delete don't collide with the text rows above. */
+    .rss-table td.dl-actions,
+    .rss-table td:last-child {
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid var(--border) !important;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+    /* Progress bar stays full-width on its own row — it would be
+     * cramped in a columnar stack otherwise. */
+    .dl-progress-wrap {
+        width: 100%;
+    }
+}
+
 .rss-decision-rejected,
 .rss-decision-error {
     background: rgba(211, 125, 125, 0.12);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2352,10 +2352,25 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .cf-row-link {
     color: inherit;
     text-decoration: none;
-    display: block;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
 }
 .cf-row-link:hover {
     color: var(--accent);
+}
+.cf-row-name {
+    overflow-wrap: anywhere;
+    flex: 1 1 auto;
+    min-width: 0;
+}
+.cf-row-spec-count {
+    color: var(--text-dim);
+    font-size: 11px;
+    font-weight: 400;
+    white-space: nowrap;
+    flex-shrink: 0;
 }
 .cf-row-selected {
     background: rgba(203, 166, 247, 0.08);
@@ -2363,8 +2378,52 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .cf-row-selected .cf-name {
     color: var(--accent);
 }
-.cf-row-selected::after {
-    content: none;
+/* Origin indicator as a colored dot inline with the name so the list pane
+ * doesn't need a standalone Source column at tablet widths. Hover shows the
+ * full label via the title attribute. */
+.cf-origin-dot {
+    width: 8px;
+    height: 8px;
+    flex-shrink: 0;
+    border-radius: 50%;
+    display: inline-block;
+    background: var(--text-dim);
+}
+.cf-origin-dot-defaults { background: var(--accent); }
+.cf-origin-dot-import { background: #8ccc97; }
+.cf-origin-dot-manual { background: var(--text-dim); }
+
+/* Tighten Score + Delete action columns so the Name column keeps as much
+ * width as possible inside the ~490px list pane. */
+.cf-list-score-col {
+    width: 64px;
+    text-align: right;
+    white-space: nowrap;
+}
+.cf-list-action-col {
+    width: 36px;
+    text-align: right;
+    padding-right: 8px !important;
+}
+/* Icon-only danger button (the × for Delete). Matches the btn-danger
+ * color scheme at a tighter footprint. */
+.btn-icon-danger {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 18px;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+.btn-icon-danger:hover {
+    background: rgba(220, 70, 70, 0.12);
+    color: #e06b6b;
+    border-color: rgba(220, 70, 70, 0.3);
 }
 
 /* Trash-Guides description callout shown above the edit form when the

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2737,18 +2737,34 @@ input[type="file"]::file-selector-button:hover {
     font-style: italic;
     opacity: 0.7;
 }
-/* Delete sits in the top-right corner, revealed on card hover so the
- * grid doesn't scream "× × × ×" to the eye at rest. */
+/* Delete × replaces the origin dot at the top-left on hover. The dot
+ * and the × share the same position so the card's top-right score
+ * badge stays untouched (otherwise the × would overlap the score).
+ * The dot fades out on hover and the × fades in — same pixel slot,
+ * two affordances: at-rest the user sees origin, on hover they get
+ * the delete action. */
 .cf-card-actions {
     position: absolute;
-    top: 8px;
-    right: 8px;
+    top: 12px;
+    left: 10px;
     opacity: 0;
     transition: opacity 0.15s;
+    pointer-events: none;
 }
 .cf-card:hover .cf-card-actions,
 .cf-card:focus-within .cf-card-actions {
     opacity: 1;
+    pointer-events: auto;
+}
+/* Fade the origin dot out on hover so the × isn't stacked on top of
+ * it. visibility:hidden would drop the element from hit-testing; we
+ * just need visual suppression, so opacity is enough. */
+.cf-card .cf-origin-dot {
+    transition: opacity 0.15s;
+}
+.cf-card:hover .cf-origin-dot,
+.cf-card:focus-within .cf-origin-dot {
+    opacity: 0;
 }
 /* Trailing "+ Add" tile — same dimensions as a CF card but dashed border
  * and centered label so it reads as a create affordance, not a real
@@ -2792,26 +2808,31 @@ input[type="file"]::file-selector-button:hover {
 .cf-origin-dot-defaults { background: var(--accent); }
 .cf-origin-dot-import { background: #8ccc97; }
 .cf-origin-dot-manual { background: var(--text-dim); }
-/* Icon-only danger button (× for Delete). Kept from the earlier
- * tightening commit — used here on the absolutely-positioned card
- * action stack so the × isn't in the primary click path. */
+/* Icon-only danger button (× for Delete). Sits on top of the card
+ * content via absolute positioning on .cf-card-actions, so the
+ * background MUST be fully opaque — an rgba() fill with alpha <1
+ * lets the content behind (e.g. the CF name or score) bleed
+ * through, which reads as a glitch. */
 .btn-icon-danger {
-    width: 26px;
-    height: 26px;
+    width: 22px;
+    height: 22px;
     padding: 0;
     border-radius: 6px;
-    border: 1px solid transparent;
+    border: 1px solid var(--border);
     background: var(--bg-card);
     color: var(--text-dim);
-    font-size: 16px;
+    font-size: 14px;
     line-height: 1;
     cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     transition: background 0.15s, color 0.15s, border-color 0.15s;
 }
 .btn-icon-danger:hover {
-    background: rgba(220, 70, 70, 0.15);
-    color: #e06b6b;
-    border-color: rgba(220, 70, 70, 0.35);
+    background: #5a2b2b;
+    color: #ffb3b3;
+    border-color: #8a3a3a;
 }
 
 /* Trash-Guides description callout shown above the edit form when the

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -179,14 +179,48 @@ body {
         flex-wrap: wrap;
     }
 
-    /* Logs: there is no :hover on touch, and tr-level onclick on mobile
-     * Firefox was unreliable even when wired up directly. Drop the
-     * tap-to-expand pattern on phone and just always show detail fully
-     * wrapped — the desktop's ellipsis+hover exists to save vertical
-     * space, and mobile rows are already one-per-screen-width anyway. */
+    /* Logs: the desktop table uses `table-layout: fixed` with per-cell
+     * `overflow: hidden`, which at phone widths collapses columns into
+     * equal-split boxes that then clip the message to a few characters
+     * (often to nothing visible). On phone, convert the table into a
+     * stacked card per row: top metadata strip (level + timestamp +
+     * category) over a full-width wrapped message and detail block.
+     * There's no :hover on touch, so always show detail fully. */
+    .log-table {
+        table-layout: auto;
+        display: block;
+    }
+    .log-table thead { display: none; }
+    .log-table tbody { display: block; }
+    .log-table tr.log-row {
+        display: block;
+        padding: 10px 12px;
+        border-bottom: 1px solid rgba(42, 42, 58, 0.4);
+    }
+    .log-table td {
+        display: block;
+        padding: 0;
+        border: none;
+        overflow: visible;
+        text-overflow: clip;
+        background: transparent;
+    }
+    .log-table td.log-col-time,
+    .log-table td.log-col-level,
+    .log-table td.log-col-cat {
+        display: inline-block;
+        vertical-align: middle;
+        margin-right: 8px;
+        font-size: 11px;
+    }
+    .log-table td.log-col-time { white-space: nowrap; }
+    .log-table td.log-col-msg { margin-top: 6px; }
+    .log-row .log-message { display: block; overflow-wrap: anywhere; }
     .log-row .log-detail {
+        display: block;
         white-space: normal;
         word-break: break-word;
+        margin-top: 4px;
     }
     .log-expand-hint { display: none; }
     .log-row-has-detail { cursor: default; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2296,6 +2296,36 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     font-weight: 500;
 }
 
+/* #11.5 — two-column Defaults & Threshold panel. Bundled set (install/
+ * reset buttons) on the left, Minimum Score input on the right. Stacks
+ * below --bp-tablet (reused when #20 lands). */
+.cf-defaults-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: 20px;
+}
+@media (max-width: 760px) {
+    .cf-defaults-grid {
+        grid-template-columns: 1fr;
+    }
+}
+.cf-defaults-col {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+.cf-defaults-subtitle {
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    margin: 0;
+}
+.cf-min-score-form {
+    margin: 0;
+}
+
 /* #11.1 — Sonarr-style CF card grid (full-width flex-wrap of ~300px
  * cards). Replaced the earlier two-pane table layout because compressing
  * a list into 490px made names wrap ugly and the + Delete button clip.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3482,9 +3482,20 @@ input[type="file"]::file-selector-button:hover {
     background: rgba(203, 166, 247, 0.04);
 }
 
-.log-row:hover .log-detail {
+/* Expand the wrapped detail on hover (desktop) OR on tap via the
+ * `log-row-expanded` class toggled by the delegated click handler in
+ * system.html's log script (mobile — :hover doesn't fire on touch). */
+.log-row:hover .log-detail,
+.log-row.log-row-expanded .log-detail {
     white-space: normal;
     word-break: break-word;
+}
+.log-row.log-row-expanded {
+    background: rgba(203, 166, 247, 0.04);
+}
+/* Give tap rows a little visual hint they're interactive on mobile. */
+@media (max-width: 640px) {
+    .log-row { cursor: pointer; }
 }
 
 /* RSS */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -102,6 +102,24 @@ body {
     .content {
         padding: 24px 14px calc(80px + env(safe-area-inset-bottom, 0px));
     }
+
+    /* Wide data tables (Groups, CF import collision review) become
+     * independently scrollable on mobile so they don't push the form
+     * above them past the viewport. `display: block` sacrifices the
+     * accessibility tree's table semantics at this width — worth it
+     * to stop the parent-container width leak. */
+    .group-source-table {
+        display: block;
+        overflow-x: auto;
+        max-width: 100%;
+        -webkit-overflow-scrolling: touch;
+    }
+    /* Pre-wrap form-hint so it doesn't get dragged wider when a
+     * sibling (e.g. a wide table below) temporarily forces the
+     * parent container past viewport during layout. */
+    .form-hint {
+        overflow-wrap: anywhere;
+    }
 }
 
 /* #20 — Mobile tab bar default (hidden). The actual phone-width swap

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -56,6 +56,9 @@ body {
 @media (max-width: 640px) {
     body {
         font-size: 16px;
+        /* Padding so the fixed bottom tab bar (56px tall + safe-area
+         * inset for iOS home indicator) doesn't overlap page content. */
+        padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
     }
     input[type="text"],
     input[type="search"],
@@ -68,6 +71,15 @@ body {
     textarea {
         font-size: 16px;
     }
+}
+
+/* #20 — Mobile tab bar default (hidden). The actual phone-width swap
+ * (hide .nav-links, show tab bar) lives further down after the
+ * default `.nav-links { display: flex }` rule so the cascade works
+ * out — an earlier media-query rule loses to a later unscoped rule
+ * with equal specificity. */
+.mobile-tabbar {
+    display: none;
 }
 
 /* --- Nav --- */
@@ -110,6 +122,58 @@ body {
 .nav-links a:hover { color: var(--text); background: var(--bg-elevated); }
 .nav-links a.active { color: var(--accent); background: rgba(203, 166, 247, 0.08); }
 .nav-logout { color: var(--text-dim) !important; }
+
+/* #20 — Below --bp-phone, hide the top nav's link strip and show
+ * the fixed bottom tab bar declared at the top of the file. This
+ * block must live AFTER the default `.nav-links { display: flex }`
+ * rule above or the cascade reorders it out of effect. */
+@media (max-width: 640px) {
+    .nav-links {
+        display: none;
+    }
+    .mobile-tabbar {
+        display: flex;
+        position: fixed;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 100;
+        background: rgba(15, 15, 19, 0.96);
+        backdrop-filter: blur(10px);
+        border-top: 1px solid var(--border);
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+    }
+    .mobile-tab {
+        flex: 1 1 0;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        padding: 8px 4px 6px;
+        color: var(--text-dim);
+        text-decoration: none;
+        min-height: 56px;
+        transition: color 0.15s;
+    }
+    .mobile-tab svg {
+        flex-shrink: 0;
+    }
+    .mobile-tab-label {
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.2px;
+    }
+    .mobile-tab.active {
+        color: var(--accent);
+    }
+    .mobile-tab:hover {
+        color: var(--text-bright);
+    }
+    .mobile-tab.active:hover {
+        color: var(--accent);
+    }
+}
 
 /* --- Content --- */
 .content {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2109,42 +2109,71 @@ fieldset legend {
     .folder-select { max-width: none; width: 100%; }
     .season-header { padding: 12px 14px; }
 
-    /* #20 — Episode table on phone. Previous pass collapsed rows into
-     * stacked cards, but the user preferred the desktop table shape.
-     * Keep the <table> layout and just tighten it: hide aired+size,
-     * shrink padding/fonts, let quality badges size naturally, and
-     * allow action icons to wrap within their cell so the row height
-     * grows instead of the row overflowing. */
+    /* #20 — Episode table on phone. Keep the table shape but break the
+     * actions cell onto its own line underneath the primary row — at
+     * phone widths there's no room for three 34px icons after status/
+     * num/mon/title/quality without squeezing title to nothing.
+     *
+     * Done by turning each <tr> into a CSS grid with two template
+     * rows: primary data on top, actions spanning full width below.
+     * No card border — just a separator line between rows so it still
+     * reads like a table, not a stack of cards. */
     .episode-table { font-size: 12px; }
-    .episode-table thead th { padding: 6px 4px; font-size: 10px; }
-    .episode-table td { padding: 6px 4px; vertical-align: middle; }
+    .episode-table thead { display: none; }
+    .episode-table tbody,
+    .episode-table { display: block; width: 100%; }
+    .episode-table tr {
+        display: grid;
+        grid-template-columns: auto auto auto 1fr auto;
+        grid-template-areas:
+            "status num mon title quality"
+            "actions actions actions actions actions";
+        align-items: center;
+        gap: 4px 8px;
+        padding: 8px 4px;
+        border-bottom: 1px solid var(--border);
+    }
+    .episode-table td {
+        padding: 0;
+        border: none;
+        vertical-align: middle;
+    }
+    .ep-col-status { grid-area: status; width: auto; }
+    .ep-col-num { grid-area: num; width: auto; text-align: left; }
+    .ep-col-monitor { grid-area: mon; width: auto; }
+    .ep-col-title {
+        grid-area: title;
+        min-width: 0;
+        overflow-wrap: break-word;
+        word-break: normal;
+    }
     .ep-col-aired { display: none; }
     .ep-col-size { display: none; }
-    .ep-col-status { width: 24px; }
-    .ep-col-num { width: 28px; }
-    .ep-col-monitor { width: auto; }
-    /* `overflow-wrap: anywhere` would drop the cell's min-content width
-     * to one character, which table layout then happily collapses to
-     * one-char-per-line. `break-word` lets long words break but keeps
-     * min-content as the longest word so the column stays usable. */
-    .ep-col-title { overflow-wrap: break-word; word-break: normal; }
-    .ep-filename { max-width: 140px; }
-    .ep-col-quality { width: auto; min-width: 0; text-align: center; }
+    .ep-col-quality {
+        grid-area: quality;
+        width: auto;
+        min-width: 0;
+        text-align: right;
+        white-space: nowrap;
+    }
     .tag-quality { padding: 1px 5px; font-size: 9px; }
     .ep-col-actions {
+        grid-area: actions;
         width: auto;
-        white-space: normal;
         text-align: right;
+        padding-top: 6px;
+        white-space: normal;
     }
     .ep-col-actions .icon-btn {
         display: inline-flex;
-        min-width: 34px;
-        min-height: 34px;
-        width: 34px;
-        height: 34px;
+        min-width: 40px;
+        min-height: 40px;
+        width: 40px;
+        height: 40px;
         padding: 0;
-        margin: 2px;
+        margin: 0 0 0 6px;
     }
+    .ep-filename { max-width: none; }
     .ep-mon-btn { padding: 3px 8px; min-height: 28px; font-size: 11px; }
 }
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2579,6 +2579,48 @@ input[type="file"]::file-selector-button:hover {
  * a list into 490px made names wrap ugly and the + Delete button clip.
  * Each card is a clickable tile that deep-links to ?edit_id=N; the
  * editor form still lives below the grid (modal-ified in stage 2). */
+/* Stand-alone input class for inputs that live outside a .form-group
+ * (the CF filter search box, the RSS filter search box, etc.). Mirrors
+ * the .form-group input treatment so these don't fall back to the
+ * browser-default white chrome. */
+.settings-input {
+    padding: 10px 12px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 14px;
+    font-family: var(--font-body);
+    transition: border-color 0.15s;
+}
+.settings-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+/* Chromium/WebKit render input[type=search] with its own internal
+ * search-cancel button and rounded corners; reset those so the input
+ * matches the rest of the dark theme. */
+.settings-input[type="search"] {
+    -webkit-appearance: none;
+    appearance: none;
+}
+.settings-input[type="search"]::-webkit-search-cancel-button {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 14px;
+    height: 14px;
+    margin-left: 6px;
+    background: var(--text-dim);
+    mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18 6L6 18M6 6l12 12' stroke='black' stroke-width='3' fill='none' stroke-linecap='round'/></svg>") center/contain no-repeat;
+    -webkit-mask: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'><path d='M18 6L6 18M6 6l12 12' stroke='black' stroke-width='3' fill='none' stroke-linecap='round'/></svg>") center/contain no-repeat;
+    cursor: pointer;
+    opacity: 0.6;
+}
+.settings-input[type="search"]::-webkit-search-cancel-button:hover {
+    opacity: 1;
+    background: var(--accent);
+}
+
 .cf-list-filter {
     margin-bottom: 14px;
     width: 100%;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -196,6 +196,7 @@ body {
         display: block;
         padding: 10px 12px;
         border-bottom: 1px solid rgba(42, 42, 58, 0.4);
+        background: var(--bg-card);
     }
     .log-table td {
         display: block;
@@ -215,11 +216,17 @@ body {
     }
     .log-table td.log-col-time { white-space: nowrap; }
     .log-table td.log-col-msg { margin-top: 6px; }
-    .log-row .log-message { display: block; overflow-wrap: anywhere; }
+    .log-row .log-message {
+        display: block;
+        overflow-wrap: break-word;
+        word-break: normal;
+        color: var(--text);
+    }
     .log-row .log-detail {
         display: block;
         white-space: normal;
-        word-break: break-word;
+        overflow-wrap: break-word;
+        word-break: normal;
         margin-top: 4px;
     }
     .log-expand-hint { display: none; }
@@ -2116,7 +2123,11 @@ fieldset legend {
     .ep-col-status { width: 24px; }
     .ep-col-num { width: 28px; }
     .ep-col-monitor { width: auto; }
-    .ep-col-title { min-width: 0; overflow-wrap: anywhere; }
+    /* `overflow-wrap: anywhere` would drop the cell's min-content width
+     * to one character, which table layout then happily collapses to
+     * one-char-per-line. `break-word` lets long words break but keeps
+     * min-content as the longest word so the column stays usable. */
+    .ep-col-title { overflow-wrap: break-word; word-break: normal; }
     .ep-filename { max-width: 140px; }
     .ep-col-quality { width: auto; min-width: 0; text-align: center; }
     .tag-quality { padding: 1px 5px; font-size: 9px; }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -473,6 +473,87 @@ fieldset legend {
 .col-seed, .col-leech, .col-dl { width: 50px; text-align: right; }
 .col-actions { width: 70px; text-align: right; }
 
+/* #20 — Search results card view (mobile). Dual-markup approach:
+ * results-table above renders both desktop and mobile shapes
+ * server-side, CSS hides one per viewport. loadMore() appends to
+ * both so paginated results stay in sync if the user resizes. */
+.results-cards {
+    display: none;
+}
+@media (max-width: 640px) {
+    .results-table {
+        display: none;
+    }
+    .results-cards {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+}
+.result-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 12px 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+/* Same batch/trusted tinting as the table rows (blue / green /
+ * purple stripes) so color-coding is consistent across viewports. */
+.result-card.is-batch {
+    border-left: 3px solid var(--blue);
+    background: var(--blue-bg);
+}
+.result-card.is-trusted {
+    border-left: 3px solid var(--green);
+    background: var(--green-bg);
+}
+.result-card.is-batch.is-trusted {
+    border-left: 3px solid var(--purple);
+    background: var(--purple-bg);
+}
+.result-card-header {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+}
+.result-card-title {
+    color: var(--text);
+    text-decoration: none;
+    font-size: 14px;
+    line-height: 1.4;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow-wrap: anywhere;
+    font-weight: 500;
+}
+.result-card-title:hover {
+    color: var(--accent);
+}
+.result-card-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+.result-card-footer {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 12px;
+    border-top: 1px solid var(--border);
+    padding-top: 10px;
+}
+.result-card-meta {
+    font-size: 12px;
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+.result-card-footer .btn-grab {
+    margin-left: auto;
+    padding: 8px 16px;
+}
+
 .col-name a {
     color: var(--text);
     text-decoration: none;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2383,6 +2383,85 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     font-size: 12px;
 }
 
+/* #11.3 — Import preview panel. One row per parsed entry with a
+ * status badge on the left (new / collision / invalid), the CF name
+ * and score/spec-count in the middle, and an inline error message
+ * below for invalid rows. */
+.cf-import-preview {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    max-height: 320px;
+    overflow-y: auto;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 6px 10px;
+    background: var(--bg-elevated);
+}
+.cf-import-preview-row {
+    display: grid;
+    grid-template-columns: 90px 1fr auto;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 4px;
+    border-bottom: 1px solid var(--border);
+}
+.cf-import-preview-row:last-child {
+    border-bottom: none;
+}
+.cf-import-status-badge {
+    display: inline-block;
+    text-align: center;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: var(--bg);
+    color: var(--text-dim);
+}
+.cf-import-status-badge.cf-import-status-new {
+    background: rgba(140, 204, 151, 0.12);
+    color: #8ccc97;
+    border-color: rgba(140, 204, 151, 0.3);
+}
+.cf-import-status-badge.cf-import-status-collision {
+    background: rgba(234, 179, 8, 0.14);
+    color: #e6c86b;
+    border-color: rgba(234, 179, 8, 0.35);
+}
+.cf-import-status-badge.cf-import-status-invalid {
+    background: rgba(220, 70, 70, 0.12);
+    color: #e06b6b;
+    border-color: rgba(220, 70, 70, 0.3);
+}
+.cf-import-name {
+    font-weight: 500;
+    color: var(--text-bright);
+    overflow-wrap: anywhere;
+    min-width: 0;
+}
+.cf-import-meta {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 10px;
+    font-size: 12px;
+    white-space: nowrap;
+}
+.cf-import-error {
+    grid-column: 1 / -1;
+    font-size: 11px;
+    color: #e06b6b;
+    font-family: monospace;
+    word-break: break-word;
+    background: rgba(220, 70, 70, 0.06);
+    padding: 4px 8px;
+    border-radius: 4px;
+    margin-top: 4px;
+}
+
 /* #11.1 — Sonarr-style CF card grid (full-width flex-wrap of ~300px
  * cards). Replaced the earlier two-pane table layout because compressing
  * a list into 490px made names wrap ugly and the + Delete button clip.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2334,6 +2334,31 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
 .system-tab:hover { color: var(--text); }
 .system-tab.active { color: var(--accent); border-bottom-color: var(--accent); }
 
+/* #20 commit 7 — On phone the tab strip wraps to 2-3 lines (Connections
+ * / Preferred Quality & Releases / Custom Formats / Release Groups /
+ * General at 412px is way too much for one row). Convert to a
+ * horizontally-scrolling strip with snap points so each tab lands
+ * cleanly at the left edge. Same treatment for .settings-tabs and
+ * .system-tabs since they share the same class. */
+@media (max-width: 640px) {
+    .system-tabs {
+        flex-wrap: nowrap;
+        overflow-x: auto;
+        scroll-snap-type: x proximity;
+        scrollbar-width: none;
+        -webkit-overflow-scrolling: touch;
+    }
+    .system-tabs::-webkit-scrollbar {
+        display: none;
+    }
+    .system-tab {
+        flex-shrink: 0;
+        scroll-snap-align: start;
+        padding: 10px 14px;
+        font-size: 13px;
+    }
+}
+
 .settings-tabs {
     margin-bottom: 24px;
 }

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -54,18 +54,23 @@ body {
  * slightly so copy is legible at phone widths without the browser's
  * own text-zoom fallback kicking in. */
 @media (max-width: 640px) {
+    /* Pin html + body at the viewport width. Firefox mobile honors
+     * `overflow-x: hidden` on body only if the element establishes a
+     * containing block that doesn't get stretched by descendants;
+     * setting max-width: 100vw on html forces that. Both html and
+     * body get overflow-x: hidden + max-width: 100vw so a descendant
+     * with intrinsic width > viewport (a select with long option
+     * text, a wide nav anchor, etc.) gets clipped rather than
+     * forcing the whole page to h-scroll. */
+    html, body {
+        overflow-x: hidden;
+        max-width: 100vw;
+    }
     body {
         font-size: 16px;
         /* Padding so the fixed bottom tab bar (56px tall + safe-area
          * inset for iOS home indicator) doesn't overlap page content. */
         padding-bottom: calc(56px + env(safe-area-inset-bottom, 0px));
-        /* Safety net: anything that somehow ends up wider than the
-         * viewport (e.g. long CF JSON in an edit textarea, a wide
-         * table that escaped its scroll wrapper) gets clipped
-         * instead of forcing the whole page to h-scroll. The
-         * expected-to-scroll elements (`.rss-table-wrap`,
-         * `.system-tabs`) each manage their own overflow-x: auto. */
-        overflow-x: hidden;
     }
     input[type="text"],
     input[type="search"],

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2667,7 +2667,11 @@ input[type="file"]::file-selector-button:hover {
 .cf-card-title-row {
     display: flex;
     align-items: flex-start;
-    gap: 8px;
+    /* Wider gap so the × button that replaces the dot on hover
+     * doesn't crowd the name text. The dot is 8px, the × is ~20px;
+     * matching the × width in the gap keeps the name visually anchored
+     * at the same position regardless of hover state. */
+    gap: 16px;
     min-width: 0;
     flex: 1 1 auto;
 }
@@ -2745,7 +2749,10 @@ input[type="file"]::file-selector-button:hover {
  * the delete action. */
 .cf-card-actions {
     position: absolute;
-    top: 12px;
+    top: 13px;
+    /* Left-align the × with the dot's natural position. Card body has
+     * padding-left: 16px; the dot is 8px so its center is at ~x=20.
+     * The 20px × button centered on that center = left:10px. */
     left: 10px;
     opacity: 0;
     transition: opacity 0.15s;
@@ -2814,10 +2821,10 @@ input[type="file"]::file-selector-button:hover {
  * lets the content behind (e.g. the CF name or score) bleed
  * through, which reads as a glitch. */
 .btn-icon-danger {
-    width: 22px;
-    height: 22px;
+    width: 20px;
+    height: 20px;
     padding: 0;
-    border-radius: 6px;
+    border-radius: 5px;
     border: 1px solid var(--border);
     background: var(--bg-card);
     color: var(--text-dim);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -98,9 +98,17 @@ body {
         box-sizing: border-box;
     }
     /* Fieldset padding is 24px on desktop; shrink on phone so the
-     * input grid has more usable horizontal space. */
+     * input grid has more usable horizontal space.
+     *
+     * `min-width: 0` works around a long-standing browser quirk where
+     * <fieldset> defaults to `min-width: min-content`, so a wide child
+     * (like the group-source-table before its scroll wrap caught it)
+     * would force the fieldset past the viewport and cut the page off.
+     * Without this, the Release Groups tab renders fine horizontally
+     * but the fieldset's computed height clips below the real content. */
     fieldset {
         padding: 16px;
+        min-width: 0;
     }
     /* Content container padding tightens from 24px to 14px side-padding
      * so forms don't get squeezed on both sides. */
@@ -108,13 +116,14 @@ body {
         padding: 24px 14px calc(80px + env(safe-area-inset-bottom, 0px));
     }
 
-    /* Wide data tables (Groups, CF import collision review) become
-     * independently scrollable on mobile so they don't push the form
-     * above them past the viewport. `display: block` sacrifices the
-     * accessibility tree's table semantics at this width — worth it
-     * to stop the parent-container width leak. */
-    .group-source-table {
-        display: block;
+    /* Wide data tables (Groups, CF import collision review) that live
+     * directly in their section need a scrolling parent on mobile. The
+     * template wraps them in a `<div class="table-scroll-wrap">` so
+     * the table can keep its native <table> layout (display:block on
+     * the table itself broke the internal row layout in some contexts).
+     * `-webkit-overflow-scrolling: touch` preserves inertial scrolling
+     * on iOS. */
+    .table-scroll-wrap {
         overflow-x: auto;
         max-width: 100%;
         -webkit-overflow-scrolling: touch;
@@ -3537,6 +3546,22 @@ input[type="file"]::file-selector-button:hover {
     max-width: 100%;
 }
 
+/* Chevron indicator so rows with hidden detail look tappable. Rotates
+ * 180° when the row is expanded. Only visible on rows carrying the
+ * `log-row-has-detail` class (rows without detail have nothing to
+ * expand and don't get an onclick handler either). */
+.log-expand-hint {
+    display: inline-block;
+    margin-left: 6px;
+    color: var(--text-dim);
+    font-size: 10px;
+    transition: transform 0.15s ease;
+    vertical-align: middle;
+}
+.log-row.log-row-expanded .log-expand-hint {
+    transform: rotate(180deg);
+}
+
 /* Log Level Badges */
 .log-badge {
     display: inline-block;
@@ -3591,10 +3616,10 @@ input[type="file"]::file-selector-button:hover {
 .log-row.log-row-expanded {
     background: rgba(203, 166, 247, 0.04);
 }
-/* Give tap rows a little visual hint they're interactive on mobile. */
-@media (max-width: 640px) {
-    .log-row { cursor: pointer; }
-}
+/* Only log rows carrying detail get an onclick + interactive cursor.
+ * Rows without detail have nothing to expand, so tapping them doing
+ * nothing was the previous confusing behavior — hide the affordance. */
+.log-row-has-detail { cursor: pointer; }
 
 /* RSS */
 .rss-panel {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -3331,6 +3331,38 @@ input[type="file"]::file-selector-button:hover {
     font-size: 13px;
 }
 
+/* #20 commit 9 — Touch-target minimums. Below --bp-phone every tappable
+ * button gets bumped to at least a 40x40 hit area (WCAG 2.5.5
+ * recommends 44x44; .btn-sm at 40 is our compromise for density).
+ * Icon-only buttons get the full 44x44 since the visible control
+ * is already small and fingers are imprecise. Checkbox rows gain
+ * vertical padding so the whole row is tappable, not just the 16px
+ * checkbox square. */
+@media (max-width: 640px) {
+    .btn-sm {
+        min-height: 40px;
+        padding: 8px 14px;
+        font-size: 14px;
+    }
+    .btn-ghost,
+    .btn-icon,
+    .btn-icon-sm,
+    .btn-icon-danger {
+        min-width: 44px;
+        min-height: 44px;
+    }
+    .checkbox-row,
+    .checkbox-label {
+        padding: 8px 0;
+    }
+    /* Card-level action clusters (Grab button, etc.) go full-width so
+     * the thumb has the whole row to aim at. */
+    .result-card-footer .btn-grab {
+        flex: 1 1 auto;
+        min-width: 0;
+    }
+}
+
 /* Log Table */
 .logs-container {
     border: 1px solid var(--border);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -138,13 +138,26 @@ body {
         right: 0;
         bottom: 0;
         z-index: 100;
-        background: rgba(15, 15, 19, 0.96);
-        backdrop-filter: blur(10px);
+        background: var(--bg);
         border-top: 1px solid var(--border);
         padding-bottom: env(safe-area-inset-bottom, 0px);
+        /* Promote to its own GPU compositing layer so address-bar
+         * show/hide on iOS Safari doesn't repaint the blurred
+         * backdrop-filter layer on every scroll tick. Combined with
+         * dropping the blur entirely (solid bg above) to prevent the
+         * jitter users were seeing. */
+        will-change: transform;
+        transform: translateZ(0);
     }
     .mobile-tab {
-        flex: 1 1 0;
+        /* Explicit equal-width (1/5) instead of `flex: 1 1 0`. With
+         * flex-basis:0, column-flex children whose natural content
+         * width varies slightly (ICON + short label) can trigger
+         * sub-pixel rounding that makes Library/System feel further
+         * apart than Search/Downloads/Settings. Pinning each tab to
+         * 20% guarantees geometric parity regardless of content. */
+        flex: 0 0 20%;
+        width: 20%;
         display: flex;
         flex-direction: column;
         align-items: center;
@@ -3569,68 +3582,16 @@ input[type="file"]::file-selector-button:hover {
     color: var(--green);
 }
 
-/* #20 — Collapse .rss-table rows into stacked "cards" on phone
- * viewports. Used by the downloads page (queue / history / blocklist)
- * plus the System RSS decisions and Scheduled Tasks tables. Rather
- * than dual markup — which would triple the template work for six+
- * tables — we reshape the existing rows via display: block. The
- * tradeoff: accessibility tree loses the table semantics at phone
- * widths; acceptable because the data is still per-row and the
- * desktop/tablet path keeps the real table.
- *
- * Each <tr> becomes a padded card; each <td> becomes a row inside
- * that card with the first column (usually the name) bolded, and
- * the action column pushed to a footer row with horizontal flex. */
-@media (max-width: 640px) {
-    .rss-table,
-    .rss-table tbody,
-    .rss-table tr,
-    .rss-table td {
-        display: block;
-        width: 100%;
-    }
-    .rss-table thead {
-        display: none;
-    }
-    .rss-table-wrap {
-        overflow-x: visible;
-    }
-    .rss-table tr {
-        background: var(--bg-card);
-        border: 1px solid var(--border);
-        border-radius: var(--radius);
-        padding: 12px 14px;
-        margin-bottom: 10px;
-    }
-    .rss-table td {
-        border: none !important;
-        padding: 3px 0;
-        font-size: 13px;
-    }
-    .rss-table td:first-child {
-        font-weight: 500;
-        color: var(--text-bright);
-        padding: 0 0 8px;
-        border-bottom: 1px solid var(--border) !important;
-        margin-bottom: 8px;
-    }
-    /* Action columns (buttons) sit on their own row flex-wrapped so
-     * play/pause/delete don't collide with the text rows above. */
-    .rss-table td.dl-actions,
-    .rss-table td:last-child {
-        margin-top: 8px;
-        padding-top: 8px;
-        border-top: 1px solid var(--border) !important;
-        display: flex;
-        flex-wrap: wrap;
-        gap: 8px;
-    }
-    /* Progress bar stays full-width on its own row — it would be
-     * cramped in a columnar stack otherwise. */
-    .dl-progress-wrap {
-        width: 100%;
-    }
-}
+/* #20 follow-up — .rss-table tables (downloads, RSS decisions,
+ * scheduled tasks) keep their real table shape on mobile. An
+ * earlier attempt to reshape them as cards via display:block broke
+ * more than it fixed (form layouts overflowed, RSS status stat
+ * rows collapsed into illegible stacks). `.rss-table-wrap` already
+ * has `overflow: auto`, so content wider than the viewport scrolls
+ * naturally within the wrapper — the right UX for data tables at
+ * small widths. Dedicated dual-markup card lists live only where
+ * the table shape doesn't carry its weight (search results,
+ * episode table — see 8ca7fca and 3fc9d17). */
 
 .rss-decision-rejected,
 .rss-decision-error {

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -178,6 +178,33 @@ body {
     .form-group > div[style*="display: flex"] {
         flex-wrap: wrap;
     }
+
+    /* Logs: there is no :hover on touch, and tr-level onclick on mobile
+     * Firefox was unreliable even when wired up directly. Drop the
+     * tap-to-expand pattern on phone and just always show detail fully
+     * wrapped — the desktop's ellipsis+hover exists to save vertical
+     * space, and mobile rows are already one-per-screen-width anyway. */
+    .log-row .log-detail {
+        white-space: normal;
+        word-break: break-word;
+    }
+    .log-expand-hint { display: none; }
+    .log-row-has-detail { cursor: default; }
+
+    /* Series detail: strip the outer season-section card on phone so
+     * the rounded-border container doesn't nest around the already-
+     * carded episode rows (created duplicated visible lines around
+     * the table). Season header stays as a flat header; episodes sit
+     * directly below it as independent cards. */
+    .season-section {
+        background: transparent;
+        border: none;
+        border-radius: 0;
+        overflow: visible;
+        margin-bottom: 20px;
+    }
+    .season-header { padding: 10px 0; }
+    .season-body { border-top: none; padding-top: 6px; }
 }
 
 /* #20 — Mobile tab bar default (hidden). The actual phone-width swap

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -25,6 +25,16 @@
     --font-mono: 'JetBrains Mono', 'Fira Code', monospace;
     --radius: 6px;
     --radius-lg: 10px;
+    /* #20 — Breakpoint system. Exposed as custom properties so JS that
+     * needs to know "am I on mobile" can read them via getComputedStyle
+     * instead of duplicating pixel values. The @media queries throughout
+     * the stylesheet still hardcode these numbers because `@media
+     * (max-width: var(--bp-phone))` is only supported in very recent
+     * browsers; a comment at each @media block references which
+     * breakpoint it's targeting. */
+    --bp-phone: 640px;
+    --bp-tablet: 900px;
+    --bp-desktop: 1100px;
 }
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -36,6 +46,28 @@ body {
     font-size: 15px;
     line-height: 1.6;
     -webkit-font-smoothing: antialiased;
+}
+
+/* #20 — Mobile reset. Below --bp-phone iOS Safari will auto-zoom on
+ * any form input whose font-size is < 16px, so everything that accepts
+ * keyboard input gets bumped to 16px. Also scale body font-size up
+ * slightly so copy is legible at phone widths without the browser's
+ * own text-zoom fallback kicking in. */
+@media (max-width: 640px) {
+    body {
+        font-size: 16px;
+    }
+    input[type="text"],
+    input[type="search"],
+    input[type="number"],
+    input[type="password"],
+    input[type="email"],
+    input[type="url"],
+    input[type="tel"],
+    select,
+    textarea {
+        font-size: 16px;
+    }
 }
 
 /* --- Nav --- */

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -125,6 +125,50 @@ body {
     .form-hint {
         overflow-wrap: anywhere;
     }
+
+    /* Specific overflow culprits identified during phone testing.
+     * Each of these set a fixed/min width that forced their parent
+     * past the viewport at ~500px widths. */
+
+    /* RSS-decisions "Reason" column had `min-width: 420px` which
+     * alone exceeds a 412px viewport. Let the cell shrink to its
+     * share of the table width; the text wraps via .rss-reason-text
+     * `white-space: pre-wrap` so long reasons stay readable. */
+    .rss-reason-cell {
+        min-width: 0;
+    }
+
+    /* RSS-decisions filter-row text input had `flex: 1 1 320px` so
+     * its natural size pushed siblings off-screen. Shrink to zero
+     * basis so the flex container can honor the viewport. */
+    .rss-table-controls input,
+    .rss-table-controls select {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+
+    /* Logs-table fixed-width columns collectively exceed 500px
+     * (160 + 70 + 100 + content = 330+ reserved). Drop the
+     * hard widths on mobile and let content dictate width; the
+     * table wrapper keeps overflow-x: auto as a fallback. */
+    .log-col-time,
+    .log-col-level,
+    .log-col-cat {
+        width: auto;
+        min-width: 0;
+    }
+    .log-col-time {
+        font-size: 11px;
+        white-space: nowrap;
+    }
+
+    /* Password/API-key/download-path rows use inline `display: flex;
+     * gap: 8px;` with `white-space: nowrap` buttons that refuse to
+     * shrink. Allow the row to wrap so Show/Copy can drop below the
+     * input rather than fighting it for width. */
+    .form-group > div[style*="display: flex"] {
+        flex-wrap: wrap;
+    }
 }
 
 /* #20 — Mobile tab bar default (hidden). The actual phone-width swap

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2296,6 +2296,77 @@ html:not([data-title-language]) .title-switcher .title-option[data-title-lang="e
     font-weight: 500;
 }
 
+/* #11.1 — Two-pane CF layout (list on the left, editor on the right).
+ * Proportions: 1fr list + 1.2fr editor so the editor's textarea gets
+ * enough width without starving the list name column. Collapses to a
+ * single column below 1080px because the editor form becomes unusable
+ * at narrower widths; the full mobile treatment lands in #20. */
+.cf-panes {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.2fr);
+    gap: 20px;
+    align-items: start;
+    margin-bottom: 20px;
+}
+@media (max-width: 1080px) {
+    .cf-panes {
+        grid-template-columns: 1fr;
+    }
+}
+.cf-pane-list,
+.cf-pane-editor {
+    margin-bottom: 0;
+}
+/* Header pill + "+ New" button live on the same right-aligned row so the
+ * list header reads as "Title | count • new-button". */
+.cf-list-header-actions {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+.cf-list-filter {
+    margin-bottom: 14px;
+    width: 100%;
+}
+/* Soft cap on the list pane height so a 28-entry default set doesn't
+ * push the editor pane off-screen. The editor is the thing the user is
+ * actively typing in; the list stays scrollable. */
+.cf-list-scroll {
+    max-height: 560px;
+    overflow-y: auto;
+    border-top: 1px solid var(--border);
+}
+.cf-list-scroll .group-source-table {
+    margin-top: 0;
+    border-top: none;
+}
+/* Sticky header so scrolling through the list keeps the column labels
+ * visible. Requires the table to live inside .cf-list-scroll (which
+ * establishes the scroll container). */
+.cf-list-scroll .group-source-table thead {
+    position: sticky;
+    top: 0;
+    background: var(--bg-card);
+    z-index: 1;
+}
+.cf-row-link {
+    color: inherit;
+    text-decoration: none;
+    display: block;
+}
+.cf-row-link:hover {
+    color: var(--accent);
+}
+.cf-row-selected {
+    background: rgba(203, 166, 247, 0.08);
+}
+.cf-row-selected .cf-name {
+    color: var(--accent);
+}
+.cf-row-selected::after {
+    content: none;
+}
+
 /* Trash-Guides description callout shown above the edit form when the
    CF carries a `trash_description` field. Replaces the inline-styled
    white box that broke the dark theme. */

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,6 +33,35 @@
         {% block content %}{% endblock %}
     </main>
 
+    {# #20 — Fixed bottom tab bar for mobile. Hidden above --bp-phone
+       via CSS; the top nav's .nav-links is hidden below --bp-phone so
+       exactly one nav is visible at any width. Five slots: Library,
+       Search, Downloads, Settings, System. Logout doesn't get a tab
+       — it lives in a Settings-page footer when needed. Icons are
+       inline SVG so no asset pipeline is required. #}
+    <nav class="mobile-tabbar" aria-label="Primary">
+        <a href="/" class="mobile-tab {% if page == "library" %}active{% endif %}" aria-label="Library">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+            <span class="mobile-tab-label">Library</span>
+        </a>
+        <a href="/search" class="mobile-tab {% if page == "search" %}active{% endif %}" aria-label="Search">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+            <span class="mobile-tab-label">Search</span>
+        </a>
+        <a href="/downloads" class="mobile-tab {% if page == "downloads" %}active{% endif %}" aria-label="Downloads">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+            <span class="mobile-tab-label">Downloads</span>
+        </a>
+        <a href="/settings" class="mobile-tab {% if page == "settings" %}active{% endif %}" aria-label="Settings">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+            <span class="mobile-tab-label">Settings</span>
+        </a>
+        <a href="/system" class="mobile-tab {% if page == "system" %}active{% endif %}" aria-label="System">
+            <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
+            <span class="mobile-tab-label">System</span>
+        </a>
+    </nav>
+
     <!-- Shared confirm modal — used by any page that needs a yes/no
          prompt instead of the browser's native confirm(). Invoked via
          window.ryokanConfirm({title, body, yesLabel, noLabel, extras}).

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,8 @@
          checkboxes to render inside the modal body; the resolved promise
          carries back their values. -->
     <div class="modal-backdrop" id="ryokan-confirm-modal" style="display:none">
-        <div class="modal" style="max-width:420px">
+        <div class="modal" style="max-width:420px"
+             role="dialog" aria-modal="true" aria-labelledby="ryokan-confirm-title">
             <div class="modal-header">
                 <h3 id="ryokan-confirm-title">Confirm</h3>
                 <button class="btn-icon" type="button" id="ryokan-confirm-close" aria-label="Close">
@@ -91,7 +92,8 @@
          Invoked via window.ryokanAlert({title, body, okLabel}). Returns
          a promise that resolves when the user dismisses the modal. -->
     <div class="modal-backdrop" id="ryokan-alert-modal" style="display:none">
-        <div class="modal" style="max-width:420px">
+        <div class="modal" style="max-width:420px"
+             role="dialog" aria-modal="true" aria-labelledby="ryokan-alert-title">
             <div class="modal-header">
                 <h3 id="ryokan-alert-title">Notice</h3>
                 <button class="btn-icon" type="button" id="ryokan-alert-close" aria-label="Close">
@@ -113,7 +115,8 @@
          that resolves to the submitted string, or null if cancelled.
          `validator` is an optional sync function (value) => errorString | null. -->
     <div class="modal-backdrop" id="ryokan-prompt-modal" style="display:none">
-        <div class="modal" style="max-width:420px">
+        <div class="modal" style="max-width:420px"
+             role="dialog" aria-modal="true" aria-labelledby="ryokan-prompt-title">
             <div class="modal-header">
                 <h3 id="ryokan-prompt-title">Enter value</h3>
                 <button class="btn-icon" type="button" id="ryokan-prompt-close" aria-label="Close">

--- a/templates/help.html
+++ b/templates/help.html
@@ -58,19 +58,19 @@
 
     <section class="help-section" id="forgot-password">
         <h3>Forgot your password?</h3>
-        <p>Ryokan stores the admin account in the same SQLite database as the rest of its config. There are two ways to recover access if you've forgotten your password. Both only wipe the <code>users</code> and <code>sessions</code> tables — your Jellyfin / qBittorrent credentials and other settings survive the reset.</p>
+        <p>Ryokan stores the admin account in the same SQLite database as the rest of its config. There are two ways to recover access if you've forgotten your password. Both only wipe the <code>users</code> and <code>sessions</code> tables; your Jellyfin / qBittorrent credentials and other settings survive the reset.</p>
 
-        <h4>Option 1 — restart with the reset flag</h4>
+        <h4>Option 1: restart with the reset flag</h4>
         <p>On the machine running Ryokan:</p>
         <ol>
             <li>Create an empty sentinel file alongside the database: <code>touch data/.reset-auth</code></li>
             <li>Restart Ryokan with the environment variable <code>RYOKAN_RESET_AUTH=1</code> set, or with the <code>--reset-auth</code> CLI flag.</li>
-            <li>Open Ryokan in your browser — you'll be redirected to the first-run setup page. Create a new admin account.</li>
+            <li>Open Ryokan in your browser. You'll be redirected to the first-run setup page; create a new admin account.</li>
             <li>Remove the sentinel file: <code>rm data/.reset-auth</code>. Leaving it in place is harmless, but the env var alone won't wipe auth again without the sentinel.</li>
         </ol>
         <p>The sentinel file is required so that a stuck-on <code>RYOKAN_RESET_AUTH=1</code> in a <code>docker-compose.yml</code> can't accidentally wipe auth on every boot. Recovery is always a deliberate two-step action.</p>
 
-        <h4>Option 2 — sqlite3 recipe</h4>
+        <h4>Option 2: sqlite3 recipe</h4>
         <p>If you can't easily restart Ryokan with a new environment variable (e.g. you're on a managed deployment), shut Ryokan down and run this once against the database:</p>
         <pre><code>sqlite3 data/ryokan.db "DELETE FROM users; DELETE FROM sessions;"</code></pre>
         <p>Then start Ryokan back up and create a new admin account through the first-run setup.</p>

--- a/templates/needs_review.html
+++ b/templates/needs_review.html
@@ -22,8 +22,8 @@
     <p>No episodes currently flagged for review.</p>
     <p class="form-hint">
         This view fills up when the classifier lands on a low-confidence
-        verdict — either because no single layer was strong enough or because
-        two strong layers disagreed. Manual overrides and post-download
+        verdict: either no single layer was strong enough, or two strong
+        layers disagreed. Manual overrides and post-download
         ffprobe checks usually keep it empty.
     </p>
 </div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -92,6 +92,37 @@
             </tbody>
         </table>
 
+        {# #20 — Dual markup. Cards render on phone viewports via CSS
+           swap; the table above stays the canonical representation
+           for desktop. loadMore() appends rows to both containers so
+           paginated results show up regardless of viewport. #}
+        <div class="results-cards" id="results-cards">
+            {% for r in results %}
+            <div class="result-card {% if r.is_batch %}is-batch{% endif %} {% if r.is_trusted %}is-trusted{% endif %}">
+                <div class="result-card-header">
+                    <span class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}">{{ r.score }}</span>
+                    <a class="result-card-title" href="{{ r.link }}" target="_blank" rel="noopener">{{ r.title }}</a>
+                </div>
+                <div class="result-card-tags">
+                    {% if r.is_batch %}<span class="tag tag-batch">BATCH</span>{% endif %}
+                    {% if r.is_trusted %}<span class="tag tag-trusted">TRUSTED</span>{% endif %}
+                    {% if !r.group.is_empty() %}<span class="tag tag-group">{{ r.group }}</span>{% endif %}
+                    {% if !r.resolution.is_empty() %}<span class="tag tag-res">{{ r.resolution }}p</span>{% endif %}
+                </div>
+                <div class="result-card-footer">
+                    <span class="result-card-meta">{{ r.size }}</span>
+                    <span class="result-card-meta"><span class="seed-count">{{ r.seeders }}</span> S</span>
+                    <span class="result-card-meta"><span class="leech-count">{{ r.leechers }}</span> L</span>
+                    {% if !r.magnet.is_empty() %}
+                    <button class="btn btn-grab" onclick="grabRelease('{{ r.magnet }}', this)">Grab</button>
+                    {% else if !r.torrent.is_empty() %}
+                    <button class="btn btn-grab" onclick="grabRelease('{{ r.torrent }}', this)">Grab</button>
+                    {% endif %}
+                </div>
+            </div>
+            {% endfor %}
+        </div>
+
         <div class="load-more-area" id="load-more-area" {% if !has_next %}style="display:none"{% endif %}>
             <button class="btn btn-load-more" id="load-more-btn" onclick="loadMore()">Load page 2</button>
             <span class="load-more-status" id="load-more-status"></span>
@@ -153,13 +184,12 @@ function loadMore() {
             }
 
             const tbody = document.getElementById('results-body');
+            const cards = document.getElementById('results-cards');
             for (const r of results) {
-                const tr = document.createElement('tr');
                 let rowClass = '';
                 if (r.is_batch && r.is_trusted) rowClass = 'is-batch is-trusted';
                 else if (r.is_batch) rowClass = 'is-batch';
                 else if (r.is_trusted) rowClass = 'is-trusted';
-                if (rowClass) tr.className = rowClass;
 
                 let scoreClass = r.score >= 60 ? 'score-high' : r.score >= 30 ? 'score-mid' : 'score-low';
                 let tags = '';
@@ -171,6 +201,9 @@ function loadMore() {
                 const grabUrl = r.magnet || r.torrent || '';
                 const grabBtn = grabUrl ? `<button class="btn btn-grab" onclick="grabRelease('${escAttr(grabUrl)}', this)">Grab</button>` : '';
 
+                // Table row (desktop).
+                const tr = document.createElement('tr');
+                if (rowClass) tr.className = rowClass;
                 tr.innerHTML = `
                     <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
                     <td class="col-name">
@@ -184,6 +217,28 @@ function loadMore() {
                     <td class="col-actions">${grabBtn}</td>
                 `;
                 tbody.appendChild(tr);
+
+                // Card (mobile). Same data, different shape. Hidden above
+                // --bp-phone via CSS; loadMore keeps both in sync so a
+                // viewport resize post-load still renders correctly.
+                if (cards) {
+                    const card = document.createElement('div');
+                    card.className = `result-card${rowClass ? ' ' + rowClass : ''}`;
+                    card.innerHTML = `
+                        <div class="result-card-header">
+                            <span class="score-badge ${scoreClass}">${r.score}</span>
+                            <a class="result-card-title" href="${escAttr(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>
+                        </div>
+                        <div class="result-card-tags">${tags}</div>
+                        <div class="result-card-footer">
+                            <span class="result-card-meta">${escHtml(r.size)}</span>
+                            <span class="result-card-meta"><span class="seed-count">${r.seeders}</span> S</span>
+                            <span class="result-card-meta"><span class="leech-count">${r.leechers}</span> L</span>
+                            ${grabBtn}
+                        </div>
+                    `;
+                    cards.appendChild(card);
+                }
             }
 
             totalResults += results.length;

--- a/templates/series.html
+++ b/templates/series.html
@@ -208,7 +208,7 @@
             <button class="monitor-all-btn {% if all_monitored %}is-active{% endif %}" type="button"
                 id="btn-monitor-all"
                 onclick="toggleMonitorAll({{ id }}, {{ all_monitored }})"
-                title="{% if all_monitored %}All monitored — click to unmonitor all{% else %}Click to monitor all episodes{% endif %}"
+                title="{% if all_monitored %}All monitored. Click to unmonitor all{% else %}Click to monitor all episodes{% endif %}"
                 aria-label="Toggle monitor all episodes">
                 {% if all_monitored %}
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>
@@ -253,7 +253,7 @@
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
                         </span>
                         {% else if ep.downloaded %}
-                        <span class="ep-status-icon ep-have" title="Downloaded (post-processing disabled — file not in library root)">
+                        <span class="ep-status-icon ep-have" title="Downloaded (post-processing disabled; file not in library root)">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
                         </span>
                         {% else %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -181,7 +181,7 @@
                     <option value="bluray_bdmv" {% if config.cutoff_source == "bluray_bdmv" %}selected{% endif %}>BD-RAW</option>
                     <option value="dvd" {% if config.cutoff_source == "dvd" %}selected{% endif %}>DVD</option>
                 </select>
-                <span class="form-hint">Stop upgrading once the existing file reaches this source at or above the cutoff resolution. Should be ≥ preferred source. BD-Remux and BD-RAW require a matching sub-tier — plain BD encodes will stay upgradeable.</span>
+                <span class="form-hint">Stop upgrading once the existing file reaches this source at or above the cutoff resolution. Should be ≥ preferred source. BD-Remux and BD-RAW require a matching sub-tier. Plain BD encodes will stay upgradeable.</span>
             </div>
             <div class="form-group">
                 <label for="cutoff_resolution">Cutoff Resolution</label>
@@ -260,12 +260,12 @@
                     <input type="checkbox" name="post_processing_enabled" id="post_processing_enabled" {% if config.post_processing_enabled %}checked{% endif %}>
                     <span>Enable post-processing</span>
                 </label>
-                <span class="form-hint">When enabled, Ryokan will rename and move completed downloads into your media library and write NFO sidecar files for Jellyfin. No external metadata providers are queried — data already in the database is used. Requires a configured media root and qBittorrent.</span>
+                <span class="form-hint">When enabled, Ryokan will rename and move completed downloads into your media library and write NFO sidecar files for Jellyfin. No external metadata providers are queried; data already in the database is used. Requires a configured media root and qBittorrent.</span>
             </div>
             <div class="form-group">
                 <label for="post_processing_mode">File operation mode</label>
                 <select name="post_processing_mode" id="post_processing_mode">
-                    <option value="hardlink" {% if config.post_processing_mode == "hardlink" %}selected{% endif %}>Hardlink (recommended — preserves seeding, no extra disk space)</option>
+                    <option value="hardlink" {% if config.post_processing_mode == "hardlink" %}selected{% endif %}>Hardlink (recommended; preserves seeding, no extra disk space)</option>
                     <option value="copy" {% if config.post_processing_mode == "copy" %}selected{% endif %}>Copy (safe across filesystems, uses extra disk space)</option>
                     <option value="move" {% if config.post_processing_mode == "move" %}selected{% endif %}>Move (frees download space, breaks seeding)</option>
                 </select>
@@ -320,7 +320,7 @@
                         {% if let Some(existing) = s.existing_source %}
                         <span class="tag tag-res" title="Accepting will overwrite the existing mapping">conflicts: {{ existing.as_str() }}</span>
                         {% else %}
-                        <span class="form-hint">— (new)</span>
+                        <span class="form-hint">(new)</span>
                         {% endif %}
                     </td>
                     <td>
@@ -563,53 +563,51 @@
     {% endif %}
 
     {# ── Defaults & Threshold (#11.5) ────────────────────────────────
-       Collapses three separate cf-section cards (Install Defaults,
-       Reset Defaults, Minimum Score) into one. Minimum Score and
-       Defaults logically belong together — both are "global CF
-       configuration" knobs that don't live on any individual CF. The
-       empty-state card above also shows an Install Defaults button;
-       this section is the always-available canonical home for the
-       same action. #}
+       Stacks two blocks vertically: Bundled Defaults on top (install
+       and reset actions), Minimum Score below. Originally tried a
+       two-column grid but the Min Score block ended up reading as an
+       orphan on the right; a vertical stack is cleaner and keeps the
+       related Install/Reset copy next to its buttons. #}
     <div class="cf-section">
         <div class="cf-section-header">
             <h3>Defaults &amp; Threshold</h3>
         </div>
+
+        <h4 class="cf-defaults-subtitle">Bundled defaults</h4>
         <p class="cf-section-desc">
-            <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 penalty) — existing names are skipped so repeat clicks are safe.
-            <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file; manual and imported CFs are untouched.
-            <strong>Minimum Score</strong> is a floor — auto-search drops releases whose summed CF score falls below it; interactive search still shows everything. Leave blank to disable the floor.
+            <strong>Install Defaults</strong> adds the bundled anime-tuned Custom Formats (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit / x265, FLAC / Opus, plus an 8-bit mp4 penalty). Repeat clicks are safe: existing names are skipped.
         </p>
-        <div class="cf-defaults-grid">
-            <div class="cf-defaults-col">
-                <h4 class="cf-defaults-subtitle">Bundled set</h4>
-                <div class="settings-inline-actions">
-                    <form method="post" action="/settings/custom-formats/install-defaults"
-                          data-ryokan-confirm-title="Install bundled defaults"
-                          data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
-                          data-ryokan-confirm-label="Install">
-                        <button type="submit" class="btn btn-primary">Install Defaults</button>
-                    </form>
-                    <form method="post" action="/settings/custom-formats/reset-defaults"
-                          data-ryokan-confirm-title="Reset bundled defaults"
-                          data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
-                          data-ryokan-confirm-label="Reset">
-                        <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
-                    </form>
-                </div>
-            </div>
-            <div class="cf-defaults-col">
-                <h4 class="cf-defaults-subtitle">Score floor</h4>
-                <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form cf-min-score-form">
-                    <div class="form-group" style="margin-bottom: 12px">
-                        <input type="number" name="minimum_score" id="cf_min_score"
-                            value="{{ custom_format_min_score_display }}"
-                            placeholder="(blank = no floor)"
-                            aria-label="Minimum score">
-                    </div>
-                    <button type="submit" class="btn btn-primary">Save Minimum Score</button>
-                </form>
-            </div>
+        <p class="cf-section-desc">
+            <strong>Reset to Defaults</strong> drops every row with Source = <em>default</em> and re-installs the bundled set from scratch. Useful if you edited a default CF and want the original back. Manual and imported CFs are untouched.
+        </p>
+        <div class="settings-inline-actions">
+            <form method="post" action="/settings/custom-formats/install-defaults"
+                  data-ryokan-confirm-title="Install bundled defaults"
+                  data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
+                  data-ryokan-confirm-label="Install">
+                <button type="submit" class="btn btn-primary">Install Defaults</button>
+            </form>
+            <form method="post" action="/settings/custom-formats/reset-defaults"
+                  data-ryokan-confirm-title="Reset bundled defaults"
+                  data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
+                  data-ryokan-confirm-label="Reset">
+                <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
+            </form>
         </div>
+
+        <h4 class="cf-defaults-subtitle" style="margin-top: 24px">Minimum score</h4>
+        <p class="cf-section-desc">
+            Auto-search drops any release whose summed CF score falls below this floor. Interactive search still shows everything. Leave blank to disable the floor entirely.
+        </p>
+        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form cf-min-score-form">
+            <div class="form-group cf-min-score-group">
+                <input type="number" name="minimum_score" id="cf_min_score"
+                    value="{{ custom_format_min_score_display }}"
+                    placeholder="(blank = no floor)"
+                    aria-label="Minimum score">
+                <button type="submit" class="btn btn-primary">Save</button>
+            </div>
+        </form>
     </div>
 
     {# ── Export (#11.4) ─────────────────────────────────────────────
@@ -623,7 +621,7 @@
         </div>
         <p class="cf-section-desc">
             <strong>Ryokan (native)</strong> keeps every selected CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
-            <strong>Sonarr-safe</strong> drops selected CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
+            <strong>Sonarr-safe</strong> drops selected CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance. Dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
         </p>
 
         <div class="cf-export-mode-row">
@@ -751,10 +749,10 @@
         {% else %}
         <form method="post" action="/settings/custom-formats/import" class="settings-form">
             <p class="cf-section-desc" style="margin-top:0">
-                Paste a Sonarr v4 CF export or upload a .json file. Accepts a single object, an array, or <code>{"custom_formats":[…]}</code> wrapper. Every entry runs through the same compiler as the create form — invalid entries are flagged for review before any are written.
+                Paste a Sonarr v4 CF export or upload a .json file. Accepts a single object, an array, or <code>{"custom_formats":[…]}</code> wrapper. Every entry runs through the same compiler as the create form. Invalid entries are flagged for review before any are written.
             </p>
             <div class="form-group">
-                <label for="cf_import_file">Upload JSON file <span class="form-hint">(optional — fills the textarea below)</span></label>
+                <label for="cf_import_file">Upload JSON file <span class="form-hint">(optional; fills the textarea below)</span></label>
                 <input type="file" id="cf_import_file" accept="application/json,.json"
                     onchange="cfImportFilePicked(this)">
             </div>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -612,18 +612,67 @@
         </div>
     </div>
 
-    {# ── Import / Export ────────────────────────────────────────────── #}
+    {# ── Export (#11.4) ─────────────────────────────────────────────
+       Per-CF checkbox selector + mode radio + two actions (download
+       file / copy to clipboard). The selector only renders when at
+       least one CF exists — exporting 0 rows isn't useful. #}
+    {% if !custom_formats.is_empty() %}
     <div class="cf-section">
         <div class="cf-section-header">
-            <h3>Import / Export</h3>
+            <h3>Export</h3>
         </div>
         <p class="cf-section-desc">
-            <strong>Export All</strong> keeps every saved CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
-            <strong>Sonarr-safe</strong> drops whole CFs containing Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
+            <strong>Ryokan (native)</strong> keeps every selected CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
+            <strong>Sonarr-safe</strong> drops selected CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance — dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
         </p>
-        <div class="settings-inline-actions" style="margin-bottom: 16px;">
-            <a href="/settings/custom-formats/export" class="btn btn-secondary">Export All as JSON</a>
-            <a href="/settings/custom-formats/export?mode=sonarr-safe" class="btn btn-secondary">Export (Sonarr-safe)</a>
+
+        <div class="cf-export-mode-row">
+            <label class="cf-export-mode">
+                <input type="radio" name="cf_export_mode" value="" checked>
+                <span>Ryokan (native)</span>
+            </label>
+            <label class="cf-export-mode">
+                <input type="radio" name="cf_export_mode" value="sonarr-safe">
+                <span>Sonarr-safe</span>
+            </label>
+        </div>
+
+        <div class="cf-export-selector">
+            <div class="cf-export-selector-head">
+                <span class="cf-defaults-subtitle" style="margin:0">Custom formats to include</span>
+                <div class="settings-inline-actions">
+                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(true)">Select all</button>
+                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(false)">Select none</button>
+                </div>
+            </div>
+            <div class="cf-export-list">
+                {% for cf in custom_formats %}
+                <label class="cf-export-check">
+                    <input type="checkbox" name="cf_export_ids" value="{{ cf.row.id }}" checked>
+                    <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"></span>
+                    <span class="cf-export-check-name">{{ cf.row.name }}</span>
+                    <span class="cf-export-check-score cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                        {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
+                    </span>
+                </label>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="settings-inline-actions" style="margin-top: 16px">
+            <button type="button" class="btn btn-primary" onclick="cfExportDownload()">Export JSON</button>
+            <button type="button" class="btn btn-secondary" onclick="cfExportClipboard(this)">Copy to clipboard</button>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── Import ─────────────────────────────────────────────────────
+       Import flow redesign (preview + status badges + inline collision
+       resolution) lives in #11.3. For this commit the existing
+       paste-and-submit form stays as-is. #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Import</h3>
         </div>
 
         {% if let Some(review) = custom_format_import_review %}
@@ -800,6 +849,77 @@ function closeCfEditorModal() {
         if (ev.key === 'Escape' && modal.style.display !== 'none') closeCfEditorModal();
     });
 })();
+
+// #11.4 — CF export selector. Radios pick the mode, checkboxes pick the
+// ids, then two actions: download the file (via the existing GET endpoint)
+// or copy the pretty-printed JSON to the clipboard (same endpoint, fetch
+// then navigator.clipboard.writeText).
+
+function cfExportSelectAll(state) {
+    document.querySelectorAll('input[name="cf_export_ids"]').forEach(function(cb) {
+        cb.checked = state;
+    });
+}
+
+function cfExportBuildUrl() {
+    const mode = document.querySelector('input[name="cf_export_mode"]:checked');
+    const ids = Array.from(
+        document.querySelectorAll('input[name="cf_export_ids"]:checked')
+    ).map(function(cb) { return cb.value; });
+    const params = new URLSearchParams();
+    if (mode && mode.value) params.set('mode', mode.value);
+    // Only attach `ids` when the user has deselected at least one; an
+    // empty `ids` param would be interpreted by the server as "all" (by
+    // design — keeps curl workflows unchanged), but sending the full list
+    // as the default is also harmless.
+    if (ids.length > 0) params.set('ids', ids.join(','));
+    const qs = params.toString();
+    return '/settings/custom-formats/export' + (qs ? '?' + qs : '');
+}
+
+function cfExportDownload() {
+    // Simplest possible "download file" trigger: navigate to the URL —
+    // the server sets Content-Disposition: attachment and the browser
+    // handles the rest. Guards against "select none, click export" by
+    // bailing with a toast.
+    const ids = document.querySelectorAll('input[name="cf_export_ids"]:checked');
+    if (ids.length === 0) {
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'warn', title: 'Export', body: 'Select at least one Custom Format to export.' });
+        }
+        return;
+    }
+    window.location.href = cfExportBuildUrl();
+}
+
+async function cfExportClipboard(btn) {
+    const ids = document.querySelectorAll('input[name="cf_export_ids"]:checked');
+    if (ids.length === 0) {
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'warn', title: 'Export', body: 'Select at least one Custom Format to copy.' });
+        }
+        return;
+    }
+    const originalText = btn.textContent;
+    btn.disabled = true;
+    btn.textContent = 'Copying…';
+    try {
+        const resp = await fetch(cfExportBuildUrl(), { credentials: 'same-origin' });
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+        const text = await resp.text();
+        await navigator.clipboard.writeText(text);
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'success', title: 'Copied', body: ids.length + ' Custom Format(s) copied to clipboard.' });
+        }
+    } catch (e) {
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'error', title: 'Copy failed', body: String(e && e.message ? e.message : e) });
+        }
+    } finally {
+        btn.disabled = false;
+        btn.textContent = originalText;
+    }
+}
 
 function generateApiKey() {
     const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -666,10 +666,17 @@
     </div>
     {% endif %}
 
-    {# ── Import ─────────────────────────────────────────────────────
-       Import flow redesign (preview + status badges + inline collision
-       resolution) lives in #11.3. For this commit the existing
-       paste-and-submit form stays as-is. #}
+    {# ── Import (#11.3) ─────────────────────────────────────────────
+       Two-stage flow:
+       1. Paste / Upload → POST /settings/custom-formats/import.
+          - If every entry is cleanly new, server imports silently and
+            flash-toasts the summary on redirect (unchanged behavior).
+          - If any entry collides or fails to parse, server re-renders
+            this tab with custom_format_import_review populated.
+       2. Review panel shows every parsed entry with a status badge
+          (new / collision / invalid) and error message where applicable,
+          plus per-collision skip/overwrite/rename controls. Single
+          "Apply & Import" button commits everything the user chose. #}
     <div class="cf-section">
         <div class="cf-section-header">
             <h3>Import</h3>
@@ -677,16 +684,39 @@
 
         {% if let Some(review) = custom_format_import_review %}
         <div class="cf-import-review">
-            <h4>Review Import Collisions</h4>
+            <h4 style="margin-top:0">Preview</h4>
             <p class="form-hint">
-                {{ review.collisions.len() }} Custom Format(s) in your import share a name with an existing row.
-                Pick an action per collision. Entries with no collision will import as new rows regardless of these choices.
+                {{ review.entries.len() }} entry in the import payload.
+                Entries marked <strong>new</strong> will import as-is; entries marked <strong>collision</strong> need a per-row action below; entries marked <strong>invalid</strong> failed to parse and are skipped regardless.
             </p>
+            <div class="cf-import-preview">
+                {% for e in review.entries %}
+                <div class="cf-import-preview-row cf-import-status-{{ e.status }}">
+                    <span class="cf-import-status-badge cf-import-status-{{ e.status }}">{{ e.status }}</span>
+                    <span class="cf-import-name">{{ e.name }}{% if e.name.is_empty() %}<em class="form-hint">(unnamed)</em>{% endif %}</span>
+                    <span class="cf-import-meta">
+                        <span class="cf-score {% if e.score > 0 %}cf-score-positive{% else if e.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">{% if e.score > 0 %}+{% endif %}{{ e.score }}</span>
+                        <span class="form-hint">{{ e.specs_count }} spec{% if e.specs_count != 1 %}s{% endif %}</span>
+                    </span>
+                    {% if let Some(err) = e.error.as_ref() %}
+                    <div class="cf-import-error">{{ err }}</div>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
+
+            {% if !review.collisions.is_empty() %}
+            <h4 style="margin-top:24px">Resolve collisions</h4>
+            <p class="form-hint">
+                {{ review.collisions.len() }} Custom Format(s) share a name with an existing row. Pick an action per collision.
+            </p>
+            {% endif %}
             <form method="post" action="/settings/custom-formats/import-resolve" class="settings-form"
                   onsubmit="return buildCfImportResolvePayload(this);">
                 <input type="hidden" name="payload" value="{{ review.payload }}">
                 <input type="hidden" name="decisions" id="cf_import_resolve_decisions" value="">
                 <input type="hidden" name="renames" id="cf_import_resolve_renames" value="">
+                {% if !review.collisions.is_empty() %}
                 <table class="group-source-table cf-table">
                     <thead>
                         <tr>
@@ -711,27 +741,31 @@
                         {% endfor %}
                     </tbody>
                 </table>
-                <div class="settings-inline-actions" style="margin-top: 12px;">
+                {% endif %}
+                <div class="settings-inline-actions" style="margin-top: 16px;">
                     <button type="submit" class="btn btn-primary">Apply &amp; Import</button>
                     <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
                 </div>
             </form>
         </div>
-        {% endif %}
-
+        {% else %}
         <form method="post" action="/settings/custom-formats/import" class="settings-form">
+            <p class="cf-section-desc" style="margin-top:0">
+                Paste a Sonarr v4 CF export or upload a .json file. Accepts a single object, an array, or <code>{"custom_formats":[…]}</code> wrapper. Every entry runs through the same compiler as the create form — invalid entries are flagged for review before any are written.
+            </p>
             <div class="form-group">
-                <label for="cf_import_payload">Paste Sonarr v4 CF Export</label>
-                <textarea name="payload" id="cf_import_payload" rows="10" spellcheck="false"
-                    placeholder='[{"name": "...", "specifications": [...], "score": 100}, ...]'></textarea>
-                <span class="form-hint">
-                    Accepts a single object, an array, or <code>{"custom_formats":[…]}</code> wrapper.
-                    Each entry is compiled via the same parser as the create form. Per-entry failures are counted and the first error is reported.
-                    CFs whose name matches an existing row trigger a review page where you can pick <em>overwrite</em>, <em>rename</em>, or <em>skip</em> per conflict before anything is written.
-                </span>
+                <label for="cf_import_file">Upload JSON file <span class="form-hint">(optional — fills the textarea below)</span></label>
+                <input type="file" id="cf_import_file" accept="application/json,.json"
+                    onchange="cfImportFilePicked(this)">
             </div>
-            <button type="submit" class="btn btn-primary">Import</button>
+            <div class="form-group">
+                <label for="cf_import_payload">Paste Sonarr v4 CF export</label>
+                <textarea name="payload" id="cf_import_payload" rows="10" spellcheck="false"
+                    placeholder='[{"name": "...", "specifications": [...], "score": 100}, ...]' required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Preview &amp; Import</button>
         </form>
+        {% endif %}
     </div>
 </div>
 {% endif %}
@@ -854,6 +888,28 @@ function closeCfEditorModal() {
 // ids, then two actions: download the file (via the existing GET endpoint)
 // or copy the pretty-printed JSON to the clipboard (same endpoint, fetch
 // then navigator.clipboard.writeText).
+
+// #11.3 — When a JSON file is picked, read it and drop into the paste
+// textarea so the user doesn't need a two-step ceremony. The server-side
+// flow stays the same (POST payload → preview → resolve).
+function cfImportFilePicked(input) {
+    const file = input.files && input.files[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = function(ev) {
+        const target = document.getElementById('cf_import_payload');
+        if (target && ev.target && typeof ev.target.result === 'string') {
+            target.value = ev.target.result;
+            target.focus();
+        }
+    };
+    reader.onerror = function() {
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'error', title: 'Import', body: 'Could not read the file.' });
+        }
+    };
+    reader.readAsText(file);
+}
 
 function cfExportSelectAll(state) {
     document.querySelectorAll('input[name="cf_export_ids"]').forEach(function(cb) {

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -448,7 +448,7 @@
                 data-cf-score="{{ cf.row.score }}"
                 data-cf-origin="{{ cf.row.origin }}"
                 data-cf-trash-id="{% if let Some(tid) = cf.row.trash_id.as_ref() %}{{ tid|lowercase }}{% endif %}">
-                <a class="cf-card-body" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}#cf-editor">
+                <a class="cf-card-body" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}">
                     <div class="cf-card-header">
                         <div class="cf-card-title-row">
                             <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"
@@ -483,69 +483,79 @@
             </div>
             {% endfor %}
             {# Trailing add card mirrors Sonarr's "+ Add Custom Format" tile.
-               Navigates to the same URL clearing edit_id, which scrolls
-               the #cf-editor anchor below into view. #}
-            <a class="cf-card cf-card-add" href="/settings?tab=custom_formats#cf-editor">
+               Opens the editor modal in add mode via JS — no URL change
+               so hitting Cancel just returns to the same grid view. #}
+            <button type="button" class="cf-card cf-card-add" onclick="openCfEditorModal()">
                 <div class="cf-card-add-icon">+</div>
                 <div class="cf-card-add-label">Add Custom Format</div>
-            </a>
+            </button>
         </div>
         <div id="cf-list-empty-filter" class="cf-empty-state" style="display:none">
             <p>No Custom Formats match your filter.</p>
         </div>
     </div>
 
-    <div class="cf-section" id="cf-editor">
-        <div class="cf-section-header">
-            <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
-        </div>
-        <p class="cf-section-desc">
-            Full Sonarr v4 CF object. Supported spec implementations:
-            <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
-            The compiler runs before saving, so invalid JSON is rejected with an error message.
-        </p>
-        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
-            {% if let Some(edit) = custom_format_edit %}
-            <input type="hidden" name="id" value="{{ edit.row.id }}">
-            {% if let Some(desc) = edit.trash_description.as_ref() %}
-            <div class="cf-trash-description">
-                <strong>Trash Guides description</strong>
-                <div style="white-space: pre-wrap;">{{ desc }}</div>
-            </div>
-            {% endif %}
-            {% endif %}
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="cf_name">Name</label>
-                    <input type="text" name="name" id="cf_name" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
-                </div>
-                <div class="form-group">
-                    <label for="cf_score">Score</label>
-                    <input type="number" name="score" id="cf_score" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
-                <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
-                    value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
-            </div>
-            <div class="form-group">
-                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
-                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
-                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
-                <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
-            </div>
-            <div class="settings-inline-actions">
-                <button type="submit" class="btn btn-primary">
-                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+    {# Editor modal — opens on card click (deep-link via ?edit_id=N auto-
+       opens on load), or on "+ Add Custom Format" tile click. The form
+       still submits natively to the server; a successful save redirects
+       back to the tab (no modal) and a validation error redirects back
+       with ?edit_id=N and the modal re-opens with the error in &err. #}
+    <div class="modal-backdrop" id="cf-editor-modal" style="display:none">
+        <div class="modal cf-editor-modal" style="max-width:780px">
+            <div class="modal-header">
+                <h3 id="cf-editor-modal-title">{% if let Some(edit) = custom_format_edit %}Edit Custom Format{% else %}Add Custom Format{% endif %}</h3>
+                <button class="btn-icon" type="button" onclick="closeCfEditorModal()" aria-label="Close">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
                 </button>
-                {% if custom_format_edit.is_some() %}
-                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
-                {% endif %}
             </div>
-        </form>
+            <form method="post" action="/settings/custom-formats/upsert" class="settings-form cf-editor-form">
+                <div class="modal-body" style="padding:16px 24px">
+                    <p class="cf-section-desc" style="margin-top:0">
+                        Full Sonarr v4 CF object. Supported spec implementations:
+                        <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
+                        The compiler runs before saving, so invalid JSON is rejected with an error message.
+                    </p>
+                    {% if let Some(edit) = custom_format_edit %}
+                    <input type="hidden" name="id" value="{{ edit.row.id }}">
+                    {% if let Some(desc) = edit.trash_description.as_ref() %}
+                    <div class="cf-trash-description">
+                        <strong>Trash Guides description</strong>
+                        <div style="white-space: pre-wrap;">{{ desc }}</div>
+                    </div>
+                    {% endif %}
+                    {% endif %}
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="cf_name">Name</label>
+                            <input type="text" name="name" id="cf_name" required
+                                value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
+                        </div>
+                        <div class="form-group">
+                            <label for="cf_score">Score</label>
+                            <input type="number" name="score" id="cf_score" required
+                                value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
+                        <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
+                            value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+                    </div>
+                    <div class="form-group">
+                        <label for="cf_json">Sonarr v4 Custom Format JSON</label>
+                        <textarea name="json" id="cf_json" rows="14" required spellcheck="false"
+                            placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
+                        <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
+                    </div>
+                </div>
+                <div class="modal-footer" style="padding:12px 24px;border-top:1px solid var(--border);gap:8px;display:flex;justify-content:flex-end">
+                    <button type="button" class="btn btn-secondary" onclick="closeCfEditorModal()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">
+                        {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+                    </button>
+                </div>
+            </form>
+        </div>
     </div>
     {% endif %}
 
@@ -728,6 +738,58 @@ function filterCfList(query) {
     const addCard = grid.querySelector('.cf-card-add');
     if (addCard) addCard.style.display = q ? 'none' : '';
 }
+
+// #11.1 stage 2 — modal editor open/close. The modal element itself is
+// server-rendered with the pre-filled form when ?edit_id=N is set, so
+// auto-opening is just flipping display. "+ Add Custom Format" opens a
+// fresh modal — but since the form markup is tied to server-side edit
+// state, clicking + on a page that's rendering in edit mode would
+// open the edit form, not a blank one. Fix by clearing edit_id via a
+// GET navigation first whenever the user hits + from an edit-mode page.
+function openCfEditorModal() {
+    const modal = document.getElementById('cf-editor-modal');
+    if (!modal) return;
+    const params = new URLSearchParams(window.location.search);
+    // If page is in edit mode and user clicked "+ Add", navigate to the
+    // bare CF tab first so the server re-renders the empty form.
+    if (params.has('edit_id')) {
+        window.location.href = '/settings?tab=custom_formats';
+        return;
+    }
+    modal.style.display = 'flex';
+    const name = document.getElementById('cf_name');
+    if (name) name.focus();
+}
+function closeCfEditorModal() {
+    const modal = document.getElementById('cf-editor-modal');
+    if (modal) modal.style.display = 'none';
+    // Drop ?edit_id=N from the URL without reloading so Cancel doesn't
+    // leave the user on a URL that'd re-open the modal on refresh.
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('edit_id')) {
+        params.delete('edit_id');
+        const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+        history.replaceState(null, '', newUrl);
+    }
+}
+// Auto-open on load when the URL carries ?edit_id=N — the server
+// already rendered the pre-filled form inside the modal markup, so
+// this is just a display flip. Also handle backdrop click + Escape
+// to dismiss.
+(function() {
+    const modal = document.getElementById('cf-editor-modal');
+    if (!modal) return;
+    const params = new URLSearchParams(window.location.search);
+    if (params.has('edit_id')) {
+        modal.style.display = 'flex';
+    }
+    modal.addEventListener('click', function(ev) {
+        if (ev.target === modal) closeCfEditorModal();
+    });
+    document.addEventListener('keydown', function(ev) {
+        if (ev.key === 'Escape' && modal.style.display !== 'none') closeCfEditorModal();
+    });
+})();
 
 function generateApiKey() {
     const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -407,13 +407,18 @@
         Sonarr v4-compatible Custom Formats. Every matching spec contributes its score to the release total during auto-search. Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
     </p>
 
-    {# ── Current Custom Formats ─────────────────────────────────────── #}
+    {# ── List + Editor panes (#11.1) ─────────────────────────────────
+       Two-column layout: the CF list (with a live client-side filter)
+       sits on the left; the Add/Edit form for the currently-selected
+       CF sits on the right. Row click → `?edit_id=N` (server re-renders
+       the right pane). "+ New" clears `edit_id` so the right pane shows
+       the fresh "Add" form. Mobile fallback: stack (full tuning in #20). #}
+    {% if custom_formats.is_empty() %}
     <div class="cf-section">
         <div class="cf-section-header">
             <h3>Current Custom Formats</h3>
-            <span class="cf-count-pill">{{ custom_formats.len() }} total</span>
+            <span class="cf-count-pill">0 total</span>
         </div>
-        {% if custom_formats.is_empty() %}
         <div class="cf-empty-state">
             <p>You don't have any Custom Formats yet. Install the bundled anime-tuned defaults to get started with SeaDex, tier-S BD groups, 10-bit/x265, FLAC/Opus, and other curated rules.</p>
             <form method="post" action="/settings/custom-formats/install-defaults"
@@ -423,113 +428,134 @@
                 <button type="submit" class="btn btn-primary">Install Bundled Defaults</button>
             </form>
         </div>
-        {% else %}
-        <table class="group-source-table cf-table">
-            <thead>
-                <tr>
-                    <th>Name</th>
-                    <th>Score</th>
-                    <th>Specs</th>
-                    <th>Source</th>
-                    <th>Trash ID</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for cf in custom_formats %}
-                <tr>
-                    <td class="cf-name">{{ cf.row.name }}</td>
-                    <td class="cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
-                        {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
-                    </td>
-                    <td>
-                        {% if let Some(err) = cf.parse_error.as_ref() %}
-                        <span class="cf-parse-error" title="{{ err }}">parse error</span>
-                        {% else %}
-                        {{ cf.specs_count }}
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if cf.row.origin == "defaults" %}
-                        <span class="cf-origin-badge cf-origin-default" title="Installed from the bundled default set">default</span>
-                        {% else if cf.row.origin == "import" %}
-                        <span class="cf-origin-badge cf-origin-import" title="Imported from a Sonarr v4 JSON export">import</span>
-                        {% else %}
-                        <span class="cf-origin-badge cf-origin-manual" title="Created via the Add Custom Format form">manual</span>
-                        {% endif %}
-                    </td>
-                    <td>
-                        {% if let Some(tid) = cf.row.trash_id.as_ref() %}<code>{{ tid }}</code>{% else %}<span class="form-hint">—</span>{% endif %}
-                    </td>
-                    <td>
-                        <div class="settings-inline-actions">
-                            <a href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}" class="btn btn-secondary">Edit</a>
-                            <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
-                                <input type="hidden" name="id" value="{{ cf.row.id }}">
-                                <button type="submit" class="btn btn-danger">Delete</button>
-                            </form>
-                        </div>
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        {% endif %}
     </div>
-
-    {# ── Add / Edit ─────────────────────────────────────────────────── #}
-    <div class="cf-section">
-        <div class="cf-section-header">
-            <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
+    {% else %}
+    <div class="cf-panes">
+        <div class="cf-pane-list cf-section">
+            <div class="cf-section-header">
+                <h3>Current Custom Formats</h3>
+                <div class="cf-list-header-actions">
+                    <span class="cf-count-pill"><span id="cf-visible-count">{{ custom_formats.len() }}</span> / {{ custom_formats.len() }}</span>
+                    <a href="/settings?tab=custom_formats" class="btn btn-primary btn-sm">+ New</a>
+                </div>
+            </div>
+            <input type="search" id="cf-list-filter" class="settings-input cf-list-filter"
+                placeholder="Filter by name, score, trash ID, or source"
+                oninput="filterCfList(this.value)">
+            <div class="cf-list-scroll">
+                <table class="group-source-table cf-table cf-list-table">
+                    <thead>
+                        <tr>
+                            <th>Name</th>
+                            <th>Score</th>
+                            <th>Specs</th>
+                            <th>Source</th>
+                            <th>Trash ID</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="cf-list-tbody">
+                        {% for cf in custom_formats %}
+                        <tr class="cf-row{% if let Some(edit) = custom_format_edit %}{% if edit.row.id == cf.row.id %} cf-row-selected{% endif %}{% endif %}"
+                            data-cf-name="{{ cf.row.name|lowercase }}"
+                            data-cf-score="{{ cf.row.score }}"
+                            data-cf-origin="{{ cf.row.origin }}"
+                            data-cf-trash-id="{% if let Some(tid) = cf.row.trash_id.as_ref() %}{{ tid|lowercase }}{% endif %}">
+                            <td class="cf-name">
+                                <a class="cf-row-link" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}">{{ cf.row.name }}</a>
+                            </td>
+                            <td class="cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                                {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
+                            </td>
+                            <td>
+                                {% if let Some(err) = cf.parse_error.as_ref() %}
+                                <span class="cf-parse-error" title="{{ err }}">parse error</span>
+                                {% else %}
+                                {{ cf.specs_count }}
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if cf.row.origin == "defaults" %}
+                                <span class="cf-origin-badge cf-origin-default" title="Installed from the bundled default set">default</span>
+                                {% else if cf.row.origin == "import" %}
+                                <span class="cf-origin-badge cf-origin-import" title="Imported from a Sonarr v4 JSON export">import</span>
+                                {% else %}
+                                <span class="cf-origin-badge cf-origin-manual" title="Created via the Add Custom Format form">manual</span>
+                                {% endif %}
+                            </td>
+                            <td>
+                                {% if let Some(tid) = cf.row.trash_id.as_ref() %}<code>{{ tid }}</code>{% else %}<span class="form-hint">—</span>{% endif %}
+                            </td>
+                            <td>
+                                <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
+                                    <input type="hidden" name="id" value="{{ cf.row.id }}">
+                                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                                </form>
+                            </td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                <div id="cf-list-empty-filter" class="cf-empty-state" style="display:none">
+                    <p>No Custom Formats match your filter.</p>
+                </div>
+            </div>
         </div>
-        <p class="cf-section-desc">
-            Full Sonarr v4 CF object. Supported spec implementations:
-            <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
-            The compiler runs before saving, so invalid JSON is rejected with an error message.
-        </p>
-        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
-            {% if let Some(edit) = custom_format_edit %}
-            <input type="hidden" name="id" value="{{ edit.row.id }}">
-            {% if let Some(desc) = edit.trash_description.as_ref() %}
-            <div class="cf-trash-description">
-                <strong>Trash Guides description</strong>
-                <div style="white-space: pre-wrap;">{{ desc }}</div>
+
+        <div class="cf-pane-editor cf-section">
+            <div class="cf-section-header">
+                <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
             </div>
-            {% endif %}
-            {% endif %}
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="cf_name">Name</label>
-                    <input type="text" name="name" id="cf_name" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
+            <p class="cf-section-desc">
+                Full Sonarr v4 CF object. Supported spec implementations:
+                <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
+                The compiler runs before saving, so invalid JSON is rejected with an error message.
+            </p>
+            <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
+                {% if let Some(edit) = custom_format_edit %}
+                <input type="hidden" name="id" value="{{ edit.row.id }}">
+                {% if let Some(desc) = edit.trash_description.as_ref() %}
+                <div class="cf-trash-description">
+                    <strong>Trash Guides description</strong>
+                    <div style="white-space: pre-wrap;">{{ desc }}</div>
                 </div>
-                <div class="form-group">
-                    <label for="cf_score">Score</label>
-                    <input type="number" name="score" id="cf_score" required
-                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
-                <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
-                    value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
-            </div>
-            <div class="form-group">
-                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
-                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
-                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
-                <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
-            </div>
-            <div class="settings-inline-actions">
-                <button type="submit" class="btn btn-primary">
-                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
-                </button>
-                {% if custom_format_edit.is_some() %}
-                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
                 {% endif %}
-            </div>
-        </form>
+                {% endif %}
+                <div class="form-row">
+                    <div class="form-group">
+                        <label for="cf_name">Name</label>
+                        <input type="text" name="name" id="cf_name" required
+                            value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
+                    </div>
+                    <div class="form-group">
+                        <label for="cf_score">Score</label>
+                        <input type="number" name="score" id="cf_score" required
+                            value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
+                    </div>
+                </div>
+                <div class="form-group">
+                    <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
+                    <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
+                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+                </div>
+                <div class="form-group">
+                    <label for="cf_json">Sonarr v4 Custom Format JSON</label>
+                    <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
+                        placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
+                    <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
+                </div>
+                <div class="settings-inline-actions">
+                    <button type="submit" class="btn btn-primary">
+                        {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+                    </button>
+                    {% if custom_format_edit.is_some() %}
+                    <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
+                    {% endif %}
+                </div>
+            </form>
+        </div>
     </div>
+    {% endif %}
 
     {# ── Global Minimum Score ───────────────────────────────────────── #}
     <div class="cf-section">
@@ -671,6 +697,41 @@
         });
     });
 })();
+
+// #11.1 — Client-side filter for the CF list pane. Matches against the
+// `data-cf-*` attributes on each row (name is pre-lowercased server-side,
+// score/trash_id/origin match case-insensitively). Empty query = show all.
+// Updates the `#cf-visible-count` pill and toggles the "no matches"
+// placeholder so the pane doesn't render as a blank void when every row
+// is filtered out.
+function filterCfList(query) {
+    const q = (query || '').trim().toLowerCase();
+    const tbody = document.getElementById('cf-list-tbody');
+    if (!tbody) return;
+    const rows = tbody.querySelectorAll('tr.cf-row');
+    let visible = 0;
+    rows.forEach(function(row) {
+        if (!q) {
+            row.style.display = '';
+            visible++;
+            return;
+        }
+        const name = row.dataset.cfName || '';
+        const score = (row.dataset.cfScore || '').toLowerCase();
+        const trashId = row.dataset.cfTrashId || '';
+        const origin = (row.dataset.cfOrigin || '').toLowerCase();
+        const hit = name.includes(q)
+            || score.includes(q)
+            || trashId.includes(q)
+            || origin.includes(q);
+        row.style.display = hit ? '' : 'none';
+        if (hit) visible++;
+    });
+    const countEl = document.getElementById('cf-visible-count');
+    if (countEl) countEl.textContent = visible;
+    const emptyEl = document.getElementById('cf-list-empty-filter');
+    if (emptyEl) emptyEl.style.display = (visible === 0 && rows.length > 0) ? '' : 'none';
+}
 
 function generateApiKey() {
     const chars = 'abcdefghijklmnopqrstuvwxyz0123456789';

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -511,7 +511,12 @@
                     <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
                 </button>
             </div>
-            <form method="post" action="/settings/custom-formats/upsert" class="settings-form cf-editor-form">
+            {# Upsert form wraps only the body. The Save button in the
+               footer uses the HTML5 `form="cf-upsert-form"` attribute to
+               submit from outside the form element, which lets the
+               Delete form sit in the same footer without being nested
+               (invalid HTML) or colliding on submit. #}
+            <form id="cf-upsert-form" method="post" action="/settings/custom-formats/upsert" class="settings-form cf-editor-form">
                 <div class="modal-body" style="padding:16px 24px">
                     <p class="cf-section-desc" style="margin-top:0">
                         Full Sonarr v4 CF object. Supported spec implementations:
@@ -551,13 +556,31 @@
                         <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
                     </div>
                 </div>
-                <div class="modal-footer" style="padding:12px 24px;border-top:1px solid var(--border);gap:8px;display:flex;justify-content:flex-end">
+            </form>
+            <div class="modal-footer" style="padding:12px 24px;border-top:1px solid var(--border);gap:8px;display:flex;justify-content:space-between;align-items:center">
+                {# Delete lives on the left so it doesn't sit adjacent to
+                   Save Changes (reduces the chance of a misclick). Only
+                   rendered when editing; hidden by JS for the in-place
+                   Add reset. #}
+                {% if let Some(edit) = custom_format_edit %}
+                <form id="cf-delete-form" method="post" action="/settings/custom-formats/delete"
+                      data-ryokan-confirm-title="Delete Custom Format"
+                      data-ryokan-confirm-body="Delete &quot;{{ edit.row.name }}&quot;? This cannot be undone."
+                      data-ryokan-confirm-label="Delete"
+                      style="margin:0">
+                    <input type="hidden" name="id" value="{{ edit.row.id }}">
+                    <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+                {% else %}
+                <span id="cf-delete-form-placeholder"></span>
+                {% endif %}
+                <div style="display:flex;gap:8px">
                     <button type="button" class="btn btn-secondary" onclick="closeCfEditorModal()">Cancel</button>
-                    <button type="submit" class="btn btn-primary">
+                    <button type="submit" form="cf-upsert-form" class="btn btn-primary" id="cf-upsert-submit">
                         {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
                     </button>
                 </div>
-            </form>
+            </div>
         </div>
     </div>
     {% endif %}
@@ -861,8 +884,15 @@ function openCfEditorModal() {
     }
     const title = document.getElementById('cf-editor-modal-title');
     if (title) title.textContent = 'Add Custom Format';
-    const submit = modal.querySelector('button[type="submit"]');
+    const submit = document.getElementById('cf-upsert-submit');
     if (submit) submit.textContent = 'Create Custom Format';
+    // Hide the Delete form — nothing to delete when we haven't saved
+    // yet. Leaving it visible in Add mode would let the user click
+    // Delete with the previously-edited CF's hidden id still in the
+    // form (server-rendered). Hiding also collapses the footer to the
+    // single-button layout on the right.
+    const deleteForm = document.getElementById('cf-delete-form');
+    if (deleteForm) deleteForm.style.display = 'none';
 
     modal.style.display = 'flex';
     const nameEl = document.getElementById('cf_name');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -562,18 +562,11 @@
     </div>
     {% endif %}
 
-    {# ── Defaults & Threshold (#11.5) ────────────────────────────────
-       Stacks two blocks vertically: Bundled Defaults on top (install
-       and reset actions), Minimum Score below. Originally tried a
-       two-column grid but the Min Score block ended up reading as an
-       orphan on the right; a vertical stack is cleaner and keeps the
-       related Install/Reset copy next to its buttons. #}
+    {# ── Bundled Defaults (#11.5) ────────────────────────────────── #}
     <div class="cf-section">
         <div class="cf-section-header">
-            <h3>Defaults &amp; Threshold</h3>
+            <h3>Bundled Defaults</h3>
         </div>
-
-        <h4 class="cf-defaults-subtitle">Bundled defaults</h4>
         <p class="cf-section-desc">
             <strong>Install Defaults</strong> adds the bundled anime-tuned Custom Formats (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit / x265, FLAC / Opus, plus an 8-bit mp4 penalty). Repeat clicks are safe: existing names are skipped.
         </p>
@@ -594,8 +587,13 @@
                 <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
             </form>
         </div>
+    </div>
 
-        <h4 class="cf-defaults-subtitle" style="margin-top: 24px">Minimum score</h4>
+    {# ── Minimum Score ───────────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Minimum Score</h3>
+        </div>
         <p class="cf-section-desc">
             Auto-search drops any release whose summed CF score falls below this floor. Interactive search still shows everything. Leave blank to disable the floor entirely.
         </p>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -557,7 +557,14 @@
                     </div>
                 </div>
             </form>
-            <div class="modal-footer" style="padding:12px 24px;border-top:1px solid var(--border);gap:8px;display:flex;justify-content:space-between;align-items:center">
+            {# Footer uses `margin-left: auto` on the right-side button
+               group to pin it to the right regardless of whether the
+               Delete form is rendered or display:none'd. Using
+               `justify-content: space-between` here left Cancel+Save
+               stuck at the start when the Delete form was JS-hidden
+               during the in-place Add reset (flex space-between with
+               one child aligns to start). #}
+            <div class="modal-footer" style="padding:12px 24px;border-top:1px solid var(--border);gap:8px;display:flex;align-items:center">
                 {# Delete lives on the left so it doesn't sit adjacent to
                    Save Changes (reduces the chance of a misclick). Only
                    rendered when editing; hidden by JS for the in-place
@@ -571,10 +578,8 @@
                     <input type="hidden" name="id" value="{{ edit.row.id }}">
                     <button type="submit" class="btn btn-danger">Delete</button>
                 </form>
-                {% else %}
-                <span id="cf-delete-form-placeholder"></span>
                 {% endif %}
-                <div style="display:flex;gap:8px">
+                <div style="display:flex;gap:8px;margin-left:auto">
                     <button type="button" class="btn btn-secondary" onclick="closeCfEditorModal()">Cancel</button>
                     <button type="submit" form="cf-upsert-form" class="btn btn-primary" id="cf-upsert-submit">
                         {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -440,18 +440,22 @@
                 </div>
             </div>
             <input type="search" id="cf-list-filter" class="settings-input cf-list-filter"
-                placeholder="Filter by name, score, trash ID, or source"
+                placeholder="Filter by name, score, trash ID, or origin (default / import / manual)"
                 oninput="filterCfList(this.value)">
             <div class="cf-list-scroll">
+                {# Tight three-column layout (Name / Score / Actions) that
+                   fits inside the ~490px list pane without clipping. Origin
+                   is shown as a colored dot inline with the name (hover for
+                   full label); Trash ID and parse-error specs surface in
+                   the edit form on the right — no point in repeating them
+                   twice. The filter still matches on origin and trash ID
+                   via the data-cf-* attributes. #}
                 <table class="group-source-table cf-table cf-list-table">
                     <thead>
                         <tr>
                             <th>Name</th>
-                            <th>Score</th>
-                            <th>Specs</th>
-                            <th>Source</th>
-                            <th>Trash ID</th>
-                            <th></th>
+                            <th class="cf-list-score-col">Score</th>
+                            <th class="cf-list-action-col"></th>
                         </tr>
                     </thead>
                     <tbody id="cf-list-tbody">
@@ -462,34 +466,24 @@
                             data-cf-origin="{{ cf.row.origin }}"
                             data-cf-trash-id="{% if let Some(tid) = cf.row.trash_id.as_ref() %}{{ tid|lowercase }}{% endif %}">
                             <td class="cf-name">
-                                <a class="cf-row-link" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}">{{ cf.row.name }}</a>
+                                <a class="cf-row-link" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}">
+                                    <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"
+                                        title="{% if cf.row.origin == " defaults" %}From bundled defaults{% else if cf.row.origin == " import" %}Imported{% else %}Manual{% endif %}"></span>
+                                    <span class="cf-row-name">{{ cf.row.name }}</span>
+                                    {% if let Some(err) = cf.parse_error.as_ref() %}
+                                    <span class="cf-parse-error" title="{{ err }}">parse error</span>
+                                    {% else %}
+                                    <span class="cf-row-spec-count">{{ cf.specs_count }} spec{% if cf.specs_count != 1 %}s{% endif %}</span>
+                                    {% endif %}
+                                </a>
                             </td>
-                            <td class="cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                            <td class="cf-list-score-col cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
                                 {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
                             </td>
-                            <td>
-                                {% if let Some(err) = cf.parse_error.as_ref() %}
-                                <span class="cf-parse-error" title="{{ err }}">parse error</span>
-                                {% else %}
-                                {{ cf.specs_count }}
-                                {% endif %}
-                            </td>
-                            <td>
-                                {% if cf.row.origin == "defaults" %}
-                                <span class="cf-origin-badge cf-origin-default" title="Installed from the bundled default set">default</span>
-                                {% else if cf.row.origin == "import" %}
-                                <span class="cf-origin-badge cf-origin-import" title="Imported from a Sonarr v4 JSON export">import</span>
-                                {% else %}
-                                <span class="cf-origin-badge cf-origin-manual" title="Created via the Add Custom Format form">manual</span>
-                                {% endif %}
-                            </td>
-                            <td>
-                                {% if let Some(tid) = cf.row.trash_id.as_ref() %}<code>{{ tid }}</code>{% else %}<span class="form-hint">—</span>{% endif %}
-                            </td>
-                            <td>
+                            <td class="cf-list-action-col">
                                 <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
                                     <input type="hidden" name="id" value="{{ cf.row.id }}">
-                                    <button type="submit" class="btn btn-danger btn-sm">Delete</button>
+                                    <button type="submit" class="btn btn-icon-danger" title="Delete {{ cf.row.name }}" aria-label="Delete {{ cf.row.name }}">×</button>
                                 </form>
                             </td>
                         </tr>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -456,7 +456,7 @@
                     <div class="cf-card-header">
                         <div class="cf-card-title-row">
                             <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"
-                                title="{% if cf.row.origin == " defaults" %}From bundled defaults{% else if cf.row.origin == " import" %}Imported{% else %}Manual{% endif %}"></span>
+                                title="{% if cf.row.origin == "defaults" %}From bundled defaults{% else if cf.row.origin == "import" %}Imported{% else %}Manual{% endif %}"></span>
                             <h4 class="cf-card-name">{{ cf.row.name }}</h4>
                         </div>
                         <span class="cf-card-score cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
@@ -508,7 +508,8 @@
        back to the tab (no modal) and a validation error redirects back
        with ?edit_id=N and the modal re-opens with the error in &err. #}
     <div class="modal-backdrop" id="cf-editor-modal" style="display:none">
-        <div class="modal cf-editor-modal" style="max-width:780px">
+        <div class="modal cf-editor-modal" style="max-width:780px"
+             role="dialog" aria-modal="true" aria-labelledby="cf-editor-modal-title">
             <div class="modal-header">
                 <h3 id="cf-editor-modal-title">{% if let Some(edit) = custom_format_edit %}Edit Custom Format{% else %}Add Custom Format{% endif %}</h3>
                 <button class="btn-icon" type="button" onclick="closeCfEditorModal()" aria-label="Close">
@@ -671,6 +672,11 @@
                     </tbody>
                 </table>
                 </div>
+                {% endif %}
+                {% if review.has_invalid %}
+                <p class="form-hint" style="color:var(--orange); margin-top:12px">
+                    <strong>Heads up:</strong> invalid entries above are silently skipped on apply. Fix the JSON and re-paste if you need those CFs — they won't be reported as failures after import.
+                </p>
                 {% endif %}
                 <div class="settings-inline-actions" style="margin-top: 16px;">
                     <button type="submit" class="btn btn-primary">Apply &amp; Import</button>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -838,10 +838,17 @@ function filterCfList(query) {
 function openCfEditorModal() {
     const modal = document.getElementById('cf-editor-modal');
     if (!modal) return;
-    const params = new URLSearchParams(window.location.search);
-    // If page is in edit mode and user clicked "+ Add", navigate to the
-    // bare CF tab first so the server re-renders the empty form.
-    if (params.has('edit_id')) {
+    // Check the FORM state, not the URL. closeCfEditorModal drops
+    // ?edit_id=N from the URL via history.replaceState, but the form
+    // HTML was server-rendered with the previous edit's id/name/score/
+    // json pre-filled. If we open the modal in-place now, the user
+    // sees the previously-edited CF's values and submitting would
+    // update that CF rather than create a new one. Any hidden
+    // `name="id"` input in the form means we're carrying stale edit
+    // state — force a server re-render with a clean URL.
+    const editorForm = modal.querySelector('form');
+    const stale = editorForm && editorForm.querySelector('input[type="hidden"][name="id"]');
+    if (stale) {
         window.location.href = '/settings?tab=custom_formats';
         return;
     }

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -838,23 +838,35 @@ function filterCfList(query) {
 function openCfEditorModal() {
     const modal = document.getElementById('cf-editor-modal');
     if (!modal) return;
-    // Check the FORM state, not the URL. closeCfEditorModal drops
-    // ?edit_id=N from the URL via history.replaceState, but the form
-    // HTML was server-rendered with the previous edit's id/name/score/
-    // json pre-filled. If we open the modal in-place now, the user
-    // sees the previously-edited CF's values and submitting would
-    // update that CF rather than create a new one. Any hidden
-    // `name="id"` input in the form means we're carrying stale edit
-    // state — force a server re-render with a clean URL.
-    const editorForm = modal.querySelector('form');
-    const stale = editorForm && editorForm.querySelector('input[type="hidden"][name="id"]');
-    if (stale) {
-        window.location.href = '/settings?tab=custom_formats';
-        return;
+    // Reset the form to "Add Custom Format" shape in-place. The form
+    // was server-rendered with the previous edit's values if the page
+    // load had ?edit_id=N, so just flipping display:flex would show
+    // those stale fields. Navigate-to-reset (the previous fix) worked
+    // but required two clicks to see the empty modal. Clearing in-place
+    // keeps it a single click.
+    const form = modal.querySelector('form');
+    if (form) {
+        const hiddenId = form.querySelector('input[type="hidden"][name="id"]');
+        if (hiddenId) hiddenId.remove();
+        const trashDesc = form.querySelector('.cf-trash-description');
+        if (trashDesc) trashDesc.remove();
+        const name = form.querySelector('#cf_name');
+        if (name) name.value = '';
+        const score = form.querySelector('#cf_score');
+        if (score) score.value = '0';
+        const trashId = form.querySelector('#cf_trash_id');
+        if (trashId) trashId.value = '';
+        const json = form.querySelector('#cf_json');
+        if (json) json.value = '';
     }
+    const title = document.getElementById('cf-editor-modal-title');
+    if (title) title.textContent = 'Add Custom Format';
+    const submit = modal.querySelector('button[type="submit"]');
+    if (submit) submit.textContent = 'Create Custom Format';
+
     modal.style.display = 'flex';
-    const name = document.getElementById('cf_name');
-    if (name) name.focus();
+    const nameEl = document.getElementById('cf_name');
+    if (nameEl) nameEl.focus();
 }
 function closeCfEditorModal() {
     const modal = document.getElementById('cf-editor-modal');

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -559,46 +559,53 @@
     </div>
     {% endif %}
 
-    {# ── Global Minimum Score ───────────────────────────────────────── #}
+    {# ── Defaults & Threshold (#11.5) ────────────────────────────────
+       Collapses three separate cf-section cards (Install Defaults,
+       Reset Defaults, Minimum Score) into one. Minimum Score and
+       Defaults logically belong together — both are "global CF
+       configuration" knobs that don't live on any individual CF. The
+       empty-state card above also shows an Install Defaults button;
+       this section is the always-available canonical home for the
+       same action. #}
     <div class="cf-section">
         <div class="cf-section-header">
-            <h3>Global Minimum Score</h3>
-        </div>
-        <p class="cf-section-desc">
-            Auto-search drops releases whose summed CF score falls below this threshold. Interactive search still shows everything. Leave blank to disable the floor.
-        </p>
-        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form">
-            <div class="form-group">
-                <label for="cf_min_score">Minimum Score</label>
-                <input type="number" name="minimum_score" id="cf_min_score"
-                    value="{{ custom_format_min_score_display }}" placeholder="(blank = no floor)">
-            </div>
-            <button type="submit" class="btn btn-primary">Save Minimum Score</button>
-        </form>
-    </div>
-
-    {# ── Bundled Defaults ───────────────────────────────────────────── #}
-    <div class="cf-section">
-        <div class="cf-section-header">
-            <h3>Bundled Defaults</h3>
+            <h3>Defaults &amp; Threshold</h3>
         </div>
         <p class="cf-section-desc">
             <strong>Install Defaults</strong> imports the bundled anime-tuned CF set (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit/x265, FLAC/Opus, plus the 8-bit mp4 penalty) — existing names are skipped so repeat clicks are safe.
-            <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file — use this after you've edited a default CF and want the original back. Manual and imported CFs are untouched.
+            <strong>Reset to Defaults</strong> drops every row whose Source column shows <em>default</em> and re-installs them from the bundled file; manual and imported CFs are untouched.
+            <strong>Minimum Score</strong> is a floor — auto-search drops releases whose summed CF score falls below it; interactive search still shows everything. Leave blank to disable the floor.
         </p>
-        <div class="settings-inline-actions">
-            <form method="post" action="/settings/custom-formats/install-defaults"
-                  data-ryokan-confirm-title="Install bundled defaults"
-                  data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
-                  data-ryokan-confirm-label="Install">
-                <button type="submit" class="btn btn-primary">Install Defaults</button>
-            </form>
-            <form method="post" action="/settings/custom-formats/reset-defaults"
-                  data-ryokan-confirm-title="Reset bundled defaults"
-                  data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
-                  data-ryokan-confirm-label="Reset">
-                <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
-            </form>
+        <div class="cf-defaults-grid">
+            <div class="cf-defaults-col">
+                <h4 class="cf-defaults-subtitle">Bundled set</h4>
+                <div class="settings-inline-actions">
+                    <form method="post" action="/settings/custom-formats/install-defaults"
+                          data-ryokan-confirm-title="Install bundled defaults"
+                          data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
+                          data-ryokan-confirm-label="Install">
+                        <button type="submit" class="btn btn-primary">Install Defaults</button>
+                    </form>
+                    <form method="post" action="/settings/custom-formats/reset-defaults"
+                          data-ryokan-confirm-title="Reset bundled defaults"
+                          data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
+                          data-ryokan-confirm-label="Reset">
+                        <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
+                    </form>
+                </div>
+            </div>
+            <div class="cf-defaults-col">
+                <h4 class="cf-defaults-subtitle">Score floor</h4>
+                <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form cf-min-score-form">
+                    <div class="form-group" style="margin-bottom: 12px">
+                        <input type="number" name="minimum_score" id="cf_min_score"
+                            value="{{ custom_format_min_score_display }}"
+                            placeholder="(blank = no floor)"
+                            aria-label="Minimum score">
+                    </div>
+                    <button type="submit" class="btn btn-primary">Save Minimum Score</button>
+                </form>
+            </div>
         </div>
     </div>
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -475,7 +475,10 @@
                     </div>
                 </a>
                 <div class="cf-card-actions">
-                    <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
+                    <form method="post" action="/settings/custom-formats/delete" class="group-delete-form"
+                          data-ryokan-confirm-title="Delete Custom Format"
+                          data-ryokan-confirm-body="Delete &quot;{{ cf.row.name }}&quot;? This cannot be undone."
+                          data-ryokan-confirm-label="Delete">
                         <input type="hidden" name="id" value="{{ cf.row.id }}">
                         <button type="submit" class="btn btn-icon-danger" title="Delete {{ cf.row.name }}" aria-label="Delete {{ cf.row.name }}">×</button>
                     </form>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -562,106 +562,6 @@
     </div>
     {% endif %}
 
-    {# ── Bundled Defaults (#11.5) ────────────────────────────────── #}
-    <div class="cf-section">
-        <div class="cf-section-header">
-            <h3>Bundled Defaults</h3>
-        </div>
-        <p class="cf-section-desc">
-            <strong>Install Defaults</strong> adds the bundled anime-tuned Custom Formats (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit / x265, FLAC / Opus, plus an 8-bit mp4 penalty). Repeat clicks are safe: existing names are skipped.
-        </p>
-        <p class="cf-section-desc">
-            <strong>Reset to Defaults</strong> drops every row with Source = <em>default</em> and re-installs the bundled set from scratch. Useful if you edited a default CF and want the original back. Manual and imported CFs are untouched.
-        </p>
-        <div class="settings-inline-actions">
-            <form method="post" action="/settings/custom-formats/install-defaults"
-                  data-ryokan-confirm-title="Install bundled defaults"
-                  data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
-                  data-ryokan-confirm-label="Install">
-                <button type="submit" class="btn btn-primary">Install Defaults</button>
-            </form>
-            <form method="post" action="/settings/custom-formats/reset-defaults"
-                  data-ryokan-confirm-title="Reset bundled defaults"
-                  data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
-                  data-ryokan-confirm-label="Reset">
-                <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
-            </form>
-        </div>
-    </div>
-
-    {# ── Minimum Score ───────────────────────────────────────────── #}
-    <div class="cf-section">
-        <div class="cf-section-header">
-            <h3>Minimum Score</h3>
-        </div>
-        <p class="cf-section-desc">
-            Auto-search drops any release whose summed CF score falls below this floor. Interactive search still shows everything. Leave blank to disable the floor entirely.
-        </p>
-        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form cf-min-score-form">
-            <div class="form-group cf-min-score-group">
-                <input type="number" name="minimum_score" id="cf_min_score"
-                    value="{{ custom_format_min_score_display }}"
-                    placeholder="(blank = no floor)"
-                    aria-label="Minimum score">
-                <button type="submit" class="btn btn-primary">Save</button>
-            </div>
-        </form>
-    </div>
-
-    {# ── Export (#11.4) ─────────────────────────────────────────────
-       Per-CF checkbox selector + mode radio + two actions (download
-       file / copy to clipboard). The selector only renders when at
-       least one CF exists — exporting 0 rows isn't useful. #}
-    {% if !custom_formats.is_empty() %}
-    <div class="cf-section">
-        <div class="cf-section-header">
-            <h3>Export</h3>
-        </div>
-        <p class="cf-section-desc">
-            <strong>Ryokan (native)</strong> keeps every selected CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
-            <strong>Sonarr-safe</strong> drops selected CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance. Dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
-        </p>
-
-        <div class="cf-export-mode-row">
-            <label class="cf-export-mode">
-                <input type="radio" name="cf_export_mode" value="" checked>
-                <span>Ryokan (native)</span>
-            </label>
-            <label class="cf-export-mode">
-                <input type="radio" name="cf_export_mode" value="sonarr-safe">
-                <span>Sonarr-safe</span>
-            </label>
-        </div>
-
-        <div class="cf-export-selector">
-            <div class="cf-export-selector-head">
-                <span class="cf-defaults-subtitle" style="margin:0">Custom formats to include</span>
-                <div class="settings-inline-actions">
-                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(true)">Select all</button>
-                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(false)">Select none</button>
-                </div>
-            </div>
-            <div class="cf-export-list">
-                {% for cf in custom_formats %}
-                <label class="cf-export-check">
-                    <input type="checkbox" name="cf_export_ids" value="{{ cf.row.id }}" checked>
-                    <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"></span>
-                    <span class="cf-export-check-name">{{ cf.row.name }}</span>
-                    <span class="cf-export-check-score cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
-                        {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
-                    </span>
-                </label>
-                {% endfor %}
-            </div>
-        </div>
-
-        <div class="settings-inline-actions" style="margin-top: 16px">
-            <button type="button" class="btn btn-primary" onclick="cfExportDownload()">Export JSON</button>
-            <button type="button" class="btn btn-secondary" onclick="cfExportClipboard(this)">Copy to clipboard</button>
-        </div>
-    </div>
-    {% endif %}
-
     {# ── Import (#11.3) ─────────────────────────────────────────────
        Two-stage flow:
        1. Paste / Upload → POST /settings/custom-formats/import.
@@ -762,6 +662,106 @@
             <button type="submit" class="btn btn-primary">Preview &amp; Import</button>
         </form>
         {% endif %}
+    </div>
+
+    {# ── Export (#11.4) ─────────────────────────────────────────────
+       Per-CF checkbox selector + mode radio + two actions (download
+       file / copy to clipboard). The selector only renders when at
+       least one CF exists — exporting 0 rows isn't useful. #}
+    {% if !custom_formats.is_empty() %}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Export</h3>
+        </div>
+        <p class="cf-section-desc">
+            <strong>Ryokan (native)</strong> keeps every selected CF verbatim (including Ryokan-only specs like <code>Ryokan.SeaDexBestSpecification</code>) and round-trips into another Ryokan instance.
+            <strong>Sonarr-safe</strong> drops selected CFs that contain Ryokan-only specs so the file imports into a vanilla Sonarr v4 instance. Dropped CF names are written to the <a href="/system?tab=logs&amp;category=system">System log</a>.
+        </p>
+
+        <div class="cf-export-mode-row">
+            <label class="cf-export-mode">
+                <input type="radio" name="cf_export_mode" value="" checked>
+                <span>Ryokan (native)</span>
+            </label>
+            <label class="cf-export-mode">
+                <input type="radio" name="cf_export_mode" value="sonarr-safe">
+                <span>Sonarr-safe</span>
+            </label>
+        </div>
+
+        <div class="cf-export-selector">
+            <div class="cf-export-selector-head">
+                <span class="cf-defaults-subtitle" style="margin:0">Custom formats to include</span>
+                <div class="settings-inline-actions">
+                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(true)">Select all</button>
+                    <button type="button" class="btn btn-secondary btn-sm" onclick="cfExportSelectAll(false)">Select none</button>
+                </div>
+            </div>
+            <div class="cf-export-list">
+                {% for cf in custom_formats %}
+                <label class="cf-export-check">
+                    <input type="checkbox" name="cf_export_ids" value="{{ cf.row.id }}" checked>
+                    <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"></span>
+                    <span class="cf-export-check-name">{{ cf.row.name }}</span>
+                    <span class="cf-export-check-score cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                        {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
+                    </span>
+                </label>
+                {% endfor %}
+            </div>
+        </div>
+
+        <div class="settings-inline-actions" style="margin-top: 16px">
+            <button type="button" class="btn btn-primary" onclick="cfExportDownload()">Export JSON</button>
+            <button type="button" class="btn btn-secondary" onclick="cfExportClipboard(this)">Copy to clipboard</button>
+        </div>
+    </div>
+    {% endif %}
+
+    {# ── Minimum Score ───────────────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Minimum Score</h3>
+        </div>
+        <p class="cf-section-desc">
+            Auto-search drops any release whose summed CF score falls below this floor. Interactive search still shows everything. Leave blank to disable the floor entirely.
+        </p>
+        <form method="post" action="/settings/custom-formats/minimum-score" class="settings-form cf-min-score-form">
+            <div class="form-group cf-min-score-group">
+                <input type="number" name="minimum_score" id="cf_min_score"
+                    value="{{ custom_format_min_score_display }}"
+                    placeholder="(blank = no floor)"
+                    aria-label="Minimum score">
+                <button type="submit" class="btn btn-primary">Save</button>
+            </div>
+        </form>
+    </div>
+
+    {# ── Bundled Defaults (#11.5) ────────────────────────────────── #}
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Bundled Defaults</h3>
+        </div>
+        <p class="cf-section-desc">
+            <strong>Install Defaults</strong> adds the bundled anime-tuned Custom Formats (SeaDex best, Tier S BD groups, BD source, WEB groups, 10-bit / x265, FLAC / Opus, plus an 8-bit mp4 penalty). Repeat clicks are safe: existing names are skipped.
+        </p>
+        <p class="cf-section-desc">
+            <strong>Reset to Defaults</strong> drops every row with Source = <em>default</em> and re-installs the bundled set from scratch. Useful if you edited a default CF and want the original back. Manual and imported CFs are untouched.
+        </p>
+        <div class="settings-inline-actions">
+            <form method="post" action="/settings/custom-formats/install-defaults"
+                  data-ryokan-confirm-title="Install bundled defaults"
+                  data-ryokan-confirm-body="Install the bundled default Custom Formats? CFs whose name already exists will be skipped."
+                  data-ryokan-confirm-label="Install">
+                <button type="submit" class="btn btn-primary">Install Defaults</button>
+            </form>
+            <form method="post" action="/settings/custom-formats/reset-defaults"
+                  data-ryokan-confirm-title="Reset bundled defaults"
+                  data-ryokan-confirm-body="Reset the bundled defaults? Any CF with source=default will be dropped and re-installed from the bundled file. Your manual and imported CFs are untouched."
+                  data-ryokan-confirm-label="Reset">
+                <button type="submit" class="btn btn-secondary">Reset to Defaults</button>
+            </form>
+        </div>
     </div>
 </div>
 {% endif %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -860,6 +860,12 @@ function closeCfEditorModal() {
         const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
         history.replaceState(null, '', newUrl);
     }
+    // Drop the selected-card highlight. The class was server-rendered
+    // based on ?edit_id=N, so closing without a full reload leaves the
+    // highlight stuck on the originally-edited card until next refresh.
+    document.querySelectorAll('.cf-card-selected').forEach(function(el) {
+        el.classList.remove('cf-card-selected');
+    });
 }
 // Auto-open on load when the URL carries ?edit_id=N — the server
 // already rendered the pre-filled form inside the modal markup, so

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -300,6 +300,7 @@
         {% if !suggestions.is_empty() %}
         <h3 class="settings-subheading">Suggested Mappings ({{ suggestions.len() }})</h3>
         <p class="form-hint">Inferred from your manual classification overrides. When you've pinned multiple episodes from the same release group to the same source, Ryokan surfaces it here so you can teach the identity table.</p>
+        <div class="table-scroll-wrap">
         <table class="group-source-table">
             <thead>
                 <tr>
@@ -336,6 +337,7 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
         {% endif %}
 
         <h3 class="settings-subheading">Add or Update Group</h3>
@@ -368,6 +370,7 @@
         </form>
 
         <h3 class="settings-subheading">Current Entries ({{ groups.len() }})</h3>
+        <div class="table-scroll-wrap">
         <table class="group-source-table">
             <thead>
                 <tr>
@@ -397,6 +400,7 @@
                 {% endfor %}
             </tbody>
         </table>
+        </div>
     </fieldset>
 </div>
 {% endif %}
@@ -641,6 +645,7 @@
                 <input type="hidden" name="decisions" id="cf_import_resolve_decisions" value="">
                 <input type="hidden" name="renames" id="cf_import_resolve_renames" value="">
                 {% if !review.collisions.is_empty() %}
+                <div class="table-scroll-wrap">
                 <table class="group-source-table cf-table">
                     <thead>
                         <tr>
@@ -665,6 +670,7 @@
                         {% endfor %}
                     </tbody>
                 </table>
+                </div>
                 {% endif %}
                 <div class="settings-inline-actions" style="margin-top: 16px;">
                     <button type="submit" class="btn btn-primary">Apply &amp; Import</button>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -407,12 +407,15 @@
         Sonarr v4-compatible Custom Formats. Every matching spec contributes its score to the release total during auto-search. Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
     </p>
 
-    {# ── List + Editor panes (#11.1) ─────────────────────────────────
-       Two-column layout: the CF list (with a live client-side filter)
-       sits on the left; the Add/Edit form for the currently-selected
-       CF sits on the right. Row click → `?edit_id=N` (server re-renders
-       the right pane). "+ New" clears `edit_id` so the right pane shows
-       the fresh "Add" form. Mobile fallback: stack (full tuning in #20). #}
+    {# ── Card grid (#11.1, Sonarr-style) ─────────────────────────────
+       Sonarr renders CFs as a full-width flex-wrap grid of ~300px cards,
+       not a table. Each card shows the name, the score (Ryokan
+       extension — Sonarr stores score per-profile instead), an origin
+       dot, and a row of condition pills (one per spec, colored green
+       when required and red when negated). A trailing "+ Add Custom
+       Format" tile starts the create flow. Click a card → deep-link
+       `?edit_id=N` which scrolls the editor below into view; same-page
+       form edits stay until the modal work lands in stage 2. #}
     {% if custom_formats.is_empty() %}
     <div class="cf-section">
         <div class="cf-section-header">
@@ -430,124 +433,119 @@
         </div>
     </div>
     {% else %}
-    <div class="cf-panes">
-        <div class="cf-pane-list cf-section">
-            <div class="cf-section-header">
-                <h3>Current Custom Formats</h3>
-                <div class="cf-list-header-actions">
-                    <span class="cf-count-pill"><span id="cf-visible-count">{{ custom_formats.len() }}</span> / {{ custom_formats.len() }}</span>
-                    <a href="/settings?tab=custom_formats" class="btn btn-primary btn-sm">+ New</a>
-                </div>
-            </div>
-            <input type="search" id="cf-list-filter" class="settings-input cf-list-filter"
-                placeholder="Filter by name, score, trash ID, or origin (default / import / manual)"
-                oninput="filterCfList(this.value)">
-            <div class="cf-list-scroll">
-                {# Tight three-column layout (Name / Score / Actions) that
-                   fits inside the ~490px list pane without clipping. Origin
-                   is shown as a colored dot inline with the name (hover for
-                   full label); Trash ID and parse-error specs surface in
-                   the edit form on the right — no point in repeating them
-                   twice. The filter still matches on origin and trash ID
-                   via the data-cf-* attributes. #}
-                <table class="group-source-table cf-table cf-list-table">
-                    <thead>
-                        <tr>
-                            <th>Name</th>
-                            <th class="cf-list-score-col">Score</th>
-                            <th class="cf-list-action-col"></th>
-                        </tr>
-                    </thead>
-                    <tbody id="cf-list-tbody">
-                        {% for cf in custom_formats %}
-                        <tr class="cf-row{% if let Some(edit) = custom_format_edit %}{% if edit.row.id == cf.row.id %} cf-row-selected{% endif %}{% endif %}"
-                            data-cf-name="{{ cf.row.name|lowercase }}"
-                            data-cf-score="{{ cf.row.score }}"
-                            data-cf-origin="{{ cf.row.origin }}"
-                            data-cf-trash-id="{% if let Some(tid) = cf.row.trash_id.as_ref() %}{{ tid|lowercase }}{% endif %}">
-                            <td class="cf-name">
-                                <a class="cf-row-link" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}">
-                                    <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"
-                                        title="{% if cf.row.origin == " defaults" %}From bundled defaults{% else if cf.row.origin == " import" %}Imported{% else %}Manual{% endif %}"></span>
-                                    <span class="cf-row-name">{{ cf.row.name }}</span>
-                                    {% if let Some(err) = cf.parse_error.as_ref() %}
-                                    <span class="cf-parse-error" title="{{ err }}">parse error</span>
-                                    {% else %}
-                                    <span class="cf-row-spec-count">{{ cf.specs_count }} spec{% if cf.specs_count != 1 %}s{% endif %}</span>
-                                    {% endif %}
-                                </a>
-                            </td>
-                            <td class="cf-list-score-col cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
-                                {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
-                            </td>
-                            <td class="cf-list-action-col">
-                                <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
-                                    <input type="hidden" name="id" value="{{ cf.row.id }}">
-                                    <button type="submit" class="btn btn-icon-danger" title="Delete {{ cf.row.name }}" aria-label="Delete {{ cf.row.name }}">×</button>
-                                </form>
-                            </td>
-                        </tr>
+    <div class="cf-section">
+        <div class="cf-section-header">
+            <h3>Current Custom Formats</h3>
+            <span class="cf-count-pill"><span id="cf-visible-count">{{ custom_formats.len() }}</span> / {{ custom_formats.len() }}</span>
+        </div>
+        <input type="search" id="cf-list-filter" class="settings-input cf-list-filter"
+            placeholder="Filter by name, score, trash ID, or origin (default / import / manual)"
+            oninput="filterCfList(this.value)">
+        <div class="cf-card-grid" id="cf-list-tbody">
+            {% for cf in custom_formats %}
+            <div class="cf-card{% if let Some(edit) = custom_format_edit %}{% if edit.row.id == cf.row.id %} cf-card-selected{% endif %}{% endif %}"
+                data-cf-name="{{ cf.row.name|lowercase }}"
+                data-cf-score="{{ cf.row.score }}"
+                data-cf-origin="{{ cf.row.origin }}"
+                data-cf-trash-id="{% if let Some(tid) = cf.row.trash_id.as_ref() %}{{ tid|lowercase }}{% endif %}">
+                <a class="cf-card-body" href="/settings?tab=custom_formats&amp;edit_id={{ cf.row.id }}#cf-editor">
+                    <div class="cf-card-header">
+                        <div class="cf-card-title-row">
+                            <span class="cf-origin-dot cf-origin-dot-{{ cf.row.origin }}"
+                                title="{% if cf.row.origin == " defaults" %}From bundled defaults{% else if cf.row.origin == " import" %}Imported{% else %}Manual{% endif %}"></span>
+                            <h4 class="cf-card-name">{{ cf.row.name }}</h4>
+                        </div>
+                        <span class="cf-card-score cf-score {% if cf.row.score > 0 %}cf-score-positive{% else if cf.row.score < 0 %}cf-score-negative{% else %}cf-score-zero{% endif %}">
+                            {% if cf.row.score > 0 %}+{% endif %}{{ cf.row.score }}
+                        </span>
+                    </div>
+                    <div class="cf-card-pills">
+                        {% if let Some(err) = cf.parse_error.as_ref() %}
+                        <span class="cf-pill cf-pill-error" title="{{ err }}">parse error</span>
+                        {% else if cf.spec_labels.is_empty() %}
+                        <span class="cf-pill cf-pill-muted">no conditions</span>
+                        {% else %}
+                        {% for s in cf.spec_labels %}
+                        <span class="cf-pill{% if s.negate %} cf-pill-negate{% else if s.required %} cf-pill-required{% endif %}"
+                            title="{{ s.implementation }}{% if s.negate %} (negate){% endif %}{% if s.required %} (required){% endif %}">
+                            {{ s.name }}
+                        </span>
                         {% endfor %}
-                    </tbody>
-                </table>
-                <div id="cf-list-empty-filter" class="cf-empty-state" style="display:none">
-                    <p>No Custom Formats match your filter.</p>
+                        {% endif %}
+                    </div>
+                </a>
+                <div class="cf-card-actions">
+                    <form method="post" action="/settings/custom-formats/delete" class="group-delete-form" onsubmit="return confirm('Delete Custom Format: {{ cf.row.name }}?');">
+                        <input type="hidden" name="id" value="{{ cf.row.id }}">
+                        <button type="submit" class="btn btn-icon-danger" title="Delete {{ cf.row.name }}" aria-label="Delete {{ cf.row.name }}">×</button>
+                    </form>
                 </div>
             </div>
+            {% endfor %}
+            {# Trailing add card mirrors Sonarr's "+ Add Custom Format" tile.
+               Navigates to the same URL clearing edit_id, which scrolls
+               the #cf-editor anchor below into view. #}
+            <a class="cf-card cf-card-add" href="/settings?tab=custom_formats#cf-editor">
+                <div class="cf-card-add-icon">+</div>
+                <div class="cf-card-add-label">Add Custom Format</div>
+            </a>
         </div>
+        <div id="cf-list-empty-filter" class="cf-empty-state" style="display:none">
+            <p>No Custom Formats match your filter.</p>
+        </div>
+    </div>
 
-        <div class="cf-pane-editor cf-section">
-            <div class="cf-section-header">
-                <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
-            </div>
-            <p class="cf-section-desc">
-                Full Sonarr v4 CF object. Supported spec implementations:
-                <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
-                The compiler runs before saving, so invalid JSON is rejected with an error message.
-            </p>
-            <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
-                {% if let Some(edit) = custom_format_edit %}
-                <input type="hidden" name="id" value="{{ edit.row.id }}">
-                {% if let Some(desc) = edit.trash_description.as_ref() %}
-                <div class="cf-trash-description">
-                    <strong>Trash Guides description</strong>
-                    <div style="white-space: pre-wrap;">{{ desc }}</div>
-                </div>
-                {% endif %}
-                {% endif %}
-                <div class="form-row">
-                    <div class="form-group">
-                        <label for="cf_name">Name</label>
-                        <input type="text" name="name" id="cf_name" required
-                            value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
-                    </div>
-                    <div class="form-group">
-                        <label for="cf_score">Score</label>
-                        <input type="number" name="score" id="cf_score" required
-                            value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
-                    </div>
-                </div>
-                <div class="form-group">
-                    <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
-                    <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
-                        value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
-                </div>
-                <div class="form-group">
-                    <label for="cf_json">Sonarr v4 Custom Format JSON</label>
-                    <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
-                        placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
-                    <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
-                </div>
-                <div class="settings-inline-actions">
-                    <button type="submit" class="btn btn-primary">
-                        {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
-                    </button>
-                    {% if custom_format_edit.is_some() %}
-                    <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
-                    {% endif %}
-                </div>
-            </form>
+    <div class="cf-section" id="cf-editor">
+        <div class="cf-section-header">
+            <h3>{% if let Some(edit) = custom_format_edit %}Edit Custom Format #{{ edit.row.id }}{% else %}Add Custom Format{% endif %}</h3>
         </div>
+        <p class="cf-section-desc">
+            Full Sonarr v4 CF object. Supported spec implementations:
+            <code>ReleaseTitleSpecification</code>, <code>ReleaseGroupSpecification</code>, <code>SizeSpecification</code>, <code>ResolutionSpecification</code>, <code>SourceSpecification</code>, <code>Ryokan.SeaDexBestSpecification</code>.
+            The compiler runs before saving, so invalid JSON is rejected with an error message.
+        </p>
+        <form method="post" action="/settings/custom-formats/upsert" class="settings-form">
+            {% if let Some(edit) = custom_format_edit %}
+            <input type="hidden" name="id" value="{{ edit.row.id }}">
+            {% if let Some(desc) = edit.trash_description.as_ref() %}
+            <div class="cf-trash-description">
+                <strong>Trash Guides description</strong>
+                <div style="white-space: pre-wrap;">{{ desc }}</div>
+            </div>
+            {% endif %}
+            {% endif %}
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="cf_name">Name</label>
+                    <input type="text" name="name" id="cf_name" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.name }}{% endif %}">
+                </div>
+                <div class="form-group">
+                    <label for="cf_score">Score</label>
+                    <input type="number" name="score" id="cf_score" required
+                        value="{% if let Some(edit) = custom_format_edit %}{{ edit.row.score }}{% else %}0{% endif %}">
+                </div>
+            </div>
+            <div class="form-group">
+                <label for="cf_trash_id">Trash ID <span class="form-hint">(optional)</span></label>
+                <input type="text" name="trash_id" id="cf_trash_id" placeholder="e.g. ed38b0b3..."
+                    value="{% if let Some(edit) = custom_format_edit %}{% if let Some(tid) = edit.row.trash_id.as_ref() %}{{ tid }}{% endif %}{% endif %}">
+            </div>
+            <div class="form-group">
+                <label for="cf_json">Sonarr v4 Custom Format JSON</label>
+                <textarea name="json" id="cf_json" rows="16" required spellcheck="false"
+                    placeholder='{ "name": "My CF", "specifications": [ ... ] }'>{% if let Some(edit) = custom_format_edit %}{{ edit.row.json }}{% endif %}</textarea>
+                <span class="form-hint">A top-level <code>trash_description</code> field is preserved verbatim and shown above when editing.</span>
+            </div>
+            <div class="settings-inline-actions">
+                <button type="submit" class="btn btn-primary">
+                    {% if custom_format_edit.is_some() %}Save Changes{% else %}Create Custom Format{% endif %}
+                </button>
+                {% if custom_format_edit.is_some() %}
+                <a href="/settings?tab=custom_formats" class="btn btn-secondary">Cancel</a>
+                {% endif %}
+            </div>
+        </form>
     </div>
     {% endif %}
 
@@ -692,39 +690,43 @@
     });
 })();
 
-// #11.1 — Client-side filter for the CF list pane. Matches against the
-// `data-cf-*` attributes on each row (name is pre-lowercased server-side,
-// score/trash_id/origin match case-insensitively). Empty query = show all.
-// Updates the `#cf-visible-count` pill and toggles the "no matches"
-// placeholder so the pane doesn't render as a blank void when every row
-// is filtered out.
+// #11.1 — Client-side filter for the CF card grid. Matches against
+// `data-cf-*` attributes on each card (name is pre-lowercased
+// server-side, score/trash_id/origin match case-insensitively). Empty
+// query = show all. Updates the `#cf-visible-count` pill and toggles
+// the "no matches" placeholder so the grid doesn't render as a blank
+// void when every card is filtered out.
 function filterCfList(query) {
     const q = (query || '').trim().toLowerCase();
-    const tbody = document.getElementById('cf-list-tbody');
-    if (!tbody) return;
-    const rows = tbody.querySelectorAll('tr.cf-row');
+    const grid = document.getElementById('cf-list-tbody');
+    if (!grid) return;
+    const cards = grid.querySelectorAll('.cf-card:not(.cf-card-add)');
     let visible = 0;
-    rows.forEach(function(row) {
+    cards.forEach(function(card) {
         if (!q) {
-            row.style.display = '';
+            card.style.display = '';
             visible++;
             return;
         }
-        const name = row.dataset.cfName || '';
-        const score = (row.dataset.cfScore || '').toLowerCase();
-        const trashId = row.dataset.cfTrashId || '';
-        const origin = (row.dataset.cfOrigin || '').toLowerCase();
+        const name = card.dataset.cfName || '';
+        const score = (card.dataset.cfScore || '').toLowerCase();
+        const trashId = card.dataset.cfTrashId || '';
+        const origin = (card.dataset.cfOrigin || '').toLowerCase();
         const hit = name.includes(q)
             || score.includes(q)
             || trashId.includes(q)
             || origin.includes(q);
-        row.style.display = hit ? '' : 'none';
+        card.style.display = hit ? '' : 'none';
         if (hit) visible++;
     });
     const countEl = document.getElementById('cf-visible-count');
     if (countEl) countEl.textContent = visible;
     const emptyEl = document.getElementById('cf-list-empty-filter');
-    if (emptyEl) emptyEl.style.display = (visible === 0 && rows.length > 0) ? '' : 'none';
+    if (emptyEl) emptyEl.style.display = (visible === 0 && cards.length > 0) ? '' : 'none';
+    // Hide the trailing "+ Add" tile while the user is filtering —
+    // mixing it into search results reads as noise.
+    const addCard = grid.querySelector('.cf-card-add');
+    if (addCard) addCard.style.display = q ? 'none' : '';
 }
 
 function generateApiKey() {

--- a/templates/system.html
+++ b/templates/system.html
@@ -81,7 +81,7 @@
         </thead>
         <tbody id="log-tbody">
             {% for entry in logs %}
-            <tr class="log-row log-level-{{ entry.level }}{% if !entry.detail.is_empty() %} log-row-has-detail{% endif %}" data-id="{{ entry.id }}"{% if !entry.detail.is_empty() %} onclick="toggleLogRowExpand(event)" role="button" tabindex="0"{% endif %}>
+            <tr class="log-row log-level-{{ entry.level }}" data-id="{{ entry.id }}">
                 <td class="log-col-time" title="{{ entry.timestamp }}">{{ entry.timestamp }}</td>
                 <td class="log-col-level"><span class="log-badge log-badge-{{ entry.level }}">{{ entry.level }}</span></td>
                 <td class="log-col-cat">{{ entry.category }}</td>
@@ -89,7 +89,6 @@
                     <span class="log-message">{{ entry.message }}</span>
                     {% if !entry.detail.is_empty() %}
                     <span class="log-detail" title="{{ entry.detail }}">{{ entry.detail }}</span>
-                    <span class="log-expand-hint" aria-hidden="true">▾</span>
                     {% endif %}
                 </td>
             </tr>
@@ -170,22 +169,16 @@ function pollLogs() {
             for (let i = entries.length - 1; i >= 0; i--) {
                 const e = entries[i];
                 if (e.id > latestId) latestId = e.id;
-                const hasDetail = !!(e.detail && e.detail.length);
                 const tr = document.createElement('tr');
-                tr.className = `log-row log-level-${e.level} log-row-new${hasDetail ? ' log-row-has-detail' : ''}`;
+                tr.className = `log-row log-level-${e.level} log-row-new`;
                 tr.dataset.id = e.id;
-                if (hasDetail) {
-                    tr.setAttribute('role', 'button');
-                    tr.setAttribute('tabindex', '0');
-                    tr.onclick = toggleLogRowExpand;
-                }
                 tr.innerHTML = `
                     <td class="log-col-time" title="${escapeHtml(e.timestamp)}">${escapeHtml(e.timestamp)}</td>
                     <td class="log-col-level"><span class="log-badge log-badge-${e.level}">${escapeHtml(e.level)}</span></td>
                     <td class="log-col-cat">${escapeHtml(e.category)}</td>
                     <td class="log-col-msg">
                         <span class="log-message">${escapeHtml(e.message)}</span>
-                        ${hasDetail ? `<span class="log-detail" title="${escapeHtml(e.detail)}">${escapeHtml(e.detail)}</span><span class="log-expand-hint" aria-hidden="true">▾</span>` : ''}
+                        ${e.detail ? `<span class="log-detail" title="${escapeHtml(e.detail)}">${escapeHtml(e.detail)}</span>` : ''}
                     </td>`;
                 tbody.insertBefore(tr, tbody.firstChild);
                 // Remove new-row highlight after animation.
@@ -207,19 +200,6 @@ function stopPolling() {
 document.getElementById('poll-toggle').addEventListener('change', function() {
     if (this.checked) startPolling(); else stopPolling();
 });
-
-// Tap-to-expand on log rows. Desktop picks up :hover; mobile doesn't,
-// so toggle `.log-row-expanded` on click. Each <tr> carries an explicit
-// onclick="toggleLogRowExpand(event)" attribute (and role="button") in
-// both the server-rendered template and the pollLogs runtime path —
-// delegated handlers on tbody weren't reliably firing on tr/td taps in
-// mobile Firefox, so a direct onclick is the safer option.
-function toggleLogRowExpand(ev) {
-    const row = ev.target.closest('.log-row');
-    if (!row) return;
-    if (ev.target.closest('a, button, input')) return;
-    row.classList.toggle('log-row-expanded');
-}
 
 startPolling();
 </script>

--- a/templates/system.html
+++ b/templates/system.html
@@ -201,6 +201,17 @@ document.getElementById('poll-toggle').addEventListener('change', function() {
     if (this.checked) startPolling(); else stopPolling();
 });
 
+// Tap-to-expand on log rows. Desktop picks up :hover, mobile doesn't,
+// so toggle `.log-row-expanded` on click (delegated so polled-in rows
+// inherit it without rebinding). Skip the toggle when the user is
+// clicking a link or button inside the row.
+document.getElementById('log-tbody')?.addEventListener('click', function(ev) {
+    const row = ev.target.closest('.log-row');
+    if (!row) return;
+    if (ev.target.closest('a, button, input')) return;
+    row.classList.toggle('log-row-expanded');
+});
+
 startPolling();
 </script>
 

--- a/templates/system.html
+++ b/templates/system.html
@@ -81,7 +81,7 @@
         </thead>
         <tbody id="log-tbody">
             {% for entry in logs %}
-            <tr class="log-row log-level-{{ entry.level }}" data-id="{{ entry.id }}" onclick="toggleLogRowExpand(event)" role="button" tabindex="0">
+            <tr class="log-row log-level-{{ entry.level }}{% if !entry.detail.is_empty() %} log-row-has-detail{% endif %}" data-id="{{ entry.id }}"{% if !entry.detail.is_empty() %} onclick="toggleLogRowExpand(event)" role="button" tabindex="0"{% endif %}>
                 <td class="log-col-time" title="{{ entry.timestamp }}">{{ entry.timestamp }}</td>
                 <td class="log-col-level"><span class="log-badge log-badge-{{ entry.level }}">{{ entry.level }}</span></td>
                 <td class="log-col-cat">{{ entry.category }}</td>
@@ -89,6 +89,7 @@
                     <span class="log-message">{{ entry.message }}</span>
                     {% if !entry.detail.is_empty() %}
                     <span class="log-detail" title="{{ entry.detail }}">{{ entry.detail }}</span>
+                    <span class="log-expand-hint" aria-hidden="true">▾</span>
                     {% endif %}
                 </td>
             </tr>
@@ -169,19 +170,22 @@ function pollLogs() {
             for (let i = entries.length - 1; i >= 0; i--) {
                 const e = entries[i];
                 if (e.id > latestId) latestId = e.id;
+                const hasDetail = !!(e.detail && e.detail.length);
                 const tr = document.createElement('tr');
-                tr.className = `log-row log-level-${e.level} log-row-new`;
+                tr.className = `log-row log-level-${e.level} log-row-new${hasDetail ? ' log-row-has-detail' : ''}`;
                 tr.dataset.id = e.id;
-                tr.setAttribute('role', 'button');
-                tr.setAttribute('tabindex', '0');
-                tr.onclick = toggleLogRowExpand;
+                if (hasDetail) {
+                    tr.setAttribute('role', 'button');
+                    tr.setAttribute('tabindex', '0');
+                    tr.onclick = toggleLogRowExpand;
+                }
                 tr.innerHTML = `
                     <td class="log-col-time" title="${escapeHtml(e.timestamp)}">${escapeHtml(e.timestamp)}</td>
                     <td class="log-col-level"><span class="log-badge log-badge-${e.level}">${escapeHtml(e.level)}</span></td>
                     <td class="log-col-cat">${escapeHtml(e.category)}</td>
                     <td class="log-col-msg">
                         <span class="log-message">${escapeHtml(e.message)}</span>
-                        ${e.detail ? `<span class="log-detail" title="${escapeHtml(e.detail)}">${escapeHtml(e.detail)}</span>` : ''}
+                        ${hasDetail ? `<span class="log-detail" title="${escapeHtml(e.detail)}">${escapeHtml(e.detail)}</span><span class="log-expand-hint" aria-hidden="true">▾</span>` : ''}
                     </td>`;
                 tbody.insertBefore(tr, tbody.firstChild);
                 // Remove new-row highlight after animation.

--- a/templates/system.html
+++ b/templates/system.html
@@ -81,7 +81,7 @@
         </thead>
         <tbody id="log-tbody">
             {% for entry in logs %}
-            <tr class="log-row log-level-{{ entry.level }}" data-id="{{ entry.id }}">
+            <tr class="log-row log-level-{{ entry.level }}" data-id="{{ entry.id }}" onclick="toggleLogRowExpand(event)" role="button" tabindex="0">
                 <td class="log-col-time" title="{{ entry.timestamp }}">{{ entry.timestamp }}</td>
                 <td class="log-col-level"><span class="log-badge log-badge-{{ entry.level }}">{{ entry.level }}</span></td>
                 <td class="log-col-cat">{{ entry.category }}</td>
@@ -172,6 +172,9 @@ function pollLogs() {
                 const tr = document.createElement('tr');
                 tr.className = `log-row log-level-${e.level} log-row-new`;
                 tr.dataset.id = e.id;
+                tr.setAttribute('role', 'button');
+                tr.setAttribute('tabindex', '0');
+                tr.onclick = toggleLogRowExpand;
                 tr.innerHTML = `
                     <td class="log-col-time" title="${escapeHtml(e.timestamp)}">${escapeHtml(e.timestamp)}</td>
                     <td class="log-col-level"><span class="log-badge log-badge-${e.level}">${escapeHtml(e.level)}</span></td>
@@ -201,16 +204,18 @@ document.getElementById('poll-toggle').addEventListener('change', function() {
     if (this.checked) startPolling(); else stopPolling();
 });
 
-// Tap-to-expand on log rows. Desktop picks up :hover, mobile doesn't,
-// so toggle `.log-row-expanded` on click (delegated so polled-in rows
-// inherit it without rebinding). Skip the toggle when the user is
-// clicking a link or button inside the row.
-document.getElementById('log-tbody')?.addEventListener('click', function(ev) {
+// Tap-to-expand on log rows. Desktop picks up :hover; mobile doesn't,
+// so toggle `.log-row-expanded` on click. Each <tr> carries an explicit
+// onclick="toggleLogRowExpand(event)" attribute (and role="button") in
+// both the server-rendered template and the pollLogs runtime path —
+// delegated handlers on tbody weren't reliably firing on tr/td taps in
+// mobile Firefox, so a direct onclick is the safer option.
+function toggleLogRowExpand(ev) {
     const row = ev.target.closest('.log-row');
     if (!row) return;
     if (ev.target.closest('a, button, input')) return;
     row.classList.toggle('log-row-expanded');
-});
+}
 
 startPolling();
 </script>


### PR DESCRIPTION
## Summary

Two issues, one PR, mostly template + CSS churn (no backend changes beyond a small CF import preview handler):

- **#11 — CF page UX rework.** Sonarr v4-style card grid for the Custom Formats list, modal editor replacing the scroll-jumping inline form, redesigned import flow with per-entry preview (new / collision / invalid), per-CF export selector with clipboard copy, consolidated Defaults + Minimum Score panel, and every native `confirm()`/`alert()` replaced with the Ryokan modal primitives from #15.
- **#20 — Mobile layout pass.** Bring the UX up to Seerr/Jellyseerr level on phone. Mobile bottom tab bar, viewport-width clamp, full-screen modals below breakpoint, tight poster grid, card-layout conversions for Search / Downloads / Series / Logs, touch-target minimums, dozens of width-overflow fixes found during OP15 testing.

## On #11.2 (structured spec editor)

Originally planned as part of #11 but **no longer shipping.** The CF pipeline is end-to-end functional with what's in this PR: import from TRaSH Guides / Sonarr exports with per-entry preview, JSON textarea for hand-authoring, card grid + condition pills for browsing, per-CF export with clipboard, bundled defaults install/reset, minimum-score threshold, and full delete/rename/upsert lifecycle. A structured dropdown editor is pure ergonomic polish on a feature that already works, and Ryokan's audience (anime nerds running Sonarr/qBit/Jellyfin) reads JSON fine. Closing it out of the 1.0 scope rather than deferring.

## Files touched

```
static/css/style.css     | +1097
templates/settings.html  |  +707
templates/base.html      |   +29
templates/search.html    |   +59
...  (8 files, +1876/-203)
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 419 pass, 0 fail
- [x] Manual: CF list renders as card grid; click-to-edit opens modal
- [x] Manual: CF import from TRaSH Guides JSON shows preview panel correctly
- [x] Manual: CF export selector with clipboard works
- [x] Manual: OP15 phone testing across Library / Search / Downloads / Series / Settings / System — no horizontal scroll, all action buttons reachable
- [x] Manual: log table renders as stacked cards below 640px with full detail always visible
- [x] Manual: episode table keeps desktop shape on phone with actions row underneath

closes #11
closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)