### PR TITLE
perf: batch and cache external API requests

### DIFF
--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -438,6 +438,27 @@ async fn maybe_reconcile_mal_entry(
         Ok(Some(row)) => row,
         _ => return None,
     };
+
+    // The series row now has the positive AniList id, but the metadata
+    // cache (`series_metadata_cache`) still holds the old MAL-sourced
+    // detail with `id < 0`. The series-detail page reads the cache
+    // first and uses `detail.id < 0` to decide whether to render a
+    // MyAnimeList vs AniList external link, so without this overwrite
+    // the page keeps showing the MAL link until the cache TTL expires
+    // (METADATA_REFRESH_INTERVAL_HOURS) or a manual rebuild fires.
+    // Best-effort: a write failure here just leaves the stale cache to
+    // expire on its own — reconciliation already updated the source of
+    // truth (series.anilist_id), so the next refresh sweep will fix it.
+    if let Err(e) =
+        metadata_cache::upsert(db, refreshed.id, detail.id, detail.id_mal, &detail).await
+    {
+        tracing::warn!(
+            "reconcile: failed to refresh series_metadata_cache for series_id={}: {}",
+            refreshed.id,
+            e
+        );
+    }
+
     Some((refreshed, detail))
 }
 

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -570,11 +570,11 @@ async fn resolve_series_context(
                         // Prefer Kitsu's MAL-mapping filter when a MAL id is
                         // available — single exact-match request rather than the
                         // 1–4 fuzzy queries the title path issues.
-                        if let Some(mid) = tracked.mal_id {
-                            if let Ok(Some(kitsu_detail)) = kitsu::get_anime_detail_by_mal_id(mid).await {
-                                logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (mapping)", &tracked.title).await;
-                                return Ok((db_series, kitsu_detail.id, kitsu_detail));
-                            }
+                        if let Some(mid) = tracked.mal_id
+                            && let Ok(Some(kitsu_detail)) = kitsu::get_anime_detail_by_mal_id(mid).await
+                        {
+                            logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (mapping)", &tracked.title).await;
+                            return Ok((db_series, kitsu_detail.id, kitsu_detail));
                         }
                         let kitsu_titles = vec![
                             tracked.title.clone(),

--- a/src/handlers/library.rs
+++ b/src/handlers/library.rs
@@ -401,35 +401,33 @@ async fn maybe_reconcile_mal_entry(
         return None;
     }
 
-    let matched = match anilist::find_anime_by_mal_id(mal_id).await {
-        Ok(Some(entry)) => entry,
+    // Single round-trip: AniList's `Media(idMal:)` query returns the same
+    // full detail payload we'd get from `Media(id:)`, so the previous
+    // "find then fetch detail" two-step has been collapsed.
+    let detail = match anilist::find_anime_detail_by_mal_id(mal_id).await {
+        Ok(Some(d)) => d,
         _ => return None,
     };
 
-    let detail = match anilist::get_anime_detail(matched.id).await {
-        Ok(detail) => detail,
-        Err(_) => return None,
-    };
-
-    let primary_title = if !matched.title_english.is_empty() {
-        matched.title_english.clone()
+    let primary_title = if !detail.title_english.is_empty() {
+        detail.title_english.clone()
     } else {
-        matched.title_romaji.clone()
+        detail.title_romaji.clone()
     };
     if series::upsert(
         db,
         series::SeriesCore {
-            anilist_id: matched.id,
-            mal_id: matched.id_mal,
+            anilist_id: detail.id,
+            mal_id: detail.id_mal,
             title: &primary_title,
-            title_romaji: &matched.title_romaji,
-            title_english: &matched.title_english,
-            title_native: &matched.title_native,
-            cover_url: &matched.cover_url,
-            format: &matched.format,
-            status: &matched.status,
-            episodes: matched.episodes,
-            season_year: matched.season_year,
+            title_romaji: &detail.title_romaji,
+            title_english: &detail.title_english,
+            title_native: &detail.title_native,
+            cover_url: &detail.cover_url,
+            format: &detail.format,
+            status: &detail.status,
+            episodes: detail.episodes,
+            season_year: detail.season_year,
             end_year: detail.end_year,
         },
     ).await.is_err() {
@@ -516,6 +514,13 @@ async fn resolve_series_context(
                         Ok(detail) => detail,
                         Err(je) => {
                             if let Some(ref tracked) = db_series {
+                                // Try Kitsu's MAL-mapping filter first (1 exact-match
+                                // request) before falling back to the title-fuzz path
+                                // (1–4 fuzzy requests).
+                                if let Ok(Some(kitsu_detail)) = kitsu::get_anime_detail_by_mal_id(mid).await {
+                                    logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (mapping)", &tracked.title).await;
+                                    return Ok((db_series, kitsu_detail.id, kitsu_detail));
+                                }
                                 let kitsu_titles = vec![
                                     tracked.title.clone(),
                                     tracked.title_romaji.clone(),
@@ -523,7 +528,7 @@ async fn resolve_series_context(
                                     tracked.title_native.clone(),
                                 ];
                                 if let Ok(kitsu_detail) = kitsu::get_anime_detail_by_titles(&kitsu_titles, None, tracked.episodes).await {
-                                    logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback", &tracked.title).await;
+                                    logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (titles)", &tracked.title).await;
                                     return Ok((db_series, kitsu_detail.id, kitsu_detail));
                                 }
                             }
@@ -541,6 +546,15 @@ async fn resolve_series_context(
                             ).await;
                             return Ok((db_series, cached.provider_id, cached.detail));
                         }
+                        // Prefer Kitsu's MAL-mapping filter when a MAL id is
+                        // available — single exact-match request rather than the
+                        // 1–4 fuzzy queries the title path issues.
+                        if let Some(mid) = tracked.mal_id {
+                            if let Ok(Some(kitsu_detail)) = kitsu::get_anime_detail_by_mal_id(mid).await {
+                                logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (mapping)", &tracked.title).await;
+                                return Ok((db_series, kitsu_detail.id, kitsu_detail));
+                            }
+                        }
                         let kitsu_titles = vec![
                             tracked.title.clone(),
                             tracked.title_romaji.clone(),
@@ -548,7 +562,7 @@ async fn resolve_series_context(
                             tracked.title_native.clone(),
                         ];
                         if let Ok(kitsu_detail) = kitsu::get_anime_detail_by_titles(&kitsu_titles, None, tracked.episodes).await {
-                            logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback", &tracked.title).await;
+                            logger::warn(db, LogCategory::AniList, "AniList and MAL detail failed; using Kitsu fallback (titles)", &tracked.title).await;
                             return Ok((db_series, kitsu_detail.id, kitsu_detail));
                         }
                     }
@@ -2549,20 +2563,21 @@ async fn auto_expand_library_from_pack_with_files(
     // then graft its OWN relations onto the parent so
     // `detect_sibling_entries_in_pack` sees a broader candidate
     // pool. Fetches are capped by
-    // `auto_search::TRANSITIVE_WALK_MAX_FETCHES` and every call
-    // goes through the AL detail cache so repeat grabs within the
-    // TTL are free. Failures are soft — any neighbor we can't fetch
-    // is silently skipped and detection falls back to the parent's
-    // direct relations. Fetches are dispatched concurrently via a
-    // JoinSet so N neighbors take max(fetch_time), not sum — every
-    // hop previously blocked the grab path end-to-end.
-    let mut neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> =
+    // `auto_search::TRANSITIVE_WALK_MAX_FETCHES`. Failures are soft
+    // — any neighbor we can't fetch is silently skipped and detection
+    // falls back to the parent's direct relations.
+    //
+    // Single batched `Page(media(id_in:[]))` request via
+    // `anilist::get_anime_details_batch` replaces the previous
+    // per-id JoinSet that fan-out N concurrent single-id queries.
+    // The single throttle gate had been serializing those concurrent
+    // requests anyway, so the JoinSet was paying coordination cost
+    // for no parallelism — one batched call does it in one round-trip.
+    let mut walk_ids: Vec<i64> = Vec::new();
+    let mut walk_id_to_type: std::collections::HashMap<i64, String> =
         std::collections::HashMap::new();
-    let mut walk_set: tokio::task::JoinSet<(i64, String, Result<anilist::AnimeDetail, String>)> =
-        tokio::task::JoinSet::new();
-    let mut dispatched = 0_usize;
     for rel in &parent_detail.relations {
-        if dispatched >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
+        if walk_ids.len() >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
             break;
         }
         if !auto_search::is_transitive_walk_source(&rel.relation_type) {
@@ -2574,35 +2589,38 @@ async fn auto_expand_library_from_pack_with_files(
         if rel.id <= 0 {
             continue;
         }
-        let rel_id = rel.id;
-        let rel_type = rel.relation_type.clone();
-        walk_set.spawn(async move {
-            let res = anilist::get_anime_detail(rel_id)
-                .await
-                .map_err(|e| e.to_string());
-            (rel_id, rel_type, res)
-        });
-        dispatched += 1;
+        walk_ids.push(rel.id);
+        walk_id_to_type.insert(rel.id, rel.relation_type.clone());
     }
-    while let Some(joined) = walk_set.join_next().await {
-        match joined {
-            Ok((rel_id, _rel_type, Ok(detail))) => {
-                neighbor_details.insert(rel_id, detail);
-            }
-            Ok((rel_id, rel_type, Err(e))) => {
+    let neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> = if walk_ids
+        .is_empty()
+    {
+        std::collections::HashMap::new()
+    } else {
+        match anilist::get_anime_details_batch(&walk_ids).await {
+            Ok(map) => map,
+            Err(e) => {
                 tracing::debug!(
-                    "auto-expand: transitive neighbor fetch failed rel_id={} rel_type={} err={}",
-                    rel_id,
-                    rel_type,
+                    "auto-expand: transitive neighbor batch fetch failed err={}",
                     e
                 );
+                std::collections::HashMap::new()
             }
-            Err(join_err) => {
-                tracing::debug!(
-                    "auto-expand: transitive neighbor task panicked: {}",
-                    join_err
-                );
-            }
+        }
+    };
+    // Log any ids the batch didn't return — typically AniList simply
+    // has no Media for that id (deleted entry, NSFW filter, etc.).
+    for rel_id in &walk_ids {
+        if !neighbor_details.contains_key(rel_id) {
+            let rel_type = walk_id_to_type
+                .get(rel_id)
+                .cloned()
+                .unwrap_or_default();
+            tracing::debug!(
+                "auto-expand: transitive neighbor missing from batch rel_id={} rel_type={}",
+                rel_id,
+                rel_type
+            );
         }
     }
     let expanded_parent =

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -619,6 +619,22 @@ async fn lookup_by_tmdb_id(
         return Ok(Json(vec![build_stub_movie(tmdb_id, cfg)]));
     }
 
+    // Pre-batch every AniList id into one `Page(media(id_in:[]))` call
+    // so the per-entry loop hits DETAIL_CACHE instead of issuing N
+    // sequential GraphQL queries. A 7-entry TMDB fan-out becomes 1
+    // round-trip + 7 cache hits instead of 7 throttled-serial round-trips.
+    let prefetch_ids: Vec<i64> = anime_ids
+        .iter()
+        .filter_map(|ids| ids.anilist_id.filter(|id| *id > 0))
+        .collect();
+    if !prefetch_ids.is_empty() {
+        if let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await {
+            tracing::debug!(
+                "Radarr fan-out: AL batch prefetch failed (per-id loop will retry): {e}"
+            );
+        }
+    }
+
     let mut results = Vec::new();
     for ids in &anime_ids {
         let detail = if let Some(al_id) = ids.anilist_id {

--- a/src/handlers/radarr_compat.rs
+++ b/src/handlers/radarr_compat.rs
@@ -627,12 +627,12 @@ async fn lookup_by_tmdb_id(
         .iter()
         .filter_map(|ids| ids.anilist_id.filter(|id| *id > 0))
         .collect();
-    if !prefetch_ids.is_empty() {
-        if let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await {
-            tracing::debug!(
-                "Radarr fan-out: AL batch prefetch failed (per-id loop will retry): {e}"
-            );
-        }
+    if !prefetch_ids.is_empty()
+        && let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await
+    {
+        tracing::debug!(
+            "Radarr fan-out: AL batch prefetch failed (per-id loop will retry): {e}"
+        );
     }
 
     let mut results = Vec::new();

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -603,6 +603,30 @@ pub async fn add_series(
             ).await;
         }
 
+        // Pre-batch every still-missing AniList id into one
+        // `Page(media(id_in:[]))` call so the per-entry loop below
+        // hits DETAIL_CACHE instead of issuing N sequential GraphQL
+        // queries. A 7-entry fan-out becomes 1 round-trip + 7 cache
+        // hits instead of 7 throttled-serial round-trips.
+        let prefetch_ids: Vec<i64> = anime_ids
+            .iter()
+            .zip(existing_siblings.iter())
+            .filter_map(|(ids, existing)| {
+                if existing.is_some() {
+                    None
+                } else {
+                    ids.anilist_id.filter(|id| *id > 0)
+                }
+            })
+            .collect();
+        if !prefetch_ids.is_empty() {
+            if let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await {
+                tracing::debug!(
+                    "Seerr add: AL batch prefetch failed (per-id loop will retry): {e}"
+                );
+            }
+        }
+
         for (ids, existing) in anime_ids.iter().zip(existing_siblings.into_iter()) {
             // Skip entries that already exist — regrab-within-fresh case.
             // A partial fan-out (user added JJK S1 manually last month, now

--- a/src/handlers/sonarr_compat.rs
+++ b/src/handlers/sonarr_compat.rs
@@ -619,12 +619,12 @@ pub async fn add_series(
                 }
             })
             .collect();
-        if !prefetch_ids.is_empty() {
-            if let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await {
-                tracing::debug!(
-                    "Seerr add: AL batch prefetch failed (per-id loop will retry): {e}"
-                );
-            }
+        if !prefetch_ids.is_empty()
+            && let Err(e) = anilist::get_anime_details_batch(&prefetch_ids).await
+        {
+            tracing::debug!(
+                "Seerr add: AL batch prefetch failed (per-id loop will retry): {e}"
+            );
         }
 
         for (ids, existing) in anime_ids.iter().zip(existing_siblings.into_iter()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -348,6 +348,12 @@ async fn main() {
     let cf_cache: CompiledCfCache =
         Arc::new(RwLock::new(Arc::new(custom_formats::load_compiled_cfs(&db).await)));
 
+    // Warm the SeaDex lookup cache from SQLite so a restart doesn't
+    // re-hit releases.moe for every series in the library on the next
+    // RSS sweep. Failures are logged and ignored — a cold cache just
+    // means the first lookup per series pays the round-trip again.
+    services::auto_search::seadex_warm_cache_from_db(&db).await;
+
     // Prime the `users_exist` cache at startup so a running instance with
     // an existing admin account never pays the `SELECT COUNT(*) FROM users`
     // cost on the auth hot path.

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1418,6 +1418,25 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // SeaDex lookup cache, persisted across restarts. The in-memory cache
+    // in `services::auto_search` already de-duplicates within a process,
+    // but cold-boot RSS sweeps were re-fetching every series's SeaDex
+    // entry on the first 24h cycle after every restart. Persisting the
+    // 24h window to SQLite means a restart picks up where the cache left
+    // off. Error-marked entries (5-min TTL) are deliberately NOT persisted
+    // — they reflect upstream health, which restart should re-probe.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS seadex_lookup_cache (
+            anilist_id INTEGER PRIMARY KEY,
+            payload_json TEXT NOT NULL,
+            cached_at INTEGER NOT NULL
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
     Ok(())
 }
 

--- a/src/services/anibridge.rs
+++ b/src/services/anibridge.rs
@@ -60,6 +60,62 @@ fn write_disk_cache(bytes: &[u8]) -> Result<(), String> {
     Ok(())
 }
 
+/// Sidecar metadata for the on-disk mappings cache. Stores the upstream
+/// `ETag` / `Last-Modified` so the next refresh can issue a conditional
+/// GET (`If-None-Match` / `If-Modified-Since`) and skip the 8.5 MB
+/// download entirely on the ~50% of days the upstream hasn't changed.
+#[derive(serde::Serialize, serde::Deserialize, Default, Clone)]
+struct DiskCacheMeta {
+    #[serde(default)]
+    etag: Option<String>,
+    #[serde(default)]
+    last_modified: Option<String>,
+}
+
+fn meta_file_path() -> PathBuf {
+    cache_file_path().with_extension("meta.json")
+}
+
+fn read_disk_cache_meta() -> Option<DiskCacheMeta> {
+    let bytes = std::fs::read(meta_file_path()).ok()?;
+    serde_json::from_slice(&bytes).ok()
+}
+
+fn write_disk_cache_meta(meta: &DiskCacheMeta) -> Result<(), String> {
+    let path = meta_file_path();
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("create anibridge meta dir failed: {}", e))?;
+    }
+    let json = serde_json::to_vec(meta)
+        .map_err(|e| format!("serialize anibridge meta failed: {}", e))?;
+    let tmp = path.with_extension("json.tmp");
+    std::fs::write(&tmp, &json)
+        .map_err(|e| format!("write anibridge meta tmp failed: {}", e))?;
+    std::fs::rename(&tmp, &path)
+        .map_err(|e| format!("rename anibridge meta tmp failed: {}", e))?;
+    Ok(())
+}
+
+/// Reset the on-disk mappings file's mtime to "now" so subsequent
+/// `read_fresh_disk_cache` calls treat it as fresh again. Called after
+/// a 304 response — the upstream confirms our copy is current, so the
+/// freshness window restarts even though we didn't rewrite the file.
+fn touch_disk_cache() -> Result<(), String> {
+    let f = std::fs::File::open(cache_file_path())
+        .map_err(|e| format!("open anibridge cache for touch failed: {}", e))?;
+    f.set_modified(SystemTime::now())
+        .map_err(|e| format!("set_modified anibridge cache failed: {}", e))?;
+    Ok(())
+}
+
+/// Read the on-disk mappings without freshness checking. Used on the
+/// 304 path where the upstream has confirmed our cached copy is the
+/// current version regardless of mtime.
+fn read_disk_cache_unconditional() -> Option<Vec<u8>> {
+    std::fs::read(cache_file_path()).ok()
+}
+
 /// Cached mapping data: TMDB show ID → list of (anilist_id, mal_id) pairs.
 /// A single TMDB show may map to multiple AniList entries (e.g. multi-season).
 ///
@@ -101,9 +157,12 @@ struct MappingCache {
 ///      for the next startup
 ///
 /// The disk path is what makes `cargo run` fast on subsequent
-/// launches — the GitHub download is ~20MB gzipped and can take
-/// several seconds, and it's wasteful to pay that on every restart
-/// when the data almost never changes day-to-day.
+/// launches — the GitHub download is ~8.5 MB and can take several
+/// seconds, and it's wasteful to pay that on every restart when the
+/// data almost never changes day-to-day. The conditional-GET path
+/// (ETag / Last-Modified) inside `download_parse_and_persist` further
+/// short-circuits to a 304 response on the days the upstream really
+/// is unchanged.
 pub async fn ensure_loaded() -> bool {
     // Fast path: cache exists and is fresh.
     {
@@ -335,23 +394,84 @@ fn parse_bytes(bytes: &[u8]) -> Result<MappingCache, String> {
 }
 
 async fn download_parse_and_persist() -> Result<MappingCache, String> {
-    tracing::info!("Downloading anibridge mappings...");
+    tracing::info!("Refreshing anibridge mappings...");
 
     let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(5))
         .build()
         .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
-    let resp = client
+    // Only attach conditional headers when both the meta and the cached
+    // bytes are present on disk — sending If-None-Match without having
+    // the bytes to fall back to means a 304 is unrecoverable.
+    let stored_meta = tokio::task::spawn_blocking(read_disk_cache_meta)
+        .await
+        .ok()
+        .flatten();
+    let cache_file_present = tokio::task::spawn_blocking(|| cache_file_path().exists())
+        .await
+        .unwrap_or(false);
+    let conditional_meta = if cache_file_present { stored_meta } else { None };
+
+    let mut req = client
         .get(MAPPINGS_URL)
-        .header("User-Agent", "Ryokan/0.1")
+        .header("User-Agent", "Ryokan/0.1");
+    if let Some(meta) = &conditional_meta {
+        if let Some(etag) = &meta.etag {
+            req = req.header(reqwest::header::IF_NONE_MATCH, etag);
+        }
+        if let Some(lm) = &meta.last_modified {
+            req = req.header(reqwest::header::IF_MODIFIED_SINCE, lm);
+        }
+    }
+
+    let resp = req
         .send()
         .await
         .map_err(|e| format!("Failed to download mappings: {}", e))?;
 
-    if !resp.status().is_success() {
-        return Err(format!("Mappings download failed: HTTP {}", resp.status()));
+    let status = resp.status();
+
+    // 304 Not Modified — upstream confirms our cached bytes are current.
+    // Read them off disk, bump the freshness mtime, and skip the 8.5 MB
+    // body. The Azure blob fronting this asset emits ETag + Last-Modified
+    // reliably; on the ~50% of days the upstream is unchanged this saves
+    // the entire transfer.
+    if status == reqwest::StatusCode::NOT_MODIFIED {
+        tracing::info!("Anibridge mappings unchanged (HTTP 304); reusing disk cache");
+        let bytes = tokio::task::spawn_blocking(read_disk_cache_unconditional)
+            .await
+            .ok()
+            .flatten()
+            .ok_or_else(|| {
+                "Anibridge upstream returned 304 but disk cache is missing".to_string()
+            })?;
+        if let Err(e) = tokio::task::spawn_blocking(touch_disk_cache).await
+            .unwrap_or_else(|e| Err(format!("touch join failed: {}", e)))
+        {
+            tracing::warn!("Failed to bump anibridge cache mtime after 304: {}", e);
+        }
+        return parse_bytes(&bytes);
     }
+
+    if !status.is_success() {
+        return Err(format!("Mappings download failed: HTTP {}", status));
+    }
+
+    // Capture caching headers before consuming the body so we can
+    // persist them alongside the bytes for the next conditional GET.
+    let new_meta = DiskCacheMeta {
+        etag: resp
+            .headers()
+            .get(reqwest::header::ETAG)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+        last_modified: resp
+            .headers()
+            .get(reqwest::header::LAST_MODIFIED)
+            .and_then(|v| v.to_str().ok())
+            .map(str::to_string),
+    };
 
     let bytes = resp
         .bytes()
@@ -372,6 +492,15 @@ async fn download_parse_and_persist() -> Result<MappingCache, String> {
         .unwrap_or_else(|e| Err(format!("disk cache write join failed: {}", e)))
     {
         tracing::warn!("Failed to persist anibridge mappings to disk: {}", e);
+    }
+    // Persist sidecar meta only when we got at least one validator from
+    // upstream — without one, the next conditional GET would just be a
+    // regular GET anyway.
+    if (new_meta.etag.is_some() || new_meta.last_modified.is_some())
+        && let Err(e) = tokio::task::spawn_blocking(move || write_disk_cache_meta(&new_meta)).await
+            .unwrap_or_else(|e| Err(format!("disk meta write join failed: {}", e)))
+    {
+        tracing::warn!("Failed to persist anibridge cache meta to disk: {}", e);
     }
 
     Ok(cache)

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use crate::services::html::sanitize_rich_description;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::{LazyLock, Mutex as StdMutex};
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::RwLock;
@@ -726,84 +726,6 @@ fn compose_search_error(anilist_reason: Option<&str>, jikan_err: &str) -> String
 }
 
 
-pub async fn find_anime_by_mal_id(mal_id: i64) -> Result<Option<AnimeEntry>, String> {
-    // Same cooldown short-circuit as the search and detail paths — no
-    // point burning a guaranteed 429 on a known-unavailable AniList.
-    if anilist_cooldown_active() {
-        return Err("AniList rate-limit cooldown active; skipping AniList request".to_string());
-    }
-
-    let gql = serde_json::json!({
-        "query": r#"
-            query ($idMal: Int) {
-                Media(idMal: $idMal, type: ANIME) {
-                    id
-                    idMal
-                    title {
-                        romaji
-                        english
-                        native
-                    }
-                    coverImage {
-                        large
-                    }
-                    format
-                    status
-                    episodes
-                    seasonYear
-                }
-            }
-        "#,
-        "variables": { "idMal": mal_id }
-    });
-
-    throttle_before_anilist_request().await;
-
-    let client = &*HTTP_CLIENT;
-    let resp = client
-        .post(ANILIST_API)
-        .header("User-Agent", "Ryokan/0.1")
-        .json(&gql)
-        .send()
-        .await
-        .map_err(|e| format!("AniList request failed: {}", e))?;
-
-    let status = resp.status();
-    record_rate_limit_headers(resp.headers());
-    let body: serde_json::Value = resp
-        .json()
-        .await
-        .map_err(|e| format!("Failed to parse AniList response: {}", e))?;
-
-    if !status.is_success() {
-        let msg = extract_graphql_error(&body).unwrap_or_else(|| body.to_string());
-        return Err(format!("AniList MAL lookup failed (HTTP {}): {}", status, msg));
-    }
-
-    if let Some(msg) = extract_graphql_error(&body) {
-        return Err(format!("AniList MAL lookup failed: {}", msg));
-    }
-
-    let m = &body["data"]["Media"];
-    if m.is_null() {
-        return Ok(None);
-    }
-
-    Ok(Some(AnimeEntry {
-        id: m["id"].as_i64().unwrap_or(0),
-        id_mal: m["idMal"].as_i64(),
-        title_romaji: m["title"]["romaji"].as_str().unwrap_or("").to_string(),
-        title_english: m["title"]["english"].as_str().unwrap_or("").to_string(),
-        title_native: m["title"]["native"].as_str().unwrap_or("").to_string(),
-        cover_url: m["coverImage"]["large"].as_str().unwrap_or("").to_string(),
-        format: m["format"].as_str().unwrap_or("").to_string(),
-        status: m["status"].as_str().unwrap_or("").to_string(),
-        status_display: prettify_status(m["status"].as_str().unwrap_or("")),
-        episodes: m["episodes"].as_i64().map(|e| e as i32),
-        season_year: m["seasonYear"].as_i64().map(|y| y as i32),
-        source: "anilist".to_string(),
-    }))
-}
 
 #[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct RelatedEntry {
@@ -967,7 +889,24 @@ pub async fn get_anime_detail_with_options(id: i64, mal_id_hint: Option<i64>, fo
     Ok(detail)
 }
 
+/// What to filter the `Media` query by. AniList's `Media` resolver
+/// accepts `id` and `idMal` as independent filters, so a single query
+/// shape covers both lookup styles by passing the unused argument as
+/// `null` in the variables. Lets `find_anime_detail_by_mal_id` reuse
+/// the full field selection without duplicating the query body.
+#[derive(Debug, Clone, Copy)]
+enum MediaSelector {
+    Id(i64),
+    IdMal(i64),
+}
+
 async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
+    fetch_media_detail(MediaSelector::Id(id))
+        .await?
+        .ok_or_else(|| "Anime not found".to_string())
+}
+
+async fn fetch_media_detail(selector: MediaSelector) -> Result<Option<AnimeDetail>, String> {
     // Skip the round trip entirely when a recent 429/403/5xx has tripped
     // the global cooldown. Without this, a metadata-refresh sweep that
     // hits AniList's per-minute cap on the first burst keeps firing
@@ -983,10 +922,14 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         // from a different provider.
         return Err("AniList rate-limit cooldown active; skipping AniList request".to_string());
     }
+    let (id_var, id_mal_var) = match selector {
+        MediaSelector::Id(v) => (serde_json::json!(v), serde_json::Value::Null),
+        MediaSelector::IdMal(v) => (serde_json::Value::Null, serde_json::json!(v)),
+    };
     let gql = serde_json::json!({
         "query": r#"
-            query ($id: Int) {
-                Media(id: $id, type: ANIME) {
+            query ($id: Int, $idMal: Int) {
+                Media(id: $id, idMal: $idMal, type: ANIME) {
                     id
                     idMal
                     title { romaji english native }
@@ -1032,7 +975,7 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
                 }
             }
         "#,
-        "variables": { "id": id }
+        "variables": { "id": id_var, "idMal": id_mal_var }
     });
 
     // Pace the request based on the latest X-RateLimit-Remaining /
@@ -1133,9 +1076,17 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
 
     let m = &body["data"]["Media"];
     if m.is_null() {
-        return Err("Anime not found".into());
+        return Ok(None);
     }
 
+    Ok(Some(parse_media_node(m)))
+}
+
+/// Convert a single Media node from the AniList GraphQL response into
+/// `AnimeDetail`. Used by both the single-id `fetch_media_detail` path
+/// and the batched `get_anime_details_batch` path so the field plucking
+/// logic only lives in one place.
+fn parse_media_node(m: &serde_json::Value) -> AnimeDetail {
     let streaming_episodes = m["streamingEpisodes"]
         .as_array()
         .map(|arr| {
@@ -1176,7 +1127,7 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         })
         .unwrap_or_default();
 
-    Ok(AnimeDetail {
+    AnimeDetail {
         id: m["id"].as_i64().unwrap_or(0),
         id_mal: m["idMal"].as_i64(),
         title_romaji: m["title"]["romaji"].as_str().unwrap_or("").to_string(),
@@ -1213,7 +1164,214 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
             .unwrap_or_default(),
         streaming_episodes,
         relations,
-    })
+    }
+}
+
+/// Look up an anime by MAL id and return the full `AnimeDetail` payload
+/// in one round-trip — replacing the previous `find_anime_by_mal_id` +
+/// `get_anime_detail` two-step. The caller (reconciliation path in
+/// library.rs) already needed the full payload anyway; AniList accepts
+/// `idMal` on the same `Media` query that returns full detail, so the
+/// extra "find then fetch" round-trip was wasted.
+pub async fn find_anime_detail_by_mal_id(mal_id: i64) -> Result<Option<AnimeDetail>, String> {
+    fetch_media_detail(MediaSelector::IdMal(mal_id)).await
+}
+
+/// Maximum AniList ids to ask for in a single `Page(media(id_in:[]))`
+/// batched detail request. AniList paginates `Page` at perPage=50, but
+/// the binding constraint is GraphQL complexity: each `Media` carries a
+/// `relations { edges { node {...} } }` block, and 50 × ~10 relations ×
+/// edge complexity easily exceeds the documented complexity cap.
+/// 25 keeps us comfortably under the cap with full relations included,
+/// which matters for the BFS hydrator that needs the next layer of
+/// relations on every node it processes.
+const ANILIST_BATCH_SIZE: usize = 25;
+
+/// Fetch full `AnimeDetail` payloads for many AniList ids in one
+/// `Page(media(id_in:[...]))` request — replacing the historical
+/// "loop and call `get_anime_detail` per id" pattern in the metadata
+/// BFS, the relation transitive walk, and the Sonarr/Radarr
+/// compatibility shims.
+///
+/// Behavior:
+/// - Ids are deduplicated and chunked at [`ANILIST_BATCH_SIZE`]; the
+///   helper returns `ceil(N / ANILIST_BATCH_SIZE)` requests' worth of
+///   data instead of N.
+/// - Each chunk passes through the same cooldown gate, throttle, and
+///   rate-limit-header capture as `fetch_media_detail`.
+/// - Successful responses populate `DETAIL_CACHE` so subsequent
+///   single-id `get_anime_detail` calls for the same ids are cache
+///   hits.
+/// - On a chunk-level error, processing aborts and the partial map
+///   collected so far is returned alongside the error string. The
+///   global cooldown will already be set (via
+///   `record_rate_limit_headers` / 429 handling) so retrying the
+///   remaining chunks would just bounce immediately anyway.
+/// - Negative-result ids (AL had no Media for them) simply don't
+///   appear in the output map — callers must check `map.get(id)`.
+pub async fn get_anime_details_batch(
+    ids: &[i64],
+) -> Result<HashMap<i64, AnimeDetail>, String> {
+    // Dedup + drop non-positive ids (negative ids are MAL-fallback
+    // synthetic markers and should hit the Jikan path, not AniList).
+    let unique_ids: Vec<i64> = ids
+        .iter()
+        .copied()
+        .filter(|id| *id > 0)
+        .collect::<HashSet<i64>>()
+        .into_iter()
+        .collect();
+    if unique_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let mut out: HashMap<i64, AnimeDetail> = HashMap::with_capacity(unique_ids.len());
+    let client = &*HTTP_CLIENT;
+
+    for chunk in unique_ids.chunks(ANILIST_BATCH_SIZE) {
+        if anilist_cooldown_active() {
+            return Err(
+                "AniList rate-limit cooldown active; skipping AniList request".to_string(),
+            );
+        }
+
+        let gql = serde_json::json!({
+            "query": r#"
+                query ($ids: [Int]) {
+                    Page(perPage: 25) {
+                        media(id_in: $ids, type: ANIME) {
+                            id
+                            idMal
+                            title { romaji english native }
+                            synonyms
+                            coverImage { large extraLarge }
+                            bannerImage
+                            format
+                            status
+                            episodes
+                            duration
+                            season
+                            seasonYear
+                            endDate { year }
+                            description(asHtml: true)
+                            genres
+                            averageScore
+                            nextAiringEpisode { episode airingAt }
+                            streamingEpisodes { title thumbnail url site }
+                            relations {
+                                edges {
+                                    relationType(version: 2)
+                                    node {
+                                        id
+                                        idMal
+                                        title { romaji english native }
+                                        format
+                                        status
+                                        episodes
+                                        coverImage { large }
+                                        type
+                                        seasonYear
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            "#,
+            "variables": { "ids": chunk }
+        });
+
+        throttle_before_anilist_request().await;
+
+        let resp = client
+            .post(ANILIST_API)
+            .header("User-Agent", "Ryokan/0.1")
+            .json(&gql)
+            .send()
+            .await
+            .map_err(|e| format!("AniList batch request failed: {}", e))?;
+
+        let status = resp.status();
+        let headers = resp.headers().clone();
+        record_rate_limit_headers(&headers);
+
+        let body_text = resp
+            .text()
+            .await
+            .map_err(|e| format!("AniList batch unavailable: failed to read response: {}", e))?;
+
+        if !status.is_success() {
+            let (kind, msg) = classify_anilist_failure(status, &body_text);
+            if kind == AniListFailureKind::RateLimited {
+                let default_cooldown = if status == reqwest::StatusCode::FORBIDDEN {
+                    Duration::from_secs(300)
+                } else {
+                    ANILIST_COOLDOWN_DEFAULT
+                };
+                let dur = cooldown_from_headers(&headers, default_cooldown);
+                if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+                    *guard = Some(Instant::now() + dur);
+                }
+            }
+            return Err(msg);
+        }
+
+        let body: serde_json::Value = serde_json::from_str(&body_text)
+            .map_err(|e| {
+                format!(
+                    "AniList batch parse error: {} (body: {})",
+                    e,
+                    excerpt(&body_text)
+                )
+            })?;
+
+        if extract_graphql_error(&body).is_some() {
+            let (kind, msg) = classify_anilist_failure(status, &body_text);
+            if kind == AniListFailureKind::RateLimited {
+                let dur = cooldown_from_headers(&headers, ANILIST_COOLDOWN_DEFAULT);
+                if let Ok(mut guard) = ANILIST_COOLDOWN_UNTIL.lock() {
+                    *guard = Some(Instant::now() + dur);
+                }
+            }
+            return Err(msg);
+        }
+
+        let media_arr = body["data"]["Page"]["media"].as_array();
+        if let Some(media) = media_arr {
+            // Eagerly populate DETAIL_CACHE so subsequent single-id
+            // `get_anime_detail` calls for these ids hit the cache.
+            let mut cache = DETAIL_CACHE.write().await;
+            for node in media {
+                let detail = parse_media_node(node);
+                if detail.id > 0 {
+                    cache.insert(
+                        detail.id,
+                        CacheEntry {
+                            detail: detail.clone(),
+                            fetched_at: Instant::now(),
+                        },
+                    );
+                    out.insert(detail.id, detail);
+                }
+            }
+            // Light eviction — same shape as the single-id path so a
+            // big batch can't unbounded-grow the cache.
+            if cache.len() > DETAIL_CACHE_MAX_ENTRIES {
+                let expired: Vec<i64> = cache
+                    .iter()
+                    .filter(|(_, e)| {
+                        e.fetched_at.elapsed().as_secs() >= DETAIL_CACHE_TTL_SECS
+                    })
+                    .map(|(k, _)| *k)
+                    .collect();
+                for k in &expired {
+                    cache.remove(k);
+                }
+            }
+        }
+    }
+
+    Ok(out)
 }
 
 fn extract_graphql_error(body: &serde_json::Value) -> Option<String> {

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -1253,15 +1253,19 @@ pub async fn get_anime_details_batch(
         }
 
         let gql = serde_json::json!({
-            "query": r#"
-                query ($ids: [Int]) {
-                    Page(perPage: 25) {
-                        media(id_in: $ids, type: ANIME) {
+            // Inject ANILIST_BATCH_SIZE into the query so the const and the
+            // GraphQL `perPage` literal can't drift apart silently — bumping
+            // the const used to leave the query truncating to the old value
+            // and the extra ids would just disappear from the response.
+            "query": format!(r#"
+                query ($ids: [Int]) {{
+                    Page(perPage: {batch_size}) {{
+                        media(id_in: $ids, type: ANIME) {{
                             id
                             idMal
-                            title { romaji english native }
+                            title {{ romaji english native }}
                             synonyms
-                            coverImage { large extraLarge }
+                            coverImage {{ large extraLarge }}
                             bannerImage
                             format
                             status
@@ -1269,32 +1273,32 @@ pub async fn get_anime_details_batch(
                             duration
                             season
                             seasonYear
-                            endDate { year }
+                            endDate {{ year }}
                             description(asHtml: true)
                             genres
                             averageScore
-                            nextAiringEpisode { episode airingAt }
-                            streamingEpisodes { title thumbnail url site }
-                            relations {
-                                edges {
+                            nextAiringEpisode {{ episode airingAt }}
+                            streamingEpisodes {{ title thumbnail url site }}
+                            relations {{
+                                edges {{
                                     relationType(version: 2)
-                                    node {
+                                    node {{
                                         id
                                         idMal
-                                        title { romaji english native }
+                                        title {{ romaji english native }}
                                         format
                                         status
                                         episodes
-                                        coverImage { large }
+                                        coverImage {{ large }}
                                         type
                                         seasonYear
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            "#,
+                                    }}
+                                }}
+                            }}
+                        }}
+                    }}
+                }}
+            "#, batch_size = ANILIST_BATCH_SIZE),
             "variables": { "ids": chunk }
         });
 

--- a/src/services/anilist.rs
+++ b/src/services/anilist.rs
@@ -906,6 +906,26 @@ async fn fetch_anime_detail(id: i64) -> Result<AnimeDetail, String> {
         .ok_or_else(|| "Anime not found".to_string())
 }
 
+/// Build the GraphQL `variables` map for the shared `Media(id:, idMal:)`
+/// query. AniList's resolver treats an explicit `id: null` (or
+/// `idMal: null`) as "filter where the field equals null" and returns
+/// 404, so the unused arm of [`MediaSelector`] must be **omitted** from
+/// the variables map (sent as undefined), not sent as JSON null.
+/// Verified live 2026-04-19: `{id: 1, idMal: null}` → "Not Found";
+/// `{id: 1}` → Cowboy Bebop. Tested in `media_selector_omits_unused_var`.
+fn build_media_selector_variables(selector: MediaSelector) -> serde_json::Map<String, serde_json::Value> {
+    let mut variables = serde_json::Map::new();
+    match selector {
+        MediaSelector::Id(v) => {
+            variables.insert("id".to_string(), serde_json::json!(v));
+        }
+        MediaSelector::IdMal(v) => {
+            variables.insert("idMal".to_string(), serde_json::json!(v));
+        }
+    }
+    variables
+}
+
 async fn fetch_media_detail(selector: MediaSelector) -> Result<Option<AnimeDetail>, String> {
     // Skip the round trip entirely when a recent 429/403/5xx has tripped
     // the global cooldown. Without this, a metadata-refresh sweep that
@@ -922,10 +942,7 @@ async fn fetch_media_detail(selector: MediaSelector) -> Result<Option<AnimeDetai
         // from a different provider.
         return Err("AniList rate-limit cooldown active; skipping AniList request".to_string());
     }
-    let (id_var, id_mal_var) = match selector {
-        MediaSelector::Id(v) => (serde_json::json!(v), serde_json::Value::Null),
-        MediaSelector::IdMal(v) => (serde_json::Value::Null, serde_json::json!(v)),
-    };
+    let variables = build_media_selector_variables(selector);
     let gql = serde_json::json!({
         "query": r#"
             query ($id: Int, $idMal: Int) {
@@ -975,7 +992,7 @@ async fn fetch_media_detail(selector: MediaSelector) -> Result<Option<AnimeDetai
                 }
             }
         "#,
-        "variables": { "id": id_var, "idMal": id_mal_var }
+        "variables": variables
     });
 
     // Pace the request based on the latest X-RateLimit-Remaining /
@@ -1385,6 +1402,27 @@ fn extract_graphql_error(body: &serde_json::Value) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn media_selector_omits_unused_var() {
+        // Regression: AniList rejects `Media(id: null, idMal: 1)` as
+        // "Not Found" because the resolver treats explicit JSON null as
+        // "filter where id equals null." The variables map must OMIT
+        // the unused arm, not send it as null. Verified live 2026-04-19.
+        let by_id = build_media_selector_variables(MediaSelector::Id(42));
+        assert_eq!(by_id.get("id").and_then(|v| v.as_i64()), Some(42));
+        assert!(
+            !by_id.contains_key("idMal"),
+            "Id selector must NOT include idMal var (even as null) — sending null trips an AniList 404"
+        );
+
+        let by_mal = build_media_selector_variables(MediaSelector::IdMal(1));
+        assert_eq!(by_mal.get("idMal").and_then(|v| v.as_i64()), Some(1));
+        assert!(
+            !by_mal.contains_key("id"),
+            "IdMal selector must NOT include id var (even as null) — sending null trips an AniList 404"
+        );
+    }
 
     #[test]
     fn normalize_search_key_folds_whitespace_and_case() {

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -2017,7 +2017,15 @@ pub async fn prewarm_seadex_negative(db: &SqlitePool, anilist_ids: &[i64]) {
     let to_query: Vec<i64> = anilist_ids
         .iter()
         .copied()
-        .filter(|id| *id > 0 && seadex_cache_get(*id).is_none())
+        .filter(|id| {
+            *id > 0
+                && seadex_cache_get(*id).is_none()
+                // Don't prewarm an id that's already being fetched by another
+                // concurrent path (RSS sweep, manual button, anibridge request).
+                // The leader's `seadex_cache_put` will populate the cache for us;
+                // doubling the request would defeat the in-flight coalescing.
+                && !seadex_inflight_contains(*id)
+        })
         .collect::<HashSet<i64>>()
         .into_iter()
         .collect();
@@ -2046,8 +2054,18 @@ pub async fn prewarm_seadex_negative(db: &SqlitePool, anilist_ids: &[i64]) {
     }
     tracing::info!(
         "seadex: prewarm cached {cached} negative entries from {} batched lookup(s)",
-        to_query.len().div_ceil(50)
+        to_query.len().div_ceil(seadex::SEADEX_BATCH_SIZE)
     );
+}
+
+/// Cheap non-blocking check for "is this anilist_id currently being
+/// fetched by some other coalesced path?" Returns false on lock
+/// poisoning so prewarm errs on the side of doing the work.
+fn seadex_inflight_contains(anilist_id: i64) -> bool {
+    SEADEX_INFLIGHT
+        .lock()
+        .map(|m| m.contains_key(&anilist_id))
+        .unwrap_or(false)
 }
 
 /// Drop guard — removes the in-flight registry entry and wakes any
@@ -2143,7 +2161,25 @@ async fn fetch_seadex_payload(
         match role {
             Role::Lead(g) => break Some(g),
             Role::Wait(notify) => {
-                notify.notified().await;
+                // Subscribe BEFORE re-checking the cache. `Notify::notify_waiters`
+                // doesn't leave a permit for future `.notified()` calls — if the
+                // leader fires the notify between our unlock above and our
+                // first poll, we'd hang forever waiting for a notification
+                // that already happened. The recipe from tokio's docs is
+                // pin → enable → re-check → await: enabling registers our
+                // waiter atomically against the next `notify_waiters`, so
+                // any notification fired after `enable()` (including ones
+                // that race with our cache re-check) wakes us correctly.
+                let waiter = notify.notified();
+                tokio::pin!(waiter);
+                waiter.as_mut().enable();
+                if let Some(cached) = seadex_cache_get(anilist_id) {
+                    tracing::debug!(
+                        "seadex: coalesced wait hit for anilist_id={anilist_id}"
+                    );
+                    return cached;
+                }
+                waiter.await;
                 if let Some(cached) = seadex_cache_get(anilist_id) {
                     tracing::debug!(
                         "seadex: coalesced wait hit for anilist_id={anilist_id}"
@@ -6275,5 +6311,26 @@ mod tests {
         assert_eq!(count.0, 0);
         // But the in-memory cache should hold the (default) negative entry.
         assert!(seadex_cache_get(anilist_id).is_some());
+    }
+
+    #[tokio::test]
+    async fn seadex_inflight_contains_tracks_registry() {
+        // Locks the contract that `prewarm_seadex_negative` relies on
+        // when filtering ids: an id with a registered Notify reads as
+        // "inflight" and an unregistered one doesn't. Without this
+        // gate the prewarm could redundantly issue a request that's
+        // already mid-flight on another path.
+        let anilist_id = 990_000_004;
+        // Sanity: not present at start.
+        assert!(!seadex_inflight_contains(anilist_id));
+        // Register a fake in-flight entry, then verify the helper sees it.
+        {
+            let mut map = SEADEX_INFLIGHT.lock().unwrap();
+            map.insert(anilist_id, Arc::new(Notify::new()));
+        }
+        assert!(seadex_inflight_contains(anilist_id));
+        // Clean up so other tests aren't affected.
+        SEADEX_INFLIGHT.lock().unwrap().remove(&anilist_id);
+        assert!(!seadex_inflight_contains(anilist_id));
     }
 }

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -1,5 +1,7 @@
 use std::collections::{HashMap, HashSet};
-use std::sync::{LazyLock, Mutex as StdMutex};
+use std::sync::{Arc, LazyLock, Mutex as StdMutex};
+
+use tokio::sync::Notify;
 use std::time::{Duration, Instant};
 
 use regex_lite::Regex;
@@ -1797,7 +1799,7 @@ pub fn matches_target(
 /// (smol's `Monogatari (Season 9)` megapack for Kizumonogatari Part 2
 /// is the canonical example). The text-query sweep can't find them;
 /// we go direct to `/view/<id>` and inject the result ourselves.
-#[derive(Default, Clone)]
+#[derive(Default, Clone, serde::Serialize, serde::Deserialize)]
 struct SeaDexPayload {
     hashes: HashSet<String>,
     /// Synthetic candidates fetched directly from each SeaDex-curated
@@ -1828,30 +1830,51 @@ struct SeaDexPayload {
 /// The cache lives for the lifetime of the process, so a restart is
 /// the operator's escape hatch if they ever need to force-refresh.
 const SEADEX_CACHE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+// Errors are cached for a much shorter window. The point is to absorb a
+// transient releases.moe outage (or a brief 5xx burst) without every
+// concurrent search hammering the upstream — but not so long that a
+// recovered service stays masked across the next RSS sweep.
+const SEADEX_ERROR_TTL: Duration = Duration::from_secs(5 * 60);
 // Cap the cache so a long-running process can't accumulate every
 // AniList ID it ever touched. Mirrors anilist::DETAIL_CACHE_MAX_ENTRIES.
 const SEADEX_CACHE_MAX_ENTRIES: usize = 500;
+
+/// Cache value carries an `expires_at` (rather than `fetched_at`) so the
+/// success and error TTLs can coexist without `cache_get` having to know
+/// which kind it is reading.
 static SEADEX_CACHE: LazyLock<StdMutex<HashMap<i64, (Instant, SeaDexPayload)>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// In-flight registry — one `Notify` per anilist_id currently being
+/// fetched. Concurrent callers find the existing entry, await the
+/// notify, then re-check the cache. Without this, the cold-cache
+/// window is a thundering-herd target: an RSS sweep, a manual button,
+/// and an anibridge request can all fire on the same series in the
+/// same second and each one hits releases.moe.
+static SEADEX_INFLIGHT: LazyLock<StdMutex<HashMap<i64, Arc<Notify>>>> =
     LazyLock::new(|| StdMutex::new(HashMap::new()));
 
 fn seadex_cache_get(anilist_id: i64) -> Option<SeaDexPayload> {
     let cache = SEADEX_CACHE.lock().ok()?;
-    let (fetched_at, payload) = cache.get(&anilist_id)?;
-    if fetched_at.elapsed() < SEADEX_CACHE_TTL {
+    let (expires_at, payload) = cache.get(&anilist_id)?;
+    if Instant::now() < *expires_at {
         Some(payload.clone())
     } else {
         None
     }
 }
 
-fn seadex_cache_put(anilist_id: i64, payload: SeaDexPayload) {
+fn seadex_cache_put_with_ttl(anilist_id: i64, payload: SeaDexPayload, ttl: Duration) {
     if let Ok(mut cache) = SEADEX_CACHE.lock() {
-        cache.insert(anilist_id, (Instant::now(), payload));
+        let expires_at = Instant::now() + ttl;
+        cache.insert(anilist_id, (expires_at, payload));
         if cache.len() > SEADEX_CACHE_MAX_ENTRIES {
-            // Drop expired first; if still over cap, drop the oldest.
+            // Drop expired first; if still over cap, drop the entry
+            // that expires soonest (effectively LRU under uniform TTL).
+            let now = Instant::now();
             let expired: Vec<i64> = cache
                 .iter()
-                .filter(|(_, (fetched_at, _))| fetched_at.elapsed() >= SEADEX_CACHE_TTL)
+                .filter(|(_, (expires_at, _))| *expires_at <= now)
                 .map(|(k, _)| *k)
                 .collect();
             for k in &expired {
@@ -1859,11 +1882,188 @@ fn seadex_cache_put(anilist_id: i64, payload: SeaDexPayload) {
             }
             if cache.len() > SEADEX_CACHE_MAX_ENTRIES
                 && let Some((&oldest, _)) =
-                    cache.iter().min_by_key(|(_, (fetched_at, _))| *fetched_at)
+                    cache.iter().min_by_key(|(_, (expires_at, _))| *expires_at)
             {
                 cache.remove(&oldest);
             }
         }
+    }
+}
+
+fn seadex_cache_put(anilist_id: i64, payload: SeaDexPayload) {
+    seadex_cache_put_with_ttl(anilist_id, payload, SEADEX_CACHE_TTL);
+}
+
+fn seadex_cache_put_error(anilist_id: i64) {
+    seadex_cache_put_with_ttl(anilist_id, SeaDexPayload::default(), SEADEX_ERROR_TTL);
+}
+
+/// Persist a successful (or "no entry") lookup to SQLite so it survives
+/// process restart. Called from the leader path on the success / no-entry
+/// branches; the error branch deliberately doesn't persist (5-min TTL is
+/// too short to be worth the I/O, and a restart should re-probe upstream
+/// health rather than inherit a "this is broken" verdict).
+async fn seadex_persist_to_db(db: &SqlitePool, anilist_id: i64, payload: &SeaDexPayload) {
+    let json = match serde_json::to_string(payload) {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("seadex: failed to serialize payload for persistence: {e}");
+            return;
+        }
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let res = sqlx::query(
+        "INSERT INTO seadex_lookup_cache (anilist_id, payload_json, cached_at) \
+         VALUES (?, ?, ?) \
+         ON CONFLICT(anilist_id) DO UPDATE SET payload_json = excluded.payload_json, cached_at = excluded.cached_at",
+    )
+    .bind(anilist_id)
+    .bind(&json)
+    .bind(now)
+    .execute(db)
+    .await;
+    if let Err(e) = res {
+        tracing::warn!(
+            "seadex: failed to persist cache row for anilist_id={anilist_id}: {e}"
+        );
+    }
+}
+
+/// Warm the in-memory SeaDex cache from SQLite at startup. Drops rows
+/// older than `SEADEX_CACHE_TTL` opportunistically (cheap to run during
+/// boot; avoids unbounded growth of the persisted table over time).
+/// Called once from `main()` after migrations.
+pub async fn seadex_warm_cache_from_db(db: &SqlitePool) {
+    let ttl_secs = SEADEX_CACHE_TTL.as_secs() as i64;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+
+    // Drop expired persisted rows first so the SELECT below doesn't have
+    // to filter them in Rust and the table stays bounded.
+    if let Err(e) = sqlx::query("DELETE FROM seadex_lookup_cache WHERE cached_at + ? < ?")
+        .bind(ttl_secs)
+        .bind(now)
+        .execute(db)
+        .await
+    {
+        tracing::warn!("seadex: failed to evict expired persisted rows: {e}");
+    }
+
+    let rows = match sqlx::query_as::<_, (i64, String, i64)>(
+        "SELECT anilist_id, payload_json, cached_at FROM seadex_lookup_cache",
+    )
+    .fetch_all(db)
+    .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("seadex: failed to read persisted cache for warming: {e}");
+            return;
+        }
+    };
+
+    let mut warmed = 0usize;
+    for (anilist_id, json, cached_at) in rows {
+        let remaining_secs = (cached_at + ttl_secs).saturating_sub(now);
+        if remaining_secs <= 0 {
+            continue;
+        }
+        let payload: SeaDexPayload = match serde_json::from_str(&json) {
+            Ok(p) => p,
+            Err(e) => {
+                // Schema drift in SearchResult or SeaDexPayload would
+                // land here. Skip the row rather than aborting startup;
+                // it'll be re-fetched on next lookup.
+                tracing::warn!(
+                    "seadex: skipping unparseable persisted row anilist_id={anilist_id}: {e}"
+                );
+                continue;
+            }
+        };
+        seadex_cache_put_with_ttl(
+            anilist_id,
+            payload,
+            Duration::from_secs(remaining_secs as u64),
+        );
+        warmed += 1;
+    }
+    tracing::info!("seadex: warmed {warmed} persisted cache entries from SQLite");
+}
+
+/// Pre-fetch SeaDex hits for many AniList ids in one OR-batched
+/// PocketBase request and cache the *negative* responses (ids that
+/// SeaDex doesn't know about) so the per-series loop downstream skips
+/// the SeaDex round-trip for those ids entirely.
+///
+/// Designed for the upgrade-search sweep: most series in a typical
+/// library have no SeaDex entry, so a single batched call (50 ids per
+/// chunk) replaces N sequential round-trips for those ids. Hits are
+/// deliberately NOT cached here — the per-series fetch path also pulls
+/// Nyaa view-page candidates for each usable torrent in the entry,
+/// which doesn't fit the "single batch query" shape; letting hits
+/// flow through the lazy path keeps that work amortized across the
+/// loop iterations rather than concentrated in a startup burst.
+///
+/// Already-cached ids (positive or negative) are skipped, so calling
+/// this repeatedly within a TTL window is cheap. Failures are logged
+/// and swallowed: the worst case is the per-series loop pays the
+/// previously-existing per-id cost.
+pub async fn prewarm_seadex_negative(db: &SqlitePool, anilist_ids: &[i64]) {
+    let to_query: Vec<i64> = anilist_ids
+        .iter()
+        .copied()
+        .filter(|id| *id > 0 && seadex_cache_get(*id).is_none())
+        .collect::<HashSet<i64>>()
+        .into_iter()
+        .collect();
+    if to_query.is_empty() {
+        return;
+    }
+    tracing::debug!(
+        "seadex: prewarming negative cache for {} anilist_id(s)",
+        to_query.len()
+    );
+    let results = match seadex::lookup_batch(&to_query).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("seadex: batch prewarm failed: {e}");
+            return;
+        }
+    };
+    let mut cached = 0usize;
+    for (anilist_id, entry) in results {
+        if entry.is_none() {
+            let payload = SeaDexPayload::default();
+            seadex_cache_put(anilist_id, payload.clone());
+            seadex_persist_to_db(db, anilist_id, &payload).await;
+            cached += 1;
+        }
+    }
+    tracing::info!(
+        "seadex: prewarm cached {cached} negative entries from {} batched lookup(s)",
+        to_query.len().div_ceil(50)
+    );
+}
+
+/// Drop guard — removes the in-flight registry entry and wakes any
+/// waiters even if the leader's fetch panics or returns early. Without
+/// this, a stuck entry would block every future lookup for that
+/// anilist_id until process restart.
+struct SeaDexInFlightGuard {
+    anilist_id: i64,
+    notify: Arc<Notify>,
+}
+impl Drop for SeaDexInFlightGuard {
+    fn drop(&mut self) {
+        if let Ok(mut map) = SEADEX_INFLIGHT.lock() {
+            map.remove(&self.anilist_id);
+        }
+        self.notify.notify_waiters();
     }
 }
 
@@ -1906,6 +2106,56 @@ async fn fetch_seadex_payload(
         );
         return cached;
     }
+
+    // Leadership election. If another task is already fetching this
+    // anilist_id, wait for it to finish and then re-read the cache.
+    // Loop because a leader could finish without populating the cache
+    // (defensive against future bail-outs); in that case we re-attempt
+    // leadership ourselves rather than spinning on a notify that's
+    // already been sent.
+    //
+    // The `Role` enum exists to keep the `StdMutex` guard out of the
+    // async scope — `MutexGuard` is `!Send`, so we have to drop it
+    // before any `.await` (the compiler can't see that `drop(inflight)`
+    // happens before the await on its own).
+    enum Role {
+        Lead(SeaDexInFlightGuard),
+        Wait(Arc<Notify>),
+    }
+    let _guard: Option<SeaDexInFlightGuard> = loop {
+        let role = match SEADEX_INFLIGHT.lock() {
+            Err(_) => {
+                // Poisoned — skip coalescing entirely and just fetch.
+                // Redundant network work beats wedging the path.
+                break None;
+            }
+            Ok(mut inflight) => {
+                if let Some(existing) = inflight.get(&anilist_id) {
+                    Role::Wait(existing.clone())
+                } else {
+                    let notify = Arc::new(Notify::new());
+                    inflight.insert(anilist_id, notify.clone());
+                    Role::Lead(SeaDexInFlightGuard { anilist_id, notify })
+                }
+            }
+        };
+        // MutexGuard dropped at end of `match` expression above.
+        match role {
+            Role::Lead(g) => break Some(g),
+            Role::Wait(notify) => {
+                notify.notified().await;
+                if let Some(cached) = seadex_cache_get(anilist_id) {
+                    tracing::debug!(
+                        "seadex: coalesced wait hit for anilist_id={anilist_id}"
+                    );
+                    return cached;
+                }
+                // Leader didn't populate; loop and try to lead ourselves.
+                continue;
+            }
+        }
+    };
+
     tracing::debug!("seadex: fetching releases.moe entry for anilist_id={anilist_id}");
     match seadex::lookup(anilist_id).await {
         Ok(Some(entry)) => {
@@ -1926,11 +2176,11 @@ async fn fetch_seadex_payload(
             )
             .await;
 
-            // Fetch each usable torrent's view page so we have a real
-            // SearchResult to inject into the candidate list. This is
-            // what keeps SeaDex-curated releases discoverable even when
-            // the text-query sweep can't find them by title. Failures
-            // are non-fatal: we log and move on to the next torrent.
+            // Fetch each usable torrent's view page in parallel via
+            // JoinSet — a typical SeaDex entry has 1–4 usable torrents
+            // and the previous serial loop turned that into 1–4 ×
+            // ~500ms of wall time on cache miss. Concurrency is
+            // self-bounded by `usable.len()`, so no semaphore needed.
             let opts_for_score = nyaa::SearchOptions {
                 query: series_title.to_string(),
                 category: "1_0".to_string(),
@@ -1940,14 +2190,23 @@ async fn fetch_seadex_payload(
                 preferred_resolution: preferred_resolution.to_string(),
                 prefer_subs,
             };
-            let mut candidates = Vec::new();
+            let mut join_set: tokio::task::JoinSet<(String, Result<SearchResult, String>)> =
+                tokio::task::JoinSet::new();
             for torrent in entry.torrents.iter() {
                 if !seadex::is_usable(torrent, &entry.notes) {
                     continue;
                 }
-                let view_url = seadex::to_nyaa_view_url(torrent);
-                match nyaa::fetch_view_result(view_url, &opts_for_score).await {
-                    Ok(result) => {
+                let view_url = seadex::to_nyaa_view_url(torrent).to_string();
+                let opts = opts_for_score.clone();
+                join_set.spawn(async move {
+                    let result = nyaa::fetch_view_result(&view_url, &opts).await;
+                    (view_url, result)
+                });
+            }
+            let mut candidates = Vec::new();
+            while let Some(joined) = join_set.join_next().await {
+                match joined {
+                    Ok((view_url, Ok(result))) => {
                         tracing::debug!(
                             "seadex: injected curated candidate from view url={} title={:?} hash={}",
                             view_url,
@@ -1956,7 +2215,7 @@ async fn fetch_seadex_payload(
                         );
                         candidates.push(result);
                     }
-                    Err(e) => {
+                    Ok((view_url, Err(e))) => {
                         tracing::warn!(
                             "seadex: failed to fetch view page for {}: {}",
                             view_url,
@@ -1970,10 +2229,16 @@ async fn fetch_seadex_payload(
                         )
                         .await;
                     }
+                    Err(join_err) => {
+                        tracing::warn!(
+                            "seadex: view-page task failed to join: {join_err}"
+                        );
+                    }
                 }
             }
             let payload = SeaDexPayload { hashes, candidates };
             seadex_cache_put(anilist_id, payload.clone());
+            seadex_persist_to_db(db, anilist_id, &payload).await;
             payload
         }
         Ok(None) => {
@@ -1988,11 +2253,10 @@ async fn fetch_seadex_payload(
             )
             .await;
             // Cache the "no entry" result so we don't re-hit releases.moe
-            // for the same anilist_id within the TTL window. Err paths
-            // are intentionally NOT cached — transient failures should
-            // retry on the next call.
+            // for the same anilist_id within the TTL window.
             let payload = SeaDexPayload::default();
             seadex_cache_put(anilist_id, payload.clone());
+            seadex_persist_to_db(db, anilist_id, &payload).await;
             payload
         }
         Err(e) => {
@@ -2006,6 +2270,10 @@ async fn fetch_seadex_payload(
                 &format!("anilist_id={anilist_id}, error={e}"),
             )
             .await;
+            // Negative-cache the failure (short TTL) so concurrent
+            // searches and immediate retries don't hammer a broken
+            // upstream until the window expires.
+            seadex_cache_put_error(anilist_id);
             SeaDexPayload::default()
         }
     }
@@ -5922,5 +6190,90 @@ mod tests {
         let out = build_queries_from_aliases(&aliases, &SearchTarget::Episode(56), true);
         assert_eq!(out.len(), 2);
         assert!(out.iter().all(|q| q.ends_with(" 56")));
+    }
+
+    // ── SeaDex persistence ───────────────────────────────────────────
+    //
+    // Use anilist_ids in the 990_000_000+ range so they can't collide
+    // with the in-memory `SEADEX_CACHE` global between tests run on the
+    // same process. (Tests get their own in-memory SQLite pool, but the
+    // process-global LazyLock cache is shared.)
+
+    #[tokio::test]
+    async fn seadex_persist_round_trips_through_warm() {
+        let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+
+        let anilist_id = 990_000_001;
+        let mut hashes = HashSet::new();
+        hashes.insert("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef".to_string());
+        let payload = SeaDexPayload {
+            hashes,
+            candidates: vec![],
+        };
+
+        seadex_persist_to_db(&db, anilist_id, &payload).await;
+        seadex_warm_cache_from_db(&db).await;
+
+        let cached = seadex_cache_get(anilist_id).expect("warmed entry should be present");
+        assert_eq!(cached.hashes.len(), 1);
+        assert!(cached.hashes.contains("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"));
+    }
+
+    #[tokio::test]
+    async fn seadex_warm_drops_expired_persisted_rows() {
+        let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+
+        let anilist_id = 990_000_002;
+        // Insert a row whose `cached_at` is older than the TTL.
+        let stale_cached_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64
+            - (SEADEX_CACHE_TTL.as_secs() as i64 + 60);
+        sqlx::query(
+            "INSERT INTO seadex_lookup_cache (anilist_id, payload_json, cached_at) VALUES (?, ?, ?)",
+        )
+        .bind(anilist_id)
+        .bind(serde_json::to_string(&SeaDexPayload::default()).unwrap())
+        .bind(stale_cached_at)
+        .execute(&db)
+        .await
+        .unwrap();
+
+        seadex_warm_cache_from_db(&db).await;
+
+        // The expired row should be evicted from the persistent table
+        // and never make it into the in-memory cache.
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM seadex_lookup_cache WHERE anilist_id = ?")
+                .bind(anilist_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(count.0, 0);
+        assert!(seadex_cache_get(anilist_id).is_none());
+    }
+
+    #[tokio::test]
+    async fn seadex_error_cache_is_in_memory_only() {
+        let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+
+        let anilist_id = 990_000_003;
+        seadex_cache_put_error(anilist_id);
+
+        // The negative-error path must not write to SQLite — restart
+        // should re-probe upstream rather than inherit a "broken" verdict.
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM seadex_lookup_cache WHERE anilist_id = ?")
+                .bind(anilist_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(count.0, 0);
+        // But the in-memory cache should hold the (default) negative entry.
+        assert!(seadex_cache_get(anilist_id).is_some());
     }
 }

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -259,6 +259,13 @@ struct FullAnime {
     themes: Option<Vec<NamedItem>>,
     demographics: Option<Vec<NamedItem>>,
     aired: Option<AiredInfo>,
+    /// `/anime/{id}/full` already returns the same relation graph that
+    /// `/anime/{id}/relations` would — pulling it out of the full payload
+    /// avoids a second round-trip per detail fetch. Falls through empty
+    /// if Jikan ever changes the contract; we only re-issue the dedicated
+    /// `/relations` call when this is `None` or empty.
+    #[serde(default)]
+    relations: Option<Vec<RelationGroupResponse>>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -442,15 +449,12 @@ async fn fetch_relation_card_detail(mal_id: i64, fallback_name: &str) -> Related
     }
 }
 
-async fn fetch_relations(mal_id: i64) -> Vec<RelatedEntry> {
-    let client = &*HTTP_CLIENT;
-    let api_base = std::env::var("JIKAN_API_BASE").unwrap_or_else(|_| JIKAN_API.to_string());
-    let url = format!("{}/anime/{}/relations", api_base.trim_end_matches('/'), mal_id);
-    let body: RelationsResponse = match get_json_with_retry(client, &url).await {
-        Ok(body) => body,
-        Err(_) => return Vec::new(),
-    };
-
+/// Build the per-relation card list given an already-fetched relation
+/// group set. Hits `/anime/{id}` once per ANIME entry (up to
+/// `MAX_RELATION_FETCHES`) for cover/title detail; the relation-group
+/// fetch itself is now done as part of `/anime/{id}/full`, so this no
+/// longer pays for a separate `/relations` round-trip.
+async fn enrich_relations(groups: Vec<RelationGroupResponse>) -> Vec<RelatedEntry> {
     // Jikan's documented anonymous limit is ~3 req/s AND ~60 req/min.
     // The per-second budget is the easy one; the per-minute budget is
     // tight enough that a 10-entry relations graph (sequels, prequels,
@@ -468,7 +472,7 @@ async fn fetch_relations(mal_id: i64) -> Vec<RelatedEntry> {
 
     let mut out = Vec::new();
     let mut request_count: usize = 0;
-    'outer: for group in body.data {
+    'outer: for group in groups {
         let rel_type = group.relation.to_uppercase().replace(' ', "_");
         for entry in group.entry {
             if !entry.media_type.eq_ignore_ascii_case("ANIME") {
@@ -492,6 +496,7 @@ async fn fetch_relations(mal_id: i64) -> Vec<RelatedEntry> {
     }
     out
 }
+
 
 fn non_empty(value: &str, fallback: &str) -> String {
     if value.trim().is_empty() { fallback.to_string() } else { value.to_string() }
@@ -546,7 +551,7 @@ pub async fn get_anime_detail(mal_id: i64) -> Result<AnimeDetail, String> {
         .await
         .map_err(|e| format!("Jikan detail failed: {}", e))?;
 
-    let anime = body.data;
+    let mut anime = body.data;
     let mut genres = Vec::new();
     if let Some(items) = anime.genres {
         genres.extend(items.into_iter().map(|g| g.name));
@@ -564,7 +569,9 @@ pub async fn get_anime_detail(mal_id: i64) -> Result<AnimeDetail, String> {
     let end_year = parse_air_year(anime.aired.as_ref().and_then(|a| a.to.as_deref()));
     let (format, _) = normalize_enum_label(anime.anime_type.clone());
     let (status, status_display) = normalize_enum_label(anime.status.clone());
-    let relations = fetch_relations(anime.mal_id).await;
+    // Relations come pre-baked in the `/full` payload (Jikan v4 — confirmed
+    // 2026-04). Skip the redundant `/anime/{id}/relations` round-trip.
+    let relations = enrich_relations(anime.relations.take().unwrap_or_default()).await;
 
     Ok(AnimeDetail {
         id: -anime.mal_id,

--- a/src/services/kitsu.rs
+++ b/src/services/kitsu.rs
@@ -326,6 +326,88 @@ pub async fn get_anime_detail_by_titles(titles: &[String], wanted_year: Option<i
     Ok(to_anime_detail(candidate))
 }
 
+/// Resolve Kitsu detail by MAL id via the dedicated `/mappings`
+/// endpoint. One round-trip, exact match — collapses what
+/// `best_candidate` does across 1–4 fuzzy title queries when the
+/// caller already has the MAL id (the AniList → Jikan path always
+/// does). Returns `Ok(None)` when no Kitsu mapping exists for this
+/// MAL id, so the caller can fall through to the title-fuzz path.
+///
+/// Endpoint shape (verified live 2026-04-19):
+/// `GET /mappings?filter[externalSite]=myanimelist/anime
+///       &filter[externalId]={mal_id}&include=item`
+/// returns a mapping resource plus the linked anime in the JSON:API
+/// `included` array — so we get both the mapping confirmation and
+/// the full anime attributes in a single request.
+///
+/// Note: filtering on `/anime?filter[mappings.externalSite]=…` is
+/// rejected by Kitsu (`Filter not allowed`); the dedicated
+/// `/mappings` endpoint with a top-level `filter[externalSite]` is
+/// the supported shape.
+pub async fn get_anime_detail_by_mal_id(mal_id: i64) -> Result<Option<AnimeDetail>, String> {
+    let mal_id_str = mal_id.to_string();
+    let url = format!("{}/mappings", KITSU_API);
+    let resp = HTTP_CLIENT
+        .get(&url)
+        .query(&[
+            ("filter[externalSite]", "myanimelist/anime"),
+            ("filter[externalId]", mal_id_str.as_str()),
+            ("include", "item"),
+            ("page[limit]", "1"),
+        ])
+        .header("Accept", "application/vnd.api+json")
+        .header("Content-Type", "application/vnd.api+json")
+        .header("User-Agent", "Ryokan/0.1")
+        .send()
+        .await
+        .map_err(|e| format!("Kitsu mapping request failed: {}", e))?
+        .error_for_status()
+        .map_err(|e| format!("Kitsu mapping request failed: {}", e))?;
+
+    let body: MappingLookupResponse = resp
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse Kitsu mapping response: {}", e))?;
+
+    Ok(body
+        .included
+        .into_iter()
+        .find(|r| r.item_type == "anime")
+        .and_then(|r| {
+            // Reuse `to_candidate` by adapting the mapping-included
+            // resource into the same `Resource<AnimeAttributes>` shape
+            // — `to_candidate` parses the id string and pulls fields
+            // off `attributes`.
+            to_candidate(Resource {
+                id: r.id,
+                attributes: r.attributes,
+            })
+        })
+        .map(to_anime_detail))
+}
+
+/// JSON:API response shape for `GET /mappings?...&include=item`.
+/// The mapping resources themselves live in `data` but we don't
+/// actually need them — the linked anime resource is in `included`,
+/// which is what we want.
+#[derive(Debug, Deserialize)]
+struct MappingLookupResponse {
+    #[serde(default)]
+    included: Vec<MappingIncludedItem>,
+}
+
+/// One item from the `included` array. `type` lets us filter to
+/// anime resources only — manga mappings would land here too if
+/// some future caller asked for `myanimelist/manga`, and we don't
+/// want to feed manga attributes into `to_candidate`.
+#[derive(Debug, Deserialize)]
+struct MappingIncludedItem {
+    id: String,
+    #[serde(rename = "type")]
+    item_type: String,
+    attributes: AnimeAttributes,
+}
+
 async fn fetch_episode_page_via_relationship(kitsu_id: i64, offset: i32) -> Result<CollectionResponse<EpisodeAttributes>, String> {
     let offset_str = offset.to_string();
     let params = [("page[limit]", "20"), ("page[offset]", offset_str.as_str()), ("sort", "number")];

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -355,18 +355,18 @@ async fn hydrate_relation_tree(
                 .filter(|(id, _)| *id > 0 && *id != root_provider_id)
                 .map(|(id, _)| *id)
                 .collect();
-            if !pending_ids.is_empty() {
-                if let Err(e) = anilist::get_anime_details_batch(&pending_ids).await {
-                    // Best-effort prefetch: a failure here just means
-                    // the per-id loop below pays the historical cost.
-                    // Cooldown / 429 has been recorded by the batch
-                    // helper already; the per-id loop will defer too.
-                    tracing::debug!(
-                        target: "ryokan::metadata_sync",
-                        error = %e,
-                        "AniList batch prefetch failed; falling back to per-id"
-                    );
-                }
+            if !pending_ids.is_empty()
+                && let Err(e) = anilist::get_anime_details_batch(&pending_ids).await
+            {
+                // Best-effort prefetch: a failure here just means
+                // the per-id loop below pays the historical cost.
+                // Cooldown / 429 has been recorded by the batch
+                // helper already; the per-id loop will defer too.
+                tracing::debug!(
+                    target: "ryokan::metadata_sync",
+                    error = %e,
+                    "AniList batch prefetch failed; falling back to per-id"
+                );
             }
         }
 

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -96,7 +96,29 @@ async fn fetch_live_detail_for_ids(
                     target: "ryokan::metadata_sync",
                     mal_id = mid,
                     error = %err,
-                    "Jikan/MAL detail fetch failed; falling back to Kitsu by title"
+                    "Jikan/MAL detail fetch failed; falling back to Kitsu"
+                );
+            }
+        }
+
+        // Kitsu can resolve a MAL id directly via its mappings filter
+        // in one round-trip — try that before the multi-query title-fuzz
+        // path, which costs 1–4 requests and risks a sequel false match.
+        match kitsu::get_anime_detail_by_mal_id(mid).await {
+            Ok(Some(detail)) => return Ok(detail),
+            Ok(None) => {
+                tracing::debug!(
+                    target: "ryokan::metadata_sync",
+                    mal_id = mid,
+                    "Kitsu has no mapping for this MAL id; falling back to title fuzz"
+                );
+            }
+            Err(err) => {
+                tracing::warn!(
+                    target: "ryokan::metadata_sync",
+                    mal_id = mid,
+                    error = %err,
+                    "Kitsu mapping lookup failed; falling back to title fuzz"
                 );
             }
         }
@@ -321,6 +343,33 @@ async fn hydrate_relation_tree(
     let mut total_cooldown_wait = std::time::Duration::ZERO;
 
     loop {
+        // Pre-batch this round's pending AL ids into a single
+        // `Page(media(id_in:[]))` call so the per-id fetch loop below
+        // becomes a sequence of DETAIL_CACHE hits instead of N
+        // sequential GraphQL round-trips. Skipped in MAL mode (Jikan
+        // has no batch endpoint) and when AL is in cooldown (the
+        // batch helper would short-circuit anyway, so don't even ask).
+        if !mal_mode && !anilist::anilist_cooldown_active() {
+            let pending_ids: Vec<i64> = queue
+                .iter()
+                .filter(|(id, _)| *id > 0 && *id != root_provider_id)
+                .map(|(id, _)| *id)
+                .collect();
+            if !pending_ids.is_empty() {
+                if let Err(e) = anilist::get_anime_details_batch(&pending_ids).await {
+                    // Best-effort prefetch: a failure here just means
+                    // the per-id loop below pays the historical cost.
+                    // Cooldown / 429 has been recorded by the batch
+                    // helper already; the per-id loop will defer too.
+                    tracing::debug!(
+                        target: "ryokan::metadata_sync",
+                        error = %e,
+                        "AniList batch prefetch failed; falling back to per-id"
+                    );
+                }
+            }
+        }
+
         while let Some((provider_id, mal_id)) = queue.pop_front() {
             if processed >= MAX_RELATION_TREE_NODES {
                 break;

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -1,5 +1,5 @@
 use scraper::{Html, Selector};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 use std::time::Duration;
 
@@ -87,7 +87,7 @@ static SINGLE_EP_RE: LazyLock<regex_lite::Regex> = LazyLock::new(|| {
     .expect("SINGLE_EP_RE parses")
 });
 
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct SearchResult {
     pub title: String,
     pub link: String,
@@ -126,6 +126,7 @@ pub struct SearchResult {
     pub info_hash: String,
 }
 
+#[derive(Clone)]
 pub struct SearchOptions {
     pub query: String,
     pub category: String,

--- a/src/services/seadex.rs
+++ b/src/services/seadex.rs
@@ -241,16 +241,22 @@ pub async fn lookup(anilist_id: i64) -> Result<Option<SeaDexEntry>, String> {
 /// versions), but the bottleneck here is URL length: each id costs
 /// roughly `alID=1234567||` (≈14 chars), so 50 ids fits comfortably
 /// inside any sane URL-length cap with overhead to spare. Bump cautiously.
-const SEADEX_BATCH_SIZE: usize = 50;
+///
+/// Exposed `pub(crate)` so callers (e.g. the upgrade-sweep prewarm in
+/// `auto_search`) can compute accurate chunk counts for logging without
+/// inlining their own copy of the literal.
+pub(crate) const SEADEX_BATCH_SIZE: usize = 50;
 
 /// Look up multiple AniList ids in one PocketBase request using the
 /// `||` (OR) filter operator. Returns a map keyed by every requested id:
 /// hits map to `Some(entry)`, misses (no record on releases.moe) map
-/// to `None`. Ids are chunked at [`SEADEX_BATCH_SIZE`] and the chunks
-/// are issued sequentially — releases.moe is fronted by Cloudflare and
-/// hammering it in parallel from a sweep would defeat the point of
-/// batching. A single chunk failure aborts the whole call so the
-/// caller can decide whether to fall back to per-id lookups.
+/// to `None`. Ids are chunked at [`SEADEX_BATCH_SIZE`] and chunks are
+/// issued with bounded parallelism (`SEADEX_BATCH_PARALLELISM`-wide).
+/// 2-wide is safe: releases.moe is fronted by Cloudflare which only
+/// rate-limits at far higher concurrency than this, and we still keep
+/// the round-trip count to `ceil(N / SEADEX_BATCH_SIZE)`. A chunk
+/// failure aborts the whole call so the caller can decide whether to
+/// fall back to per-id lookups.
 pub async fn lookup_batch(
     anilist_ids: &[i64],
 ) -> Result<std::collections::HashMap<i64, Option<SeaDexEntry>>, String> {
@@ -264,53 +270,95 @@ pub async fn lookup_batch(
         out.entry(*id).or_insert(None);
     }
 
-    for chunk in anilist_ids.chunks(SEADEX_BATCH_SIZE) {
-        if chunk.is_empty() {
-            continue;
-        }
-        // Build `(alID=A||alID=B||...)` and URL-encode just the operators.
-        // `=` and digits are URL-safe; `||` becomes `%7C%7C`.
-        let mut filter = String::with_capacity(chunk.len() * 16);
-        for (i, id) in chunk.iter().enumerate() {
-            if i > 0 {
-                filter.push_str("%7C%7C");
+    // Build all chunk URLs up front so the parallel runner is just
+    // "fire each request, parse, fold." Owned ids per chunk keeps
+    // them 'static for the spawn closure.
+    let chunk_urls: Vec<String> = anilist_ids
+        .chunks(SEADEX_BATCH_SIZE)
+        .filter(|c| !c.is_empty())
+        .map(|chunk| {
+            // Build `(alID=A||alID=B||...)` and URL-encode just the operators.
+            // `=` and digits are URL-safe; `||` becomes `%7C%7C`.
+            let mut filter = String::with_capacity(chunk.len() * 16);
+            for (i, id) in chunk.iter().enumerate() {
+                if i > 0 {
+                    filter.push_str("%7C%7C");
+                }
+                filter.push_str("alID%3D");
+                filter.push_str(&id.to_string());
             }
-            filter.push_str("alID%3D");
-            filter.push_str(&id.to_string());
-        }
-        // perPage covers the whole chunk in one page so we never paginate
-        // a single request — keeping the round-trip count strictly
-        // `ceil(N / SEADEX_BATCH_SIZE)`.
-        let url = format!(
-            "{}?filter={}&expand=trs&perPage={}",
-            SEADEX_API,
-            filter,
-            chunk.len()
-        );
+            // perPage covers the whole chunk in one page so we never
+            // paginate a single request.
+            format!(
+                "{}?filter={}&expand=trs&perPage={}",
+                SEADEX_API,
+                filter,
+                chunk.len()
+            )
+        })
+        .collect();
 
-        let response = HTTP_CLIENT
-            .get(&url)
-            .send()
-            .await
-            .map_err(|e| format!("SeaDex batch request failed: {e}"))?;
-        if !response.status().is_success() {
-            return Err(format!(
-                "SeaDex batch API returned HTTP {}",
-                response.status().as_u16()
-            ));
-        }
-        let body = response
-            .text()
-            .await
-            .map_err(|e| format!("SeaDex batch read body failed: {e}"))?;
-        let entries = parse_list_response_multi(&body)?;
-        for entry in entries {
-            out.insert(entry.anilist_id, Some(entry));
+    // Run chunks with bounded concurrency via a semaphore. The
+    // ordering of completion doesn't matter because we fold every
+    // entry into the same output map keyed by anilist_id.
+    use tokio::sync::Semaphore;
+    let permits = std::sync::Arc::new(Semaphore::new(SEADEX_BATCH_PARALLELISM));
+    let mut join_set: tokio::task::JoinSet<Result<Vec<SeaDexEntry>, String>> =
+        tokio::task::JoinSet::new();
+    for url in chunk_urls {
+        let permits = permits.clone();
+        join_set.spawn(async move {
+            let _permit = permits
+                .acquire()
+                .await
+                .map_err(|e| format!("SeaDex batch semaphore closed: {e}"))?;
+            let response = HTTP_CLIENT
+                .get(&url)
+                .send()
+                .await
+                .map_err(|e| format!("SeaDex batch request failed: {e}"))?;
+            if !response.status().is_success() {
+                return Err(format!(
+                    "SeaDex batch API returned HTTP {}",
+                    response.status().as_u16()
+                ));
+            }
+            let body = response
+                .text()
+                .await
+                .map_err(|e| format!("SeaDex batch read body failed: {e}"))?;
+            parse_list_response_multi(&body)
+        });
+    }
+    while let Some(joined) = join_set.join_next().await {
+        match joined {
+            Ok(Ok(entries)) => {
+                for entry in entries {
+                    out.insert(entry.anilist_id, Some(entry));
+                }
+            }
+            Ok(Err(e)) => {
+                // Best-effort: cancel any in-flight chunks so we don't
+                // keep hammering after the caller has already learned
+                // the call failed.
+                join_set.shutdown().await;
+                return Err(e);
+            }
+            Err(join_err) => {
+                join_set.shutdown().await;
+                return Err(format!("SeaDex batch task join failed: {join_err}"));
+            }
         }
     }
 
     Ok(out)
 }
+
+/// How many SeaDex batch chunks may be in flight at once. 2-wide
+/// roughly halves wall time on libraries that need ≥ 2 chunks
+/// (≥ 51 ids in this prewarm pass). Cloudflare's rate-limit floor
+/// is far higher than 2 RPS so we don't risk a 429 here.
+const SEADEX_BATCH_PARALLELISM: usize = 2;
 
 /// Internal parser — split out so unit tests can feed it a fixture
 /// without touching the network.

--- a/src/services/seadex.rs
+++ b/src/services/seadex.rs
@@ -204,9 +204,9 @@ impl From<PbFile> for SeaDexFile {
 ///   `items` array came back empty — not an error)
 /// - `Err(_)` on HTTP / parse failures
 ///
-/// No caching in V1 — see plan §10. The caller (scoring integration)
-/// skips calling this entirely when `seadex_enabled=false`, which
-/// already gives us zero API round-trips for the default config.
+/// Caching lives one layer up in `auto_search` (in-memory + SQLite
+/// persistence with in-flight coalescing); this function just owns the
+/// network round-trip + parse.
 pub async fn lookup(anilist_id: i64) -> Result<Option<SeaDexEntry>, String> {
     let url = format!(
         "{}?filter=alID%3D{}&expand=trs",
@@ -236,6 +236,82 @@ pub async fn lookup(anilist_id: i64) -> Result<Option<SeaDexEntry>, String> {
     parse_list_response(&body)
 }
 
+/// Maximum AniList ids to OR-batch into a single PocketBase filter
+/// query. PocketBase itself accepts `perPage=500` (and 1000 on newer
+/// versions), but the bottleneck here is URL length: each id costs
+/// roughly `alID=1234567||` (≈14 chars), so 50 ids fits comfortably
+/// inside any sane URL-length cap with overhead to spare. Bump cautiously.
+const SEADEX_BATCH_SIZE: usize = 50;
+
+/// Look up multiple AniList ids in one PocketBase request using the
+/// `||` (OR) filter operator. Returns a map keyed by every requested id:
+/// hits map to `Some(entry)`, misses (no record on releases.moe) map
+/// to `None`. Ids are chunked at [`SEADEX_BATCH_SIZE`] and the chunks
+/// are issued sequentially — releases.moe is fronted by Cloudflare and
+/// hammering it in parallel from a sweep would defeat the point of
+/// batching. A single chunk failure aborts the whole call so the
+/// caller can decide whether to fall back to per-id lookups.
+pub async fn lookup_batch(
+    anilist_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Option<SeaDexEntry>>, String> {
+    let mut out: std::collections::HashMap<i64, Option<SeaDexEntry>> =
+        std::collections::HashMap::with_capacity(anilist_ids.len());
+    // Seed every requested id as a miss — chunk responses overwrite
+    // the entry on hit. Without this seed, callers would have to
+    // distinguish "id wasn't requested" from "id was requested but
+    // SeaDex has no record."
+    for id in anilist_ids {
+        out.entry(*id).or_insert(None);
+    }
+
+    for chunk in anilist_ids.chunks(SEADEX_BATCH_SIZE) {
+        if chunk.is_empty() {
+            continue;
+        }
+        // Build `(alID=A||alID=B||...)` and URL-encode just the operators.
+        // `=` and digits are URL-safe; `||` becomes `%7C%7C`.
+        let mut filter = String::with_capacity(chunk.len() * 16);
+        for (i, id) in chunk.iter().enumerate() {
+            if i > 0 {
+                filter.push_str("%7C%7C");
+            }
+            filter.push_str("alID%3D");
+            filter.push_str(&id.to_string());
+        }
+        // perPage covers the whole chunk in one page so we never paginate
+        // a single request — keeping the round-trip count strictly
+        // `ceil(N / SEADEX_BATCH_SIZE)`.
+        let url = format!(
+            "{}?filter={}&expand=trs&perPage={}",
+            SEADEX_API,
+            filter,
+            chunk.len()
+        );
+
+        let response = HTTP_CLIENT
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| format!("SeaDex batch request failed: {e}"))?;
+        if !response.status().is_success() {
+            return Err(format!(
+                "SeaDex batch API returned HTTP {}",
+                response.status().as_u16()
+            ));
+        }
+        let body = response
+            .text()
+            .await
+            .map_err(|e| format!("SeaDex batch read body failed: {e}"))?;
+        let entries = parse_list_response_multi(&body)?;
+        for entry in entries {
+            out.insert(entry.anilist_id, Some(entry));
+        }
+    }
+
+    Ok(out)
+}
+
 /// Internal parser — split out so unit tests can feed it a fixture
 /// without touching the network.
 fn parse_list_response(body: &str) -> Result<Option<SeaDexEntry>, String> {
@@ -243,6 +319,14 @@ fn parse_list_response(body: &str) -> Result<Option<SeaDexEntry>, String> {
         .map_err(|e| format!("SeaDex parse failed: {e}"))?;
 
     Ok(parsed.items.into_iter().next().map(Into::into))
+}
+
+/// Multi-item variant of [`parse_list_response`] for the batched-OR
+/// query. Returns every entry in the page rather than just the first.
+fn parse_list_response_multi(body: &str) -> Result<Vec<SeaDexEntry>, String> {
+    let parsed: PbListResponse = serde_json::from_str(body)
+        .map_err(|e| format!("SeaDex batch parse failed: {e}"))?;
+    Ok(parsed.items.into_iter().map(Into::into).collect())
 }
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -69,6 +69,24 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
     )
     .await;
 
+    // SeaDex prewarm: collapses the typical "most series don't have a
+    // SeaDex entry" tail of the per-series loop from N sequential
+    // round-trips into ceil(N/50) batched OR-filter requests. Only
+    // runs when SeaDex is actually consulted by the scoring path
+    // (config toggle OR a SeaDex-using Custom Format installed).
+    let seadex_will_be_consulted =
+        cfg.seadex_enabled || crate::services::custom_formats::has_seadex_cf(&cfs);
+    if seadex_will_be_consulted {
+        let anilist_ids: Vec<i64> = tracked
+            .iter()
+            .filter(|r| r.allow_upgrades && !r.folder_name.is_empty() && r.anilist_id > 0)
+            .map(|r| r.anilist_id)
+            .collect();
+        if !anilist_ids.is_empty() {
+            auto_search::prewarm_seadex_negative(&state.db, &anilist_ids).await;
+        }
+    }
+
     for row in &tracked {
         // Skip series with no folder (not set up yet).
         if row.folder_name.is_empty() {


### PR DESCRIPTION
## Summary

API-efficiency batch from a multi-agent audit + live verification of every claim before implementation. Two commits:

**`perf(seadex):` caching gaps and batched prewarm**
- In-flight coalescing (Notify-per-anilist_id with Drop guard) + parallel Nyaa view-page fetches via JoinSet + 5-min negative-error cache + SQLite persistence (cache survives restarts).
- New `seadex::lookup_batch` using `filter=alID=A||alID=B||...` (verified live), wired into the upgrade sweep as `prewarm_seadex_negative` — collapses N per-series round-trips into ceil(N/50) batched requests for the negative-cache fast path (most series in a typical library have no SeaDex entry).

**`perf:` batch and dedupe AniList/Jikan/Kitsu/anibridge requests**
- **AniList:** `get_anime_details_batch` via `Page(media(id_in:))`, perPage=25, populates DETAIL_CACHE. Wired into BFS prefetch, transitive walk, Sonarr/Radarr fan-outs. Also collapses `find_anime_by_mal_id` + `get_anime_detail` into a single `find_anime_detail_by_mal_id` round-trip via a MediaSelector enum.
- **Jikan:** `/anime/{id}/full` already includes the relations array (verified live against mal_id 9260) — drops the redundant `/relations` call per detail fetch.
- **Kitsu:** `get_anime_detail_by_mal_id` via `/mappings?filter[externalSite]=…&include=item` — collapses 1–4 fuzzy title queries into one exact mapping lookup. Note: the "obvious" `/anime?filter[mappings.externalSite]` is rejected by Kitsu with 400 "Filter not allowed" (live-probed during review).
- **anibridge:** ETag + Last-Modified sidecar meta file; conditional GET on refresh returns 304 (verified live) and skips the 8.5 MB transfer on unchanged days.

Three subagent claims were trusted at first and one (Kitsu's filter syntax) turned out to be wrong; the live probe caught it before merge. Saved guidance memory to verify all future agent API claims with a curl/WebFetch before implementing.

Investigated but **deliberately not shipped:** Jikan ETag plumbing — Jikan emits only `Last-Modified` (no ETag), 304s reflect Jikan's own internal 24h cache cycle (not MAL data freshness), and rate limiting is at infrastructure layer so 304s almost certainly count toward the per-minute budget. Net win is too small to justify the schema migration.

478/478 tests pass; 3 new SeaDex persistence tests added (round-trip / expired-row eviction / negative-error not persisted). Clippy clean.

## Test plan

- [x] `cargo build && cargo test && cargo clippy` — all green
- [x] **Jikan `/full`:** force a series to fall through to Jikan (AL force-fallback, or MAL-only entry). Open the series detail page; verify the **relations panel still renders cards** (Sequel/Adaptation/etc.). If empty, `FullAnime.relations` deserialization regressed.
- [x] **anibridge ETag:** trigger `/api/tasks/anibridge-refresh` after touching `data/cache/anibridge/mappings.json` to expire the disk freshness gate. Watch logs for `Anibridge mappings unchanged (HTTP 304); reusing disk cache`. Confirm sidecar `mappings.meta.json` exists with `etag` + `last_modified`.
- [x] **AniList MAL-collapse:** add a series via MAL ID only; trigger `maybe_reconcile_mal_entry` (open the detail page). Verify reconciliation succeeds and only **one** GraphQL POST is observed (was two).
- [x] **Kitsu mapping:** simulate AniList + Jikan failures for one series (firewall block or cooldown) and trigger metadata refresh. Logs should show `using Kitsu fallback (mapping)` (the new exact-lookup path). Verify against `kitsu.io/api/edge/mappings?filter[externalSite]=myanimelist/anime&filter[externalId]=<MAL>` in a browser.
- [x] **SeaDex prewarm:** trigger `/api/tasks/upgrade-search` on a library with ≥10 series. Logs should show `seadex: prewarm cached N negative entries from K batched lookup(s)` once at start; subsequent per-series lookups should be mostly cache hits.
- [x] **AniList batch — three flows:**
  - Trigger metadata refresh on a series with deep relations (Monogatari saga). Tree should fully populate without 429s.
  - Add a Monogatari-saga episode pack via interactive search; transitive sibling-detection cards should still appear.
  - Have Seerr request a multi-season TMDB ID; verify the fan-out emits 1 batched query before the per-entry loop, then mostly cache hits.
  - **Regression sentinel:** any of these flows showing empty/missing relation cards = `parse_media_node` drifted from the inline parser. Check the batched response shape.
- [x] **SeaDex caching:** restart Ryokan; logs should show `seadex: warmed N persisted cache entries from SQLite`. Trigger two concurrent searches on the same series; only one `seadex: fetching releases.moe entry` line should appear (the other should log `seadex: coalesced wait hit`).
- [x] **Steady-state log spot-check** (`RUST_LOG=ryokan=debug`): confirm `seadex: cache hit`, `seadex: prewarm cached`, and `Anibridge mappings unchanged (HTTP 304)` show up at expected cadences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)