### PR TITLE
release: v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,7 +2274,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "1.1.0"
+version = "1.1.1"
 edition = "2024"
 rust-version = "1.95"
 


### PR DESCRIPTION
Bumps `Cargo.toml` to 1.1.1 for the tag cut.

Ships the dep-hygiene changeset merged in #60 — every direct dep at latest stable, reqwest 0.13 TLS swap (native-tls → rustls + aws-lc), plus docs callouts for the new `cmake` build prereq and the `SSL_CERT_FILE` caveat for self-hosted Jikan behind a private CA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)