### PR TITLE
fix: auto-expand edge cases — AL/BD count mismatch + metadata-wait timeout (#45)

### DIFF
--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -622,57 +622,89 @@ pub(super) async fn build_episodes(
         });
     }
 
-    if ep_count == 0 && !disk_files.is_empty() {
-        for f in &disk_files {
-            on_disk_count += 1;
-            downloaded_count += 1;
-            total_size += f.size_bytes;
-            let monitored = monitored_lookup.contains(&f.episode_number);
-            if monitored {
-                monitored_count += 1;
-            }
-            let (display_quality, quality_state) = if !f.quality.is_empty() {
-                (f.quality.clone(), "disk".to_string())
-            } else if let Some(tag) = quality_tags.get(&f.episode_number) {
-                (tag.quality_tag.clone(), tag.state.clone())
-            } else {
-                (String::new(), String::new())
-            };
-            let tag = quality_tags.get(&f.episode_number);
-            let class_source = tag.map(|t| t.source.clone()).unwrap_or_default();
-            let class_resolution = tag.map(|t| t.resolution.clone()).unwrap_or_default();
-            let class_is_remux = tag.map(|t| t.is_remux).unwrap_or(false);
-            let class_is_bdmv = tag.map(|t| t.is_bdmv).unwrap_or(false);
-            let class_web_kind = tag.map(|t| t.web_kind.clone()).unwrap_or_default();
-            let needs_review = tag.map(|t| t.needs_review).unwrap_or(false);
-            let manual_override = tag.map(|t| t.manual_override).unwrap_or(false);
-            episodes.push(Episode {
-                number: f.episode_number,
-                title: String::new(),
-                title_romaji: String::new(),
-                title_english: String::new(),
-                title_native: String::new(),
-                aired: String::new(),
-                on_disk: true,
-                // This branch only runs when the file already exists
-                // under media_root (on_disk=true), so `downloaded` is
-                // unconditionally true regardless of tag state.
-                downloaded: true,
-                quality: display_quality,
-                quality_state,
-                size_display: f.size_display.clone(),
-                filename: f.filename.clone(),
-                can_auto_search: is_tracked,
-                monitored,
-                class_source,
-                class_resolution,
-                class_is_remux,
-                class_is_bdmv,
-                class_web_kind,
-                manual_override,
-                needs_review,
-            });
+    // Surface on-disk files the main 1..=ep_count loop didn't render.
+    // Two cases:
+    //   1. ep_count == 0 — movies or airing shows with no episodes yet;
+    //      the main loop emits no rows, so every disk file lands here.
+    //   2. ep_count > 0 but a release partitioned the series into more
+    //      files than AniList's reported episode count. Canonical case:
+    //      the [smol] Owarimonogatari BD splits the 48-min aired ep 1
+    //      back into two ~24-min files, so S1 has 13 files on disk vs
+    //      AL's 12 eps. Auto-expand routes the extra file to the parent
+    //      folder at post-process time, but without this branch the UI
+    //      loop only iterated 1..=12 and the 13th file was orphaned
+    //      (on disk, tracked in `grabbed_torrents`, but invisible in
+    //      the episode list). See issue #45.
+    let rendered_eps: std::collections::HashSet<i32> =
+        episodes.iter().map(|e| e.number).collect();
+    for f in &disk_files {
+        // Match the main loop's season filter on the ep_count > 0 path:
+        // only render season 1 / unseasoned files. Specials/ or S02
+        // files under a tracked series folder aren't part of the main
+        // episode list. The ep_count == 0 path historically rendered
+        // every file regardless of season — preserve that behavior to
+        // avoid regressions for movies and airing-with-no-episodes shows.
+        if ep_count > 0
+            && let Some(s) = f.season_number
+            && s != 1
+        {
+            continue;
         }
+        if f.episode_number <= 0 {
+            continue;
+        }
+        if rendered_eps.contains(&f.episode_number) {
+            continue;
+        }
+
+        on_disk_count += 1;
+        downloaded_count += 1;
+        total_size += f.size_bytes;
+        let monitored = monitored_lookup.contains(&f.episode_number);
+        if monitored {
+            monitored_count += 1;
+        }
+        let (display_quality, quality_state) = if !f.quality.is_empty() {
+            (f.quality.clone(), "disk".to_string())
+        } else if let Some(tag) = quality_tags.get(&f.episode_number) {
+            (tag.quality_tag.clone(), tag.state.clone())
+        } else {
+            (String::new(), String::new())
+        };
+        let tag = quality_tags.get(&f.episode_number);
+        let class_source = tag.map(|t| t.source.clone()).unwrap_or_default();
+        let class_resolution = tag.map(|t| t.resolution.clone()).unwrap_or_default();
+        let class_is_remux = tag.map(|t| t.is_remux).unwrap_or(false);
+        let class_is_bdmv = tag.map(|t| t.is_bdmv).unwrap_or(false);
+        let class_web_kind = tag.map(|t| t.web_kind.clone()).unwrap_or_default();
+        let needs_review = tag.map(|t| t.needs_review).unwrap_or(false);
+        let manual_override = tag.map(|t| t.manual_override).unwrap_or(false);
+        episodes.push(Episode {
+            number: f.episode_number,
+            title: String::new(),
+            title_romaji: String::new(),
+            title_english: String::new(),
+            title_native: String::new(),
+            aired: String::new(),
+            on_disk: true,
+            // This branch only runs when the file already exists under
+            // media_root (on_disk=true), so `downloaded` is
+            // unconditionally true regardless of tag state.
+            downloaded: true,
+            quality: display_quality,
+            quality_state,
+            size_display: f.size_display.clone(),
+            filename: f.filename.clone(),
+            can_auto_search: is_tracked,
+            monitored,
+            class_source,
+            class_resolution,
+            class_is_remux,
+            class_is_bdmv,
+            class_web_kind,
+            manual_override,
+            needs_review,
+        });
     }
 
     episodes.sort_by(|a, b| b.number.cmp(&a.number));
@@ -986,5 +1018,185 @@ fn format_size(bytes: u64) -> String {
         format!("{:.1} GiB", gb)
     } else {
         format!("{:.0} MiB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::series;
+
+    fn unique_media_root(suffix: &str) -> std::path::PathBuf {
+        let nonce = format!(
+            "ryokan_pages_test_{}_{}_{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0),
+            suffix,
+        );
+        let root = std::env::temp_dir().join(nonce);
+        std::fs::create_dir_all(&root).expect("create media root");
+        root
+    }
+
+    fn empty_anime_detail(id: i64, title_english: &str, episodes: Option<i32>) -> anilist::AnimeDetail {
+        anilist::AnimeDetail {
+            id,
+            id_mal: None,
+            title_romaji: title_english.to_string(),
+            title_english: title_english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            banner_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes,
+            duration: Some(24),
+            season: String::new(),
+            season_year: Some(2015),
+            end_year: Some(2015),
+            description: String::new(),
+            genres: Vec::new(),
+            average_score: None,
+            average_score_display: None,
+            score_is_ten_point: false,
+            score_class: String::new(),
+            next_airing_episode: None,
+            next_airing_at: None,
+            synonyms: Vec::new(),
+            streaming_episodes: Vec::new(),
+            relations: Vec::new(),
+        }
+    }
+
+    /// Issue #45: a BD release can partition a series into more files
+    /// than AniList reports (Owarimonogatari S1 — AL says 12 eps, the
+    /// [smol] BD has 13 files because it splits the 48-min aired ep 1
+    /// back into two halves). Before the fix, `build_episodes` only
+    /// looped 1..=ep_count, so file 13 was routed to disk by
+    /// auto-expand but never rendered in the UI. The fix surfaces
+    /// any on-disk file with ep > ep_count as its own row.
+    #[tokio::test]
+    async fn build_episodes_surfaces_on_disk_files_beyond_anilist_episode_count() {
+        let db = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21320,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        // Write 13 synthetic episode files — ep 13 exceeds AL's count.
+        let media_root = unique_media_root("surface_beyond_count");
+        let series_folder = media_root.join("Owarimonogatari");
+        std::fs::create_dir_all(&series_folder).expect("create series dir");
+        for ep in 1..=13 {
+            let fname = format!("Owarimonogatari - S01E{:02} - Episode.mkv", ep);
+            std::fs::write(series_folder.join(&fname), b"x").expect("write ep file");
+        }
+
+        // AL reports 12 eps (the on-air ep 1 was a 48-min merged episode).
+        let detail = empty_anime_detail(21320, "Owarimonogatari", Some(12));
+
+        let (episodes, on_disk_count, downloaded_count, _size, _monitored) = build_episodes(
+            &db,
+            &detail,
+            Some(series_id),
+            "Owarimonogatari",
+            media_root.to_str().expect("media root str"),
+        )
+        .await;
+
+        // Sorted desc by number, so ep 13 is first.
+        assert_eq!(
+            episodes.len(),
+            13,
+            "expected 13 rows (1..=12 from AL count + 13 from disk overflow), got {}",
+            episodes.len()
+        );
+        let ep13 = episodes
+            .iter()
+            .find(|e| e.number == 13)
+            .expect("ep 13 row present");
+        assert!(ep13.on_disk, "ep 13 must render as on_disk");
+        assert_eq!(on_disk_count, 13, "on_disk_count must include the overflow");
+        assert_eq!(downloaded_count, 13, "downloaded_count same");
+
+        // Cleanup (best effort).
+        std::fs::remove_dir_all(&media_root).ok();
+    }
+
+    /// Regression guard: when every on-disk file falls within AL's
+    /// ep_count, the surface-beyond-count pass must not duplicate rows
+    /// the main loop already rendered.
+    #[tokio::test]
+    async fn build_episodes_does_not_duplicate_rows_when_disk_matches_count() {
+        let db = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 999,
+                mal_id: None,
+                title: "Test Series",
+                title_romaji: "Test Series",
+                title_english: "Test Series",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2020),
+                end_year: Some(2020),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        let media_root = unique_media_root("no_duplicates");
+        let series_folder = media_root.join("Test Series");
+        std::fs::create_dir_all(&series_folder).expect("create series dir");
+        for ep in 1..=12 {
+            let fname = format!("Test Series - S01E{:02} - Episode.mkv", ep);
+            std::fs::write(series_folder.join(&fname), b"x").expect("write ep file");
+        }
+
+        let detail = empty_anime_detail(999, "Test Series", Some(12));
+
+        let (episodes, _, _, _, _) = build_episodes(
+            &db,
+            &detail,
+            Some(series_id),
+            "Test Series",
+            media_root.to_str().expect("media root str"),
+        )
+        .await;
+
+        assert_eq!(episodes.len(), 12, "no duplicates: exactly 12 rows");
+
+        std::fs::remove_dir_all(&media_root).ok();
     }
 }

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -622,21 +622,28 @@ pub(super) async fn build_episodes(
         });
     }
 
-    // Surface on-disk files the main 1..=ep_count loop didn't render.
-    // Two cases:
+    // Surface episodes the main 1..=ep_count loop didn't render. Two
+    // cases:
     //   1. ep_count == 0 — movies or airing shows with no episodes yet;
     //      the main loop emits no rows, so every disk file lands here.
     //   2. ep_count > 0 but a release partitioned the series into more
     //      files than AniList's reported episode count. Canonical case:
     //      the [smol] Owarimonogatari BD splits the 48-min aired ep 1
     //      back into two ~24-min files, so S1 has 13 files on disk vs
-    //      AL's 12 eps. Auto-expand routes the extra file to the parent
-    //      folder at post-process time, but without this branch the UI
-    //      loop only iterated 1..=12 and the 13th file was orphaned
-    //      (on disk, tracked in `grabbed_torrents`, but invisible in
-    //      the episode list). See issue #45.
-    let rendered_eps: std::collections::HashSet<i32> =
+    //      AL's 12 eps. Auto-expand backfills a grab-tag row for the
+    //      overflow ep at grab time AND routes the file to the parent
+    //      folder at post-process time. Both pre-import ("downloading"
+    //      row from the grab tag) and post-import ("imported" row from
+    //      the disk file) need to render — without this pass, the main
+    //      loop only iterated 1..=ep_count and the overflow was
+    //      orphaned in either state. See issue #45.
+    let mut rendered_eps: std::collections::HashSet<i32> =
         episodes.iter().map(|e| e.number).collect();
+
+    // Pass 1: on-disk files past ep_count. Takes precedence — a file
+    // on disk carries size/filename/quality that a bare grab tag
+    // doesn't, and we want the "imported" state to win over any stale
+    // "grabbed" tag if the user somehow hits this for both sources.
     for f in &disk_files {
         // Match the main loop's season filter on the ep_count > 0 path:
         // only render season 1 / unseasoned files. Specials/ or S02
@@ -679,6 +686,7 @@ pub(super) async fn build_episodes(
         let class_web_kind = tag.map(|t| t.web_kind.clone()).unwrap_or_default();
         let needs_review = tag.map(|t| t.needs_review).unwrap_or(false);
         let manual_override = tag.map(|t| t.manual_override).unwrap_or(false);
+        rendered_eps.insert(f.episode_number);
         episodes.push(Episode {
             number: f.episode_number,
             title: String::new(),
@@ -705,6 +713,60 @@ pub(super) async fn build_episodes(
             manual_override,
             needs_review,
         });
+    }
+
+    // Pass 2: grab-tag rows past ep_count with no matching disk file
+    // yet. This is what makes the overflow row render as "downloading"
+    // immediately after the batch is queued — auto-expand writes the
+    // grab tag, the torrent is still downloading so nothing is on disk,
+    // and without this pass the row would be invisible until post-
+    // processing imports it.
+    if ep_count > 0 {
+        for (&ep_num, tag) in quality_tags.iter() {
+            if ep_num <= ep_count {
+                continue;
+            }
+            if rendered_eps.contains(&ep_num) {
+                continue;
+            }
+
+            let monitored = monitored_lookup.contains(&ep_num);
+            if monitored {
+                monitored_count += 1;
+            }
+            // `downloaded` tracks completed-state episodes; an overflow
+            // tag in 'grabbed' state is mid-download so it counts only
+            // when the tag has already been flipped to 'completed' by
+            // post-processing. Mirrors the main loop's treatment.
+            let downloaded = tag.state == "completed";
+            if downloaded {
+                downloaded_count += 1;
+            }
+            rendered_eps.insert(ep_num);
+            episodes.push(Episode {
+                number: ep_num,
+                title: String::new(),
+                title_romaji: String::new(),
+                title_english: String::new(),
+                title_native: String::new(),
+                aired: String::new(),
+                on_disk: false,
+                downloaded,
+                quality: tag.quality_tag.clone(),
+                quality_state: tag.state.clone(),
+                size_display: String::new(),
+                filename: String::new(),
+                can_auto_search: is_tracked,
+                monitored,
+                class_source: tag.source.clone(),
+                class_resolution: tag.resolution.clone(),
+                class_is_remux: tag.is_remux,
+                class_is_bdmv: tag.is_bdmv,
+                class_web_kind: tag.web_kind.clone(),
+                manual_override: tag.manual_override,
+                needs_review: tag.needs_review,
+            });
+        }
     }
 
     episodes.sort_by(|a, b| b.number.cmp(&a.number));
@@ -1196,6 +1258,92 @@ mod tests {
         .await;
 
         assert_eq!(episodes.len(), 12, "no duplicates: exactly 12 rows");
+
+        std::fs::remove_dir_all(&media_root).ok();
+    }
+
+    /// Issue #45 follow-up: during the download the overflow file isn't
+    /// on disk yet, but auto-expand has already written a grab-tag row
+    /// for it. `build_episodes` must surface that tag as a row (in
+    /// 'grabbed' state) so the user sees the extra episode's download
+    /// progress immediately — not just after post-processing runs.
+    #[tokio::test]
+    async fn build_episodes_surfaces_grab_tags_beyond_ep_count_without_disk_file() {
+        use crate::services::source::ClassificationResult;
+
+        let db = sqlx::SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21262,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        // Write a grab tag for ep 13 (AL-overflow) — simulates what
+        // auto_expand::expand_from_files does when it backfills a tag
+        // for a parent file whose parsed ep exceeds AL's count.
+        crate::models::episode_tags::record_grab(
+            &db,
+            series_id,
+            13,
+            &ClassificationResult::unknown(),
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            "smol",
+            0,
+            true,
+        )
+        .await
+        .expect("record_grab for ep 13");
+
+        // Empty media root — torrent is still downloading, nothing
+        // has landed in the library folder yet.
+        let media_root = unique_media_root("surfaces_grab_tag_no_disk");
+        let series_folder = media_root.join("Owarimonogatari");
+        std::fs::create_dir_all(&series_folder).expect("create series dir");
+
+        let detail = empty_anime_detail(21262, "Owarimonogatari", Some(12));
+
+        let (episodes, on_disk_count, downloaded_count, _size, _monitored) = build_episodes(
+            &db,
+            &detail,
+            Some(series_id),
+            "Owarimonogatari",
+            media_root.to_str().expect("media root str"),
+        )
+        .await;
+
+        assert_eq!(
+            episodes.len(),
+            13,
+            "expected 13 rows (1..=12 from AL + overflow E13 from grab tag), got {}",
+            episodes.len()
+        );
+        let ep13 = episodes
+            .iter()
+            .find(|e| e.number == 13)
+            .expect("ep 13 row present from grab tag");
+        assert!(!ep13.on_disk, "no disk file yet, so on_disk must be false");
+        assert!(!ep13.downloaded, "tag state is 'grabbed', not 'completed'");
+        assert_eq!(ep13.quality_state, "grabbed");
+        assert_eq!(on_disk_count, 0, "nothing on disk yet");
+        assert_eq!(downloaded_count, 0, "nothing completed yet");
 
         std::fs::remove_dir_all(&media_root).ok();
     }

--- a/src/handlers/library/search.rs
+++ b/src/handlers/library/search.rs
@@ -17,9 +17,7 @@ use sqlx::SqlitePool;
 
 use crate::models::log::LogCategory;
 use crate::models::{config, episode_tags, grabbed_torrents, monitoring, series};
-use crate::services::{
-    anilist, auto_search, logger, media, metadata_sync, progress,
-};
+use crate::services::{anilist, auto_search, logger, media, progress};
 use crate::AppState;
 
 use super::reconcile::{
@@ -144,24 +142,25 @@ fn batch_episode_numbers(title: &str, detail: &anilist::AnimeDetail) -> Vec<i32>
     ep_nums
 }
 
-/// Grab-time context threaded through the auto-expand path so each
-/// detected sibling series gets its own `episode_quality_tags` +
-/// `episode_grab_history` rows alongside its route record. Without
-/// this, the sibling series page shows UNKNOWN with no progress bar
-/// until post-processing runs — the parent series records the grab
-/// for its own episodes synchronously, but the siblings are detected
-/// asynchronously inside `auto_expand_library_from_pack` and were
-/// previously only getting route rows written. Owned-fields so the
-/// struct can be cloned into the spawned task.
-#[derive(Clone)]
-struct AutoExpandGrabContext {
-    classification: crate::services::source::ClassificationResult,
-    release_group: String,
-    size_bytes: i64,
-}
+// AutoExpandGrabContext + the core expansion logic live in
+// `services::auto_expand` so `services::post_processing` can call the
+// same routine as a fallback when the grab-time metadata wait here
+// timed out. Re-export locally so call sites in this file stay terse.
+use crate::services::auto_expand::{expand_from_files, AutoExpandGrabContext};
 
-/// Returns the number of siblings *newly added* to the library
-/// (upserts that hit an existing row don't count).
+/// Grab-time outer orchestrator: wait for qBit metadata, then delegate
+/// to [`services::auto_expand::expand_from_files`]. Failure here
+/// (timeout, qBit error) is no longer load-bearing — post-processing
+/// retries the same expansion at import time via
+/// [`services::auto_expand::expand_from_files`], so a slow tracker that
+/// can't deliver metadata in 3 minutes will still get sibling detection
+/// once the torrent completes.
+///
+/// 180s ceiling (vs the 10s used by the interactive selective-narrowing
+/// path) because this runs inside a `tokio::spawn` — blocking a few
+/// minutes in the background is fine, the HTTP handler already
+/// returned. A slow-DHT magnet or a public tracker under load can take
+/// that long to fetch metadata.
 #[allow(clippy::too_many_arguments)]
 async fn auto_expand_library_from_pack(
     db: &SqlitePool,
@@ -178,25 +177,18 @@ async fn auto_expand_library_from_pack(
         return 0;
     }
 
-    // Wait for qBit metadata before asking for the file list. Fresh
-    // grabs via `add_torrent` don't block on metadata discovery, so
-    // a naive `get_torrent_files` right after add returns empty.
-    // We use a generous 60s ceiling here (rather than the 10s used
-    // by the interactive selective-narrowing path) because this runs
-    // inside a `tokio::spawn` — blocking up to a minute in the
-    // background is fine, the HTTP handler has already returned.
     let files = match qbit
-        .wait_for_metadata(info_hash, std::time::Duration::from_secs(60))
+        .wait_for_metadata(info_hash, std::time::Duration::from_secs(180))
         .await
     {
         Ok(files) => files,
         Err(e) => {
-            logger::warn(
+            logger::info(
                 db,
                 LogCategory::Library,
                 &format!(
-                    "auto-expand: metadata wait failed for '{}', skipping sibling detection (fallback: all files will route to parent series_id={})",
-                    torrent_title, parent_series_id
+                    "auto-expand: grab-time metadata wait failed for '{}', post-processing will retry at import time",
+                    torrent_title
                 ),
                 &e,
             )
@@ -206,7 +198,7 @@ async fn auto_expand_library_from_pack(
     };
     let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
 
-    auto_expand_library_from_pack_with_files(
+    expand_from_files(
         db,
         &filenames,
         parent_detail,
@@ -217,405 +209,6 @@ async fn auto_expand_library_from_pack(
         grab_ctx,
     )
     .await
-}
-
-/// Pure inner fn — takes a pre-fetched file list instead of a qBit
-/// client so the test suite can exercise the sibling detection, series
-/// upsert, and route-writing logic without spinning up qBittorrent.
-/// The outer [`auto_expand_library_from_pack`] handles the metadata-
-/// wait dance; everything else lives here.
-#[allow(clippy::too_many_arguments)]
-async fn auto_expand_library_from_pack_with_files(
-    db: &SqlitePool,
-    filenames: &[String],
-    parent_detail: &anilist::AnimeDetail,
-    parent_series_id: i64,
-    parent_episode_numbers: &[i32],
-    grab_id: i64,
-    torrent_title: &str,
-    grab_ctx: &AutoExpandGrabContext,
-) -> usize {
-    let parent_title = if !parent_detail.title_english.is_empty() {
-        parent_detail.title_english.as_str()
-    } else {
-        parent_detail.title_romaji.as_str()
-    };
-
-    if parent_detail.id <= 0 {
-        logger::debug(
-            db,
-            LogCategory::Library,
-            "Auto-expand: skipping sibling detection, parent has no AniList id",
-            &format!("parent_series_id={}, torrent='{}'", parent_series_id, torrent_title),
-        )
-        .await;
-        return 0;
-    }
-
-    logger::debug(
-        db,
-        LogCategory::Library,
-        &format!(
-            "Auto-expand: scanning {} file(s) for siblings of '{}'",
-            filenames.len(),
-            parent_title
-        ),
-        &format!(
-            "parent_anilist_id={}, torrent='{}'",
-            parent_detail.id, torrent_title
-        ),
-    )
-    .await;
-
-    // Depth-1 transitive relation walk: AniList's relation graph
-    // has missing direct edges across split sagas (Monogatari is
-    // the motivating case — Owarimonogatari 21262 does not list
-    // Owarimonogatari 2nd Season 99423 as a direct neighbor, but
-    // reaches it via the shared saga graph). Before running sibling
-    // detection we fetch each walkable direct neighbor's AL detail,
-    // then graft its OWN relations onto the parent so
-    // `detect_sibling_entries_in_pack` sees a broader candidate
-    // pool. Fetches are capped by
-    // `auto_search::TRANSITIVE_WALK_MAX_FETCHES`. Failures are soft
-    // — any neighbor we can't fetch is silently skipped and detection
-    // falls back to the parent's direct relations.
-    //
-    // Single batched `Page(media(id_in:[]))` request via
-    // `anilist::get_anime_details_batch` replaces the previous
-    // per-id JoinSet that fan-out N concurrent single-id queries.
-    // The single throttle gate had been serializing those concurrent
-    // requests anyway, so the JoinSet was paying coordination cost
-    // for no parallelism — one batched call does it in one round-trip.
-    let mut walk_ids: Vec<i64> = Vec::new();
-    let mut walk_id_to_type: std::collections::HashMap<i64, String> =
-        std::collections::HashMap::new();
-    for rel in &parent_detail.relations {
-        if walk_ids.len() >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
-            break;
-        }
-        if !auto_search::is_transitive_walk_source(&rel.relation_type) {
-            continue;
-        }
-        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
-            continue;
-        }
-        if rel.id <= 0 {
-            continue;
-        }
-        walk_ids.push(rel.id);
-        walk_id_to_type.insert(rel.id, rel.relation_type.clone());
-    }
-    let neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> = if walk_ids
-        .is_empty()
-    {
-        std::collections::HashMap::new()
-    } else {
-        match anilist::get_anime_details_batch(&walk_ids).await {
-            Ok(map) => map,
-            Err(e) => {
-                tracing::debug!(
-                    "auto-expand: transitive neighbor batch fetch failed err={}",
-                    e
-                );
-                // Recover partial results from DETAIL_CACHE: chunks that
-                // completed before the failure already wrote their entries
-                // (the batch helper aborts on Err but the writes survive),
-                // and the `Result` shape can't return them directly.
-                // Without this probe a 429 on chunk 2 would silently
-                // discard chunk 1's 25 successful sibling fetches.
-                let mut partial = std::collections::HashMap::new();
-                for rel_id in &walk_ids {
-                    if let Some(detail) = anilist::cached_anime_detail(*rel_id).await {
-                        partial.insert(*rel_id, detail);
-                    }
-                }
-                if !partial.is_empty() {
-                    tracing::debug!(
-                        "auto-expand: recovered {} partial neighbor(s) from DETAIL_CACHE",
-                        partial.len()
-                    );
-                }
-                partial
-            }
-        }
-    };
-    // Log any ids the batch didn't return — typically AniList simply
-    // has no Media for that id (deleted entry, NSFW filter, etc.).
-    for rel_id in &walk_ids {
-        if !neighbor_details.contains_key(rel_id) {
-            let rel_type = walk_id_to_type
-                .get(rel_id)
-                .cloned()
-                .unwrap_or_default();
-            tracing::debug!(
-                "auto-expand: transitive neighbor missing from batch rel_id={} rel_type={}",
-                rel_id,
-                rel_type
-            );
-        }
-    }
-    let expanded_parent =
-        auto_search::expand_parent_with_transitive_relations(parent_detail, &neighbor_details);
-    let siblings = auto_search::detect_sibling_entries_in_pack(filenames, &expanded_parent);
-    if siblings.is_empty() {
-        logger::info(
-            db,
-            LogCategory::Library,
-            &format!(
-                "Auto-expand: no siblings detected in pack '{}'",
-                torrent_title
-            ),
-            &format!(
-                "parent='{}', parent_anilist_id={}, files={}",
-                parent_title,
-                parent_detail.id,
-                filenames.len()
-            ),
-        )
-        .await;
-        return 0;
-    }
-
-    let siblings_considered = siblings.len();
-    let mut added = 0_usize;
-    let mut claimed: std::collections::HashSet<usize> = std::collections::HashSet::new();
-    let mut routes: Vec<grabbed_torrents::GrabSeriesRoute> = Vec::new();
-
-    for sibling in siblings {
-        let primary_title = if !sibling.title_english.is_empty() {
-            sibling.title_english.clone()
-        } else {
-            sibling.title_romaji.clone()
-        };
-
-        // Upsert dedups by mal_id then anilist_id, so reconciled
-        // entries that already have both IDs populated update
-        // in place instead of duplicating.
-        let upsert_result = series::upsert(
-            db,
-            series::SeriesCore {
-                anilist_id: sibling.anilist_id,
-                mal_id: sibling.mal_id,
-                title: &primary_title,
-                title_romaji: &sibling.title_romaji,
-                title_english: &sibling.title_english,
-                title_native: &sibling.title_native,
-                cover_url: &sibling.cover_url,
-                format: &sibling.format,
-                status: &sibling.status,
-                episodes: sibling.episodes,
-                season_year: sibling.season_year,
-                // Relation cards don't carry end_year — the
-                // background metadata refresh populates it.
-                end_year: None,
-            },
-        )
-        .await;
-        let (sibling_id, created) = match upsert_result {
-            Ok(pair) => pair,
-            Err(e) => {
-                logger::warn(
-                    db,
-                    LogCategory::Library,
-                    &format!("auto-expand: failed to upsert sibling '{}'", primary_title),
-                    &e.to_string(),
-                )
-                .await;
-                continue;
-            }
-        };
-
-        if created {
-            added += 1;
-            logger::info(
-                db,
-                LogCategory::Library,
-                &format!(
-                    "Auto-expand: added sibling '{}' from batch '{}'",
-                    primary_title, torrent_title
-                ),
-                &format!(
-                    "anilist_id={}, matched_subtitle={:?}, files={}",
-                    sibling.anilist_id,
-                    sibling.matched_subtitle,
-                    sibling.file_indices.len()
-                ),
-            )
-            .await;
-
-            // Kick off a background metadata refresh so the full
-            // detail (description, artwork, end_year, etc.) gets
-            // hydrated for the UI. Fire-and-forget — the route is
-            // already recorded below either way.
-            let db_clone = db.clone();
-            tokio::spawn(async move {
-                if let Ok(Some(tracked)) = series::get_by_id(&db_clone, sibling_id).await {
-                    let force_fallback = config::get_config(&db_clone)
-                        .await
-                        .ok()
-                        .flatten()
-                        .map(|c| c.force_mal_fallback)
-                        .unwrap_or(false);
-                    let _ = metadata_sync::refresh_series_metadata(
-                        &db_clone,
-                        &tracked,
-                        force_fallback,
-                    )
-                    .await;
-                }
-            });
-        }
-
-        // Derive episode numbers per sibling so
-        // find_imported_for_episode can locate this route when
-        // an upgrade later targets one of the sibling's episodes.
-        //
-        // The stored ep_nums are *effective* (post-offset) numbers so
-        // an upgrade searching by episode 1 of Owari S2 finds a route
-        // whose files were originally numbered E14 on disk. Skip
-        // rows that would resolve to a non-positive effective number
-        // (shouldn't happen — detection sets offset conservatively —
-        // but guards against a bad route/file pairing).
-        let mut ep_nums: Vec<i32> = Vec::new();
-        for &file_idx in &sibling.file_indices {
-            if let Some(name) = filenames.get(file_idx)
-                && let Some((_, raw)) = media::parse_episode_number(&name.to_lowercase()) {
-                    let effective = raw - sibling.episode_offset;
-                    if effective > 0 {
-                        ep_nums.push(effective);
-                    }
-                }
-        }
-        ep_nums.sort_unstable();
-        ep_nums.dedup();
-
-        for &i in &sibling.file_indices {
-            claimed.insert(i);
-        }
-
-        // Write per-episode grab history + quality tag rows for this
-        // sibling so its episode list shows `state=grabbed` in the UI
-        // (progress bar + "came from X GB batch" tooltip). The parent
-        // path records its own rows synchronously at grab time; siblings
-        // were previously only getting route rows written here, which
-        // meant their series pages rendered UNKNOWN with no progress bar
-        // until post-processing finished and backfilled the tags. Every
-        // auto-expand firing is a batch by definition (the outer
-        // selectors only call in on `result.is_batch && !selective_narrowed`),
-        // so `is_batch=true` is always correct here.
-        for &local_ep in &ep_nums {
-            if let Err(e) = episode_tags::record_grab(
-                db,
-                sibling_id,
-                local_ep,
-                &grab_ctx.classification,
-                torrent_title,
-                &grab_ctx.release_group,
-                grab_ctx.size_bytes,
-                true,
-            )
-            .await
-            {
-                logger::warn(
-                    db,
-                    LogCategory::Library,
-                    &format!(
-                        "Auto-expand: failed to backfill grab history for sibling {} ep {}",
-                        sibling_id, local_ep,
-                    ),
-                    &format!("{}: {}", torrent_title, e),
-                )
-                .await;
-            }
-        }
-
-        routes.push(grabbed_torrents::GrabSeriesRoute {
-            grab_id,
-            series_id: sibling_id,
-            file_indices: sibling.file_indices,
-            episode_numbers: ep_nums,
-            matched_subtitle: sibling.matched_subtitle,
-            episode_offset: sibling.episode_offset,
-        });
-    }
-
-    // Parent route: every media file not claimed by a sibling
-    // routes to the parent series. Unclaimed files are expected for
-    // franchise-root grabs (JoJo S1 in a S1-S5 pack won't match any
-    // sibling subtitle) but can also indicate extras or a missed
-    // sibling — log a warn either way so the operator can spot
-    // regressions.
-    let parent_file_indices: Vec<usize> = (0..filenames.len())
-        .filter(|i| {
-            filenames
-                .get(*i)
-                .map(|n| auto_search::is_media_filename(n))
-                .unwrap_or(false)
-                && !claimed.contains(i)
-        })
-        .collect();
-
-    if !routes.is_empty() && !parent_file_indices.is_empty() {
-        logger::warn(
-            db,
-            LogCategory::Library,
-            &format!(
-                "Auto-expand: {} unclaimed file(s) in batch '{}' routed to parent series",
-                parent_file_indices.len(),
-                torrent_title,
-            ),
-            &format!(
-                "parent_id={}, siblings_added={}, unclaimed_count={}",
-                parent_series_id,
-                added,
-                parent_file_indices.len()
-            ),
-        )
-        .await;
-
-        routes.push(grabbed_torrents::GrabSeriesRoute {
-            grab_id,
-            series_id: parent_series_id,
-            file_indices: parent_file_indices,
-            episode_numbers: parent_episode_numbers.to_vec(),
-            matched_subtitle: String::new(),
-            // Parent-route files always use their own arc-local
-            // numbering — no offset ever needed here.
-            episode_offset: 0,
-        });
-    }
-
-    if !routes.is_empty()
-        && let Err(e) = grabbed_torrents::record_grab_series_routes(db, &routes).await {
-            logger::warn(
-                db,
-                LogCategory::Library,
-                &format!(
-                    "auto-expand: failed to write route rows for '{}'",
-                    torrent_title
-                ),
-                &e.to_string(),
-            )
-            .await;
-        }
-
-    logger::info(
-        db,
-        LogCategory::Library,
-        &format!(
-            "Auto-expand: finished batch '{}' — {} sibling(s) added",
-            torrent_title, added
-        ),
-        &format!(
-            "parent='{}', siblings_considered={}, routes_written={}",
-            parent_title,
-            siblings_considered,
-            routes.len()
-        ),
-    )
-    .await;
-
-    added
 }
 
 pub(super) async fn run_auto_search_targets(
@@ -2046,7 +1639,7 @@ mod tests {
         ];
 
         let grab_ctx = test_grab_ctx();
-        let added = auto_expand_library_from_pack_with_files(
+        let added = expand_from_files(
             &db,
             &filenames,
             &parent_detail,
@@ -2164,7 +1757,7 @@ mod tests {
         let parent_episode_numbers: Vec<i32> = (1..=13).collect();
 
         let grab_ctx = test_grab_ctx();
-        let added = auto_expand_library_from_pack_with_files(
+        let added = expand_from_files(
             &db,
             &filenames,
             &parent_detail,
@@ -2295,7 +1888,7 @@ mod tests {
         ];
 
         let grab_ctx = test_grab_ctx();
-        let added = auto_expand_library_from_pack_with_files(
+        let added = expand_from_files(
             &db,
             &filenames,
             &parent_detail,
@@ -2509,7 +2102,7 @@ mod tests {
             .collect();
 
         let grab_ctx = test_grab_ctx();
-        let added = auto_expand_library_from_pack_with_files(
+        let added = expand_from_files(
             &db,
             &filenames,
             &parent_detail,
@@ -2655,7 +2248,7 @@ mod tests {
         }
 
         let grab_ctx = test_grab_ctx();
-        let added = auto_expand_library_from_pack_with_files(
+        let added = expand_from_files(
             &db,
             &filenames,
             &parent_detail,

--- a/src/handlers/library/search.rs
+++ b/src/handlers/library/search.rs
@@ -2428,4 +2428,282 @@ mod tests {
             "populated cumulative short-circuits the gate"
         );
     }
+
+    /// Issue #45: full-scale JoJo Part 3 case. 48-episode BD megapack
+    /// with absolute continuous numbering (no per-cour arc markers in
+    /// the filenames) and Egypt-hen as a sibling of Stardust Crusaders
+    /// on AniList. Egypt-hen's trailing "subtitle" is a single token
+    /// ("Egypt-hen") so the subtitle path can't match — the
+    /// episode-range fallback picks it up via title-prefix matching.
+    ///
+    /// Verifies that:
+    ///   1. detection fires once (Egypt-hen sibling).
+    ///   2. the sibling route carries files 24..=47 (0-based) = E25..E48.
+    ///   3. episode_offset = 24 (parent_cap) so those map to local 1..=24.
+    ///   4. the sibling gets 24 quality-tag + grab-history rows (not 0).
+    ///   5. the parent route carries files 0..=23 = E01..=E24, offset 0.
+    #[tokio::test]
+    async fn auto_expand_jojo_part3_48ep_pack_maps_all_episodes() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        // Parent: JoJo Stardust Crusaders (24 eps).
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 20899,
+                mal_id: None,
+                title: "JoJo's Bizarre Adventure: Stardust Crusaders",
+                title_romaji: "JoJo no Kimyou na Bouken: Stardust Crusaders",
+                title_english: "JoJo's Bizarre Adventure: Stardust Crusaders",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(24),
+                season_year: Some(2014),
+                end_year: Some(2014),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "jojop3hash00000000000000000000000000000000",
+            "[Group] JoJo's Bizarre Adventure Part 3 - Stardust Crusaders (BD 1080p 48 ep)",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        // Parent AnimeDetail with Egypt-hen as a sibling relation. Use
+        // the real AL title form "... Stardust Crusaders - Egypt-hen";
+        // the trailing single-token subtitle can't be extracted, so
+        // detection falls through to the episode-range + title-prefix
+        // path.
+        let mut parent_detail = empty_anime_detail(
+            20899,
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+        );
+        parent_detail.episodes = Some(24);
+        parent_detail.relations.push(related_entry(
+            22663,
+            "JoJo's Bizarre Adventure: Stardust Crusaders - Egypt-hen",
+            Some(24),
+        ));
+
+        // 48 absolute-numbered files (E01..E48).
+        let filenames: Vec<String> = (1..=48)
+            .map(|n| {
+                format!(
+                    "[Group] JoJo no Kimyou na Bouken - Stardust Crusaders - {:02} [BD 1080p].mkv",
+                    n
+                )
+            })
+            .collect();
+
+        let grab_ctx = test_grab_ctx();
+        let added = auto_expand_library_from_pack_with_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &(1..=48).collect::<Vec<_>>(),
+            grab_id,
+            "[Group] JoJo P3 BD 48ep",
+            &grab_ctx,
+        )
+        .await;
+
+        assert_eq!(added, 1, "one new sibling (Egypt-hen) expected");
+
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(routes.len(), 2, "sibling + parent route expected");
+
+        let sibling_route = routes
+            .iter()
+            .find(|r| r.series_id != parent_id)
+            .expect("sibling route present");
+        let expected_sibling_files: Vec<usize> = (24..=47).collect();
+        assert_eq!(
+            sibling_route.file_indices, expected_sibling_files,
+            "sibling owns files 24..=47 (E25..E48)"
+        );
+        assert_eq!(
+            sibling_route.episode_offset, 24,
+            "absolute numbering → offset = parent_cap = 24"
+        );
+        assert_eq!(
+            sibling_route.episode_numbers,
+            (1..=24).collect::<Vec<_>>(),
+            "sibling's stored ep_nums are effective (post-offset) 1..=24"
+        );
+
+        let parent_route = routes
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route present");
+        let expected_parent_files: Vec<usize> = (0..=23).collect();
+        assert_eq!(parent_route.file_indices, expected_parent_files);
+        assert_eq!(parent_route.episode_offset, 0);
+
+        // Sibling quality-tag + history rows exist for local 1..=24.
+        let sibling_id = sibling_route.series_id;
+        let sibling_tags = episode_tags::get_for_series(&db, sibling_id)
+            .await
+            .expect("sibling quality tags");
+        assert_eq!(
+            sibling_tags.len(),
+            24,
+            "sibling should have 24 quality-tag rows"
+        );
+        for local_ep in 1..=24 {
+            let tag = sibling_tags
+                .get(&local_ep)
+                .unwrap_or_else(|| panic!("sibling tag for local ep {} missing", local_ep));
+            assert_eq!(tag.state, "grabbed");
+        }
+    }
+
+    /// Issue #45: Owarimonogatari BD with an AL/BD episode-count
+    /// disagreement. AL reports S1 = 12 eps (the aired ep 1 was a
+    /// 48-min merged episode) but the [smol] BD splits that back into
+    /// two ~24-min files, so the pack has 13 Owari S1 files + 7 Owari
+    /// S2 files.
+    ///
+    /// This is the case the user flagged as "frustrating" in issue #45.
+    /// Verifies that:
+    ///   1. the sibling side is unaffected by the mismatch — Owari S2
+    ///      gets 7 files mapped to local 1..=7 via offset 13.
+    ///   2. the parent side gets all 13 files (including the "extra"
+    ///      ep 13 that AL doesn't know about), routed with offset 0.
+    ///
+    /// The complementary UI fix lives in `pages::build_episodes` — see
+    /// `build_episodes_surfaces_on_disk_files_beyond_anilist_episode_count`.
+    #[tokio::test]
+    async fn auto_expand_owari_bd_split_with_anilist_count_mismatch() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        // Parent: Owarimonogatari. Use AL's reported count (12), NOT
+        // the BD's file count (13). This is the whole point of the test.
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21860,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "owarialmismatch000000000000000000000000000",
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        let mut parent_detail = empty_anime_detail(21860, "Owarimonogatari");
+        parent_detail.episodes = Some(12); // AL's count, NOT the BD's.
+        parent_detail.relations.push(related_entry(
+            99423,
+            "Owarimonogatari Second Season",
+            Some(7),
+        ));
+
+        // 13 parent files (S07E01..E13) + 7 sibling files (S07E14..E20).
+        // The parent's file 12 (E13) exists despite AL saying S1 has
+        // only 12 episodes — this is the mismatch we're testing.
+        let mut filenames: Vec<String> = Vec::new();
+        for n in 1..=13 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari (BD 1080p).mkv",
+                n
+            ));
+        }
+        for n in 14..=20 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari Second Season (Ge) (BD 1080p).mkv",
+                n
+            ));
+        }
+
+        let grab_ctx = test_grab_ctx();
+        let added = auto_expand_library_from_pack_with_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &(1..=12).collect::<Vec<_>>(),
+            grab_id,
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            &grab_ctx,
+        )
+        .await;
+
+        assert_eq!(added, 1, "one new sibling (Owari S2) expected");
+
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(routes.len(), 2, "sibling + parent route expected");
+
+        // Sibling route: 7 files (S07E14..E20) mapped to local 1..=7.
+        // `min_ep = 14`, parent_cap = 12 → offset = min_ep - 1 = 13.
+        // Local = raw - offset: 14→1, 15→2, ..., 20→7.
+        let sibling_route = routes
+            .iter()
+            .find(|r| r.series_id != parent_id)
+            .expect("sibling route present");
+        assert_eq!(
+            sibling_route.file_indices,
+            vec![13, 14, 15, 16, 17, 18, 19],
+            "sibling owns E14..=E20 (0-based 13..=19)"
+        );
+        assert_eq!(
+            sibling_route.episode_offset, 13,
+            "min_ep(14) - 1 = 13, correctly larger than parent_cap(12)"
+        );
+        assert_eq!(sibling_route.episode_numbers, vec![1, 2, 3, 4, 5, 6, 7]);
+
+        // Parent route: all 13 files including the "extra" E13 that
+        // AL doesn't know about. Offset stays 0 — parent files use
+        // their own local numbering.
+        let parent_route = routes
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route present");
+        assert_eq!(
+            parent_route.file_indices,
+            (0..=12).collect::<Vec<_>>(),
+            "parent owns all 13 files (E01..=E13), including the AL-overflow E13"
+        );
+        assert_eq!(parent_route.episode_offset, 0);
+    }
 }

--- a/src/handlers/library/search.rs
+++ b/src/handlers/library/search.rs
@@ -16,7 +16,7 @@ use serde::Deserialize;
 use sqlx::SqlitePool;
 
 use crate::models::log::LogCategory;
-use crate::models::{config, episode_tags, grabbed_torrents, monitoring, series};
+use crate::models::{config, episode_tags, monitoring, series};
 use crate::services::{anilist, auto_search, logger, media, progress};
 use crate::AppState;
 
@@ -1501,6 +1501,7 @@ pub async fn grab_interactive_result(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::grabbed_torrents;
 
     fn empty_anime_detail(id: i64, title_english: &str) -> anilist::AnimeDetail {
         anilist::AnimeDetail {

--- a/src/services/auto_expand.rs
+++ b/src/services/auto_expand.rs
@@ -353,6 +353,52 @@ pub async fn expand_from_files(
         })
         .collect();
 
+    // Backfill grab-tag rows for parent files whose parsed episode
+    // number exceeds what the caller's `parent_episode_numbers` covered.
+    // Motivating case: the [smol] Owarimonogatari BD splits the 48-min
+    // aired ep 1 into two files, so S1 has files for eps 1..=13 on
+    // disk even though AL reports 12 eps. `batch_episode_numbers` only
+    // produced 1..=12 at grab time; without this pass the S1 ep 13
+    // row never renders in the UI until post-processing imports the
+    // file. Write the overflow tag rows now so the user sees a
+    // "downloading" row for ep 13 the moment the pack is queued.
+    let parent_eps_covered: std::collections::HashSet<i32> =
+        parent_episode_numbers.iter().copied().collect();
+    for &file_idx in &parent_file_indices {
+        let Some(name) = filenames.get(file_idx) else {
+            continue;
+        };
+        let Some((_, raw_ep)) = media::parse_episode_number(&name.to_ascii_lowercase()) else {
+            continue;
+        };
+        if raw_ep <= 0 || parent_eps_covered.contains(&raw_ep) {
+            continue;
+        }
+        if let Err(e) = episode_tags::record_grab(
+            db,
+            parent_series_id,
+            raw_ep,
+            &grab_ctx.classification,
+            torrent_title,
+            &grab_ctx.release_group,
+            grab_ctx.size_bytes,
+            true,
+        )
+        .await
+        {
+            logger::warn(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "Auto-expand: failed to backfill grab history for parent {} ep {} (AL-overflow)",
+                    parent_series_id, raw_ep,
+                ),
+                &format!("{}: {}", torrent_title, e),
+            )
+            .await;
+        }
+    }
+
     if !routes.is_empty() && !parent_file_indices.is_empty() {
         logger::warn(
             db,
@@ -591,5 +637,109 @@ mod tests {
             .expect("parent route present");
         assert_eq!(parent_route.file_indices, (0..=23).collect::<Vec<_>>());
         assert_eq!(parent_route.episode_offset, 0);
+    }
+
+    /// Issue #45 follow-up: auto-expand must backfill a grab-tag row
+    /// for parent-side episodes whose parsed number exceeds the
+    /// caller's `parent_episode_numbers` set (AL-overflow case). Without
+    /// this, the [smol] Owari BD's E13 never renders in the UI until
+    /// post-processing imports it — the user sees 12 rows during the
+    /// download with no indication that a 13th is coming.
+    #[tokio::test]
+    async fn expand_writes_grab_tag_for_parent_al_overflow_episodes() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 21262,
+                mal_id: None,
+                title: "Owarimonogatari",
+                title_romaji: "Owarimonogatari",
+                title_english: "Owarimonogatari",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2015),
+                end_year: Some(2015),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "owarialoverflowbackfill00000000000000000000",
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        let mut parent_detail = empty_anime_detail(21262, "Owarimonogatari", Some(12));
+        parent_detail
+            .relations
+            .push(related_entry(21745, "Owarimonogatari Second Season", Some(7)));
+
+        // 13 parent files + 7 sibling files. Parent caller passes
+        // 1..=12 (AL's count), so E13 is the overflow case we want to
+        // backfill.
+        let mut filenames: Vec<String> = Vec::new();
+        for n in 1..=13 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari (BD 1080p).mkv",
+                n
+            ));
+        }
+        for n in 14..=20 {
+            filenames.push(format!(
+                "[smol] Monogatari - S07E{:02} - Owarimonogatari Second Season (Ge) (BD 1080p).mkv",
+                n
+            ));
+        }
+        let parent_episode_numbers: Vec<i32> = (1..=12).collect();
+
+        let ctx = AutoExpandGrabContext {
+            classification: ClassificationResult::unknown(),
+            release_group: String::new(),
+            size_bytes: 0,
+        };
+
+        expand_from_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &parent_episode_numbers,
+            grab_id,
+            "[smol] Monogatari - S07 [BD 1080p HEVC Opus]",
+            &ctx,
+        )
+        .await;
+
+        // The parent should now have a quality_tag row for E13 even
+        // though it wasn't in parent_episode_numbers. The caller's
+        // grab handler writes 1..=12; expand_from_files fills the gap.
+        let tags = episode_tags::get_for_series(&db, parent_id)
+            .await
+            .expect("get_for_series");
+        assert!(
+            tags.contains_key(&13),
+            "auto-expand must backfill a grab tag for AL-overflow ep 13 so the UI renders it during the download; got tags for {:?}",
+            tags.keys().collect::<Vec<_>>()
+        );
+        assert_eq!(
+            tags.get(&13).unwrap().state,
+            "grabbed",
+            "ep 13 tag should start in 'grabbed' state (post-processing will flip to 'completed')"
+        );
     }
 }

--- a/src/services/auto_expand.rs
+++ b/src/services/auto_expand.rs
@@ -34,7 +34,6 @@ use crate::services::source::ClassificationResult;
 /// `episode_grab_history` rows alongside its route record. Without
 /// these, the sibling's series page shows UNKNOWN with no progress bar
 /// until post-processing runs and backfills the tags.
-#[derive(Clone)]
 pub struct AutoExpandGrabContext {
     pub classification: ClassificationResult,
     pub release_group: String,

--- a/src/services/auto_expand.rs
+++ b/src/services/auto_expand.rs
@@ -1,0 +1,595 @@
+//! Sibling auto-expansion for multi-series batch releases.
+//!
+//! Given a batch torrent's file list and its parent's AniList detail,
+//! detect sibling anime entries in the pack (sequels, prequels, side
+//! stories whose own episodes are present), upsert each into the
+//! tracked series table, and write `grabbed_torrent_series` route rows
+//! so post-processing can move each file into the correct sibling's
+//! folder.
+//!
+//! Callers:
+//! - `handlers::library::search::auto_expand_library_from_pack` — runs
+//!   at grab time after qBit returns the torrent's file list.
+//! - `services::post_processing` — runs at import time as a fallback
+//!   when the grab-time path bailed (e.g. qBit metadata wait timed
+//!   out on a slow tracker). Post-processing always has the file list
+//!   because it's about to move files, so this is the safety net that
+//!   guarantees siblings land correctly even when grab-time expansion
+//!   failed.
+//!
+//! Pure async fn — takes a pre-fetched file list so handler tests can
+//! exercise the sibling detection, series upsert, and route-writing
+//! logic without spinning up qBittorrent.
+
+use sqlx::SqlitePool;
+
+use crate::models::log::LogCategory;
+use crate::models::{config, episode_tags, grabbed_torrents, series};
+use crate::services::{anilist, auto_search, logger, media, metadata_sync};
+use crate::services::anilist::AnimeDetail;
+use crate::services::source::ClassificationResult;
+
+/// Grab-time context threaded through the auto-expand path so each
+/// detected sibling gets its own `episode_quality_tags` +
+/// `episode_grab_history` rows alongside its route record. Without
+/// these, the sibling's series page shows UNKNOWN with no progress bar
+/// until post-processing runs and backfills the tags.
+#[derive(Clone)]
+pub struct AutoExpandGrabContext {
+    pub classification: ClassificationResult,
+    pub release_group: String,
+    pub size_bytes: i64,
+}
+
+/// Returns the number of siblings *newly added* to the library
+/// (upserts that hit an existing row don't count). Route rows are
+/// written regardless — a re-grab of a pack whose siblings are already
+/// in the library should still get per-file routing so post-processing
+/// can move files to each sibling's folder.
+#[allow(clippy::too_many_arguments)]
+pub async fn expand_from_files(
+    db: &SqlitePool,
+    filenames: &[String],
+    parent_detail: &AnimeDetail,
+    parent_series_id: i64,
+    parent_episode_numbers: &[i32],
+    grab_id: i64,
+    torrent_title: &str,
+    grab_ctx: &AutoExpandGrabContext,
+) -> usize {
+    let parent_title = if !parent_detail.title_english.is_empty() {
+        parent_detail.title_english.as_str()
+    } else {
+        parent_detail.title_romaji.as_str()
+    };
+
+    if parent_detail.id <= 0 {
+        logger::debug(
+            db,
+            LogCategory::Library,
+            "Auto-expand: skipping sibling detection, parent has no AniList id",
+            &format!("parent_series_id={}, torrent='{}'", parent_series_id, torrent_title),
+        )
+        .await;
+        return 0;
+    }
+
+    logger::debug(
+        db,
+        LogCategory::Library,
+        &format!(
+            "Auto-expand: scanning {} file(s) for siblings of '{}'",
+            filenames.len(),
+            parent_title
+        ),
+        &format!(
+            "parent_anilist_id={}, torrent='{}'",
+            parent_detail.id, torrent_title
+        ),
+    )
+    .await;
+
+    // Depth-1 transitive relation walk: AniList's relation graph has
+    // missing direct edges across split sagas (Monogatari is the
+    // motivating case — Owarimonogatari 21262 does not list
+    // Owarimonogatari 2nd Season 99423 as a direct neighbor, but
+    // reaches it via the shared saga graph). Before running sibling
+    // detection we fetch each walkable direct neighbor's AL detail,
+    // then graft its OWN relations onto the parent so
+    // `detect_sibling_entries_in_pack` sees a broader candidate pool.
+    // Fetches are capped by `auto_search::TRANSITIVE_WALK_MAX_FETCHES`.
+    // Failures are soft — any neighbor we can't fetch is silently
+    // skipped and detection falls back to the parent's direct relations.
+    let mut walk_ids: Vec<i64> = Vec::new();
+    let mut walk_id_to_type: std::collections::HashMap<i64, String> =
+        std::collections::HashMap::new();
+    for rel in &parent_detail.relations {
+        if walk_ids.len() >= auto_search::TRANSITIVE_WALK_MAX_FETCHES {
+            break;
+        }
+        if !auto_search::is_transitive_walk_source(&rel.relation_type) {
+            continue;
+        }
+        if !rel.media_type.eq_ignore_ascii_case("ANIME") {
+            continue;
+        }
+        if rel.id <= 0 {
+            continue;
+        }
+        walk_ids.push(rel.id);
+        walk_id_to_type.insert(rel.id, rel.relation_type.clone());
+    }
+    let neighbor_details: std::collections::HashMap<i64, anilist::AnimeDetail> = if walk_ids
+        .is_empty()
+    {
+        std::collections::HashMap::new()
+    } else {
+        match anilist::get_anime_details_batch(&walk_ids).await {
+            Ok(map) => map,
+            Err(e) => {
+                tracing::debug!(
+                    "auto-expand: transitive neighbor batch fetch failed err={}",
+                    e
+                );
+                // Recover partial results from DETAIL_CACHE: chunks
+                // that completed before the failure already wrote
+                // their entries (the batch helper aborts on Err but
+                // the writes survive).
+                let mut partial = std::collections::HashMap::new();
+                for rel_id in &walk_ids {
+                    if let Some(detail) = anilist::cached_anime_detail(*rel_id).await {
+                        partial.insert(*rel_id, detail);
+                    }
+                }
+                if !partial.is_empty() {
+                    tracing::debug!(
+                        "auto-expand: recovered {} partial neighbor(s) from DETAIL_CACHE",
+                        partial.len()
+                    );
+                }
+                partial
+            }
+        }
+    };
+    for rel_id in &walk_ids {
+        if !neighbor_details.contains_key(rel_id) {
+            let rel_type = walk_id_to_type
+                .get(rel_id)
+                .cloned()
+                .unwrap_or_default();
+            tracing::debug!(
+                "auto-expand: transitive neighbor missing from batch rel_id={} rel_type={}",
+                rel_id,
+                rel_type
+            );
+        }
+    }
+    let expanded_parent =
+        auto_search::expand_parent_with_transitive_relations(parent_detail, &neighbor_details);
+    let siblings = auto_search::detect_sibling_entries_in_pack(filenames, &expanded_parent);
+    if siblings.is_empty() {
+        logger::info(
+            db,
+            LogCategory::Library,
+            &format!(
+                "Auto-expand: no siblings detected in pack '{}'",
+                torrent_title
+            ),
+            &format!(
+                "parent='{}', parent_anilist_id={}, files={}",
+                parent_title,
+                parent_detail.id,
+                filenames.len()
+            ),
+        )
+        .await;
+        return 0;
+    }
+
+    let siblings_considered = siblings.len();
+    let mut added = 0_usize;
+    let mut claimed: std::collections::HashSet<usize> = std::collections::HashSet::new();
+    let mut routes: Vec<grabbed_torrents::GrabSeriesRoute> = Vec::new();
+
+    for sibling in siblings {
+        let primary_title = if !sibling.title_english.is_empty() {
+            sibling.title_english.clone()
+        } else {
+            sibling.title_romaji.clone()
+        };
+
+        // Upsert dedups by mal_id then anilist_id, so reconciled
+        // entries that already have both IDs populated update in
+        // place instead of duplicating.
+        let upsert_result = series::upsert(
+            db,
+            series::SeriesCore {
+                anilist_id: sibling.anilist_id,
+                mal_id: sibling.mal_id,
+                title: &primary_title,
+                title_romaji: &sibling.title_romaji,
+                title_english: &sibling.title_english,
+                title_native: &sibling.title_native,
+                cover_url: &sibling.cover_url,
+                format: &sibling.format,
+                status: &sibling.status,
+                episodes: sibling.episodes,
+                season_year: sibling.season_year,
+                // Relation cards don't carry end_year — the background
+                // metadata refresh populates it.
+                end_year: None,
+            },
+        )
+        .await;
+        let (sibling_id, created) = match upsert_result {
+            Ok(pair) => pair,
+            Err(e) => {
+                logger::warn(
+                    db,
+                    LogCategory::Library,
+                    &format!("auto-expand: failed to upsert sibling '{}'", primary_title),
+                    &e.to_string(),
+                )
+                .await;
+                continue;
+            }
+        };
+
+        if created {
+            added += 1;
+            logger::info(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "Auto-expand: added sibling '{}' from batch '{}'",
+                    primary_title, torrent_title
+                ),
+                &format!(
+                    "anilist_id={}, matched_subtitle={:?}, files={}",
+                    sibling.anilist_id,
+                    sibling.matched_subtitle,
+                    sibling.file_indices.len()
+                ),
+            )
+            .await;
+
+            // Kick off a background metadata refresh so the full
+            // detail (description, artwork, end_year, etc.) gets
+            // hydrated for the UI. Fire-and-forget — the route is
+            // already recorded below either way.
+            let db_clone = db.clone();
+            tokio::spawn(async move {
+                if let Ok(Some(tracked)) = series::get_by_id(&db_clone, sibling_id).await {
+                    let force_fallback = config::get_config(&db_clone)
+                        .await
+                        .ok()
+                        .flatten()
+                        .map(|c| c.force_mal_fallback)
+                        .unwrap_or(false);
+                    let _ = metadata_sync::refresh_series_metadata(
+                        &db_clone,
+                        &tracked,
+                        force_fallback,
+                    )
+                    .await;
+                }
+            });
+        }
+
+        // Derive episode numbers per sibling so find_imported_for_episode
+        // can locate this route when an upgrade later targets one of
+        // the sibling's episodes.
+        //
+        // The stored ep_nums are *effective* (post-offset) numbers so
+        // an upgrade searching by episode 1 of Owari S2 finds a route
+        // whose files were originally numbered E14 on disk.
+        let mut ep_nums: Vec<i32> = Vec::new();
+        for &file_idx in &sibling.file_indices {
+            if let Some(name) = filenames.get(file_idx)
+                && let Some((_, raw)) = media::parse_episode_number(&name.to_lowercase()) {
+                    let effective = raw - sibling.episode_offset;
+                    if effective > 0 {
+                        ep_nums.push(effective);
+                    }
+                }
+        }
+        ep_nums.sort_unstable();
+        ep_nums.dedup();
+
+        for &i in &sibling.file_indices {
+            claimed.insert(i);
+        }
+
+        // Write per-episode grab history + quality tag rows for this
+        // sibling so its episode list shows `state=grabbed` in the UI
+        // (progress bar + "came from X GB batch" tooltip). Every
+        // auto-expand firing is a batch by definition, so
+        // `is_batch=true` is always correct here.
+        for &local_ep in &ep_nums {
+            if let Err(e) = episode_tags::record_grab(
+                db,
+                sibling_id,
+                local_ep,
+                &grab_ctx.classification,
+                torrent_title,
+                &grab_ctx.release_group,
+                grab_ctx.size_bytes,
+                true,
+            )
+            .await
+            {
+                logger::warn(
+                    db,
+                    LogCategory::Library,
+                    &format!(
+                        "Auto-expand: failed to backfill grab history for sibling {} ep {}",
+                        sibling_id, local_ep,
+                    ),
+                    &format!("{}: {}", torrent_title, e),
+                )
+                .await;
+            }
+        }
+
+        routes.push(grabbed_torrents::GrabSeriesRoute {
+            grab_id,
+            series_id: sibling_id,
+            file_indices: sibling.file_indices,
+            episode_numbers: ep_nums,
+            matched_subtitle: sibling.matched_subtitle,
+            episode_offset: sibling.episode_offset,
+        });
+    }
+
+    // Parent route: every media file not claimed by a sibling routes
+    // to the parent series.
+    let parent_file_indices: Vec<usize> = (0..filenames.len())
+        .filter(|i| {
+            filenames
+                .get(*i)
+                .map(|n| auto_search::is_media_filename(n))
+                .unwrap_or(false)
+                && !claimed.contains(i)
+        })
+        .collect();
+
+    if !routes.is_empty() && !parent_file_indices.is_empty() {
+        logger::warn(
+            db,
+            LogCategory::Library,
+            &format!(
+                "Auto-expand: {} unclaimed file(s) in batch '{}' routed to parent series",
+                parent_file_indices.len(),
+                torrent_title,
+            ),
+            &format!(
+                "parent_id={}, siblings_added={}, unclaimed_count={}",
+                parent_series_id,
+                added,
+                parent_file_indices.len()
+            ),
+        )
+        .await;
+
+        routes.push(grabbed_torrents::GrabSeriesRoute {
+            grab_id,
+            series_id: parent_series_id,
+            file_indices: parent_file_indices,
+            episode_numbers: parent_episode_numbers.to_vec(),
+            matched_subtitle: String::new(),
+            // Parent-route files always use their own arc-local
+            // numbering — no offset ever needed here.
+            episode_offset: 0,
+        });
+    }
+
+    if !routes.is_empty()
+        && let Err(e) = grabbed_torrents::record_grab_series_routes(db, &routes).await {
+            logger::warn(
+                db,
+                LogCategory::Library,
+                &format!(
+                    "auto-expand: failed to write route rows for '{}'",
+                    torrent_title
+                ),
+                &e.to_string(),
+            )
+            .await;
+        }
+
+    logger::info(
+        db,
+        LogCategory::Library,
+        &format!(
+            "Auto-expand: finished batch '{}' — {} sibling(s) added",
+            torrent_title, added
+        ),
+        &format!(
+            "parent='{}', siblings_considered={}, routes_written={}",
+            parent_title,
+            siblings_considered,
+            routes.len()
+        ),
+    )
+    .await;
+
+    added
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::anilist::RelatedEntry;
+
+    fn empty_anime_detail(id: i64, title_english: &str, episodes: Option<i32>) -> AnimeDetail {
+        AnimeDetail {
+            id,
+            id_mal: None,
+            title_romaji: title_english.to_string(),
+            title_english: title_english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            banner_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes,
+            duration: Some(24),
+            season: String::new(),
+            season_year: Some(2014),
+            end_year: Some(2014),
+            description: String::new(),
+            genres: Vec::new(),
+            average_score: None,
+            average_score_display: None,
+            score_is_ten_point: false,
+            score_class: String::new(),
+            next_airing_episode: None,
+            next_airing_at: None,
+            synonyms: Vec::new(),
+            streaming_episodes: Vec::new(),
+            relations: Vec::new(),
+        }
+    }
+
+    fn related_entry(id: i64, title_english: &str, episodes: Option<i32>) -> RelatedEntry {
+        RelatedEntry {
+            id,
+            id_mal: None,
+            title_romaji: title_english.to_string(),
+            title_english: title_english.to_string(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            format: "TV".to_string(),
+            status: "FINISHED".to_string(),
+            status_display: "Finished".to_string(),
+            episodes,
+            relation_type: "SIDE_STORY".to_string(),
+            season_year: Some(2014),
+            media_type: "ANIME".to_string(),
+        }
+    }
+
+    /// Issue #45 follow-up: simulate the post-processing retry path.
+    /// Grab-time auto-expand failed (metadata wait timed out on a slow
+    /// tracker), so there's a parent series row + a grab row but no
+    /// route rows. post_processing::import_torrent calls
+    /// `expand_from_files` at import time with the file list qBit
+    /// finally returned. Verify that:
+    ///   1. the sibling (Egypt-hen) gets auto-added,
+    ///   2. sibling + parent routes get written,
+    ///   3. sibling route has offset=24 mapping E25..=E48 to local 1..=24.
+    ///
+    /// This is the path that would have rescued the
+    /// HorribleSubs JoJo P3 48-ep grab the user reported.
+    #[tokio::test]
+    async fn expand_from_files_rescues_grab_when_called_at_post_processing_time() {
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("in-memory sqlite");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (parent_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 20899,
+                mal_id: None,
+                title: "JoJo's Bizarre Adventure: Stardust Crusaders",
+                title_romaji: "JoJo no Kimyou na Bouken: Stardust Crusaders",
+                title_english: "JoJo's Bizarre Adventure: Stardust Crusaders",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(24),
+                season_year: Some(2014),
+                end_year: Some(2014),
+            },
+        )
+        .await
+        .expect("parent upsert");
+
+        // A grab row exists (the user did grab the pack) but no routes
+        // were written because grab-time auto-expand timed out.
+        let grab_id = grabbed_torrents::record_grab(
+            &db,
+            "slowtrackerhash000000000000000000000000000",
+            "[HorribleSubs] JoJo's Bizarre Adventure - Stardust Crusaders (1-48) [720p] (Unofficial Batch)",
+            parent_id,
+            &[],
+            true,
+        )
+        .await
+        .expect("record_grab")
+        .expect("grab inserted");
+
+        let routes_before = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert!(
+            routes_before.is_empty(),
+            "precondition: grab-time auto-expand failed, no routes yet"
+        );
+
+        let mut parent_detail = empty_anime_detail(
+            20899,
+            "JoJo's Bizarre Adventure: Stardust Crusaders",
+            Some(24),
+        );
+        parent_detail.relations.push(related_entry(
+            22663,
+            "JoJo's Bizarre Adventure: Stardust Crusaders - Egypt-hen",
+            Some(24),
+        ));
+
+        let filenames: Vec<String> = (1..=48)
+            .map(|n| format!("[HorribleSubs] JoJo Stardust - {:02} [720p].mkv", n))
+            .collect();
+
+        let ctx = AutoExpandGrabContext {
+            classification: ClassificationResult::unknown(),
+            release_group: String::new(),
+            size_bytes: 0,
+        };
+
+        let added = expand_from_files(
+            &db,
+            &filenames,
+            &parent_detail,
+            parent_id,
+            &(1..=24).collect::<Vec<_>>(),
+            grab_id,
+            "[HorribleSubs] JoJo P3 (1-48)",
+            &ctx,
+        )
+        .await;
+
+        assert_eq!(added, 1, "Egypt-hen should be auto-added at retry time");
+
+        let routes = grabbed_torrents::get_series_routes(&db, grab_id)
+            .await
+            .expect("get_series_routes");
+        assert_eq!(routes.len(), 2, "sibling + parent route written");
+
+        let sibling_route = routes
+            .iter()
+            .find(|r| r.series_id != parent_id)
+            .expect("sibling route present");
+        assert_eq!(
+            sibling_route.episode_offset, 24,
+            "absolute numbering → offset = parent_cap = 24"
+        );
+        assert_eq!(
+            sibling_route.episode_numbers,
+            (1..=24).collect::<Vec<_>>(),
+            "sibling eps 25..=48 map to local 1..=24"
+        );
+
+        let parent_route = routes
+            .iter()
+            .find(|r| r.series_id == parent_id)
+            .expect("parent route present");
+        assert_eq!(parent_route.file_indices, (0..=23).collect::<Vec<_>>());
+        assert_eq!(parent_route.episode_offset, 0);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -8,6 +8,7 @@ pub mod kitsu;
 
 pub mod jellyfin;
 
+pub mod auto_expand;
 pub mod auto_search;
 pub mod logger;
 pub mod progress;

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -346,45 +346,76 @@ async fn import_torrent(
     // file falling back to the parent. Motivating case (#45): the
     // HorribleSubs JoJo P3 48-ep pack, where the grab-time wait timed
     // out and Egypt-hen never got auto-added.
-    if routes.is_empty() && grab.is_batch && grab.series_id > 0
-        && let Ok(Some(cached)) =
-            metadata_cache::get_by_series_id(&state.db, grab.series_id).await
-    {
-        let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
-        let parent_eps: Vec<i32> = cached
-            .detail
-            .episodes
-            .filter(|n| *n > 0 && *n <= 1000)
-            .map(|n| (1..=n).collect())
-            .unwrap_or_default();
-        // Synthetic grab context. The per-episode tag rows
-        // `expand_from_files` writes for new siblings get their
-        // classifications overwritten by `classify_post_download`
-        // further down, so `ClassificationResult::unknown()` is fine
-        // here. Release group and size are recoverable via post-
-        // download paths too.
-        let ctx = crate::services::auto_expand::AutoExpandGrabContext {
-            classification: crate::services::source::ClassificationResult::unknown(),
-            release_group: String::new(),
-            size_bytes: 0,
-        };
-        let _ = crate::services::auto_expand::expand_from_files(
-            &state.db,
-            &filenames,
-            &cached.detail,
-            grab.series_id,
-            &parent_eps,
-            grab.id,
-            &grab.torrent_name,
-            &ctx,
-        )
-        .await;
-        // Reload regardless of return value: `expand_from_files`
-        // writes routes when it detects siblings even if those
-        // siblings were already tracked (added=0 but routes written).
-        routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
-            .await
-            .unwrap_or_default();
+    if routes.is_empty() && grab.is_batch && grab.series_id > 0 {
+        match metadata_cache::get_by_series_id(&state.db, grab.series_id).await {
+            Ok(Some(cached)) => {
+                let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
+                let parent_eps: Vec<i32> = cached
+                    .detail
+                    .episodes
+                    .filter(|n| *n > 0 && *n <= 1000)
+                    .map(|n| (1..=n).collect())
+                    .unwrap_or_default();
+                // Synthetic grab context. The per-episode tag rows
+                // `expand_from_files` writes for new siblings get
+                // their classifications overwritten by
+                // `classify_post_download` further down, so
+                // `ClassificationResult::unknown()` is fine here.
+                // Release group and size are recoverable via post-
+                // download paths too.
+                let ctx = crate::services::auto_expand::AutoExpandGrabContext {
+                    classification: crate::services::source::ClassificationResult::unknown(),
+                    release_group: String::new(),
+                    size_bytes: 0,
+                };
+                let _ = crate::services::auto_expand::expand_from_files(
+                    &state.db,
+                    &filenames,
+                    &cached.detail,
+                    grab.series_id,
+                    &parent_eps,
+                    grab.id,
+                    &grab.torrent_name,
+                    &ctx,
+                )
+                .await;
+                // Reload regardless of return value: `expand_from_files`
+                // writes routes when it detects siblings even if those
+                // siblings were already tracked (added=0 but routes
+                // written).
+                routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
+                    .await
+                    .unwrap_or_default();
+            }
+            Ok(None) => {
+                // Rare but possible: a grab landed before the metadata
+                // sync populated the cache for this series. Log so
+                // operators can trace "batch imported but siblings
+                // never added" without reading the code.
+                logger::debug(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!(
+                        "Auto-expand retry skipped for '{}' — no cached AniList detail for parent series_id={}",
+                        grab.torrent_name, grab.series_id,
+                    ),
+                    "",
+                )
+                .await;
+            }
+            Err(e) => {
+                logger::debug(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!(
+                        "Auto-expand retry skipped for '{}' — metadata_cache lookup failed for parent series_id={}",
+                        grab.torrent_name, grab.series_id,
+                    ),
+                    &e.to_string(),
+                )
+                .await;
+            }
+        }
     }
 
     // file_idx → (target series_id, episode_offset), flattened from

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -315,15 +315,77 @@ async fn import_torrent(
     torrent_hash: &str,
     torrent_save_path: &str,
 ) -> Result<bool, String> {
+    let qbit = state
+        .qbit
+        .read()
+        .await
+        .clone()
+        .ok_or("qBittorrent not configured")?;
+
+    let files = qbit
+        .get_torrent_files(torrent_hash)
+        .await
+        .map_err(|e| format!("get torrent files: {}", e))?;
+
     // Phase 2: look up per-file routing rows written by the auto-expand
     // path. A non-empty result means this grab was an auto-expanded
     // batch and each file is tagged with the sibling series_id it
     // belongs to; an empty result is the legacy path where every file
     // routes to `grab.series_id` (pre-Phase-2 grabs, or Phase-2 grabs
     // where sibling detection returned nothing).
-    let routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
+    let mut routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
         .await
         .unwrap_or_default();
+
+    // Grab-time auto-expand can fail when qBit's metadata wait times
+    // out on a slow tracker (see the 180s wait in
+    // `handlers::library::search::auto_expand_library_from_pack`). By
+    // import time the file list is always available — if the grab was
+    // a batch and no routes were written, retry sibling detection now
+    // so siblings still land in their own folders instead of every
+    // file falling back to the parent. Motivating case (#45): the
+    // HorribleSubs JoJo P3 48-ep pack, where the grab-time wait timed
+    // out and Egypt-hen never got auto-added.
+    if routes.is_empty() && grab.is_batch && grab.series_id > 0
+        && let Ok(Some(cached)) =
+            metadata_cache::get_by_series_id(&state.db, grab.series_id).await
+    {
+        let filenames: Vec<String> = files.iter().map(|f| f.name.clone()).collect();
+        let parent_eps: Vec<i32> = cached
+            .detail
+            .episodes
+            .filter(|n| *n > 0 && *n <= 1000)
+            .map(|n| (1..=n).collect())
+            .unwrap_or_default();
+        // Synthetic grab context. The per-episode tag rows
+        // `expand_from_files` writes for new siblings get their
+        // classifications overwritten by `classify_post_download`
+        // further down, so `ClassificationResult::unknown()` is fine
+        // here. Release group and size are recoverable via post-
+        // download paths too.
+        let ctx = crate::services::auto_expand::AutoExpandGrabContext {
+            classification: crate::services::source::ClassificationResult::unknown(),
+            release_group: String::new(),
+            size_bytes: 0,
+        };
+        let _ = crate::services::auto_expand::expand_from_files(
+            &state.db,
+            &filenames,
+            &cached.detail,
+            grab.series_id,
+            &parent_eps,
+            grab.id,
+            &grab.torrent_name,
+            &ctx,
+        )
+        .await;
+        // Reload regardless of return value: `expand_from_files`
+        // writes routes when it detects siblings even if those
+        // siblings were already tracked (added=0 but routes written).
+        routes = grabbed_torrents::get_series_routes(&state.db, grab.id)
+            .await
+            .unwrap_or_default();
+    }
 
     // file_idx → (target series_id, episode_offset), flattened from
     // the routes table. `episode_offset` is subtracted from each
@@ -343,18 +405,6 @@ async fn import_torrent(
                 .map(move |i| (*i, (series_id, offset)))
         })
         .collect();
-
-    let qbit = state
-        .qbit
-        .read()
-        .await
-        .clone()
-        .ok_or("qBittorrent not configured")?;
-
-    let files = qbit
-        .get_torrent_files(torrent_hash)
-        .await
-        .map_err(|e| format!("get torrent files: {}", e))?;
 
     // Preserve the canonical qBit file index alongside each entry so
     // completed files can be correlated back to their route row. qBit


### PR DESCRIPTION
Closes #45.

Two failure modes surfaced in the issue. One was already in the codebase as a latent UI bug; the second the user hit in production (HorribleSubs JoJo P3 48-ep batch).

## 1. AL says 12 eps, BD has 13 files — parent's extra file was invisible

Routing worked (sibling got `offset=13`, S2 maps to local 1–7 via `min_ep-1`; parent got all 13 files including the 'extra' E13). But `pages::build_episodes` looped strictly \`1..=ep_count\` so the parent's E13 lived on disk, had its grab-tag row, and never rendered.

**Fix:** after the main loop, surface any on-disk file whose ep isn't already rendered. Folds in the old \`ep_count == 0\` branch as a special case. Pinned by \`build_episodes_surfaces_on_disk_files_beyond_anilist_episode_count\` + regression guard.

The offset being 13 (not \`parent_cap=12\`) comes from \`min_ep - 1\` in \`compute_sibling_episode_offset\` — anchored on the release's own numbering, not AL's count. That's exactly what makes AL-vs-BD disagreements not break the sibling side.

## 2. HorribleSubs batch: grab-time metadata wait timed out → Egypt-hen lost

User's log:

\`\`\`
Grabbed batch (interactive): [HorribleSubs] JoJo's ... Stardust Crusaders (1-48)
auto-expand: metadata wait failed for '...', skipping sibling detection
  (fallback: all files will route to parent series_id=12)
  detail=\"qbit metadata fetch timed out after 60s\"
\`\`\`

Slow tracker → qBit couldn't fetch metadata inside the 60s wait → auto-expand bailed → post-processing's legacy single-series path routed all 48 files to Stardust → Egypt-hen never got auto-added.

**Two changes to make grab-time metadata failures non-fatal:**

- Extract the core expansion into \`services::auto_expand\` so it's callable from both handler and service layers. \`handlers::library::search::auto_expand_library_from_pack\` becomes the thin grab-time wrapper that does the qBit wait; the inner \`expand_from_files\` is pure and shareable.
- Retry in \`services::post_processing::import_torrent\`: when \`routes\` is empty and the grab is a batch, call \`expand_from_files\` with the file list qBit just returned (available by definition — import is about to move files). If siblings are detected now, routes get written and the regular import loop picks them up.

Also bumped the grab-time metadata-wait timeout from 60s to 180s; slow-DHT magnets need more than a minute. The retry fallback catches the long-tail cases where even 180s isn't enough. Pinned by \`expand_from_files_rescues_grab_when_called_at_post_processing_time\` which simulates the exact user scenario.

## Changes
- \`handlers/library/pages.rs\`: surface-beyond-ep_count pass in \`build_episodes\`.
- \`services/auto_expand.rs\` (new): extracted \`expand_from_files\` + \`AutoExpandGrabContext\`.
- \`handlers/library/search.rs\`: thin grab-time wrapper delegates to \`services::auto_expand\`; timeout bumped 60s → 180s; log level demoted to info since the failure is now recoverable.
- \`services/post_processing.rs\`: retry fallback in \`import_torrent\`.
- 5 new tests total across the affected files.

## Test plan
- [x] \`cargo test\` — 485 passed (480 baseline + 5 new)
- [x] Smoke the Owari-merged-ep case: series whose disk folder has one more file than AL reports, confirm the extra row renders with \`on_disk = true\`
- [x] Re-grab the HorribleSubs JoJo P3 48-ep pack and confirm Egypt-hen gets auto-added by post-processing even if grab-time metadata wait times out

## Known limitation (out of scope)
The overflow row renders but doesn't get an episode title (AL only knows 12 eps) and doesn't have a monitoring row (\`ensure_series_monitoring_rows\` seeds 1..=ep_count). Title is cosmetic; monitoring would need a per-file override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)