### PR TITLE
chore(ci): add Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      cargo-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore(deps)
+      include: scope
+
+  - package-ecosystem: github-actions
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch
+    commit-message:
+      prefix: chore(ci)
+      include: scope
+
+  - package-ecosystem: docker
+    directory: /
+    target-branch: dev
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: chore(docker)
+      include: scope


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` covering cargo, github-actions, and docker
- Weekly cadence; minor+patch grouped per-ecosystem to cut PR noise
- PRs target `dev` so they flow through the normal dev→main path

Needs to land on `main` (the default branch) for Dependabot to pick up the config at all.

## Test plan
- [ ] CI green
- [ ] After merge, confirm Dependabot appears under repo Insights → Dependency graph → Dependabot

🤖 Generated with [Claude Code](https://claude.com/claude-code)