### PR TITLE
feat(download-client): Deluge + remote path mapping (#63 Phase 2)

### DIFF
--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -603,16 +603,134 @@ pub async fn settings_submit(
 
     // #63 Phase 2 — client-switch handling. If the user changed
     // `active_client` on this save, any `grabbed_torrents` rows still
-    // in `state='pending'` point at the OLD client, which Ryokan is
-    // about to stop talking to. Mark them `failed` so they drop out
-    // of the partial UNIQUE index on (hash) and the user can re-grab
-    // cleanly in the new client. See the plan's "client-switch
-    // handling" section for why we chose the destructive path over
-    // per-hash cross-client reconciliation.
+    // in `state='pending'` point at the OLD client (Ryokan is about
+    // to stop talking to it). Three things need to happen, in order:
+    //
+    //   1. **Delete only the in-flight torrents from the OLD client.**
+    //      An `state='pending'` row at this point is either
+    //      mid-download OR complete-but-not-yet-imported. Deleting
+    //      the mid-download ones is the user's intent ("cancel my
+    //      in-flight grabs"). Deleting the completed-but-not-yet-
+    //      imported ones would wipe finished files the user almost
+    //      certainly wants to keep — they're identical to an already-
+    //      imported torrent from the user's perspective; the only
+    //      difference is post-processing didn't happen to run yet.
+    //      So we gate the delete on `!is_complete()` from the old
+    //      client's view.
+    //
+    //   2. **Mark ALL pending rows as `failed` regardless of delete
+    //      outcome.** The old client is about to disappear from
+    //      AppState; Ryokan can't track these grabs anymore. They
+    //      need to drop out of the partial UNIQUE index on `(hash)
+    //      WHERE state IN ('pending','imported')` so a re-grab in
+    //      the new client can't dedupe against them. Completed
+    //      torrents the user wants to keep stay on the old client's
+    //      disk; Ryokan just forgets about them. The user can still
+    //      see the files manually.
+    //
+    //   3. **Swap the AppState Arc** (further down in the
+    //      `active_tab == "integrations"` block).
+    //
+    // Delete happens BEFORE the Arc swap because the read lock still
+    // holds the OLD client's Arc at this point.
     if active_tab == "integrations"
         && let Some(old) = existing_cfg.as_ref()
         && old.active_client != cfg.active_client
     {
+        let pending = crate::models::grabbed_torrents::get_all_pending(&state.db)
+            .await
+            .unwrap_or_default();
+
+        if !pending.is_empty()
+            && let Some(old_client) = state.download_client.read().await.clone()
+        {
+            // Build a hash → state_kind map from the old client's
+            // current view. `list_scoped` returns only Ryokan-owned
+            // torrents, which is a superset of our pending grabs in
+            // the steady state. Failure to fetch == treat as empty
+            // map (can't determine completion); we'll skip deletion
+            // to be safe and let the user clean up manually.
+            let states: std::collections::HashMap<
+                String,
+                crate::services::download_client::DownloadItemState,
+            > = old_client
+                .list_scoped()
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|t| (t.hash.to_lowercase(), t.state_kind))
+                .collect();
+
+            let mut deleted = 0usize;
+            let mut skipped_complete = 0usize;
+            let mut delete_failures: Vec<String> = Vec::new();
+            for grab in &pending {
+                if grab.hash.is_empty() {
+                    continue;
+                }
+                let hash_lc = grab.hash.to_lowercase();
+                // Only delete the torrent if the old client reports
+                // it's NOT complete. Missing from the map (e.g. user
+                // already deleted it manually in the old client, or
+                // `list_scoped` failed) also skips deletion — we'd
+                // rather leave a dangling download-client row than
+                // delete a completed file the user wanted to keep.
+                match states.get(&hash_lc) {
+                    Some(state) if !state.is_complete() => {
+                        match old_client.delete(&hash_lc, true).await {
+                            Ok(()) => deleted += 1,
+                            Err(e) => delete_failures.push(format!("{}: {}", grab.torrent_name, e)),
+                        }
+                    }
+                    Some(_) => skipped_complete += 1,
+                    None => {
+                        // Not in the old client's list. Could be
+                        // already manually removed, could be that
+                        // list_scoped failed. Either way, skip
+                        // deletion — no action we can take that's
+                        // safer than leaving it alone.
+                    }
+                }
+            }
+            if deleted > 0 {
+                logger::info(
+                    &state.db,
+                    LogCategory::System,
+                    &format!(
+                        "Cancelled {deleted} in-flight grab(s) from {} during client switch",
+                        old.active_client
+                    ),
+                    "",
+                )
+                .await;
+            }
+            if skipped_complete > 0 {
+                logger::info(
+                    &state.db,
+                    LogCategory::System,
+                    &format!(
+                        "Left {skipped_complete} completed grab(s) on {} intact during client switch — files preserved",
+                        old.active_client
+                    ),
+                    "",
+                )
+                .await;
+            }
+            if !delete_failures.is_empty() {
+                logger::warn(
+                    &state.db,
+                    LogCategory::System,
+                    &format!(
+                        "{} in-flight grab(s) could not be deleted from {} — DB state still flipped",
+                        delete_failures.len(),
+                        old.active_client
+                    ),
+                    &delete_failures.join("; "),
+                )
+                .await;
+            }
+        }
+
         let n = crate::models::grabbed_torrents::mark_all_pending_failed(
             &state.db,
             &format!(
@@ -631,10 +749,11 @@ pub async fn settings_submit(
             )
             .await;
             notices.push(format!(
-                "Client changed from {} to {}; {n} pending grab{} cancelled.",
+                "Client changed from {} to {}; {n} pending grab{} released (in-flight downloads cancelled on {}; any completed files preserved).",
                 old.active_client,
                 cfg.active_client,
                 if n == 1 { "" } else { "s" },
+                old.active_client,
             ));
         }
     }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -154,11 +154,26 @@ pub struct SettingsQuery {
 #[derive(Deserialize)]
 pub struct SettingsForm {
     tab: Option<String>,
+    /// #63 Phase 2 — which download client is active. Accepted
+    /// values: "qbittorrent" | "deluge". Settings save branches on
+    /// this to construct the concrete trait impl.
+    #[serde(default)]
+    active_client: String,
     qbit_url: String,
     qbit_user: String,
     qbit_pass: String,
     qbit_category: String,
     qbit_download_path: String,
+    #[serde(default)]
+    deluge_url: String,
+    #[serde(default)]
+    deluge_password: String,
+    #[serde(default)]
+    deluge_label: String,
+    #[serde(default)]
+    remote_path_remote: String,
+    #[serde(default)]
+    remote_path_local: String,
     jellyfin_url: String,
     jellyfin_api_key: String,
     preferred_groups: String,
@@ -388,12 +403,40 @@ pub async fn settings_submit(
         .unwrap_or(false);
 
     let cfg = config::Config {
+        active_client: match form.active_client.trim() {
+            "deluge" => "deluge".to_string(),
+            // Any other value (including empty from pre-Phase-2 form
+            // submissions) collapses to qbittorrent — preserves the
+            // Phase 1 default and avoids accidentally switching users
+            // onto a client they haven't configured.
+            _ => "qbittorrent".to_string(),
+        },
         qbit_url: form.qbit_url.trim().to_string(),
         qbit_user: form.qbit_user.trim().to_string(),
         qbit_pass: form.qbit_pass,
         qbit_category: form.qbit_category.trim().to_string(),
         qbit_download_path: form
             .qbit_download_path
+            .trim()
+            .trim_end_matches('/')
+            .to_string(),
+        deluge_url: form.deluge_url.trim().trim_end_matches('/').to_string(),
+        deluge_password: form.deluge_password,
+        deluge_label: {
+            let trimmed = form.deluge_label.trim();
+            if trimmed.is_empty() {
+                "ryokan".to_string()
+            } else {
+                trimmed.to_string()
+            }
+        },
+        remote_path_remote: form
+            .remote_path_remote
+            .trim()
+            .trim_end_matches('/')
+            .to_string(),
+        remote_path_local: form
+            .remote_path_local
             .trim()
             .trim_end_matches('/')
             .to_string(),
@@ -558,31 +601,72 @@ pub async fn settings_submit(
     logger::info(&state.db, LogCategory::System, "Settings saved", "").await;
     let mut notices: Vec<String> = vec!["Settings saved.".to_string()];
 
-    if active_tab == "integrations" {
-        if !cfg.qbit_url.is_empty() {
-            let client: std::sync::Arc<dyn DownloadClient> = std::sync::Arc::new(QbitClient::new(
-                &cfg.qbit_url,
-                &cfg.qbit_user,
-                &cfg.qbit_pass,
-                &cfg.qbit_category,
+    // #63 Phase 2 — client-switch handling. If the user changed
+    // `active_client` on this save, any `grabbed_torrents` rows still
+    // in `state='pending'` point at the OLD client, which Ryokan is
+    // about to stop talking to. Mark them `failed` so they drop out
+    // of the partial UNIQUE index on (hash) and the user can re-grab
+    // cleanly in the new client. See the plan's "client-switch
+    // handling" section for why we chose the destructive path over
+    // per-hash cross-client reconciliation.
+    if active_tab == "integrations"
+        && let Some(old) = existing_cfg.as_ref()
+        && old.active_client != cfg.active_client
+    {
+        let n = crate::models::grabbed_torrents::mark_all_pending_failed(
+            &state.db,
+            &format!(
+                "client switched: {} → {}",
+                old.active_client, cfg.active_client
+            ),
+        )
+        .await
+        .unwrap_or(0);
+        if n > 0 {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Marked {n} pending grabs as failed after client switch"),
+                &format!("old={}, new={}", old.active_client, cfg.active_client),
+            )
+            .await;
+            notices.push(format!(
+                "Client changed from {} to {}; {n} pending grab{} cancelled.",
+                old.active_client,
+                cfg.active_client,
+                if n == 1 { "" } else { "s" },
             ));
-            match client.test().await {
-                Ok(version) => {
-                    logger::info(
-                        &state.db,
-                        LogCategory::QBit,
-                        &format!("Connected to qBittorrent {}", version),
-                        &cfg.qbit_url,
-                    )
-                    .await;
-                    notices.push(format!("qBittorrent connected ({}).", version));
-                    *state.download_client.write().await = Some(client);
+        }
+    }
+
+    if active_tab == "integrations" {
+        let (client_label, configured) = match cfg.active_client.as_str() {
+            "deluge" => ("Deluge", !cfg.deluge_url.is_empty()),
+            _ => ("qBittorrent", !cfg.qbit_url.is_empty()),
+        };
+        if configured {
+            let client = crate::services::download_client::build_download_client(&cfg);
+            if let Some(client) = client {
+                match client.test().await {
+                    Ok(version) => {
+                        logger::info(
+                            &state.db,
+                            LogCategory::QBit,
+                            &format!("Connected to {} {}", client_label, version),
+                            &cfg.qbit_url,
+                        )
+                        .await;
+                        notices.push(format!("{client_label} connected ({version})."));
+                        *state.download_client.write().await = Some(client);
+                    }
+                    Err(e) => {
+                        logger::error(&state.db, LogCategory::QBit, "Connection failed", &e).await;
+                        *state.download_client.write().await = None;
+                        notices.push(format!("{client_label} connection failed: {e}."));
+                    }
                 }
-                Err(e) => {
-                    logger::error(&state.db, LogCategory::QBit, "Connection failed", &e).await;
-                    *state.download_client.write().await = None;
-                    notices.push(format!("qBittorrent connection failed: {}.", e));
-                }
+            } else {
+                *state.download_client.write().await = None;
             }
         } else {
             *state.download_client.write().await = None;

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -740,6 +740,26 @@ pub async fn settings_submit(
         )
         .await
         .unwrap_or(0);
+
+        // Clear the per-episode "grabbed" UI state for every canceled
+        // grab. `grabbed_torrents.state='failed'` alone isn't enough —
+        // the series page reads `episode_quality_tags.state` for the
+        // UI checkmark / badge, and the existing manual-cancel paths
+        // (`handlers::library::episodes::cancel_pending_episode`,
+        // `services::post_processing::run_once_inner` on stale-torrent
+        // reconciliation) both call `episode_tags::clear_tags_for_removal`
+        // alongside their mark-removed calls. The client-switch path
+        // has to mirror that: without this, episodes sit forever in
+        // "grabbed" state with no backing torrent.
+        for grab in &pending {
+            let _ = crate::models::episode_tags::clear_tags_for_removal(
+                &state.db,
+                grab.series_id,
+                &grab.episode_numbers,
+            )
+            .await;
+        }
+
         if n > 0 {
             logger::info(
                 &state.db,

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -774,27 +774,50 @@ pub async fn settings_submit(
     }
 
     if active_tab == "integrations" {
-        let (client_label, configured) = match cfg.active_client.as_str() {
-            "deluge" => ("Deluge", !cfg.deluge_url.is_empty()),
-            _ => ("qBittorrent", !cfg.qbit_url.is_empty()),
+        let (client_label, configured, client_url) = match cfg.active_client.as_str() {
+            "deluge" => (
+                "Deluge",
+                !cfg.deluge_url.is_empty(),
+                cfg.deluge_url.as_str(),
+            ),
+            _ => (
+                "qBittorrent",
+                !cfg.qbit_url.is_empty(),
+                cfg.qbit_url.as_str(),
+            ),
         };
         if configured {
             let client = crate::services::download_client::build_download_client(&cfg);
             if let Some(client) = client {
                 match client.test().await {
                     Ok(version) => {
+                        // `LogCategory::QBit` is reused here for
+                        // every download client for now — log
+                        // message body carries the real client name
+                        // in "Connected to X Y.Z", so filtering by
+                        // category still surfaces the events. A
+                        // dedicated `LogCategory::DownloadClient`
+                        // would be cleaner but churns every existing
+                        // qBit log entry's category too; Phase 3
+                        // cleanup.
                         logger::info(
                             &state.db,
                             LogCategory::QBit,
-                            &format!("Connected to {} {}", client_label, version),
-                            &cfg.qbit_url,
+                            &format!("Connected to {client_label} {version}"),
+                            client_url,
                         )
                         .await;
                         notices.push(format!("{client_label} connected ({version})."));
                         *state.download_client.write().await = Some(client);
                     }
                     Err(e) => {
-                        logger::error(&state.db, LogCategory::QBit, "Connection failed", &e).await;
+                        logger::error(
+                            &state.db,
+                            LogCategory::QBit,
+                            &format!("{client_label} connection failed"),
+                            &e,
+                        )
+                        .await;
                         *state.download_client.write().await = None;
                         notices.push(format!("{client_label} connection failed: {e}."));
                     }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -171,9 +171,7 @@ pub struct SettingsForm {
     #[serde(default)]
     deluge_label: String,
     #[serde(default)]
-    remote_path_remote: String,
-    #[serde(default)]
-    remote_path_local: String,
+    deluge_download_path: String,
     jellyfin_url: String,
     jellyfin_api_key: String,
     preferred_groups: String,
@@ -430,13 +428,8 @@ pub async fn settings_submit(
                 trimmed.to_string()
             }
         },
-        remote_path_remote: form
-            .remote_path_remote
-            .trim()
-            .trim_end_matches('/')
-            .to_string(),
-        remote_path_local: form
-            .remote_path_local
+        deluge_download_path: form
+            .deluge_download_path
             .trim()
             .trim_end_matches('/')
             .to_string(),

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -642,17 +642,25 @@ pub async fn settings_submit(
             // torrents, which is a superset of our pending grabs in
             // the steady state. Failure to fetch == treat as empty
             // map (can't determine completion); we'll skip deletion
-            // to be safe and let the user clean up manually.
+            // to be safe and let the user clean up manually, and
+            // surface that in the UI notice so they know to look.
+            let list_scoped_result = old_client.list_scoped().await;
+            let list_scoped_failed = list_scoped_result.is_err();
             let states: std::collections::HashMap<
                 String,
                 crate::services::download_client::DownloadItemState,
-            > = old_client
-                .list_scoped()
-                .await
+            > = list_scoped_result
                 .unwrap_or_default()
                 .into_iter()
                 .map(|t| (t.hash.to_lowercase(), t.state_kind))
                 .collect();
+
+            if list_scoped_failed {
+                notices.push(format!(
+                    "Couldn't reach {} to cancel in-flight torrents — verify and clean up manually if any were still downloading.",
+                    old.active_client,
+                ));
+            }
 
             let mut deleted = 0usize;
             let mut skipped_complete = 0usize;
@@ -724,15 +732,9 @@ pub async fn settings_submit(
             }
         }
 
-        let n = crate::models::grabbed_torrents::mark_all_pending_failed(
-            &state.db,
-            &format!(
-                "client switched: {} → {}",
-                old.active_client, cfg.active_client
-            ),
-        )
-        .await
-        .unwrap_or(0);
+        let n = crate::models::grabbed_torrents::mark_all_pending_failed(&state.db)
+            .await
+            .unwrap_or(0);
 
         // Clear the per-episode "grabbed" UI state for every canceled
         // grab. `grabbed_torrents.state='failed'` alone isn't enough —

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use utoipa_swagger_ui::SwaggerUi;
 
 use services::{
     custom_formats::{self, CompiledCfCache},
-    download_client::{DownloadClient, qbittorrent::QbitClient},
+    download_client::DownloadClient,
     jellyfin::JellyfinClient,
     progress::ProgressRegistry,
 };
@@ -373,18 +373,15 @@ async fn main() {
         users_exist,
     };
 
-    // Initialize download client from saved config if available.
-    // Phase 1: only qBittorrent is a concrete impl; Phase 2+ will
-    // branch on `config.active_client` once the config migration lands.
+    // Initialize download client from saved config. Branches on
+    // `config.active_client` — the per-client credential columns
+    // (qbit_*, deluge_*) coexist on the same `config` row so a user
+    // can switch between them in Settings without losing the other's
+    // setup. Phase 3+ will add transmission/rtorrent arms here.
     if let Ok(Some(config)) = models::config::get_config(&db).await {
-        if !config.qbit_url.is_empty() {
-            let client: Arc<dyn DownloadClient> = Arc::new(QbitClient::new(
-                &config.qbit_url,
-                &config.qbit_user,
-                &config.qbit_pass,
-                &config.qbit_category,
-            ));
-            *state.download_client.write().await = Some(client);
+        let client = services::download_client::build_download_client(&config);
+        if client.is_some() {
+            *state.download_client.write().await = client;
         }
         if !config.jellyfin_url.is_empty() && !config.jellyfin_api_key.is_empty() {
             let client = JellyfinClient::new(&config.jellyfin_url, &config.jellyfin_api_key);

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -12,6 +12,11 @@ pub struct Config {
     pub qbit_user: String,
     pub qbit_pass: String,
     pub qbit_category: String,
+    /// Where Ryokan reads qBit's completed files from its own
+    /// filesystem. Overrides whatever qBit itself reports as
+    /// `save_path` — needed when qBit runs in a container (it sees
+    /// `/downloads`, Ryokan-on-host sees e.g. `/home/user/downloads`)
+    /// or on a seedbox (Ryokan reads via SSHFS/NFS mount).
     pub qbit_download_path: String,
     /// Deluge Web UI base URL (e.g. `http://host:8112`). The
     /// DelugeClient impl appends `/json` internally.
@@ -21,10 +26,10 @@ pub struct Config {
     /// Defaults to `"ryokan"`; users can override if running multiple
     /// Ryokan instances against one Deluge.
     pub deluge_label: String,
-    /// Remote → local path prefix rewrite applied in post-processing
-    /// before any filesystem op. Empty = no rewrite (local client).
-    pub remote_path_remote: String,
-    pub remote_path_local: String,
+    /// Per-client counterpart to `qbit_download_path` — where Ryokan
+    /// reads Deluge's completed files from its own filesystem.
+    /// Shape mirrors qbit_download_path exactly.
+    pub deluge_download_path: String,
     pub jellyfin_url: String,
     pub jellyfin_api_key: String,
     pub preferred_groups: String,
@@ -95,8 +100,7 @@ impl Default for Config {
             deluge_url: String::new(),
             deluge_password: String::new(),
             deluge_label: "ryokan".to_string(),
-            remote_path_remote: String::new(),
-            remote_path_local: String::new(),
+            deluge_download_path: String::new(),
             jellyfin_url: String::new(),
             jellyfin_api_key: String::new(),
             preferred_groups: String::new(),
@@ -143,8 +147,7 @@ struct ConfigRow {
     deluge_url: String,
     deluge_password: String,
     deluge_label: String,
-    remote_path_remote: String,
-    remote_path_local: String,
+    deluge_download_path: String,
     jellyfin_url: String,
     jellyfin_api_key: String,
     preferred_groups: String,
@@ -181,7 +184,7 @@ struct ConfigRow {
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, remote_path_remote, remote_path_local, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
+        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -196,8 +199,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         deluge_url: r.deluge_url,
         deluge_password: r.deluge_password,
         deluge_label: r.deluge_label,
-        remote_path_remote: r.remote_path_remote,
-        remote_path_local: r.remote_path_local,
+        deluge_download_path: r.deluge_download_path,
         jellyfin_url: r.jellyfin_url,
         jellyfin_api_key: r.jellyfin_api_key,
         preferred_groups: r.preferred_groups,
@@ -236,8 +238,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, remote_path_remote, remote_path_local, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             active_client = excluded.active_client,
             qbit_url = excluded.qbit_url,
@@ -248,8 +250,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             deluge_url = excluded.deluge_url,
             deluge_password = excluded.deluge_password,
             deluge_label = excluded.deluge_label,
-            remote_path_remote = excluded.remote_path_remote,
-            remote_path_local = excluded.remote_path_local,
+            deluge_download_path = excluded.deluge_download_path,
             jellyfin_url = excluded.jellyfin_url,
             jellyfin_api_key = excluded.jellyfin_api_key,
             preferred_groups = excluded.preferred_groups,
@@ -292,8 +293,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(&config.deluge_url)
     .bind(&config.deluge_password)
     .bind(&config.deluge_label)
-    .bind(&config.remote_path_remote)
-    .bind(&config.remote_path_local)
+    .bind(&config.deluge_download_path)
     .bind(&config.jellyfin_url)
     .bind(&config.jellyfin_api_key)
     .bind(&config.preferred_groups)

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -3,11 +3,28 @@ use sqlx::{FromRow, SqlitePool};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
+    /// Download-client discriminator — `"qbittorrent" | "deluge"` for
+    /// now; Phase 3+ adds `"transmission"` and `"rtorrent"`. Determines
+    /// which concrete trait impl `AppState.download_client` is
+    /// initialized with at startup and on settings save.
+    pub active_client: String,
     pub qbit_url: String,
     pub qbit_user: String,
     pub qbit_pass: String,
     pub qbit_category: String,
     pub qbit_download_path: String,
+    /// Deluge Web UI base URL (e.g. `http://host:8112`). The
+    /// DelugeClient impl appends `/json` internally.
+    pub deluge_url: String,
+    pub deluge_password: String,
+    /// Scoping label set on every Ryokan-owned torrent in Deluge.
+    /// Defaults to `"ryokan"`; users can override if running multiple
+    /// Ryokan instances against one Deluge.
+    pub deluge_label: String,
+    /// Remote → local path prefix rewrite applied in post-processing
+    /// before any filesystem op. Empty = no rewrite (local client).
+    pub remote_path_remote: String,
+    pub remote_path_local: String,
     pub jellyfin_url: String,
     pub jellyfin_api_key: String,
     pub preferred_groups: String,
@@ -69,11 +86,17 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Self {
         Self {
+            active_client: "qbittorrent".to_string(),
             qbit_url: String::new(),
             qbit_user: String::new(),
             qbit_pass: String::new(),
             qbit_category: String::new(),
             qbit_download_path: String::new(),
+            deluge_url: String::new(),
+            deluge_password: String::new(),
+            deluge_label: "ryokan".to_string(),
+            remote_path_remote: String::new(),
+            remote_path_local: String::new(),
             jellyfin_url: String::new(),
             jellyfin_api_key: String::new(),
             preferred_groups: String::new(),
@@ -111,11 +134,17 @@ impl Default for Config {
 
 #[derive(Debug, FromRow)]
 struct ConfigRow {
+    active_client: String,
     qbit_url: String,
     qbit_user: String,
     qbit_pass: String,
     qbit_category: String,
     qbit_download_path: String,
+    deluge_url: String,
+    deluge_password: String,
+    deluge_label: String,
+    remote_path_remote: String,
+    remote_path_local: String,
     jellyfin_url: String,
     jellyfin_api_key: String,
     preferred_groups: String,
@@ -152,17 +181,23 @@ struct ConfigRow {
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
+        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, remote_path_remote, remote_path_local, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
 
     Ok(row.map(|r| Config {
+        active_client: r.active_client,
         qbit_url: r.qbit_url,
         qbit_user: r.qbit_user,
         qbit_pass: r.qbit_pass,
         qbit_category: r.qbit_category,
         qbit_download_path: r.qbit_download_path,
+        deluge_url: r.deluge_url,
+        deluge_password: r.deluge_password,
+        deluge_label: r.deluge_label,
+        remote_path_remote: r.remote_path_remote,
+        remote_path_local: r.remote_path_local,
         jellyfin_url: r.jellyfin_url,
         jellyfin_api_key: r.jellyfin_api_key,
         preferred_groups: r.preferred_groups,
@@ -201,14 +236,20 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, remote_path_remote, remote_path_local, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
+            active_client = excluded.active_client,
             qbit_url = excluded.qbit_url,
             qbit_user = excluded.qbit_user,
             qbit_pass = excluded.qbit_pass,
             qbit_category = excluded.qbit_category,
             qbit_download_path = excluded.qbit_download_path,
+            deluge_url = excluded.deluge_url,
+            deluge_password = excluded.deluge_password,
+            deluge_label = excluded.deluge_label,
+            remote_path_remote = excluded.remote_path_remote,
+            remote_path_local = excluded.remote_path_local,
             jellyfin_url = excluded.jellyfin_url,
             jellyfin_api_key = excluded.jellyfin_api_key,
             preferred_groups = excluded.preferred_groups,
@@ -242,11 +283,17 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             default_restrict_to_uploader = excluded.default_restrict_to_uploader
         "#,
     )
+    .bind(&config.active_client)
     .bind(&config.qbit_url)
     .bind(&config.qbit_user)
     .bind(&config.qbit_pass)
     .bind(&config.qbit_category)
     .bind(&config.qbit_download_path)
+    .bind(&config.deluge_url)
+    .bind(&config.deluge_password)
+    .bind(&config.deluge_label)
+    .bind(&config.remote_path_remote)
+    .bind(&config.remote_path_local)
     .bind(&config.jellyfin_url)
     .bind(&config.jellyfin_api_key)
     .bind(&config.preferred_groups)

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -418,11 +418,10 @@ pub async fn mark_failed(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
 /// collision. Returns the number of rows updated so the caller can
 /// surface "N pending grabs cancelled" in the UI notice.
 ///
-/// `reason` is stored in the `torrent_name`-adjacent notes? — no,
-/// there's no free-text failure_reason column today. Accepted as a
-/// parameter for forward-compat (and logged by the caller); the SQL
-/// just flips state.
-pub async fn mark_all_pending_failed(db: &SqlitePool, _reason: &str) -> Result<u64, sqlx::Error> {
+/// No reason string is stored — `grabbed_torrents` has no free-text
+/// failure_reason column today. Callers log the reason separately
+/// at `info` level if they want it on the trail.
+pub async fn mark_all_pending_failed(db: &SqlitePool) -> Result<u64, sqlx::Error> {
     let result =
         sqlx::query("UPDATE grabbed_torrents SET state = 'failed' WHERE state = 'pending'")
             .execute(db)

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -408,6 +408,28 @@ pub async fn mark_failed(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
+/// Mark every `pending` grab row as `failed`. Used by the #63 Phase 2
+/// client-switch handler: when the user changes `active_client` in
+/// Settings, any grab that was in-flight against the old client is
+/// now orphaned (the new client has never seen that hash). Dropping
+/// them from `pending` means they fall out of the partial UNIQUE
+/// index on `(hash) WHERE state IN ('pending', 'imported')` and the
+/// user can cleanly re-grab in the new client without a dedupe
+/// collision. Returns the number of rows updated so the caller can
+/// surface "N pending grabs cancelled" in the UI notice.
+///
+/// `reason` is stored in the `torrent_name`-adjacent notes? — no,
+/// there's no free-text failure_reason column today. Accepted as a
+/// parameter for forward-compat (and logged by the caller); the SQL
+/// just flips state.
+pub async fn mark_all_pending_failed(db: &SqlitePool, _reason: &str) -> Result<u64, sqlx::Error> {
+    let result =
+        sqlx::query("UPDATE grabbed_torrents SET state = 'failed' WHERE state = 'pending'")
+            .execute(db)
+            .await?;
+    Ok(result.rows_affected())
+}
+
 pub async fn mark_removed(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE grabbed_torrents SET state = 'removed' WHERE id = ?")
         .bind(id)

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1132,13 +1132,28 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
-    // #63 Phase 2 — Remote path mapping for seedbox setups. When the
-    // active download client is on a different host than Ryokan, the
-    // `content_path` the client reports points at the seedbox
-    // filesystem. Post-processing rewrites that path by replacing
-    // `remote_path_remote` prefix with `remote_path_local` before
-    // any filesystem op. Modeled on Sonarr's Remote Path Mapping.
-    // Empty strings = no rewrite (local client or no mapping needed).
+    // #63 Phase 2 — Per-client download path, same shape as the
+    // long-standing `qbit_download_path`. Ryokan reads the client's
+    // completed files from `<client>_download_path`; the client's
+    // own reported save_path (container-internal, or on a seedbox)
+    // isn't reachable from Ryokan's process without translation.
+    // Single-field-per-client is simpler than the prefix-pair
+    // `remote_path_remote` / `remote_path_local` design from the
+    // initial Phase 2 sketch — matches user mental model ("where
+    // does Ryokan see Deluge's downloads?") and parallels how
+    // `qbit_download_path` has always worked.
+    sqlx::query("ALTER TABLE config ADD COLUMN deluge_download_path TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+
+    // Phase 2.1 — columns added on the initial Phase 2 sketch of a
+    // global `remote_path_remote` / `remote_path_local` pair.
+    // Retained as dead columns (dropping would force a full-table
+    // rewrite on every boot, per the code-review finding that bit
+    // Phase 1 on the qbit_content_path rename). The `Config` struct
+    // no longer reads these fields; they sit unused until a future
+    // DROP COLUMN ever lands.
     sqlx::query("ALTER TABLE config ADD COLUMN remote_path_remote TEXT NOT NULL DEFAULT ''")
         .execute(db)
         .await
@@ -1147,6 +1162,31 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .execute(db)
         .await
         .ok();
+
+    // One-time data migration: preserve any `remote_path_local`
+    // values users set under the Phase 2 sketch (only really
+    // reachable on the dev branch pre-merge). Copy into whichever
+    // per-client download_path is active at migration time. Guarded
+    // by target-field-empty so re-running on already-migrated DBs
+    // is a no-op (the per-client field is authoritative once set).
+    let _ = sqlx::query(
+        "UPDATE config
+         SET deluge_download_path = remote_path_local
+         WHERE active_client = 'deluge'
+           AND remote_path_local <> ''
+           AND deluge_download_path = ''",
+    )
+    .execute(db)
+    .await;
+    let _ = sqlx::query(
+        "UPDATE config
+         SET qbit_download_path = remote_path_local
+         WHERE active_client = 'qbittorrent'
+           AND remote_path_local <> ''
+           AND qbit_download_path = ''",
+    )
+    .execute(db)
+    .await;
 
     // Rename `qbit_content_path` → `client_content_path` so the field
     // name reflects the trait abstraction. Uses the same state-matrix

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1114,6 +1114,40 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // #63 Phase 2 — Deluge credentials + label. The label is Deluge's
+    // scoping mechanism (Ryokan sets it per-grab via
+    // `label.set_torrent`) and defaults to "ryokan" at trait-impl
+    // construction when empty here. Same base-URL pattern as qBit
+    // (the `/json` suffix is appended inside the DelugeClient impl).
+    sqlx::query("ALTER TABLE config ADD COLUMN deluge_url TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE config ADD COLUMN deluge_password TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE config ADD COLUMN deluge_label TEXT NOT NULL DEFAULT 'ryokan'")
+        .execute(db)
+        .await
+        .ok();
+
+    // #63 Phase 2 — Remote path mapping for seedbox setups. When the
+    // active download client is on a different host than Ryokan, the
+    // `content_path` the client reports points at the seedbox
+    // filesystem. Post-processing rewrites that path by replacing
+    // `remote_path_remote` prefix with `remote_path_local` before
+    // any filesystem op. Modeled on Sonarr's Remote Path Mapping.
+    // Empty strings = no rewrite (local client or no mapping needed).
+    sqlx::query("ALTER TABLE config ADD COLUMN remote_path_remote TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+    sqlx::query("ALTER TABLE config ADD COLUMN remote_path_local TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+
     // Rename `qbit_content_path` → `client_content_path` so the field
     // name reflects the trait abstraction. Uses the same state-matrix
     // reconciler as the PR #37 rename so half-migrated DBs survive.

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -331,12 +331,16 @@ fn is_disconnect_error(msg: &str) -> bool {
 impl DownloadClient for DelugeClient {
     async fn test(&self) -> Result<String, String> {
         self.connect().await?;
-        // `daemon.info` returns the daemon version string. It's the
-        // cheapest post-connect RPC that proves the daemon is
-        // actually responding, not just the web proxy.
+        // `daemon.get_version` returns the Deluge daemon version
+        // string ("2.2.0" etc.). Picked over `daemon.info` — the
+        // latter is NOT exposed through the web-proxy's `/json`
+        // endpoint (only the raw daemon RPC on port 58846), so
+        // calling it here returns "Unknown method" post-connect
+        // and the settings page shows "Connection failed" despite
+        // the handshake working. Live-probed 2026-04-21.
         let version: String =
-            serde_json::from_value(self.connected_rpc("daemon.info", json!([])).await?)
-                .map_err(|e| format!("Deluge daemon.info parse failed: {e}"))?;
+            serde_json::from_value(self.connected_rpc("daemon.get_version", json!([])).await?)
+                .map_err(|e| format!("Deluge daemon.get_version parse failed: {e}"))?;
         Ok(version)
     }
 

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -64,12 +64,6 @@ pub struct DelugeClient {
     password: String,
     label: String,
     http: Client,
-    /// Cached daemon host id from `web.get_hosts`. Captured once on
-    /// first connect; Deluge web UI only has one real daemon slot in
-    /// practice. Wrapped in `Mutex<Option>` rather than `OnceCell`
-    /// so a daemon swap (config change → restart) can re-populate it
-    /// via the reconnect path without tearing down the whole client.
-    host_id: Arc<Mutex<Option<String>>>,
     /// Flipped to `true` after a successful `auth.login` +
     /// `web.connect`. Any RPC error that smells like "session
     /// expired" or "not connected to daemon" clears it so the next
@@ -169,7 +163,6 @@ impl DelugeClient {
                 label.to_string()
             },
             http,
-            host_id: Arc::new(Mutex::new(None)),
             connected: Arc::new(AtomicBool::new(false)),
             connect_lock: Arc::new(Mutex::new(())),
         }
@@ -230,7 +223,11 @@ impl DelugeClient {
             return Err("Deluge auth failed: invalid password".into());
         }
 
-        // Step 2: resolve host_id and connect to the daemon.
+        // Step 2: resolve host_id and connect to the daemon. No need
+        // to cache the host_id across calls — every `connect()`
+        // invocation re-fetches it, which is fine because
+        // `connect()` only runs on initial handshake + session
+        // expiry re-probes (not per-call).
         let hosts_raw = self.rpc("web.get_hosts", json!([])).await?;
         let hosts: Vec<Value> = serde_json::from_value(hosts_raw)
             .map_err(|e| format!("Deluge web.get_hosts parse failed: {e}"))?;
@@ -241,7 +238,6 @@ impl DelugeClient {
             .and_then(|v| v.as_str())
             .ok_or("Deluge web.get_hosts returned no hosts")?
             .to_string();
-        *self.host_id.lock().await = Some(host_id.clone());
 
         // web.connect returns the list of daemon methods now available
         // via RPC. We don't inspect the list — the only signal we need
@@ -353,7 +349,7 @@ impl DownloadClient for DelugeClient {
         Ok(version)
     }
 
-    async fn add_torrent(&self, url: &str, _info_hash: &str) -> Result<AddOutcome, String> {
+    async fn add_torrent(&self, url: &str, info_hash: &str) -> Result<AddOutcome, String> {
         // `core.add_torrent_magnet` for magnet URIs; `core.add_torrent_url`
         // for http:// .torrent URLs. The distinction matters because
         // `add_torrent_magnet` errors on an http URL and vice versa
@@ -370,23 +366,47 @@ impl DownloadClient for DelugeClient {
             )
         };
 
-        let outcome = match self.connected_rpc(method, params).await {
-            Ok(Value::String(hash)) if !hash.is_empty() => {
-                // Fresh add returned the info_hash. Tag it with our
-                // scoping label; failures here are non-fatal — label
-                // plugin might be mid-enable on a fresh install and
-                // list_scoped will pick the torrent up next poll via
-                // any fallback we add later. For now, warn-log and
-                // continue so the grab isn't rejected outright.
-                let _ = self
-                    .connected_rpc("label.set_torrent", json!([hash, self.label]))
-                    .await;
-                AddOutcome::Added
+        let (outcome, hash_for_label) = match self.connected_rpc(method, params).await {
+            Ok(Value::String(hash)) if !hash.is_empty() => (AddOutcome::Added, Some(hash)),
+            Ok(_) => (AddOutcome::Added, None), // add_torrent_url returns null
+            Err(msg) if is_duplicate_add_error(&msg) => {
+                // Deluge's "already in session" error carries the
+                // infohash in the message ("Torrent already in session
+                // (<hash>)"). We don't bother parsing it out — the
+                // caller pre-computed `info_hash` and passed it in.
+                // Tag the existing torrent with our label too: if the
+                // user (or Ryokan from a prior session) manually
+                // added this torrent without the label, the re-grab
+                // should "adopt" it rather than leave it invisible to
+                // `list_scoped`.
+                (
+                    AddOutcome::AlreadyPresent,
+                    Some(info_hash.to_ascii_lowercase()),
+                )
             }
-            Ok(_) => AddOutcome::Added, // add_torrent_url returns null
-            Err(msg) if is_duplicate_add_error(&msg) => AddOutcome::AlreadyPresent,
             Err(msg) => return Err(msg),
         };
+
+        // Tag the torrent with our scoping label. Failures here are
+        // non-fatal to the grab — the torrent is in the client — but
+        // matter for `list_scoped` visibility: an unlabeled torrent
+        // won't show up in the label-filtered listing and Ryokan will
+        // sit forever waiting for it to "appear." Log so the operator
+        // has a trail when that happens.
+        if let Some(hash) = hash_for_label
+            && let Err(e) = self
+                .connected_rpc("label.set_torrent", json!([hash, self.label]))
+                .await
+        {
+            tracing::warn!(
+                target: "ryokan::download_client::deluge",
+                hash = %hash,
+                label = %self.label,
+                error = %e,
+                "label.set_torrent failed — torrent will be invisible to list_scoped until the Label plugin is working and the label is set"
+            );
+        }
+
         Ok(outcome)
     }
 
@@ -503,7 +523,23 @@ impl DownloadClient for DelugeClient {
         let map: std::collections::HashMap<String, DelugeRawTorrent> = serde_json::from_value(raw)
             .map_err(|e| format!("Deluge list_scoped parse failed: {e}"))?;
 
-        Ok(map.into_values().map(to_download_item).collect())
+        // The dict is keyed by infohash; inject the key into each
+        // `DelugeRawTorrent.hash` before conversion. We don't trust
+        // the inner `hash` field alone: `get_torrent_status` silently
+        // omits unknown keys, and future Deluge builds or forks
+        // aren't guaranteed to include `hash` in the status dict.
+        // Worst case without this: every `DownloadItem.hash` ends up
+        // empty and post-processing's grab→torrent match via
+        // `by_hash` silently fails.
+        Ok(map
+            .into_iter()
+            .map(|(key, mut raw)| {
+                if raw.hash.is_empty() {
+                    raw.hash = key;
+                }
+                to_download_item(raw)
+            })
+            .collect())
     }
 
     async fn get_files(&self, info_hash: &str) -> Result<Vec<DownloadFile>, String> {

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -366,9 +366,28 @@ impl DownloadClient for DelugeClient {
             )
         };
 
+        // Fallback hash for labeling: the caller's pre-computed
+        // info_hash, lowercased. Used in arms where Deluge doesn't
+        // hand back a hash itself (`add_torrent_url` null-return) or
+        // where the torrent already exists (AlreadyPresent).
+        // `None` if the caller didn't supply one — `info_hash` empty
+        // means `extract_hash` couldn't parse the URL and a
+        // `label.set_torrent("", ...)` call would just produce a
+        // spurious error.
+        let caller_hash = if info_hash.is_empty() {
+            None
+        } else {
+            Some(info_hash.to_ascii_lowercase())
+        };
+
         let (outcome, hash_for_label) = match self.connected_rpc(method, params).await {
             Ok(Value::String(hash)) if !hash.is_empty() => (AddOutcome::Added, Some(hash)),
-            Ok(_) => (AddOutcome::Added, None), // add_torrent_url returns null
+            // `add_torrent_url` returns null on success rather than the
+            // hash. Fall back to the caller's pre-computed `info_hash`
+            // so labeling still runs through the same post-match block
+            // as the string-return and AlreadyPresent arms — any hash
+            // we know, we label.
+            Ok(_) => (AddOutcome::Added, caller_hash.clone()),
             Err(msg) if is_duplicate_add_error(&msg) => {
                 // Deluge's "already in session" error carries the
                 // infohash in the message ("Torrent already in session
@@ -379,10 +398,7 @@ impl DownloadClient for DelugeClient {
                 // added this torrent without the label, the re-grab
                 // should "adopt" it rather than leave it invisible to
                 // `list_scoped`.
-                (
-                    AddOutcome::AlreadyPresent,
-                    Some(info_hash.to_ascii_lowercase()),
-                )
+                (AddOutcome::AlreadyPresent, caller_hash)
             }
             Err(msg) => return Err(msg),
         };
@@ -803,6 +819,50 @@ mod tests {
         assert!(is_disconnect_error("Unknown method"));
         assert!(is_disconnect_error("Not connected to a daemon"));
         assert!(!is_disconnect_error("Tracker unreachable"));
+    }
+
+    #[test]
+    fn list_scoped_hash_injection_fills_empty_inner_hash() {
+        // Guards the #2 defensive branch in `list_scoped`: when
+        // Deluge's status dict omits the `hash` field (future fork /
+        // reduced key set), the outer dict key still carries the
+        // infohash and `list_scoped` injects it. Without this fix,
+        // every `DownloadItem.hash` would be `""` and post-processing's
+        // grab→torrent match via `by_hash` would silently fail.
+        let key = "abcdef0123456789abcdef0123456789abcdef01".to_string();
+        let mut raw = DelugeRawTorrent {
+            hash: String::new(),
+            name: "silent-hash-drop test".into(),
+            state: "Downloading".into(),
+            ..Default::default()
+        };
+        // Mirror the `list_scoped` branch: inject the key iff the
+        // inner field was empty, then convert.
+        if raw.hash.is_empty() {
+            raw.hash = key.clone();
+        }
+        let item = to_download_item(raw);
+        assert_eq!(item.hash, key);
+    }
+
+    #[test]
+    fn list_scoped_hash_injection_preserves_non_empty_inner_hash() {
+        // The other half of the invariant: if the inner `hash` IS
+        // populated (common case), don't overwrite it. Belt check
+        // against a future "always trust the key" regression that
+        // would silently mismatch if Deluge ever keyed by something
+        // other than the infohash.
+        let inner_hash = "0123456789abcdef0123456789abcdef01234567";
+        let key = "wrongkey".to_string();
+        let mut raw = DelugeRawTorrent {
+            hash: inner_hash.to_string(),
+            ..Default::default()
+        };
+        if raw.hash.is_empty() {
+            raw.hash = key;
+        }
+        let item = to_download_item(raw);
+        assert_eq!(item.hash, inner_hash);
     }
 
     #[test]

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -126,6 +126,15 @@ struct DelugeRawTorrent {
     files: Vec<DelugeRawFile>,
     #[serde(default)]
     file_priorities: Vec<i32>,
+    /// Per-file progress as a parallel array aligned to `files`,
+    /// each entry 0.0–1.0 (fraction, NOT percentage). qBit's
+    /// `TorrentFile.progress` uses the same fraction scale; Deluge's
+    /// per-torrent `progress` is 0–100 but `file_progress` is 0–1.
+    /// Post-processing's "is this file complete?" check filters on
+    /// `f.progress >= 1.0`, so this array needs to be populated
+    /// correctly or every Deluge grab stays pending forever.
+    #[serde(default)]
+    file_progress: Vec<f64>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -404,7 +413,7 @@ impl DownloadClient for DelugeClient {
             let status: DelugeRawTorrent = serde_json::from_value(
                 self.connected_rpc(
                     "core.get_torrent_status",
-                    json!([hash_lc, ["files", "file_priorities"]]),
+                    json!([hash_lc, ["files", "file_priorities", "file_progress"]]),
                 )
                 .await?,
             )
@@ -501,7 +510,7 @@ impl DownloadClient for DelugeClient {
         let status: DelugeRawTorrent = serde_json::from_value(
             self.connected_rpc(
                 "core.get_torrent_status",
-                json!([info_hash, ["files", "file_priorities"]]),
+                json!([info_hash, ["files", "file_priorities", "file_progress"]]),
             )
             .await?,
         )
@@ -627,10 +636,17 @@ fn to_download_files(raw: &DelugeRawTorrent) -> Vec<DownloadFile> {
                 .copied()
                 .map(|p| p != DELUGE_PRIO_SKIP)
                 .unwrap_or(true);
+            // Deluge's `file_progress` is a parallel array of
+            // 0.0–1.0 fractions, same scale as qBit's per-file
+            // `progress`. Defaulting to 0.0 on index mismatch is
+            // safe: post-processing's completion filter requires
+            // `>= 1.0`, so a missing entry just keeps the file
+            // flagged as "not ready" for one more tick.
+            let progress = raw.file_progress.get(i).copied().unwrap_or(0.0);
             DownloadFile {
                 name: f.path.clone(),
                 size: f.size,
-                progress: 0.0, // Deluge exposes `file_progress` separately; not needed at trait level
+                progress,
                 wanted,
             }
         })

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -1,87 +1,573 @@
-//! Phase 1 Deluge stub.
+//! Deluge implementation of [`DownloadClient`]. Speaks the Deluge Web
+//! UI JSON-RPC API at `POST <base_url>/json`.
 //!
-//! Exists to exercise the [`DownloadClient`] trait shape against a
-//! second implementation at compile time, so any qBit-specific
-//! assumption that accidentally leaked into the trait surfaces as a
-//! type error *before* the 15-handler refactor in Phase 1 commits —
-//! not in Phase 2 when changing the trait means re-touching every
-//! call site. Phase 2 replaces this file with the real Deluge Web
-//! UI JSON-RPC client (see ~/Documents/ryokan-plan-pluggable-
-//! download-clients.md → Phase 2).
-//!
-//! Not constructed, not wired into `AppState`. All mutating methods
-//! are `unimplemented!()`; only `test()` and `sonarr_impl_name()`
-//! return stub values so downstream code can reference the type
-//! if it ever does.
+//! Deluge-specific quirks worth flagging for future readers (most of
+//! these are spelled out in the #63 plan at ~/Documents/ryokan-plan-
+//! pluggable-download-clients.md → Phase 2):
+//!   - **Two-step connect**: `auth.login(password)` establishes a
+//!     session cookie, but a freshly-authenticated session isn't
+//!     connected to any daemon. Every `core.*` call fails with
+//!     `"Unknown method"` (NOT "not connected" — the methods aren't
+//!     even registered on the web process) until `web.connect(host_id)`
+//!     runs. Single most common first-time integration failure.
+//!   - **Label plugin required for scoping**: Ryokan sets a per-grab
+//!     label (default `"ryokan"`) and filters `list_scoped` by it.
+//!     The Label plugin is bundled with Deluge but disabled by
+//!     default; the connection test enables it via `core.enable_plugin`
+//!     when it sees `Label` in `available_plugins` but not
+//!     `enabled_plugins`. There's an upstream Deluge bug where an
+//!     enabled-but-not-restarted Label plugin leaves RPC methods
+//!     unregistered on the web process for one session; we re-call
+//!     `web.connect` after enabling to force a method re-registration.
+//!   - **File priority scale is 0 / 1 / 4 / 7** (Skip / Low / Normal /
+//!     High), NOT qBit's 0 / 1 / 6 / 7. Writing `1` for "wanted"
+//!     would set the file to Low priority (bandwidth-de-prioritized
+//!     relative to peers), which is wrong. Ryokan writes `0` for
+//!     skip and `4` for wanted.
+//!   - **Duplicate-add detection is message-matching**: the error
+//!     code fluctuates across versions (ticket deluge-dev/#3507) so
+//!     we match on the substring `"Torrent already in session"` (and
+//!     `"Torrent already being added"` for the racing-add case).
+//!   - **No `has_metadata` field** in `core.get_torrent_status`
+//!     output — live-probed against Deluge 2.x + Label plugin 0.3.
+//!     Proxy for metadata-ready: `files` array non-empty.
+//!   - **Missing fields silently omitted**: `get_torrent_status`
+//!     drops unknown keys from the response rather than returning an
+//!     error. Every deserializer here uses `#[serde(default)]`.
 
 use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
 
-use super::{AddOutcome, DownloadClient, DownloadFile, DownloadItem, SelectiveOutcome};
+use super::{
+    AddOutcome, DownloadClient, DownloadFile, DownloadItem, DownloadItemState, SelectiveOutcome,
+};
 
-#[allow(dead_code)]
+/// Deluge file priority: 0 = Skip, 1 = Low, 4 = Normal, 7 = High.
+/// Ryokan only ever writes 0 and 4 — the Low/High levels are a
+/// Deluge-UI feature Ryokan doesn't control from scoring.
+const DELUGE_PRIO_SKIP: i32 = 0;
+const DELUGE_PRIO_NORMAL: i32 = 4;
+
+/// Metadata-wait budget for `add_torrent_with_file_filter`. Matches
+/// qBit's 10-second ceiling so selective-narrowing latency is
+/// consistent across clients — longer waits block interactive grabs.
+const METADATA_WAIT_TIMEOUT: Duration = Duration::from_secs(10);
+
 pub struct DelugeClient {
     base_url: String,
     password: String,
     label: String,
+    http: Client,
+    /// Cached daemon host id from `web.get_hosts`. Captured once on
+    /// first connect; Deluge web UI only has one real daemon slot in
+    /// practice. Wrapped in `Mutex<Option>` rather than `OnceCell`
+    /// so a daemon swap (config change → restart) can re-populate it
+    /// via the reconnect path without tearing down the whole client.
+    host_id: Arc<Mutex<Option<String>>>,
+    /// Flipped to `true` after a successful `auth.login` +
+    /// `web.connect`. Any RPC error that smells like "session
+    /// expired" or "not connected to daemon" clears it so the next
+    /// call re-runs the full handshake. Atomic so the
+    /// `ensure_connected` path doesn't serialize mutations behind a
+    /// tokio mutex.
+    connected: Arc<AtomicBool>,
+    /// Serializes concurrent `ensure_connected` calls so only one
+    /// task runs the auth + connect dance when the flag is false.
+    /// Without this, a burst of first-time callers all race to log
+    /// in and set up the Label plugin.
+    connect_lock: Arc<Mutex<()>>,
 }
 
-#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+struct RpcResponse<T> {
+    result: Option<T>,
+    error: Option<RpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RpcError {
+    message: String,
+}
+
+/// Raw torrent status fields Ryokan needs. Every field is
+/// `#[serde(default)]` because Deluge silently omits keys that
+/// aren't populated yet (e.g. pre-metadata torrents have empty
+/// `files` but no `total_size`, and plugin-provided fields like
+/// `label` only appear when the Label plugin is loaded).
+#[derive(Debug, Deserialize, Default)]
+struct DelugeRawTorrent {
+    #[serde(default)]
+    hash: String,
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    save_path: String,
+    #[serde(default)]
+    progress: f64,
+    #[serde(default)]
+    download_payload_rate: i64,
+    #[serde(default)]
+    eta: i64,
+    #[serde(default)]
+    total_size: i64,
+    #[serde(default)]
+    is_finished: bool,
+    #[serde(default)]
+    label: String,
+    #[serde(default)]
+    files: Vec<DelugeRawFile>,
+    #[serde(default)]
+    file_priorities: Vec<i32>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct DelugeRawFile {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    size: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct RpcRequest<'a> {
+    method: &'a str,
+    params: Value,
+    id: u32,
+}
+
 impl DelugeClient {
     pub fn new(base_url: &str, password: &str, label: &str) -> Self {
+        let http = Client::builder()
+            .cookie_store(true)
+            .timeout(Duration::from_secs(15))
+            .build()
+            .expect("Failed to build HTTP client");
+
         Self {
-            base_url: base_url.to_string(),
+            base_url: normalize_base_url(base_url),
             password: password.to_string(),
-            label: label.to_string(),
+            label: if label.is_empty() {
+                "ryokan".to_string()
+            } else {
+                label.to_string()
+            },
+            http,
+            host_id: Arc::new(Mutex::new(None)),
+            connected: Arc::new(AtomicBool::new(false)),
+            connect_lock: Arc::new(Mutex::new(())),
         }
     }
+
+    /// JSON-RPC round-trip. Returns the raw `result` value. The caller
+    /// is responsible for deserializing into a concrete type — keeps
+    /// the one-HTTP-call helper generic while letting each callsite
+    /// own its schema.
+    async fn rpc(&self, method: &str, params: Value) -> Result<Value, String> {
+        let req = RpcRequest {
+            method,
+            params,
+            id: 1,
+        };
+        let resp = self
+            .http
+            .post(format!("{}/json", self.base_url))
+            .json(&req)
+            .send()
+            .await
+            .map_err(|e| format!("Deluge request failed: {e}"))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!("Deluge HTTP {status}: {}", body.trim()));
+        }
+
+        let parsed: RpcResponse<Value> = resp
+            .json()
+            .await
+            .map_err(|e| format!("Deluge response parse failed: {e}"))?;
+
+        if let Some(err) = parsed.error {
+            return Err(err.message);
+        }
+        Ok(parsed.result.unwrap_or(Value::Null))
+    }
+
+    /// First-time or reconnect-after-expiry handshake:
+    /// `auth.login` → `web.get_hosts` → `web.connect`. Ensures the
+    /// Label plugin is enabled so `list_scoped` filtering works.
+    /// Serialized under `connect_lock` so concurrent callers collapse
+    /// to a single handshake rather than racing.
+    async fn connect(&self) -> Result<(), String> {
+        let _guard = self.connect_lock.lock().await;
+        // Double-check in case another task beat us through the lock.
+        if self.connected.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
+        // Step 1: auth.
+        let ok: bool =
+            serde_json::from_value(self.rpc("auth.login", json!([self.password])).await?)
+                .map_err(|e| format!("Deluge auth.login unexpected response: {e}"))?;
+        if !ok {
+            return Err("Deluge auth failed: invalid password".into());
+        }
+
+        // Step 2: resolve host_id and connect to the daemon.
+        let hosts_raw = self.rpc("web.get_hosts", json!([])).await?;
+        let hosts: Vec<Value> = serde_json::from_value(hosts_raw)
+            .map_err(|e| format!("Deluge web.get_hosts parse failed: {e}"))?;
+        let host_id = hosts
+            .first()
+            .and_then(|h| h.as_array())
+            .and_then(|a| a.first())
+            .and_then(|v| v.as_str())
+            .ok_or("Deluge web.get_hosts returned no hosts")?
+            .to_string();
+        *self.host_id.lock().await = Some(host_id.clone());
+
+        // web.connect returns the list of daemon methods now available
+        // via RPC. We don't inspect the list — the only signal we need
+        // is the absence of an error.
+        self.rpc("web.connect", json!([host_id])).await?;
+
+        // Step 3: ensure Label plugin is enabled. list_scoped's
+        // server-side `{"label": "ryokan"}` filter requires it, and so
+        // does per-torrent label assignment in add_torrent.
+        self.ensure_label_plugin(&host_id).await?;
+
+        // Step 4: ensure our label exists. Idempotent — duplicate adds
+        // error with "Label already exists" which we swallow.
+        let _ = self.ensure_label_exists().await;
+
+        self.connected.store(true, Ordering::SeqCst);
+        Ok(())
+    }
+
+    /// Detects the Label plugin state via `web.get_plugins` and
+    /// enables it via `core.enable_plugin` if missing. Re-runs
+    /// `web.connect(host_id)` after enabling because Deluge doesn't
+    /// register newly-enabled plugin RPC methods on an existing web
+    /// session until a re-connect (upstream bug, still present in
+    /// Deluge 2.x).
+    async fn ensure_label_plugin(&self, host_id: &str) -> Result<(), String> {
+        #[derive(Deserialize)]
+        struct Plugins {
+            enabled_plugins: Vec<String>,
+            available_plugins: Vec<String>,
+        }
+        let plugins: Plugins =
+            serde_json::from_value(self.rpc("web.get_plugins", json!([])).await?)
+                .map_err(|e| format!("Deluge web.get_plugins parse failed: {e}"))?;
+
+        if plugins.enabled_plugins.iter().any(|p| p == "Label") {
+            return Ok(());
+        }
+        if !plugins.available_plugins.iter().any(|p| p == "Label") {
+            return Err(
+                "Deluge Label plugin is not installed. Install the Label plugin in \
+                 Deluge (bundled; just needs enabling) and retry the connection test."
+                    .into(),
+            );
+        }
+
+        // Enable + force method re-registration via a reconnect.
+        let _ = self.rpc("core.enable_plugin", json!(["Label"])).await?;
+        self.rpc("web.connect", json!([host_id])).await?;
+        Ok(())
+    }
+
+    async fn ensure_label_exists(&self) -> Result<(), String> {
+        // Duplicate-add surfaces as {"error": {"message": "...Label
+        // already exists..."}}. Treat that as success; any other
+        // error bubbles up as-is so connection faults don't get
+        // swallowed here.
+        match self.rpc("label.add", json!([self.label])).await {
+            Ok(_) => Ok(()),
+            Err(msg) if msg.contains("Label already exists") => Ok(()),
+            Err(msg) => Err(msg),
+        }
+    }
+
+    /// Run a connected RPC call. On first invocation, runs the full
+    /// handshake. On subsequent invocations, clears the `connected`
+    /// flag and retries once if the error looks like session expiry
+    /// or daemon disconnect — both of which surface as "Unknown
+    /// method" from Deluge's web proxy rather than a 401/403 status.
+    async fn connected_rpc(&self, method: &str, params: Value) -> Result<Value, String> {
+        if !self.connected.load(Ordering::SeqCst) {
+            self.connect().await?;
+        }
+        match self.rpc(method, params.clone()).await {
+            Ok(v) => Ok(v),
+            Err(msg) if is_disconnect_error(&msg) => {
+                self.connected.store(false, Ordering::SeqCst);
+                self.connect().await?;
+                self.rpc(method, params).await
+            }
+            Err(msg) => Err(msg),
+        }
+    }
+}
+
+fn is_disconnect_error(msg: &str) -> bool {
+    // `core.*` methods disappear from the RPC surface when the web
+    // process loses its daemon connection — the Deluge web proxy
+    // returns "Unknown method" rather than a more specific status.
+    // The "Not connected to a daemon" variant shows up less often
+    // but is worth catching too.
+    msg.contains("Unknown method") || msg.contains("Not connected to a daemon")
 }
 
 #[async_trait]
 impl DownloadClient for DelugeClient {
     async fn test(&self) -> Result<String, String> {
-        Err("Deluge client not implemented — Phase 2".into())
+        self.connect().await?;
+        // `daemon.info` returns the daemon version string. It's the
+        // cheapest post-connect RPC that proves the daemon is
+        // actually responding, not just the web proxy.
+        let version: String =
+            serde_json::from_value(self.connected_rpc("daemon.info", json!([])).await?)
+                .map_err(|e| format!("Deluge daemon.info parse failed: {e}"))?;
+        Ok(version)
     }
 
-    async fn add_torrent(&self, _url: &str, _info_hash: &str) -> Result<AddOutcome, String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+    async fn add_torrent(&self, url: &str, _info_hash: &str) -> Result<AddOutcome, String> {
+        // `core.add_torrent_magnet` for magnet URIs; `core.add_torrent_url`
+        // for http:// .torrent URLs. The distinction matters because
+        // `add_torrent_magnet` errors on an http URL and vice versa
+        // (both methods parse their input and reject the other shape).
+        let (method, params) = if url.starts_with("magnet:") {
+            (
+                "core.add_torrent_magnet",
+                json!([url, {"add_paused": false}]),
+            )
+        } else {
+            (
+                "core.add_torrent_url",
+                json!([url, {"add_paused": false}, Value::Null]),
+            )
+        };
+
+        let outcome = match self.connected_rpc(method, params).await {
+            Ok(Value::String(hash)) if !hash.is_empty() => {
+                // Fresh add returned the info_hash. Tag it with our
+                // scoping label; failures here are non-fatal — label
+                // plugin might be mid-enable on a fresh install and
+                // list_scoped will pick the torrent up next poll via
+                // any fallback we add later. For now, warn-log and
+                // continue so the grab isn't rejected outright.
+                let _ = self
+                    .connected_rpc("label.set_torrent", json!([hash, self.label]))
+                    .await;
+                AddOutcome::Added
+            }
+            Ok(_) => AddOutcome::Added, // add_torrent_url returns null
+            Err(msg) if is_duplicate_add_error(&msg) => AddOutcome::AlreadyPresent,
+            Err(msg) => return Err(msg),
+        };
+        Ok(outcome)
     }
 
     async fn add_torrent_with_file_filter(
         &self,
-        _url: &str,
-        _info_hash: &str,
-        _pick: &mut (dyn for<'a> FnMut(&'a [String]) -> Option<Vec<usize>> + Send),
+        url: &str,
+        info_hash: &str,
+        pick: &mut (dyn for<'a> FnMut(&'a [String]) -> Option<Vec<usize>> + Send),
     ) -> Result<SelectiveOutcome, String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+        if info_hash.is_empty() {
+            return Err("Deluge selective download requires a known info hash".into());
+        }
+        let hash_lc = info_hash.to_ascii_lowercase();
+
+        self.add_torrent(url, &hash_lc).await?;
+
+        // Poll for metadata. Deluge has no `has_metadata` field in
+        // this version — `files` array non-empty is the signal. Same
+        // 10s budget as qBit so selective-narrowing latency is
+        // consistent across impls.
+        let start = Instant::now();
+        let mut delay = Duration::from_millis(500);
+        let files: Vec<DelugeRawFile> = loop {
+            let status: DelugeRawTorrent = serde_json::from_value(
+                self.connected_rpc(
+                    "core.get_torrent_status",
+                    json!([hash_lc, ["files", "file_priorities"]]),
+                )
+                .await?,
+            )
+            .map_err(|e| format!("Deluge metadata-poll parse failed: {e}"))?;
+            if !status.files.is_empty() {
+                break status.files;
+            }
+            if start.elapsed() >= METADATA_WAIT_TIMEOUT {
+                // Same fallback semantics as the qBit impl: drop the
+                // narrow, let the torrent download everything. The
+                // grab row stays valid; user just gets a full download
+                // instead of a filtered one.
+                return Ok(SelectiveOutcome::FullDownload);
+            }
+            tokio::time::sleep(delay).await;
+            delay = (delay * 2).min(Duration::from_secs(2));
+        };
+
+        let names: Vec<String> = files.iter().map(|f| f.path.clone()).collect();
+        let keep_indices = match pick(&names) {
+            Some(ids) if !ids.is_empty() && ids.len() < files.len() => ids,
+            _ => return Ok(SelectiveOutcome::FullDownload),
+        };
+
+        // Detect prior narrowing: if any existing priority is 0 (skip),
+        // an earlier grab has already touched this torrent. Merge the
+        // new keep set in additively — only bump new files from 0 →
+        // normal; leave files already at normal/high untouched.
+        let current: Vec<i32> = serde_json::from_value(
+            self.connected_rpc(
+                "core.get_torrent_status",
+                json!([hash_lc, ["file_priorities"]]),
+            )
+            .await?,
+        )
+        .ok()
+        .and_then(|v: Value| {
+            v.get("file_priorities")
+                .cloned()
+                .and_then(|p| serde_json::from_value(p).ok())
+        })
+        .unwrap_or_else(|| vec![DELUGE_PRIO_NORMAL; files.len()]);
+
+        let already_narrowed = current.contains(&DELUGE_PRIO_SKIP);
+
+        let mut new_priorities: Vec<i32> = current.clone();
+        if new_priorities.len() != files.len() {
+            new_priorities = vec![DELUGE_PRIO_NORMAL; files.len()];
+        }
+
+        if already_narrowed {
+            for &i in &keep_indices {
+                if let Some(slot) = new_priorities.get_mut(i)
+                    && *slot == DELUGE_PRIO_SKIP
+                {
+                    *slot = DELUGE_PRIO_NORMAL;
+                }
+            }
+        } else {
+            for (i, slot) in new_priorities.iter_mut().enumerate() {
+                *slot = if keep_indices.contains(&i) {
+                    DELUGE_PRIO_NORMAL
+                } else {
+                    DELUGE_PRIO_SKIP
+                };
+            }
+        }
+
+        self.connected_rpc(
+            "core.set_torrent_options",
+            json!([[hash_lc], {"file_priorities": new_priorities}]),
+        )
+        .await?;
+
+        Ok(SelectiveOutcome::Filtered(keep_indices))
     }
 
     async fn list_scoped(&self) -> Result<Vec<DownloadItem>, String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+        // Server-side filter by label; no client-side scanning.
+        // Empty keys list returns all fields — cheap enough at
+        // Ryokan's scope and avoids future breakage if a new field
+        // becomes load-bearing for state mapping.
+        let filter = json!({"label": self.label});
+        let raw: Value = self
+            .connected_rpc("core.get_torrents_status", json!([filter, []]))
+            .await?;
+        let map: std::collections::HashMap<String, DelugeRawTorrent> = serde_json::from_value(raw)
+            .map_err(|e| format!("Deluge list_scoped parse failed: {e}"))?;
+
+        Ok(map.into_values().map(to_download_item).collect())
     }
 
-    async fn get_files(&self, _info_hash: &str) -> Result<Vec<DownloadFile>, String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+    async fn get_files(&self, info_hash: &str) -> Result<Vec<DownloadFile>, String> {
+        let status: DelugeRawTorrent = serde_json::from_value(
+            self.connected_rpc(
+                "core.get_torrent_status",
+                json!([info_hash, ["files", "file_priorities"]]),
+            )
+            .await?,
+        )
+        .map_err(|e| format!("Deluge get_files parse failed: {e}"))?;
+        Ok(to_download_files(&status))
     }
 
-    async fn pause(&self, _info_hash: &str) -> Result<(), String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+    async fn pause(&self, info_hash: &str) -> Result<(), String> {
+        self.connected_rpc("core.pause_torrent", json!([[info_hash]]))
+            .await?;
+        Ok(())
     }
 
-    async fn resume(&self, _info_hash: &str) -> Result<(), String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+    async fn resume(&self, info_hash: &str) -> Result<(), String> {
+        self.connected_rpc("core.resume_torrent", json!([[info_hash]]))
+            .await?;
+        Ok(())
     }
 
-    async fn delete(&self, _info_hash: &str, _delete_files: bool) -> Result<(), String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+    async fn delete(&self, info_hash: &str, delete_files: bool) -> Result<(), String> {
+        // `core.remove_torrent(hash, remove_data)` — single hash,
+        // not a list. Batch removal uses `core.remove_torrents` which
+        // we don't need.
+        self.connected_rpc("core.remove_torrent", json!([info_hash, delete_files]))
+            .await?;
+        Ok(())
     }
 
     async fn set_file_wanted(
         &self,
-        _info_hash: &str,
-        _files: &[usize],
-        _wanted: bool,
+        info_hash: &str,
+        files: &[usize],
+        wanted: bool,
     ) -> Result<(), String> {
-        unimplemented!("Deluge impl lands in Phase 2")
+        // Deluge only accepts a full-length priority array — there's
+        // no partial update. Read current priorities, patch the
+        // requested indices, write back.
+        let status: DelugeRawTorrent = serde_json::from_value(
+            self.connected_rpc(
+                "core.get_torrent_status",
+                json!([info_hash, ["file_priorities", "files"]]),
+            )
+            .await?,
+        )
+        .map_err(|e| format!("Deluge set_file_wanted read failed: {e}"))?;
+
+        let len = status.files.len().max(status.file_priorities.len());
+        let mut new_prio: Vec<i32> = if status.file_priorities.len() == len {
+            status.file_priorities
+        } else {
+            vec![DELUGE_PRIO_NORMAL; len]
+        };
+
+        let target = if wanted {
+            DELUGE_PRIO_NORMAL
+        } else {
+            DELUGE_PRIO_SKIP
+        };
+        for &i in files {
+            if let Some(slot) = new_prio.get_mut(i) {
+                *slot = target;
+            }
+        }
+
+        self.connected_rpc(
+            "core.set_torrent_options",
+            json!([[info_hash], {"file_priorities": new_prio}]),
+        )
+        .await?;
+        Ok(())
     }
 
     fn sonarr_impl_name(&self) -> &'static str {
@@ -89,25 +575,235 @@ impl DownloadClient for DelugeClient {
     }
 }
 
+fn is_duplicate_add_error(msg: &str) -> bool {
+    // Deluge's error codes for duplicate-add are not stable across
+    // versions (see deluge-dev ticket #3507). Match on the two known
+    // message prefixes instead.
+    msg.contains("Torrent already in session") || msg.contains("Torrent already being added")
+}
+
+fn to_download_item(raw: DelugeRawTorrent) -> DownloadItem {
+    let state_kind = map_deluge_state(&raw);
+    // content_path for Deluge is not a native field — compute from
+    // save_path + files' common prefix via the shared helper.
+    let files_view: Vec<DownloadFile> = to_download_files(&raw);
+    let content_path = super::compute_content_path(&raw.save_path, &files_view);
+    DownloadItem {
+        hash: raw.hash,
+        name: raw.name,
+        size: raw.total_size,
+        // Deluge reports progress as a percentage (0.0–100.0);
+        // qBit reports it as a fraction (0.0–1.0). Normalize to the
+        // fraction scale so `DownloadItem.progress` means the same
+        // thing across impls.
+        progress: raw.progress / 100.0,
+        dlspeed: raw.download_payload_rate,
+        // Preserve the raw native string in `state` so the Downloads
+        // UI's label-map keeps working for qBit; Deluge's strings
+        // don't match qBit's, so the UI will fall through to the
+        // raw value in its switch default. Phase 2+ UI work can
+        // generalize once a second client is actually live.
+        state: raw.state,
+        category: raw.label,
+        eta: raw.eta,
+        save_path: raw.save_path,
+        content_path,
+        state_kind,
+    }
+}
+
+fn to_download_files(raw: &DelugeRawTorrent) -> Vec<DownloadFile> {
+    raw.files
+        .iter()
+        .enumerate()
+        .map(|(i, f)| {
+            let wanted = raw
+                .file_priorities
+                .get(i)
+                .copied()
+                .map(|p| p != DELUGE_PRIO_SKIP)
+                .unwrap_or(true);
+            DownloadFile {
+                name: f.path.clone(),
+                size: f.size,
+                progress: 0.0, // Deluge exposes `file_progress` separately; not needed at trait level
+                wanted,
+            }
+        })
+        .collect()
+}
+
+/// Map Deluge's native state machine to Ryokan's 10-variant enum.
+/// Deluge exposes fewer distinct states than qBit; this map collapses
+/// the UI-visible distinctions (stalled / queued) that Deluge doesn't
+/// natively carry into their non-distinct counterparts — losing some
+/// granularity on the Downloads page for Deluge-backed torrents, but
+/// not losing any post-processing correctness (completion detection
+/// only cares about `is_complete`, which is derived from
+/// `is_finished` + state, not from the stalled/queued subdistinction).
+fn map_deluge_state(raw: &DelugeRawTorrent) -> DownloadItemState {
+    use DownloadItemState::*;
+    match raw.state.as_str() {
+        "Error" => Errored,
+        "Checking" | "Allocating" if raw.is_finished => CheckingSeed,
+        "Checking" | "Allocating" => CheckingDownload,
+        "Moving" => {
+            // `Moving` means files are mid-storage-move — post-
+            // processing MUST NOT import until the move finishes,
+            // regardless of `is_finished`. Collapse to `Downloading`
+            // (non-complete) so `is_complete()` returns false; the
+            // raw `Moving` string is preserved in `DownloadItem.state`
+            // for UI display. No `Moving` variant in the normalized
+            // enum because qBit doesn't have a distinct moving state
+            // either (its `checkingUP` covers the same window).
+            Downloading
+        }
+        "Paused" if raw.is_finished => PausedComplete,
+        "Paused" => Paused,
+        "Queued" if raw.is_finished => SeedingQueued,
+        "Queued" => DownloadingQueued,
+        "Seeding" => Seeding,
+        "Downloading" => Downloading,
+        _ => Downloading, // unknown states default to a safe non-complete
+    }
+}
+
+fn normalize_base_url(base_url: &str) -> String {
+    let trimmed = base_url.trim().trim_end_matches('/');
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    if trimmed.starts_with("http://") || trimmed.starts_with("https://") {
+        return trimmed.to_string();
+    }
+    // Deluge's Web UI defaults to port 8112 with plain HTTP. We don't
+    // second-guess a user's scheme choice — if they type a bare host
+    // we assume HTTP on local/private IPs and HTTPS on public hosts,
+    // matching the qBit impl's heuristic.
+    let lower = trimmed.to_ascii_lowercase();
+    let is_local = lower.starts_with("localhost")
+        || lower.starts_with("127.")
+        || lower.starts_with("10.")
+        || lower.starts_with("192.168.")
+        || lower.starts_with("172.16.")
+        || lower.starts_with("172.17.")
+        || lower.starts_with("172.18.")
+        || lower.starts_with("172.19.")
+        || lower.starts_with("172.20.")
+        || lower.starts_with("172.21.")
+        || lower.starts_with("172.22.")
+        || lower.starts_with("172.23.")
+        || lower.starts_with("172.24.")
+        || lower.starts_with("172.25.")
+        || lower.starts_with("172.26.")
+        || lower.starts_with("172.27.")
+        || lower.starts_with("172.28.")
+        || lower.starts_with("172.29.")
+        || lower.starts_with("172.30.")
+        || lower.starts_with("172.31.");
+    if is_local {
+        format!("http://{}", trimmed)
+    } else {
+        format!("https://{}", trimmed)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// The load-bearing test: compiles iff the trait is object-safe
-    /// and the Deluge stub's signatures match the trait. If either
-    /// breaks, this file fails to compile — which is the whole point
-    /// of having the stub during Phase 1.
+    /// Load-bearing object-safety check from Phase 1. The stub
+    /// version of this test lived here to catch trait regressions
+    /// before the real impl landed; now it doubles as a smoke test
+    /// that the real Deluge impl is still `dyn`-compatible.
     #[test]
-    fn deluge_stub_is_object_safe() {
-        fn _assert_dyn_compatible(_c: std::sync::Arc<dyn DownloadClient>) {}
-        let deluge = std::sync::Arc::new(DelugeClient::new("http://x:8112", "", "ryokan"))
-            as std::sync::Arc<dyn DownloadClient>;
-        _assert_dyn_compatible(deluge);
+    fn deluge_client_is_object_safe() {
+        fn _assert_dyn_compatible(_c: Arc<dyn DownloadClient>) {}
+        let client = Arc::new(DelugeClient::new("http://localhost:8112", "", "ryokan"))
+            as Arc<dyn DownloadClient>;
+        _assert_dyn_compatible(client);
     }
 
-    #[tokio::test]
-    async fn deluge_stub_sonarr_impl_name() {
-        let d = DelugeClient::new("http://x:8112", "", "ryokan");
-        assert_eq!(d.sonarr_impl_name(), "Deluge");
+    #[test]
+    fn sonarr_impl_name_is_deluge() {
+        let c = DelugeClient::new("http://localhost:8112", "", "ryokan");
+        assert_eq!(c.sonarr_impl_name(), "Deluge");
+    }
+
+    #[test]
+    fn duplicate_add_error_matcher() {
+        assert!(is_duplicate_add_error(
+            "Torrent already in session (abc123)."
+        ));
+        assert!(is_duplicate_add_error(
+            "Failure: Torrent already being added..."
+        ));
+        assert!(!is_duplicate_add_error("Tracker returned error 429"));
+        assert!(!is_duplicate_add_error(""));
+    }
+
+    #[test]
+    fn disconnect_error_matcher() {
+        assert!(is_disconnect_error("Unknown method"));
+        assert!(is_disconnect_error("Not connected to a daemon"));
+        assert!(!is_disconnect_error("Tracker unreachable"));
+    }
+
+    #[test]
+    fn state_mapping_completion_semantics() {
+        let seeding = DelugeRawTorrent {
+            state: "Seeding".into(),
+            ..Default::default()
+        };
+        assert!(map_deluge_state(&seeding).is_complete());
+
+        let paused_complete = DelugeRawTorrent {
+            state: "Paused".into(),
+            is_finished: true,
+            ..Default::default()
+        };
+        assert!(map_deluge_state(&paused_complete).is_complete());
+
+        let paused_incomplete = DelugeRawTorrent {
+            state: "Paused".into(),
+            is_finished: false,
+            ..Default::default()
+        };
+        assert!(!map_deluge_state(&paused_incomplete).is_complete());
+
+        // CRITICAL: `Moving` must NOT be treated as complete even
+        // when is_finished is true — libtorrent is mid-move, reading
+        // content_path is a race.
+        let moving = DelugeRawTorrent {
+            state: "Moving".into(),
+            is_finished: true,
+            ..Default::default()
+        };
+        assert!(!map_deluge_state(&moving).is_complete());
+
+        let errored = DelugeRawTorrent {
+            state: "Error".into(),
+            ..Default::default()
+        };
+        assert!(map_deluge_state(&errored).is_errored());
+
+        let downloading = DelugeRawTorrent {
+            state: "Downloading".into(),
+            is_finished: false,
+            ..Default::default()
+        };
+        assert!(!map_deluge_state(&downloading).is_complete());
+    }
+
+    #[test]
+    fn empty_label_defaults_to_ryokan() {
+        let c = DelugeClient::new("http://localhost:8112", "", "");
+        assert_eq!(c.label, "ryokan");
+    }
+
+    #[test]
+    fn custom_label_preserved() {
+        let c = DelugeClient::new("http://localhost:8112", "", "anime-batch");
+        assert_eq!(c.label, "anime-batch");
     }
 }

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -505,6 +505,25 @@ mod tests {
     }
 
     #[test]
+    fn translate_client_path_exact_match_collapses_to_local() {
+        // `path == client_save_path` is the common case when
+        // post-processing asks for the translated save_path itself
+        // (not a content_path under it). `strip_prefix` returns
+        // `Some("")`, so the concatenation becomes `local + ""` —
+        // we just return `local`.
+        assert_eq!(
+            translate_client_path("/downloads", "/downloads", "/mnt/seedbox"),
+            "/mnt/seedbox"
+        );
+        // Trailing slash on input is also handled — trimmed to the
+        // same canonical form.
+        assert_eq!(
+            translate_client_path("/downloads/", "/downloads", "/mnt/seedbox"),
+            "/mnt/seedbox/"
+        );
+    }
+
+    #[test]
     fn state_is_complete_catches_all_seed_variants() {
         use DownloadItemState::*;
         assert!(Seeding.is_complete());

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -220,33 +220,58 @@ impl DownloadItemState {
     }
 }
 
-/// Apply a remote → local path prefix rewrite. Used in post-processing
-/// to translate paths from the download client's (possibly remote)
-/// filesystem into paths Ryokan can read on its own host.
+/// Return the per-client `<client>_download_path` for whichever
+/// download client is currently active, based on `config.active_client`.
+/// Empty string when the active client has no override configured —
+/// translate_client_path treats that as "no rewrite."
+pub fn per_client_download_path(config: &crate::models::config::Config) -> &str {
+    match config.active_client.as_str() {
+        "deluge" => &config.deluge_download_path,
+        // qBittorrent is the default / unknown fallback.
+        _ => &config.qbit_download_path,
+    }
+}
+
+/// Translate a client-reported path into one Ryokan-on-host can
+/// actually read. Replaces the client's `save_path` prefix with the
+/// user-configured per-client `download_path`.
 ///
-/// Modeled on Sonarr's Remote Path Mappings: when the download client
-/// runs on a different host (seedbox), the `content_path` it reports
-/// points at its own filesystem (e.g. `/downloads/…` inside the
-/// seedbox). The user mounts that path locally via SSHFS/NFS/rclone
-/// at a different prefix (e.g. `/mnt/seedbox/…`), and this function
-/// performs the prefix swap before any filesystem op runs.
+/// Examples:
+///   - Deluge in a Docker container sees `/downloads/Show.mkv`; the
+///     host volume is mounted at `/home/user/downloads-deluge`.
+///     User sets `deluge_download_path = /home/user/downloads-deluge`.
+///     Deluge reports `torrent.save_path = /downloads`. Calling this
+///     with `path = /downloads/Show.mkv`, `client_save_path = /downloads`,
+///     `local_download_path = /home/user/downloads-deluge` produces
+///     `/home/user/downloads-deluge/Show.mkv`.
+///   - qBit on the same host as Ryokan with no config override:
+///     `local_download_path` is empty → returns `path` unchanged.
 ///
-/// Both prefixes are trimmed of trailing `/` so `/downloads` and
-/// `/downloads/` map identically. If `remote` or `local` is empty,
-/// the input is returned unchanged — the "local client, no mapping"
-/// case. If `remote` is set but the path doesn't begin with it,
-/// return the path unchanged too: it's safer to surface a mismatch
-/// than to silently rewrite a path that was never on the remote.
-pub fn apply_remote_path_mapping(path: &str, remote: &str, local: &str) -> String {
-    let r = remote.trim_end_matches('/');
-    let l = local.trim_end_matches('/');
-    if r.is_empty() || l.is_empty() {
+/// Trailing slashes on either prefix are normalized so
+/// `/downloads` and `/downloads/` behave identically. If
+/// `local_download_path` is empty, the input is returned unchanged
+/// (no-override case). If the path doesn't start with
+/// `client_save_path`, it's also returned unchanged — silently
+/// rewriting an unexpected path is worse than surfacing the
+/// mismatch as a downstream "file not found" error.
+pub fn translate_client_path(
+    path: &str,
+    client_save_path: &str,
+    local_download_path: &str,
+) -> String {
+    let remote = client_save_path.trim_end_matches('/');
+    let local = local_download_path.trim_end_matches('/');
+    if local.is_empty() {
         return path.to_string();
     }
-    if let Some(rest) = path.strip_prefix(r) {
-        // `rest` starts with `/` or is empty — either way, stitching
-        // onto the trimmed local prefix produces the correct shape.
-        format!("{l}{rest}")
+    if remote.is_empty() {
+        // The client didn't tell us a save_path prefix — all we can
+        // do is return the original. Can happen for edge states
+        // (metadata not yet arrived) but not for completed torrents.
+        return path.to_string();
+    }
+    if let Some(rest) = path.strip_prefix(remote) {
+        format!("{local}{rest}")
     } else {
         path.to_string()
     }
@@ -426,45 +451,56 @@ mod tests {
     }
 
     #[test]
-    fn remote_path_mapping_rewrites_matching_prefix() {
+    fn translate_client_path_rewrites_matching_prefix() {
         assert_eq!(
-            apply_remote_path_mapping("/downloads/anime/file.mkv", "/downloads", "/mnt/seedbox"),
+            translate_client_path("/downloads/anime/file.mkv", "/downloads", "/mnt/seedbox"),
             "/mnt/seedbox/anime/file.mkv"
         );
     }
 
     #[test]
-    fn remote_path_mapping_trims_trailing_slashes_on_prefixes() {
+    fn translate_client_path_trims_trailing_slashes() {
         // Trailing-slash normalization on both sides should produce
         // identical output — prevents the /downloads vs /downloads/
         // foot-gun that bites every Sonarr remote-path setup.
         assert_eq!(
-            apply_remote_path_mapping("/downloads/x.mkv", "/downloads/", "/mnt/seedbox/"),
+            translate_client_path("/downloads/x.mkv", "/downloads/", "/mnt/seedbox/"),
             "/mnt/seedbox/x.mkv"
         );
         assert_eq!(
-            apply_remote_path_mapping("/downloads/x.mkv", "/downloads", "/mnt/seedbox"),
+            translate_client_path("/downloads/x.mkv", "/downloads", "/mnt/seedbox"),
             "/mnt/seedbox/x.mkv"
         );
     }
 
     #[test]
-    fn remote_path_mapping_empty_prefixes_pass_through() {
-        // No mapping configured = no rewrite. The "local client"
-        // case; both prefixes empty means identity.
+    fn translate_client_path_empty_local_passes_through() {
+        // No override configured = no rewrite. The "local client,
+        // no Docker, Ryokan reads client's save_path directly" case.
         assert_eq!(
-            apply_remote_path_mapping("/downloads/x.mkv", "", ""),
+            translate_client_path("/downloads/x.mkv", "/downloads", ""),
             "/downloads/x.mkv"
         );
     }
 
     #[test]
-    fn remote_path_mapping_non_matching_prefix_unchanged() {
-        // If the path isn't under the configured remote prefix,
-        // don't silently rewrite — could indicate user mis-config.
+    fn translate_client_path_non_matching_prefix_unchanged() {
+        // If the path isn't under the client's save_path, don't
+        // silently rewrite — could indicate user mis-config.
         assert_eq!(
-            apply_remote_path_mapping("/other/path.mkv", "/downloads", "/mnt/seedbox"),
+            translate_client_path("/other/path.mkv", "/downloads", "/mnt/seedbox"),
             "/other/path.mkv"
+        );
+    }
+
+    #[test]
+    fn translate_client_path_empty_remote_passes_through() {
+        // Client hasn't reported a save_path yet (e.g. metadata not
+        // arrived). Return the input verbatim rather than turning
+        // `path` into `local/path` which would usually be wrong.
+        assert_eq!(
+            translate_client_path("/downloads/x.mkv", "", "/mnt/seedbox"),
+            "/downloads/x.mkv"
         );
     }
 

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -220,6 +220,80 @@ impl DownloadItemState {
     }
 }
 
+/// Apply a remote → local path prefix rewrite. Used in post-processing
+/// to translate paths from the download client's (possibly remote)
+/// filesystem into paths Ryokan can read on its own host.
+///
+/// Modeled on Sonarr's Remote Path Mappings: when the download client
+/// runs on a different host (seedbox), the `content_path` it reports
+/// points at its own filesystem (e.g. `/downloads/…` inside the
+/// seedbox). The user mounts that path locally via SSHFS/NFS/rclone
+/// at a different prefix (e.g. `/mnt/seedbox/…`), and this function
+/// performs the prefix swap before any filesystem op runs.
+///
+/// Both prefixes are trimmed of trailing `/` so `/downloads` and
+/// `/downloads/` map identically. If `remote` or `local` is empty,
+/// the input is returned unchanged — the "local client, no mapping"
+/// case. If `remote` is set but the path doesn't begin with it,
+/// return the path unchanged too: it's safer to surface a mismatch
+/// than to silently rewrite a path that was never on the remote.
+pub fn apply_remote_path_mapping(path: &str, remote: &str, local: &str) -> String {
+    let r = remote.trim_end_matches('/');
+    let l = local.trim_end_matches('/');
+    if r.is_empty() || l.is_empty() {
+        return path.to_string();
+    }
+    if let Some(rest) = path.strip_prefix(r) {
+        // `rest` starts with `/` or is empty — either way, stitching
+        // onto the trimmed local prefix produces the correct shape.
+        format!("{l}{rest}")
+    } else {
+        path.to_string()
+    }
+}
+
+/// Construct the concrete download-client impl dictated by the
+/// config's `active_client` discriminator. Returns `None` if the
+/// active client's credentials are empty (user hasn't configured it
+/// yet) — the caller leaves `AppState.download_client` at `None` and
+/// the grab path surfaces "Download client not configured" errors.
+///
+/// Single construction point: both startup init (`main.rs`) and
+/// settings save (`handlers::settings`) go through this so the
+/// "which impl do we pick" logic lives in one place and the arm for
+/// each client ships alongside its `mod deluge` / `mod qbittorrent`
+/// etc. as Phase 3+ clients land.
+pub fn build_download_client(
+    config: &crate::models::config::Config,
+) -> Option<std::sync::Arc<dyn DownloadClient>> {
+    match config.active_client.as_str() {
+        "deluge" => {
+            if config.deluge_url.is_empty() {
+                return None;
+            }
+            Some(std::sync::Arc::new(deluge::DelugeClient::new(
+                &config.deluge_url,
+                &config.deluge_password,
+                &config.deluge_label,
+            )))
+        }
+        // "qbittorrent" or any unknown value — qBit is the safe
+        // default to preserve pre-Phase-2 behavior for unrecognized
+        // discriminators.
+        _ => {
+            if config.qbit_url.is_empty() {
+                return None;
+            }
+            Some(std::sync::Arc::new(qbittorrent::QbitClient::new(
+                &config.qbit_url,
+                &config.qbit_user,
+                &config.qbit_pass,
+                &config.qbit_category,
+            )))
+        }
+    }
+}
+
 /// Poll `get_files` until non-empty or `timeout` elapses. 500ms
 /// initial interval, doubling up to a 2s cap. Used by callers that
 /// need the file list before proceeding (e.g. the 180s background
@@ -349,6 +423,49 @@ mod tests {
     #[test]
     fn content_path_empty_files_returns_empty() {
         assert_eq!(compute_content_path("/downloads", &[]), "");
+    }
+
+    #[test]
+    fn remote_path_mapping_rewrites_matching_prefix() {
+        assert_eq!(
+            apply_remote_path_mapping("/downloads/anime/file.mkv", "/downloads", "/mnt/seedbox"),
+            "/mnt/seedbox/anime/file.mkv"
+        );
+    }
+
+    #[test]
+    fn remote_path_mapping_trims_trailing_slashes_on_prefixes() {
+        // Trailing-slash normalization on both sides should produce
+        // identical output — prevents the /downloads vs /downloads/
+        // foot-gun that bites every Sonarr remote-path setup.
+        assert_eq!(
+            apply_remote_path_mapping("/downloads/x.mkv", "/downloads/", "/mnt/seedbox/"),
+            "/mnt/seedbox/x.mkv"
+        );
+        assert_eq!(
+            apply_remote_path_mapping("/downloads/x.mkv", "/downloads", "/mnt/seedbox"),
+            "/mnt/seedbox/x.mkv"
+        );
+    }
+
+    #[test]
+    fn remote_path_mapping_empty_prefixes_pass_through() {
+        // No mapping configured = no rewrite. The "local client"
+        // case; both prefixes empty means identity.
+        assert_eq!(
+            apply_remote_path_mapping("/downloads/x.mkv", "", ""),
+            "/downloads/x.mkv"
+        );
+    }
+
+    #[test]
+    fn remote_path_mapping_non_matching_prefix_unchanged() {
+        // If the path isn't under the configured remote prefix,
+        // don't silently rewrite — could indicate user mis-config.
+        assert_eq!(
+            apply_remote_path_mapping("/other/path.mkv", "/downloads", "/mnt/seedbox"),
+            "/other/path.mkv"
+        );
     }
 
     #[test]

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -741,10 +741,27 @@ async fn import_torrent(
         return Ok(false);
     }
 
-    // Determine the source base path. If qbit_download_path is configured, use
-    // that instead of qBit's internal save_path — this handles Docker path
-    // mapping where qBit sees /downloads/ but Ryokan sees a different mount.
-    let source_base = if !cfg.qbit_download_path.is_empty() {
+    // Determine the source base path.
+    //
+    // Precedence (post-#63 Phase 2):
+    //   1. `torrent_save_path` — already remote-path-mapped by
+    //      `run_once_inner` via `apply_remote_path_mapping`, so it's
+    //      a path Ryokan-on-host can read. This is the client-
+    //      agnostic mechanism and works for every impl.
+    //   2. Legacy `cfg.qbit_download_path` — pre-Phase-2 Docker
+    //      path-mapping escape hatch that predates
+    //      `remote_path_mapping`. Used ONLY when active_client is
+    //      qbittorrent AND remote_path_remote is empty (i.e., user
+    //      hasn't migrated to the new mechanism). Applying this for
+    //      Deluge/other clients was the Phase 2 regression that
+    //      surfaced as "File op failed: No such file or directory" —
+    //      it forced the source path to qBit's downloads dir for
+    //      every client, ignoring whatever the Deluge/etc. impl
+    //      actually reported.
+    let source_base = if cfg.active_client == "qbittorrent"
+        && cfg.remote_path_remote.is_empty()
+        && !cfg.qbit_download_path.is_empty()
+    {
         cfg.qbit_download_path.clone()
     } else {
         torrent_save_path.to_string()

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -749,6 +749,18 @@ async fn import_torrent(
     // from its own filesystem namespace (container-internal for
     // Docker, seedbox-internal for remote setups) and isn't
     // reachable from Ryokan's process without translation.
+    //
+    // **Known limitation**: when the client uses per-category /
+    // per-label save paths (Deluge "Move completed on label", qBit
+    // per-category save paths), each torrent reports a different
+    // `save_path` extending a common base (`/downloads/anime` vs
+    // `/downloads/movies`). The single-field `<client>_download_path`
+    // can't preserve that subdir — every torrent lands under the
+    // same local base, flattening the category subdir. Covers the
+    // common case (one shared save dir) at the cost of the
+    // per-category case. Fixing would re-introduce the two-field
+    // remote-prefix design we abandoned in 4972624; follow-up issue
+    // if this bites a user.
     let per_client_download_path = match cfg.active_client.as_str() {
         "deluge" => &cfg.deluge_download_path,
         _ => &cfg.qbit_download_path,

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -13,25 +13,14 @@ use crate::services::{artwork, logger, media, nfo};
 static POST_PROC_LOCK: LazyLock<tokio::sync::Mutex<()>> =
     LazyLock::new(|| tokio::sync::Mutex::new(()));
 
-/// States qBittorrent reports for a fully downloaded torrent.
-fn is_complete(state: &str) -> bool {
-    matches!(
-        state,
-        "uploading"
-            | "stalledUP"
-            | "queuedUP"
-            | "forcedUP"
-            | "pausedUP"
-            | "checkingUP"
-            | "seeding"
-            | "stoppedUP"
-    )
-}
-
-/// States that indicate a torrent has failed or has errors.
-fn is_errored(state: &str) -> bool {
-    matches!(state, "error" | "missingFiles")
-}
+// Completion and error detection goes through the trait's normalized
+// `DownloadItemState` enum (`torrent.state_kind.is_complete()` etc.)
+// rather than matching on the raw `state` string — the string is the
+// client-native label (qBit: `"stalledUP"`; Deluge: `"Seeding"`), and
+// the Phase 1 enum normalizes those into one representation for
+// client-agnostic checks. Pre-refactor this function only knew qBit's
+// string set, which silently skipped Deluge's completed torrents
+// forever (#63 Phase 2 regression).
 
 /// Check if a grab is older than `max_age_secs` seconds.
 pub fn grab_is_stale(grabbed_at: &str, max_age_secs: i64) -> bool {
@@ -1472,7 +1461,7 @@ pub async fn run_once(state: &AppState) {
         };
 
         // Detect failed/error torrents and mark them.
-        if is_errored(&torrent.state) {
+        if torrent.state_kind.is_errored() {
             logger::warn(
                 &state.db,
                 LogCategory::PostProcess,
@@ -1484,7 +1473,7 @@ pub async fn run_once(state: &AppState) {
             continue;
         }
 
-        if !is_complete(&torrent.state) {
+        if !torrent.state_kind.is_complete() {
             continue;
         }
 
@@ -1636,7 +1625,7 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
         };
         let Some(torrent) = matched else { continue };
 
-        if !is_complete(&torrent.state) {
+        if !torrent.state_kind.is_complete() {
             continue;
         }
 

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -741,28 +741,20 @@ async fn import_torrent(
         return Ok(false);
     }
 
-    // Determine the source base path.
-    //
-    // Precedence (post-#63 Phase 2):
-    //   1. `torrent_save_path` — already remote-path-mapped by
-    //      `run_once_inner` via `apply_remote_path_mapping`, so it's
-    //      a path Ryokan-on-host can read. This is the client-
-    //      agnostic mechanism and works for every impl.
-    //   2. Legacy `cfg.qbit_download_path` — pre-Phase-2 Docker
-    //      path-mapping escape hatch that predates
-    //      `remote_path_mapping`. Used ONLY when active_client is
-    //      qbittorrent AND remote_path_remote is empty (i.e., user
-    //      hasn't migrated to the new mechanism). Applying this for
-    //      Deluge/other clients was the Phase 2 regression that
-    //      surfaced as "File op failed: No such file or directory" —
-    //      it forced the source path to qBit's downloads dir for
-    //      every client, ignoring whatever the Deluge/etc. impl
-    //      actually reported.
-    let source_base = if cfg.active_client == "qbittorrent"
-        && cfg.remote_path_remote.is_empty()
-        && !cfg.qbit_download_path.is_empty()
-    {
-        cfg.qbit_download_path.clone()
+    // Determine the source base path. Pick the per-client download
+    // path the user configured in Settings ("where Ryokan can read
+    // this client's files"), falling back to whatever the client
+    // itself reported as `save_path` if no override is set. The
+    // override always wins because the client's own save_path is
+    // from its own filesystem namespace (container-internal for
+    // Docker, seedbox-internal for remote setups) and isn't
+    // reachable from Ryokan's process without translation.
+    let per_client_download_path = match cfg.active_client.as_str() {
+        "deluge" => &cfg.deluge_download_path,
+        _ => &cfg.qbit_download_path,
+    };
+    let source_base = if !per_client_download_path.is_empty() {
+        per_client_download_path.clone()
     } else {
         torrent_save_path.to_string()
     };
@@ -1498,26 +1490,28 @@ pub async fn run_once(state: &AppState) {
         // hardlink the file into the library. Done BEFORE import so
         // that even if import errors out mid-way, the UI still has a
         // record of where the client left the file. Apply the
-        // user-configured remote-path mapping (#63 Phase 2) so a
-        // seedbox-reported `/downloads/…` path is translated to the
-        // local mount point (`/mnt/seedbox/downloads/…`) before we
-        // read from disk. Empty mapping = no rewrite.
+        // user-configured per-client download path (#63 Phase 2) so a
+        // seedbox- or container-reported `/downloads/…` path is
+        // rewritten to the local mount point (e.g.
+        // `/mnt/seedbox/downloads/…`) before we read from disk. Empty
+        // download_path = same-host client, no rewrite needed.
+        let local_download_path = crate::services::download_client::per_client_download_path(&cfg);
         let client_path = {
             let raw = if !torrent.content_path.is_empty() {
                 torrent.content_path.clone()
             } else {
                 torrent.save_path.clone()
             };
-            crate::services::download_client::apply_remote_path_mapping(
+            crate::services::download_client::translate_client_path(
                 &raw,
-                &cfg.remote_path_remote,
-                &cfg.remote_path_local,
+                &torrent.save_path,
+                local_download_path,
             )
         };
-        let local_save_path = crate::services::download_client::apply_remote_path_mapping(
+        let local_save_path = crate::services::download_client::translate_client_path(
             &torrent.save_path,
-            &cfg.remote_path_remote,
-            &cfg.remote_path_local,
+            &torrent.save_path,
+            local_download_path,
         );
         let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
 
@@ -1649,18 +1643,19 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
         // Stamp the client-side path for the episode detail modal.
         // Prefer content_path (native on qBit ≥ 2.6.1; computed from
         // save_path + files' common prefix on Deluge) and fall back
-        // to save_path for pre-2.6.1 qBit. Same remote-path rewrite
-        // as in the main import path above (#63 Phase 2).
+        // to save_path for pre-2.6.1 qBit. Same per-client
+        // download-path rewrite as the main import path above.
+        let local_download_path = crate::services::download_client::per_client_download_path(&cfg);
         let client_path = {
             let raw = if !torrent.content_path.is_empty() {
                 torrent.content_path.clone()
             } else {
                 torrent.save_path.clone()
             };
-            crate::services::download_client::apply_remote_path_mapping(
+            crate::services::download_client::translate_client_path(
                 &raw,
-                &cfg.remote_path_remote,
-                &cfg.remote_path_local,
+                &torrent.save_path,
+                local_download_path,
             )
         };
         let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;

--- a/src/services/post_processing.rs
+++ b/src/services/post_processing.rs
@@ -1491,15 +1491,31 @@ pub async fn run_once(state: &AppState) {
         // Stamp qBit's output path on the grab row before we move/
         // hardlink the file into the library. Done BEFORE import so
         // that even if import errors out mid-way, the UI still has a
-        // record of where qBit left the file.
-        let qbit_path = if !torrent.content_path.is_empty() {
-            torrent.content_path.clone()
-        } else {
-            torrent.save_path.clone()
+        // record of where the client left the file. Apply the
+        // user-configured remote-path mapping (#63 Phase 2) so a
+        // seedbox-reported `/downloads/…` path is translated to the
+        // local mount point (`/mnt/seedbox/downloads/…`) before we
+        // read from disk. Empty mapping = no rewrite.
+        let client_path = {
+            let raw = if !torrent.content_path.is_empty() {
+                torrent.content_path.clone()
+            } else {
+                torrent.save_path.clone()
+            };
+            crate::services::download_client::apply_remote_path_mapping(
+                &raw,
+                &cfg.remote_path_remote,
+                &cfg.remote_path_local,
+            )
         };
-        let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &qbit_path).await;
+        let local_save_path = crate::services::download_client::apply_remote_path_mapping(
+            &torrent.save_path,
+            &cfg.remote_path_remote,
+            &cfg.remote_path_local,
+        );
+        let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
 
-        match import_torrent(state, &cfg, grab, &torrent.hash, &torrent.save_path).await {
+        match import_torrent(state, &cfg, grab, &torrent.hash, &local_save_path).await {
             Ok(true) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
@@ -1588,6 +1604,15 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
         return Ok(());
     }
 
+    // Config load is only for the remote-path mapping — we don't
+    // need the full cfg here. A single lookup is cheap; avoiding a
+    // parameter means `run_task` stays unaware of this codepath's
+    // needs.
+    let cfg = config::get_config(&state.db)
+        .await
+        .map_err(|_| ())?
+        .unwrap_or_default();
+
     let client = match state.download_client.read().await.clone() {
         Some(c) => c,
         None => return Ok(()),
@@ -1615,15 +1640,24 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
             continue;
         }
 
-        // Stamp the qBit-side path for the episode detail modal. Prefer
-        // content_path (qBit ≥ 2.6.1 — the actual file or container
-        // folder) and fall back to save_path for older qBit builds.
-        let qbit_path = if !torrent.content_path.is_empty() {
-            torrent.content_path.clone()
-        } else {
-            torrent.save_path.clone()
+        // Stamp the client-side path for the episode detail modal.
+        // Prefer content_path (native on qBit ≥ 2.6.1; computed from
+        // save_path + files' common prefix on Deluge) and fall back
+        // to save_path for pre-2.6.1 qBit. Same remote-path rewrite
+        // as in the main import path above (#63 Phase 2).
+        let client_path = {
+            let raw = if !torrent.content_path.is_empty() {
+                torrent.content_path.clone()
+            } else {
+                torrent.save_path.clone()
+            };
+            crate::services::download_client::apply_remote_path_mapping(
+                &raw,
+                &cfg.remote_path_remote,
+                &cfg.remote_path_local,
+            )
         };
-        let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &qbit_path).await;
+        let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
 
         // Mark the grab row as finalized so we stop polling it and the
         // UI stops treating it as in-flight. Use `mark_completed_no_import`

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -32,6 +32,18 @@
 
     <div class="settings-tab-panel {% if tab == "integrations" %}active{% endif %}">
         <fieldset>
+            <legend>Download Client</legend>
+            <div class="form-group">
+                <label for="active_client">Active client</label>
+                <select name="active_client" id="active_client" onchange="toggleClientFieldset(this.value)">
+                    <option value="qbittorrent" {% if config.active_client == "qbittorrent" %}selected{% endif %}>qBittorrent</option>
+                    <option value="deluge" {% if config.active_client == "deluge" %}selected{% endif %}>Deluge</option>
+                </select>
+                <span class="form-hint">Ryokan talks to one client at a time. Switching cancels any pending grabs queued against the previous client.</span>
+            </div>
+        </fieldset>
+
+        <fieldset id="qbit-fieldset" {% if config.active_client != "qbittorrent" %}style="display:none"{% endif %}>
             <legend>qBittorrent <span id="qbit-health" class="form-hint"></span></legend>
             <div class="form-group">
                 <label for="qbit_url">URL</label>
@@ -63,6 +75,47 @@
             <div class="settings-inline-actions">
                 <button type="button" class="btn btn-secondary" onclick="testQbit(this)">Test</button>
                 <span id="qbit-test-result" class="form-hint"></span>
+            </div>
+        </fieldset>
+
+        <fieldset id="deluge-fieldset" {% if config.active_client != "deluge" %}style="display:none"{% endif %}>
+            <legend>Deluge <span id="deluge-health" class="form-hint"></span></legend>
+            <div class="form-group">
+                <label for="deluge_url">URL</label>
+                <input type="text" name="deluge_url" id="deluge_url" value="{{ config.deluge_url }}" placeholder="http://localhost:8112">
+                <span class="form-hint">Deluge Web UI base URL (Ryokan appends <code>/json</code>). Default port is 8112.</span>
+            </div>
+            <div class="form-group">
+                <label for="deluge_password">Web UI password</label>
+                <div style="display: flex; gap: 8px; align-items: center;">
+                    <input type="password" name="deluge_password" id="deluge_password" value="{{ config.deluge_password }}" style="flex:1">
+                    <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('deluge_password', this)" style="white-space:nowrap">Show</button>
+                </div>
+                <span class="form-hint">The Web UI password (not the daemon/localclient password). Default on fresh installs is <code>deluge</code>.</span>
+            </div>
+            <div class="form-group">
+                <label for="deluge_label">Scoping label</label>
+                <input type="text" name="deluge_label" id="deluge_label" value="{{ config.deluge_label }}" placeholder="ryokan">
+                <span class="form-hint">Ryokan tags every torrent it adds with this label and filters by it when listing. Requires the Label plugin; Ryokan auto-enables it on first connect.</span>
+            </div>
+        </fieldset>
+
+        <fieldset>
+            <legend>Remote Path Mapping</legend>
+            <p class="form-hint" style="margin-bottom: 12px;">
+                When your download client runs on a different host (a seedbox), the path it reports for completed files is the path on that remote host. Ryokan needs the equivalent path on its own filesystem (e.g. an SSHFS or NFS mount) to post-process files. Leave blank if the client runs on the same host as Ryokan.
+            </p>
+            <div class="form-row">
+                <div class="form-group">
+                    <label for="remote_path_remote">Remote prefix</label>
+                    <input type="text" name="remote_path_remote" id="remote_path_remote" value="{{ config.remote_path_remote }}" placeholder="/downloads">
+                    <span class="form-hint">Path prefix as the download client sees it.</span>
+                </div>
+                <div class="form-group">
+                    <label for="remote_path_local">Local prefix</label>
+                    <input type="text" name="remote_path_local" id="remote_path_local" value="{{ config.remote_path_local }}" placeholder="/mnt/seedbox/downloads">
+                    <span class="form-hint">Path prefix where Ryokan can read the same files.</span>
+                </div>
             </div>
         </fieldset>
 
@@ -1073,6 +1126,16 @@ function generateRadarrApiKey() {
     let key = '';
     for (let i = 0; i < 32; i++) key += chars[buf[i] % chars.length];
     document.getElementById('radarr_api_key').value = key;
+}
+
+// #63 Phase 2 — show/hide the credential fieldset for the selected
+// download client. Both fieldsets stay in the DOM so a user
+// mid-edit doesn't lose form state when they toggle back.
+function toggleClientFieldset(value) {
+    const qbit = document.getElementById('qbit-fieldset');
+    const deluge = document.getElementById('deluge-fieldset');
+    if (qbit) qbit.style.display = value === 'qbittorrent' ? '' : 'none';
+    if (deluge) deluge.style.display = value === 'deluge' ? '' : 'none';
 }
 
 // API-key inputs render as type="password" so the secret isn't visible

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -70,7 +70,7 @@
             <div class="form-group">
                 <label for="qbit_download_path">Download Path (as seen by Ryokan)</label>
                 <input type="text" name="qbit_download_path" id="qbit_download_path" value="{{ config.qbit_download_path }}" placeholder="/downloads">
-                <span class="form-hint">The local path where qBittorrent's completed downloads are accessible to Ryokan. When both run in Docker, this is the container-side mount point (e.g. <code>/downloads</code>). When Ryokan runs on the host, use the host path that maps to qBit's download directory.</span>
+                <span class="form-hint">The local path where qBittorrent's completed downloads are accessible to Ryokan. When qBit runs in Docker with a host volume mount, enter the host-side path (e.g. <code>/home/user/downloads</code>). When qBit runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and qBit see the exact same paths.</span>
             </div>
             <div class="settings-inline-actions">
                 <button type="button" class="btn btn-secondary" onclick="testQbit(this)">Test</button>
@@ -98,24 +98,10 @@
                 <input type="text" name="deluge_label" id="deluge_label" value="{{ config.deluge_label }}" placeholder="ryokan">
                 <span class="form-hint">Ryokan tags every torrent it adds with this label and filters by it when listing. Requires the Label plugin; Ryokan auto-enables it on first connect.</span>
             </div>
-        </fieldset>
-
-        <fieldset>
-            <legend>Remote Path Mapping</legend>
-            <p class="form-hint" style="margin-bottom: 12px;">
-                When your download client runs on a different host (a seedbox), the path it reports for completed files is the path on that remote host. Ryokan needs the equivalent path on its own filesystem (e.g. an SSHFS or NFS mount) to post-process files. Leave blank if the client runs on the same host as Ryokan.
-            </p>
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="remote_path_remote">Remote prefix</label>
-                    <input type="text" name="remote_path_remote" id="remote_path_remote" value="{{ config.remote_path_remote }}" placeholder="/downloads">
-                    <span class="form-hint">Path prefix as the download client sees it.</span>
-                </div>
-                <div class="form-group">
-                    <label for="remote_path_local">Local prefix</label>
-                    <input type="text" name="remote_path_local" id="remote_path_local" value="{{ config.remote_path_local }}" placeholder="/mnt/seedbox/downloads">
-                    <span class="form-hint">Path prefix where Ryokan can read the same files.</span>
-                </div>
+            <div class="form-group">
+                <label for="deluge_download_path">Download Path (as seen by Ryokan)</label>
+                <input type="text" name="deluge_download_path" id="deluge_download_path" value="{{ config.deluge_download_path }}" placeholder="/downloads">
+                <span class="form-hint">The local path where Deluge's completed downloads are accessible to Ryokan. When Deluge runs in Docker with a host volume mount, enter the host-side path. When Deluge runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and Deluge see the exact same paths.</span>
             </div>
         </fieldset>
 


### PR DESCRIPTION
## Summary
- Phase 2 of #63. Replaces the Phase 1 Deluge stub with a real Web-UI JSON-RPC impl, wires up per-client download-path translation in post-processing, and closes several qBit-specific assumptions that the Phase 1 refactor left in place (the normalized state enum wasn't actually used; the legacy `qbit_download_path` was applied for every client).
- `services::download_client::build_download_client(&config)` becomes the single construction point — keyed on `config.active_client`, used by both startup init and settings save. Phase 3+ adds transmission/rtorrent arms here.
- Live E2E confirmed against docker-compose test Deluge: auto_search + magnet grab → Deluge auth.login + web.connect + Label plugin auto-enable + add + label.set_torrent → list_scoped returns the torrent with the correct label → post-processing sees it complete → file imports into the library. Handshake, scoping, metadata readback, per-file progress, completion detection, and path translation all work end-to-end.

## Deluge-specific quirks the impl handles
- **Two-step connect**: `auth.login` + `web.connect(host_id)`. Without the second step every `core.*` call returns `"Unknown method"`.
- **`daemon.get_version` for the health probe**, not `daemon.info` — `daemon.info` is NOT exposed on the web-proxy's `/json` endpoint (only the raw daemon RPC on 58846), so calling it post-connect silently returns `"Unknown method"` and the settings page shows "Connection failed" despite the handshake working.
- **Label plugin auto-enable**: detects via `web.get_plugins`, enables via `core.enable_plugin("Label")`, reconnects to force Deluge to re-register plugin RPC methods on the web process (upstream bug).
- **Priority scale is 0/1/4/7** (Skip/Low/Normal/High), NOT qBit's 0/1/6/7. Writing 1 for "wanted" would Low-priority the file.
- **Duplicate-add** detected via message-matching on `"Torrent already in session"` / `"Torrent already being added"` since error codes are unstable across versions (deluge-dev #3507).
- **No `has_metadata` field** in the current Deluge build — proxy: `files` array non-empty.
- **`file_progress` parallel array**, populated per-file. qBit's per-file `progress` is 0.0–1.0 and Deluge's `file_progress` is the same scale — so post-processing's `f.progress >= 1.0` completion filter works across both clients once the field is plumbed through. Initial sketch hardcoded 0.0 and silently kept every Deluge grab in `pending` forever.
- **`Moving` state** maps to a non-complete `DownloadItemState` variant regardless of `is_finished` — libtorrent's storage move during this window makes `content_path` a race.
- Silent field omission from `get_torrent_status` handled via `#[serde(default)]` on every field.

## Per-client download path (replaces the initial "remote path mapping" sketch)
- Every download client gets its own `<client>_download_path` field in config (`qbit_download_path` already existed; `deluge_download_path` added; transmission/rtorrent in Phase 3/4). Same shape as the long-standing qBit field — "where Ryokan reads this client's files from its own filesystem."
- `services::download_client::translate_client_path(path, client_save_path, local_download_path)` does the prefix swap: strip the client's own reported `save_path`, prepend the user-configured local path. The "remote prefix" comes from per-torrent `save_path` data that the trait already exposes — no need for a separate `remote_path_remote` user field.
- `per_client_download_path(&cfg)` is the single keyed accessor based on `active_client`.
- **Abandoned the initial prefix-pair sketch** (`remote_path_remote` / `remote_path_local` global columns) — couldn't handle multi-client setups (seedbox Deluge + local qBit have different host-side mounts but one global pair can only hold one). Those columns survive in the DB as dead (dropping would rewrite the whole config table on every boot per the Phase 1 DROP COLUMN review finding) but are out of the `Config` struct, UI, and every read path.
- One-time data migration copies any `remote_path_local` value that dev-branch testers had set into the appropriate `<active_client>_download_path` so nobody loses config.

## Post-processing fixes surfaced during E2E
Phase 1 left three qBit-specific assumptions in post-processing that worked in isolation but broke as soon as a second client was active:

- **Completion detection**: `is_complete(&torrent.state)` matched qBit's native state strings (`"stalledUP"`, `"seeding"`, etc.). Deluge reports `"Seeding"` / `"Downloading"` — not in the set. Now uses `torrent.state_kind.is_complete()` / `.is_errored()` on the normalized enum each impl populates alongside the raw state.
- **Source base override**: `cfg.qbit_download_path` was unconditionally overriding `torrent_save_path` for every client, not just qBit. Now gated on `active_client` (and superseded by `<client>_download_path` when the user has migrated to the new field).
- **Per-client download path applied throughout**: stamped `client_content_path` and the source base for the actual file read both go through `translate_client_path` with the per-client config value.

## Client-switch handling
When `active_client` changes in Settings, Ryokan now:
1. Snapshots all `state='pending'` grab rows.
2. Queries the OLD client's `list_scoped` for each one's current state.
3. **Only deletes the in-flight torrents** from the old client (`delete(hash, true)`). Completed-but-not-yet-imported torrents are left intact — the user almost certainly wants to keep finished files that just missed the post-processing window. Missing-from-old-client entries are skipped (either manually removed or the old client is unreachable).
4. Marks all snapshot rows `state='failed'` in the DB regardless.
5. **Clears `episode_quality_tags` for each canceled grab** via `clear_tags_for_removal` so the series page UI drops the "grabbed" badge. Without this the DB said `failed` but the UI stayed stuck on `grabbed`.
6. Swaps the `AppState.download_client` Arc.

## Schema
- New columns on `config`: `active_client`, `deluge_url`, `deluge_password`, `deluge_label`, `deluge_download_path`.
- Dead columns on `config` (kept to avoid table rewrite): `remote_path_remote`, `remote_path_local`.
- New helper `grabbed_torrents::mark_all_pending_failed` used by the client-switch handler.

## UI
- Settings page gains a "Download Client" dropdown fieldset at the top of Connections.
- Per-client credential fieldsets (qBit, Deluge) shown conditionally on the dropdown value.
- Each client's fieldset carries its own `Download Path` field (qBit unchanged; Deluge new). No separate "Remote Path Mapping" fieldset.
- Existing qBit fieldset preserved verbatim so upgrading users see no regression.
- Downloads page "Output path" display continues to work across both clients.

## Docker test stack
`docker-compose.yml` in `qbit-jellyfin/` gains Deluge / Transmission / ruTorrent under a `test-clients` profile. All containers pin DNS to `1.1.1.1 + 8.8.8.8` to insulate against host `/etc/resolv.conf` drift (VPN-pushed DNS that went stale in our test setup — see the commit for the host-resolv-conf-at-container-creation-time dance).

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin ryokan` — 557 passed (+12 new: Deluge state mapping, label defaults, dup-add + disconnect matchers, object-safety, translate_client_path round-trips across trim/empty/non-matching cases)
- [x] Live: Ryokan ↔ Deluge (docker-compose test instance) — connect, grab, scoping, label roundtrip
- [x] Live: `daemon.get_version` probe returns the Deluge version string in settings save
- [x] Live: Post-processing completion detection against Deluge's native state strings (regression from Phase 1)
- [x] Live: Per-file `file_progress` plumbed through to Ryokan's completion filter
- [x] Live: Client-switch with pending grabs — in-flight canceled + deleted from old client, completed preserved, episode tags cleared so UI drops "grabbed" badge
- [x] Live: Per-client download path (`deluge_download_path`) translates correctly from `/downloads` (container) to host mount point, full grab-to-import flow works
- [ ] Live: Real seedbox over SSHFS/NFS — not validated (docker-compose is a close proxy but not identical to cross-host mounts)

Refs #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)