### PR TITLE
feat(classifier): unify WEB label, drop WebDl group seeding (#48)

### DIFF
--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -113,8 +113,8 @@ pub struct Episode {
     pub monitored: bool,
     /// Phase 4 classification columns — exposed to the template so the
     /// manual override picker can pre-select the current values. The
-    /// override dropdown's composite key (e.g. "bluray_remux", "web_dl")
-    /// is derived from this quartet in the template JS.
+    /// override dropdown's composite key (e.g. "bluray_remux", "web",
+    /// "webrip") is derived from this quartet in the template JS.
     pub class_source: String,
     pub class_resolution: String,
     pub class_is_remux: bool,

--- a/src/models/group_source_map.rs
+++ b/src/models/group_source_map.rs
@@ -23,15 +23,20 @@ pub struct GroupSourceEntry {
     pub is_user_edit: bool,
     pub notes: String,
     /// Optional Web sub-tier hint. Set on groups that ship **exclusively**
-    /// direct stream remuxes (WEB-DL) or exclusively re-encoded WEB
-    /// releases (WEB-Rip). Ignored unless `source == Source::Web`.
+    /// re-encoded WEB releases (WEB-Rip). Ignored unless
+    /// `source == Source::Web`.
     ///
-    /// Lets the aggregator distinguish `WEBDL-1080p` from a plain
-    /// `WEB-1080p` label when the filename itself carries no explicit
-    /// `WEB-DL` / `WEBRip` token — the SubsPlease / HorribleSubs
-    /// convention of just `(1080p)` in the release name was leaving
-    /// every Web release labelled as the generic tier, even though
-    /// those groups are always direct CR/HIDIVE remuxes.
+    /// Since issue #48 the aggregator's label layer no longer
+    /// distinguishes `WEBDL` from bare `WEB` — both render as
+    /// `WEB-1080p`. The only remaining role of `web_kind = WebDl` on
+    /// a group is CF `SourceSpecification` value-3 matching, and
+    /// since the post-#48 predicate widened value 3 to match any
+    /// `Source::Web && !WebRip`, even that hint isn't load-bearing
+    /// for CFs — bare-Web releases already match. The column is kept
+    /// for the `WebRip` side (groups that consistently ship re-
+    /// encoded WEB) so the value-4 CF path can still gate on group
+    /// identity without a filename token, and for future re-
+    /// introduction of sub-tier-specific behavior.
     pub web_kind: WebKind,
 }
 

--- a/src/models/group_source_map.rs
+++ b/src/models/group_source_map.rs
@@ -35,18 +35,19 @@ pub struct GroupSourceEntry {
     pub web_kind: WebKind,
 }
 
-/// Known-WEB-DL / -WEB-Rip groups, layered on top of `SEED_DEFAULTS` by
-/// the seed pass. A group only appears here when its output is
-/// consistently one sub-tier — most groups mix (Erai-raws ships both
-/// AVC remuxes and HEVC re-encodes, filename tokens distinguish;
-/// Judas mixes BD and WEB). Those get left as `WebKind::Unknown` so
-/// the filename / ffprobe layers stay authoritative.
-pub const SEED_WEB_KIND: &[(&str, WebKind)] = &[
-    // Direct simulcast stream remuxes — `.mkv` with softsubs overlaid,
-    // video bitstream untouched from the CR/HIDIVE source.
-    ("SubsPlease", WebKind::WebDl),
-    ("HorribleSubs", WebKind::WebDl),
-];
+/// Known-WEB-Rip groups, layered on top of `SEED_DEFAULTS` by the seed
+/// pass. A group only appears here when its output is consistently one
+/// sub-tier.
+///
+/// WebDl seeding was dropped (issue #48): the classifier's output
+/// didn't change behavior enough to justify the UI asymmetry between
+/// "WEBDL-1080p" (for seeded groups) and plain "WEB-1080p" (for
+/// everyone else), and the group-map seeding was the only path that
+/// produced WebDl without an explicit title token. Explicit-token
+/// detection still fires in `source_filename.rs`; this slice is just
+/// for groups whose filenames omit the token but whose sub-tier is
+/// known. Currently empty — add WebRip-only groups here if needed.
+pub const SEED_WEB_KIND: &[(&str, WebKind)] = &[];
 
 // ─────────────────────────────────────────────────────────────────────────
 // Seed data

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1185,13 +1185,14 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // Rewrite denormalized `quality_tag` strings on pre-existing
     // `episode_quality_tags` / `episode_grab_history` rows to match the
     // Sonarr-parity label format the classifier now emits:
-    // `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEBDL-1080p`,
-    // `WEBRip-1080p`, `WEB-1080p`, `HDTV-1080p`, `DVD-480p`, etc. This
-    // migration bridges two prior schemas: (1) very old space-joined
-    // rows like "BluRay 1080p" / "WEB-DL 1080p", and (2) the
-    // intermediate dash-joined rename (`BD-Remux-1080p`, `BD-RAW-1080p`,
+    // `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEB-1080p`,
+    // `WEBRip-1080p`, `HDTV-1080p`, `DVD-480p`, etc. This migration
+    // bridges three prior schemas: (1) very old space-joined rows
+    // like "BluRay 1080p" / "WEB-DL 1080p", (2) the intermediate
+    // dash-joined rename (`BD-Remux-1080p`, `BD-RAW-1080p`,
     // `WEBRIP-1080p`) that shipped briefly before the Sonarr-parity
-    // reorder landed.
+    // reorder landed, and (3) the post-#48 `WEBDL-1080p` intermediate
+    // that was subsequently unified into bare `WEB-1080p`.
     //
     // `episode_quality_tags` has the structured source/resolution/
     // web_kind/is_remux/is_bdmv columns, so we regenerate `quality_tag`
@@ -1279,7 +1280,7 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     //
     //   Pass A — normalize legacy space-joined tokens to the
     //            intermediate dash-joined form ("BluRay BDMV 1080p" →
-    //            "BD-RAW-1080p", "WEB-DL 1080p" → "WEBDL-1080p", etc.).
+    //            "BD-RAW-1080p", "WEB-DL 1080p" → "WEB-1080p", etc.).
     //            Only the BluRay BDMV/Remux/plain and WEB variants need
     //            ordering care: the qualified BluRay patterns must fire
     //            before the generic "BluRay " prefix is stripped.
@@ -1289,8 +1290,14 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     //            needs one entry per supported resolution because it
     //            can't swap tokens generically.
     //
-    // The straggler "WEBRIP-" → "WEBRip-" entry at the end fixes the
-    // all-caps intermediate form left by the prior rename pass.
+    // Straggler entries at the end:
+    //  - "WEBRIP-" → "WEBRip-" fixes the all-caps form from the pre-
+    //    Sonarr-parity rename pass.
+    //  - `WEBDL-<res>` → `WEB-<res>` (one per `Resolution::as_str()`
+    //    output: 480p/576p/720p/1080p/2160p) catches DBs that booted
+    //    the intermediate `WEBDL-` build between issue #48's
+    //    unification and this migration. Add a new resolution here
+    //    if the `Resolution` enum ever gains one.
     for (old, new) in [
         // ── Pass A: legacy space-joined → intermediate dash form ──
         ("BluRay BDMV ", "BD-RAW-"),

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1227,7 +1227,6 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
                     WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd') THEN 'BD'
                     WHEN LOWER(source) = 'web' THEN
                         CASE
-                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webdl', 'web-dl', 'web.dl') THEN 'WEBDL'
                             WHEN LOWER(COALESCE(web_kind, '')) IN ('webrip', 'web-rip', 'web.rip') THEN 'WEBRip'
                             ELSE 'WEB'
                         END
@@ -1253,7 +1252,6 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
                     WHEN LOWER(source) IN ('bluray', 'blu-ray', 'bd') THEN 'BD'
                     WHEN LOWER(source) = 'web' THEN
                         CASE
-                            WHEN LOWER(COALESCE(web_kind, '')) IN ('webdl', 'web-dl', 'web.dl') THEN 'WEBDL'
                             WHEN LOWER(COALESCE(web_kind, '')) IN ('webrip', 'web-rip', 'web.rip') THEN 'WEBRip'
                             ELSE 'WEB'
                         END
@@ -1298,7 +1296,10 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         ("BluRay BDMV ", "BD-RAW-"),
         ("BluRay Remux ", "BD-Remux-"),
         ("BluRay ", "BD-"),
-        ("WEB-DL ", "WEBDL-"),
+        // WebDl collapses to the bare "WEB" label (issue #48), so
+        // legacy "WEB-DL 1080p" strings rewrite straight to the new
+        // unified form, skipping the old "WEBDL-" intermediate.
+        ("WEB-DL ", "WEB-"),
         ("WEBRip ", "WEBRip-"),
         ("Web ", "WEB-"),
         ("HDTV ", "HDTV-"),
@@ -1317,6 +1318,14 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         ("BD-Remux-2160p", "BD-2160p Remux"),
         // Case-fix stragglers from the intermediate all-caps form.
         ("WEBRIP-", "WEBRip-"),
+        // Issue #48: collapse any stored `WEBDL-<res>` strings
+        // (written by prior builds) to `WEB-<res>`. Needs one entry
+        // per resolution because REPLACE is a dumb substring swap.
+        ("WEBDL-480p", "WEB-480p"),
+        ("WEBDL-576p", "WEB-576p"),
+        ("WEBDL-720p", "WEB-720p"),
+        ("WEBDL-1080p", "WEB-1080p"),
+        ("WEBDL-2160p", "WEB-2160p"),
     ] {
         let like_pat = format!("%{}%", old);
         let _ = sqlx::query(

--- a/src/services/auto_search.rs
+++ b/src/services/auto_search.rs
@@ -5921,7 +5921,7 @@ mod tests {
     fn pinned_720p_web_tag(manual_override: bool) -> crate::models::episode_tags::EpisodeQualityTag {
         crate::models::episode_tags::EpisodeQualityTag {
             episode_number: 1,
-            quality_tag: "WEBDL-720p".to_string(),
+            quality_tag: "WEB-720p".to_string(),
             release_title: "[Group] Show - 01 [WEB-DL 720p].mkv".to_string(),
             release_group: "Group".to_string(),
             state: "completed".to_string(),

--- a/src/services/custom_formats.rs
+++ b/src/services/custom_formats.rs
@@ -406,7 +406,18 @@ fn evaluate_spec_kernel(spec: &CompiledSpec, ctx: &EvalContext) -> bool {
             match sonarr_value {
                 0 => c.source == Source::Unknown,
                 1 => matches!(c.source, Source::Hdtv | Source::Tv),
-                3 => c.source == Source::Web && c.web_kind == WebKind::WebDl,
+                // Sonarr's `SourceSpecification` value 3 is strict
+                // WebDl in vanilla Sonarr. Ryokan unifies WebDl and
+                // bare Web at the label layer (issue #48) because the
+                // filename-token-or-not asymmetry was confusing users.
+                // The CF evaluator mirrors that: value 3 fires on any
+                // Source::Web that isn't explicitly WebRip, so TRaSH
+                // `anime-web-tier-*` CFs still match SubsPlease /
+                // HorribleSubs / every other WEB release regardless
+                // of whether the filename carried a `WEB-DL` token.
+                // Value 4 stays strict WebRip so penalty CFs only fire
+                // on the lower-quality sub-tier.
+                3 => c.source == Source::Web && c.web_kind != WebKind::WebRip,
                 4 => c.source == Source::Web && c.web_kind == WebKind::WebRip,
                 5 => c.source == Source::Dvd,
                 6 => c.source == Source::BluRay && !c.is_bdmv,
@@ -996,11 +1007,20 @@ mod tests {
 
         assert!(evaluate(&webdl_cf, &ctx(&cand, &webdl, &hashes)));
         assert!(!evaluate(&webdl_cf, &ctx(&cand, &webrip, &hashes)));
-        assert!(!evaluate(&webdl_cf, &ctx(&cand, &bare, &hashes)));
+        // Issue #48: bare-WEB matches the WebDl CF spec. The label
+        // layer collapsed WebDl and bare Web into a single "WEB"
+        // render, so extending value-3 matching to cover both keeps
+        // TRaSH `anime-web-tier-*` CFs functional for SubsPlease /
+        // HorribleSubs / every release whose filename doesn't carry a
+        // `WEB-DL` token. Previously bare-WEB matched nothing in the
+        // source-spec space and those releases silently scored zero.
+        assert!(evaluate(&webdl_cf, &ctx(&cand, &bare, &hashes)));
 
         assert!(evaluate(&webrip_cf, &ctx(&cand, &webrip, &hashes)));
         assert!(!evaluate(&webrip_cf, &ctx(&cand, &webdl, &hashes)));
-        // Bare-WEB deliberately matches neither (plan §4.5).
+        // WebRip stays strict — only explicit-WebRip releases match
+        // the value-4 CF, so penalty CFs fire only on the lower-
+        // quality sub-tier.
         assert!(!evaluate(&webrip_cf, &ctx(&cand, &bare, &hashes)));
     }
 

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -773,4 +773,50 @@ mod tests {
             Some((Some(0), 18))
         );
     }
+
+    // ── parse_quality branch ordering (issue #48) ────────────────────
+    //
+    // The unified-WEB branch in `parse_quality` uses `.contains("web")`
+    // which would swallow a WEBRip filename if evaluated first. These
+    // tests lock in the WebRip-before-unified-Web ordering — any
+    // reshuffle that lets a WebRip filename resolve as plain "WEB"
+    // would silently downgrade the label and potentially mislabel the
+    // release for scoring/upgrade decisions.
+
+    #[test]
+    fn parse_quality_webrip_wins_over_bare_web_branch() {
+        use super::parse_quality;
+        assert_eq!(
+            parse_quality("show.s01e01.web-rip.1080p.group.mkv"),
+            "WEBRip-1080p"
+        );
+        assert_eq!(
+            parse_quality("show.s01e01.webrip.1080p.group.mkv"),
+            "WEBRip-1080p"
+        );
+    }
+
+    #[test]
+    fn parse_quality_webdl_and_bare_web_both_render_as_web() {
+        use super::parse_quality;
+        // Issue #48 unified WebDl and bare-WEB to the same "WEB" label.
+        assert_eq!(
+            parse_quality("show.s01e01.web-dl.1080p.group.mkv"),
+            "WEB-1080p"
+        );
+        assert_eq!(
+            parse_quality("show.s01e01.webdl.1080p.group.mkv"),
+            "WEB-1080p"
+        );
+        assert_eq!(
+            parse_quality("[subsplease] show - 01 (1080p) [abcd].mkv"),
+            "1080p", // no WEB token in the filename → source stays blank
+        );
+        // A title that has `WEB` as its only source token resolves to
+        // the unified WEB label.
+        assert_eq!(
+            parse_quality("show.s01e01.web.1080p.group.mkv"),
+            "WEB-1080p"
+        );
+    }
 }

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -338,17 +338,21 @@ pub fn parse_episode_number(lower: &str) -> Option<(Option<i32>, i32)> {
 fn parse_quality(lower: &str) -> String {
     // Source type. Names match `ClassificationResult::label()` in
     // `source.rs` so disk-scanned fallback strings render the same as
-    // classifier-derived ones ("BD-1080p", "WEBDL-1080p", etc.). This
+    // classifier-derived ones ("BD-1080p", "WEB-1080p", etc.). This
     // path can't distinguish BD Remux / BD-RAW from filename tokens
     // alone; the classifier handles those through the structured
     // columns so the quality shown for a properly-classified episode
     // comes from `tag.quality_tag`, not from here.
     let source = if lower.contains("bluray") || lower.contains("blu-ray") || lower.contains("bdrip") || lower.contains("[bd") || lower.contains("(bd") {
         "BD"
-    } else if lower.contains("webdl") || lower.contains("web-dl") || lower.contains("web dl") {
-        "WEBDL"
     } else if lower.contains("webrip") || lower.contains("web-rip") {
         "WEBRip"
+    } else if lower.contains("webdl") || lower.contains("web-dl") || lower.contains("web dl") || lower.contains("web") {
+        // Unified WEB label — matches `ClassificationResult::label()`
+        // which collapses WebDl and bare Web into the same output
+        // (issue #48). WebRip stays distinct above because it's the
+        // lower-quality sub-tier power users want to spot.
+        "WEB"
     } else if lower.contains("hdtv") {
         "HDTV"
     } else if lower.contains("dvdrip") || lower.contains("dvd") {

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -808,9 +808,10 @@ mod tests {
             parse_quality("show.s01e01.webdl.1080p.group.mkv"),
             "WEB-1080p"
         );
+        // No WEB token in the filename → source stays blank.
         assert_eq!(
             parse_quality("[subsplease] show - 01 (1080p) [abcd].mkv"),
-            "1080p", // no WEB token in the filename → source stays blank
+            "1080p"
         );
         // A title that has `WEB` as its only source token resolves to
         // the unified WEB label.

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -106,7 +106,7 @@ pub struct SearchResult {
     /// for UI callers that render just the resolution tag; richer callers
     /// should use `quality_label` which encodes source+resolution+sub-tier.
     pub resolution: String,
-    /// Pre-computed Sonarr-parity label (`WEBDL-1080p`, `BD-1080p Remux`,
+    /// Pre-computed Sonarr-parity label (`WEB-1080p`, `BD-1080p Remux`,
     /// etc.) produced from the same [`crate::services::source::ClassificationResult::label`]
     /// logic as the grab-side pipeline, so the value the user sees in
     /// interactive search equals the value persisted once grabbed.

--- a/src/services/nyaa.rs
+++ b/src/services/nyaa.rs
@@ -447,15 +447,16 @@ pub async fn enrich_results_with_group_map(
             } else {
                 Resolution::from_str(&format!("{}p", r.resolution))
             };
-            // Web releases use the group table's web_kind hint (#33) so
-            // SubsPlease / HorribleSubs uploads label as `WEBDL` in
-            // interactive search instead of the generic `WEB`, matching
-            // the post-download classifier's output on the same files.
+            // Web releases unify the WebDl and bare-WEB sub-tiers into
+            // a single "WEB" label (issue #48) — matches
+            // `ClassificationResult::label()`. WebRip stays distinct
+            // because it's the lower-quality sub-tier power users want
+            // to spot.
             let source_label = match src {
                 Source::Web => match web_kind {
-                    crate::services::source::WebKind::WebDl => "WEBDL".to_string(),
                     crate::services::source::WebKind::WebRip => "WEBRip".to_string(),
-                    crate::services::source::WebKind::Unknown => "WEB".to_string(),
+                    crate::services::source::WebKind::Unknown
+                    | crate::services::source::WebKind::WebDl => "WEB".to_string(),
                 },
                 Source::BluRay => "BD".to_string(),
                 other => other.as_str().to_string(),
@@ -859,8 +860,11 @@ mod tests {
         let c = classify_search_result("Show Name - 01 (1080p) [WEB-DL].mkv");
         assert_eq!(c.resolution, "1080");
         assert_eq!(c.source, "Web");
+        // web_kind still tracks WebDl internally so CF value-3 specs
+        // match releases with explicit WEB-DL tokens. The user-facing
+        // label collapses WebDl and bare-WEB into "WEB" (issue #48).
         assert_eq!(c.web_kind, "WEB-DL");
-        assert_eq!(c.quality_label, "WEBDL-1080p");
+        assert_eq!(c.quality_label, "WEB-1080p");
     }
 
     #[test]
@@ -917,11 +921,12 @@ mod tests {
         enrich_results_with_group_map(&pool, &mut results).await;
 
         assert_eq!(results[0].source, "Web");
-        // SubsPlease ships WEB-DL exclusively (direct CR/HIDIVE stream
-        // remuxes) and the group table carries that hint, so the
-        // label resolves to the specific `WEBDL` tier rather than the
-        // generic `WEB` one.
-        assert_eq!(results[0].quality_label, "WEBDL-1080p");
+        // Issue #48: the SubsPlease WebDl seed was dropped — the
+        // distinction between "WEBDL" and "WEB" labels was more
+        // confusing than useful and nothing in the file list said
+        // the release was a stream remux vs a re-encode. The group
+        // map still pins Source::Web; the label unifies to WEB.
+        assert_eq!(results[0].quality_label, "WEB-1080p");
     }
 
     #[tokio::test]

--- a/src/services/source/mod.rs
+++ b/src/services/source/mod.rs
@@ -1119,7 +1119,10 @@ mod tests {
         let webdl = ClassificationResult { web_kind: WebKind::WebDl, ..webrip.clone() };
         assert!(webdl.rank() > webrip.rank());
         assert_eq!(webrip.label(), "WEBRip-1080p");
-        assert_eq!(webdl.label(), "WEBDL-1080p");
+        // WebDl collapses to bare "WEB" at the label layer (issue #48);
+        // the rank tiebreaker above still distinguishes it from
+        // Unknown so CF matching and scoring continue to work.
+        assert_eq!(webdl.label(), "WEB-1080p");
     }
 
     #[test]

--- a/src/services/source/types.rs
+++ b/src/services/source/types.rs
@@ -505,8 +505,8 @@ impl ClassificationResult {
 
     /// Human-readable label for logs and UI. Sonarr-style `SOURCE-RES`
     /// base with an optional space-separated BluRay sub-tier suffix:
-    /// `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEBDL-1080p`,
-    /// `WEBRip-1080p`, `WEB-1080p`, `HDTV-1080p`, `DVD-480p`, etc.
+    /// `BD-1080p`, `BD-1080p Remux`, `BD-1080p RAW`, `WEB-1080p`,
+    /// `WEBRip-1080p`, `HDTV-1080p`, `DVD-480p`, etc.
     ///
     /// Keeping the resolution adjacent to the source (rather than
     /// appending it after the sub-tier) preserves parity with Sonarr's
@@ -514,9 +514,16 @@ impl ClassificationResult {
     /// as the immutable key and bolt any Remux qualifier on afterward.
     ///
     /// Source rendering is variant-aware:
-    /// - `Source::Web` with a known `web_kind` displays as "WEBDL" or
-    ///   "WEBRip" (Sonarr-style, no internal hyphen) instead of the
-    ///   bare "WEB" fallback.
+    /// - `Source::Web` renders as bare `"WEB"` regardless of whether
+    ///   the internal `web_kind` is `WebDl` or `Unknown` — most users
+    ///   don't care about the distinction and seeing `WEBDL-1080p` on
+    ///   some releases but `WEB-1080p` on others (based on whether the
+    ///   filename happened to carry the token) produced more confusion
+    ///   than information (issue #48). The `WebRip` variant DOES render
+    ///   as `"WEBRip"` because that's the lower-quality sub-tier power
+    ///   users want to spot. `web_kind` is still tracked internally so
+    ///   Sonarr Custom Format `SourceSpecification` value 3 (WebDl)
+    ///   still matches releases with explicit `WEB-DL` tokens.
     /// - `Source::BluRay` always renders as `BD` with at most one
     ///   trailing space-separated qualifier, mutually exclusive:
     ///   ` RAW` if `is_bdmv` (highest tier — full disc), else
@@ -526,9 +533,11 @@ impl ClassificationResult {
         let source_label: String = match self.source {
             Source::Unknown => String::new(),
             Source::Web => match self.web_kind {
-                WebKind::WebDl => "WEBDL".to_string(),
                 WebKind::WebRip => "WEBRip".to_string(),
-                WebKind::Unknown => "WEB".to_string(),
+                // WebDl collapses to bare "WEB" at the label layer —
+                // see the docstring above. The enum variant still
+                // exists for CF matching and rank tiebreakers.
+                WebKind::Unknown | WebKind::WebDl => "WEB".to_string(),
             },
             Source::BluRay => "BD".to_string(),
             other => other.as_str().to_string(),

--- a/src/services/source_groups.rs
+++ b/src/services/source_groups.rs
@@ -101,18 +101,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn subsplease_is_tagged_webdl() {
-        // Motivating case for the web_kind column: SubsPlease filenames
-        // carry no "WEB-DL" / "WEBRip" token, so the filename layer
-        // leaves web_kind Unknown. The group table provides the hint
-        // so the aggregator can label the release as WEBDL-1080p
-        // instead of the generic WEB-1080p.
+    async fn subsplease_has_no_web_kind_hint() {
+        // Issue #48: the SubsPlease / HorribleSubs WebDl seeds were
+        // removed so the UI no longer labels some WEB releases as
+        // "WEBDL" while others are plain "WEB" based on whether the
+        // filename token happened to be present. SubsPlease still
+        // classifies as Source::Web via the SEED_DEFAULTS table, but
+        // web_kind stays Unknown — the aggregator now renders a
+        // unified "WEB-1080p" label regardless of group.
         let db = test_pool().await;
         let cls = classify_group(&db, "SubsPlease")
             .await
-            .expect("SubsPlease should be seeded");
+            .expect("SubsPlease should be seeded as Source::Web");
         assert_eq!(cls.evidence.source, Source::Web);
-        assert_eq!(cls.web_kind, WebKind::WebDl);
+        assert_eq!(cls.web_kind, WebKind::Unknown);
     }
 
     #[tokio::test]
@@ -185,49 +187,4 @@ mod tests {
         assert!((cls.evidence.confidence - 0.80).abs() < f32::EPSILON);
     }
 
-    #[tokio::test]
-    async fn user_edited_row_keeps_web_kind_across_reseed() {
-        // SEED_WEB_KIND's UPDATE is gated on `is_user_edit = 0`, so a
-        // user-edited row should hang onto whatever web_kind it had
-        // before the user edit — including the empty default, which
-        // matters for groups the user wants to *remove* the WEB-DL
-        // hint from (e.g. reclassifying a group we tagged as WEB-DL
-        // that actually ships WEB-Rips).
-        let db = test_pool().await;
-
-        // Seed pass populated SubsPlease → (Web, WebDl).
-        let seeded = classify_group(&db, "SubsPlease")
-            .await
-            .expect("SubsPlease seeded");
-        assert_eq!(seeded.web_kind, WebKind::WebDl);
-
-        // User overrides source → is_user_edit flips to 1.
-        // `upsert_user_edit` doesn't touch `web_kind`, so whatever was
-        // there stays — that's the pin.
-        group_source_map::upsert_user_edit(
-            &db,
-            "SubsPlease",
-            Source::BluRay,
-            0.90,
-            "imaginary override",
-        )
-        .await
-        .expect("upsert user edit");
-
-        // Re-run the migration → seed pass attempts SEED_WEB_KIND
-        // update but the `is_user_edit = 0` filter excludes this row.
-        group_source_map::migrate(&db)
-            .await
-            .expect("re-migrate");
-
-        let after = classify_group(&db, "SubsPlease")
-            .await
-            .expect("user row survives re-migrate");
-        assert_eq!(after.evidence.source, Source::BluRay, "user source wins");
-        assert_eq!(
-            after.web_kind,
-            WebKind::WebDl,
-            "user-edited row's web_kind must survive the re-seed pass"
-        );
-    }
 }

--- a/templates/series.html
+++ b/templates/series.html
@@ -438,7 +438,7 @@
                         <option value="bluray_bdmv">BD-RAW</option>
                         <option value="bluray_remux">BD-Remux</option>
                         <option value="bluray">BD</option>
-                        <option value="web_dl">WEBDL</option>
+                        <option value="web">WEB</option>
                         <option value="webrip">WEBRIP</option>
                         <option value="dvd">DVD</option>
                         <option value="hdtv">HDTV</option>
@@ -989,7 +989,7 @@ function escHtml(s) {
 //     BDMV/BDISO/BD-Raw → `BD-1080p RAW`  (raw disc image)
 //     Remux             → `BD-1080p Remux`
 //     BluRay/BDRip/BD   → `BD-1080p`      (re-encode)
-//     WEB-DL            → `WEBDL-1080p`
+//     WEB-DL / WEB      → `WEB-1080p`     (unified — issue #48)
 //     WEB-Rip           → `WEBRip-1080p`
 // Note: BDRip is a re-encode and deliberately falls into the BluRay branch,
 // NOT the BDMV branch.
@@ -1003,11 +1003,12 @@ function parseQualityFromTitle(title, resolution) {
         source = 'BD'; suffix = ' Remux';
     } else if (/\b(BluRay|Blu-?Ray|BDRip|BD|\.BD\.|\[BD\])\b/i.test(t)) {
         source = 'BD';
-    } else if (/\bWEB-?DL\b/i.test(t)) {
-        source = 'WEBDL';
     } else if (/\bWEB-?Rip\b/i.test(t)) {
+        // Check WebRip before the bare WEB branch — WebRip is the
+        // lower-quality sub-tier and deserves its own label.
         source = 'WEBRip';
-    } else if (/\bWEB\b/i.test(t)) {
+    } else if (/\bWEB(?:-?DL)?\b/i.test(t)) {
+        // WebDl and bare WEB collapse into a single "WEB" label.
         source = 'WEB';
     } else if (/\bHDTV\b/i.test(t)) {
         source = 'HDTV';
@@ -1438,7 +1439,12 @@ const OVERRIDE_SOURCE_MAP = {
     bluray_bdmv: { source: 'BluRay', is_remux: false, is_bdmv: true,  web_kind: '' },
     bluray_remux:{ source: 'BluRay', is_remux: true,  is_bdmv: false, web_kind: '' },
     bluray:      { source: 'BluRay', is_remux: false, is_bdmv: false, web_kind: '' },
-    web_dl:      { source: 'Web',    is_remux: false, is_bdmv: false, web_kind: 'WEB-DL' },
+    // Issue #48: WebDl and bare WEB collapse into a single user-
+    // selectable option. The backend still tracks `web_kind` for CF
+    // matching, but the manual override picker only offers WEB vs
+    // WEBRip — if the user wants to pin a classification, they
+    // shouldn't have to reason about the WebDl distinction.
+    web:         { source: 'Web',    is_remux: false, is_bdmv: false, web_kind: '' },
     webrip:      { source: 'Web',    is_remux: false, is_bdmv: false, web_kind: 'WEBRip' },
     dvd:         { source: 'DVD',    is_remux: false, is_bdmv: false, web_kind: '' },
     hdtv:        { source: 'HDTV',   is_remux: false, is_bdmv: false, web_kind: '' },
@@ -1458,10 +1464,11 @@ function overrideKeyFromClassification(source, isRemux, isBdmv, webKind) {
         return 'bluray';
     }
     if (src === 'web') {
+        // WebRip gets its own key; everything else (bare WEB, WebDl,
+        // Unknown sub-kind) maps to the unified 'web' key.
         const wk = (webKind || '').toLowerCase();
-        if (wk === 'web-dl' || wk === 'webdl') return 'web_dl';
         if (wk === 'webrip') return 'webrip';
-        return 'web_dl';
+        return 'web';
     }
     if (src === 'dvd') return 'dvd';
     if (src === 'hdtv') return 'hdtv';


### PR DESCRIPTION
Closes #48.

## Summary

The WEB-DL vs bare-WEB distinction was showing up as \`WEBDL-1080p\` on some releases and \`WEB-1080p\` on others based on whether the filename token happened to be present — the asymmetry was confusing and the sub-tier difference doesn't matter to most users. WEBRip stays distinct because it's the lower-quality sub-tier worth spotting.

## Changes

### Label rendering
\`ClassificationResult::label()\` renders \`WebKind::WebDl\` as \`\"WEB\"\` (same as \`Unknown\`). The enum variant stays — CF matching and the rank tiebreaker still work. Internal distinction, unified UI.

### Group seeding removed
Dropped the SubsPlease + HorribleSubs WebDl entries from \`SEED_WEB_KIND\`. Those were the only groups pushing WebDl without a filename token, which produced the asymmetric labels. Slice is now empty; both groups still classify as \`Source::Web\` via \`SEED_DEFAULTS\`.

### CF value-3 widening (follow-up commit)
\`SourceSpecification\` value 3 in the CF evaluator was strict \`WebKind::WebDl\`. After dropping the group seeds, SubsPlease / HorribleSubs releases had \`WebKind::Unknown\` and silently stopped matching TRaSH \`anime-web-tier-*\` CFs — Sonarr's enum has no \"bare WEB\" value, only WebDl (3) and WebRip (4). Widened value 3 to \`Source::Web && web_kind != WebRip\` so any non-WebRip WEB release matches. Value 4 stays strict so penalty CFs only fire on the lower-quality sub-tier.

### Consistency across surfaces
- \`nyaa.rs::enrich_results_with_group_map\` — interactive-search labels unified
- \`media.rs::parse_quality\` — on-disk filename fallback unified
- Template JS \`parseQualityFromTitle\` — interactive-search tier preview unified
- Manual-override dropdown — replaced \`WEBDL\` option with a unified \`WEB\` option. \`WEBRIP\` stays its own option.

### Migration
- \`episode_quality_tags.quality_tag\`: idempotent UPDATE rewrites rows where source=Web to \`WEB-*p\`.
- \`episode_grab_history.quality_tag\`: legacy \`WEB-DL 1080p\` collapses straight to \`WEB-1080p\`. Per-resolution \`WEBDL-*p\` → \`WEB-*p\` entries catch DBs that booted the intermediate build.
- \`web_kind\` column values are left alone — keeping \`'WEB-DL'\` lets the widened CF value-3 continue matching existing rows.

## Test plan
- [x] \`cargo test\` — 488 passed
- [x] One test removed: \`user_edited_row_keeps_web_kind_across_reseed\` depended on SubsPlease being web_kind seeded.
- [x] \`subsplease_is_tagged_webdl\` → renamed to \`subsplease_has_no_web_kind_hint\`, regression guard that the seeds stay removed.
- [x] \`source_spec_webdl_vs_webrip_vs_bare_web\` assertion flipped: bare-WEB now matches value 3.
- [x] Two new \`media.rs::parse_quality\` tests lock in the WebRip-before-unified-Web branch ordering.
- [x] Smoke in the live UI: SubsPlease releases should now label as \`WEB-1080p\` in interactive search AND in the episode list; TRaSH anime-web-tier-05 CF (which matches \`SourceSpecification\` value 3) should now fire on SubsPlease/HorribleSubs releases via the widened predicate.

## Backward compatibility

**Behavior change worth calling out:** the CF value-3 widening is a functional behavior change, not just a label rename. Before this PR, \`Source::Web + WebKind::Unknown\` releases (i.e., most non-SubsPlease WEB releases, and every SubsPlease release after the seed removal) matched *neither* value 3 nor value 4 — they silently scored zero on TRaSH anime-web CFs. After this PR they match value 3 (treated as WebDl for CF purposes) and score accordingly. Users running custom CFs that relied on the old strict \`value 3 == WebDl only\` semantics will see scoring shift upward for bare-WEB releases.

Database-wise: existing \`WEBDL-*\` strings in \`episode_quality_tags\` and \`episode_grab_history\` are rewritten to \`WEB-*\` on first boot via the idempotent migration. Running the fresh classifier against the same \`source\`/\`web_kind\` columns produces the same new strings, so a second boot is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)