### PR TITLE
chore: bump version to 1.0.0 for release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "0.1.0"
+version = "1.0.0"
 edition = "2024"
 rust-version = "1.88"
 


### PR DESCRIPTION
Single-commit version bump ahead of tagging `v1.0.0`.

Cargo.toml and Cargo.lock only — no code changes. All v1.0.0
milestone work already landed via PR #40.

Merge this, then tag `v1.0.0` on main to trigger the Docker
publish workflow.