### PR TITLE
feat(ux): 1.3.0 UX pass — batch 2 (remaining 3 items) + CI fix

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -11,6 +11,18 @@ on:
   schedule:
     - cron: "0 9 * * 1"
 
+# `rustsec/audit-check@v2` posts advisory results via the Checks API
+# and opens issue comments on the PR it's running against. Without
+# these write scopes the action still runs the audit, but the final
+# "create check run" call fails with "Resource not accessible by
+# integration" and the step errors out. Granted at the workflow level
+# so scheduled / main-push runs can also post through.
+permissions:
+  contents: read
+  checks: write
+  issues: write
+  pull-requests: write
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2285,7 +2285,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "1.2.5"
+version = "1.3.0"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2267,9 +2267,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "1.2.5"
+version = "1.3.0"
 edition = "2024"
 rust-version = "1.95"
 

--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -130,6 +130,16 @@ pub async fn downloads_page(
 ) -> Html<String> {
     let tab = normalize_tab(params.tab);
 
+    // Load once up-front so history/blocklist queries can honor the
+    // user's title_language preference. Queue doesn't need it — the
+    // torrent client reports the release filename, not the series.
+    let title_language = crate::models::config::get_config(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .map(|c| c.title_language)
+        .unwrap_or_else(|| "english".to_string());
+
     let (queue, queue_error) = if tab == "queue" {
         let client = state.download_client.read().await.clone();
         match client {
@@ -165,7 +175,7 @@ pub async fn downloads_page(
     };
 
     let history = if tab == "history" {
-        grabbed_torrents::get_all_with_series(&state.db, 500)
+        grabbed_torrents::get_all_with_series(&state.db, 500, &title_language)
             .await
             .unwrap_or_default()
     } else {
@@ -173,7 +183,7 @@ pub async fn downloads_page(
     };
 
     let blocklist = if tab == "blocklist" {
-        grabbed_torrents::get_blocked(&state.db)
+        grabbed_torrents::get_blocked(&state.db, &title_language)
             .await
             .unwrap_or_default()
     } else {

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -486,23 +486,40 @@ pub async fn set_monitoring(
     )
     .await;
 
-    // Auto-grab monitored episodes if requested (e.g. after initial add).
-    if form.auto_grab.unwrap_or(false)
-        && mode != monitoring::MonitorMode::None
+    // Auto-grab monitored episodes when either:
+    //   1. The caller explicitly asked for it via `form.auto_grab`
+    //      (e.g. the add-series flow does this once to seed the
+    //      library), gated on `config.auto_grab_on_add`; or
+    //   2. `config.search_on_monitoring_change` is on (#1.3.0 opt-in
+    //      flag). This fires on every monitoring change so users who
+    //      flip `none → all` get an immediate delta-search without
+    //      needing to click an extra button.
+    //
+    // Either trigger bails when the mode is `None` (nothing to search
+    // for) or when no download client is configured. `auto_search_
+    // series` internally walks only monitored-and-missing episodes,
+    // so narrowing transitions (`all → missing`) are a natural no-op.
+    if mode != monitoring::MonitorMode::None
         && summary.monitored_count > 0
         && state.download_client.read().await.is_some()
     {
-        let auto_grab_on_add = config::get_config(&state.db)
-            .await
-            .ok()
-            .flatten()
-            .map(|c| c.auto_grab_on_add)
-            .unwrap_or(true);
+        let cfg = config::get_config(&state.db).await.ok().flatten();
+        let auto_grab_on_add = cfg.as_ref().map(|c| c.auto_grab_on_add).unwrap_or(true);
+        let search_on_change = cfg
+            .as_ref()
+            .map(|c| c.search_on_monitoring_change)
+            .unwrap_or(false);
 
-        if auto_grab_on_add {
+        let should_search =
+            (form.auto_grab.unwrap_or(false) && auto_grab_on_add) || search_on_change;
+
+        if should_search {
             let state_clone = state.clone();
             tokio::spawn(async move {
-                // Small delay to let metadata hydration finish.
+                // Small delay to let metadata hydration finish. Not
+                // strictly needed on a monitoring-only toggle (no
+                // hydration pending) but harmless and keeps the two
+                // call paths consistent.
                 tokio::time::sleep(std::time::Duration::from_secs(3)).await;
                 let _ = auto_search_series(
                     axum::extract::State(state_clone),

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -514,13 +514,19 @@ pub async fn set_monitoring(
             (form.auto_grab.unwrap_or(false) && auto_grab_on_add) || search_on_change;
 
         if should_search {
+            // Only the add-series flow has metadata hydration in
+            // flight — that path passes `form.auto_grab = true`. A
+            // pure monitoring-toggle (flipped by the user on an
+            // already-tracked series) has nothing to wait for, so
+            // skip the 3s delay and kick off the search immediately.
+            // Reduces the "user flips monitoring then closes the tab"
+            // race window and makes the interactive case feel instant.
+            let needs_hydration_delay = form.auto_grab.unwrap_or(false);
             let state_clone = state.clone();
             tokio::spawn(async move {
-                // Small delay to let metadata hydration finish. Not
-                // strictly needed on a monitoring-only toggle (no
-                // hydration pending) but harmless and keeps the two
-                // call paths consistent.
-                tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                if needs_hydration_delay {
+                    tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+                }
                 let _ = auto_search_series(
                     axum::extract::State(state_clone),
                     axum::extract::Path(series_id),

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -304,7 +304,6 @@ pub async fn grab_release(
         let is_batch = form.is_batch.unwrap_or(false);
         let state_task = state.clone();
         let client_task = client.clone();
-        let url_task = form.url.clone();
         tokio::spawn(async move {
             let Some((series, eps)) =
                 crate::services::rss::match_library_title(&state_task.db, &title, is_batch).await
@@ -431,11 +430,6 @@ pub async fn grab_release(
                     .await;
                 });
             }
-
-            // Suppress unused-variable warning when grab_id is None
-            // (record_grab returned Err) — the if-let above already
-            // guards auto_expand on it.
-            let _ = url_task;
         });
     }
 

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -51,6 +51,23 @@ fn default_page() -> i32 {
 #[derive(Deserialize, utoipa::ToSchema)]
 pub struct GrabForm {
     url: String,
+    /// Optional release title — used for library linkage (#1.3.0 plan
+    /// item 6d). When supplied, the grab handler tries to match it
+    /// against an existing library series; on match, the grab lands
+    /// in `grabbed_torrents` linked to that series and (for batches)
+    /// auto_expand runs for sibling-series detection. Empty / absent
+    /// = behave like the original grab endpoint (fire-and-forget).
+    #[serde(default)]
+    title: Option<String>,
+    /// Optional info_hash from the frontend. Used both to key the
+    /// download-client add and (when matched) as the grabbed_torrents
+    /// primary key. Frontend sends it when known.
+    #[serde(default)]
+    info_hash: Option<String>,
+    /// Whether the release was flagged as a batch by the search UI.
+    /// Gates auto_expand at grab time.
+    #[serde(default)]
+    is_batch: Option<bool>,
 }
 
 /// Helper to build SearchOptions from config.
@@ -225,12 +242,16 @@ pub async fn grab_release(
             .clone()
     };
 
-    let info_hash = crate::services::nyaa::extract_hash(&form.url);
+    let form_hash = form.info_hash.clone().unwrap_or_default();
+    let info_hash = if !form_hash.is_empty() {
+        form_hash
+    } else {
+        crate::services::nyaa::extract_hash(&form.url)
+    };
     client
         .add_torrent(&form.url, &info_hash)
         .await
         .map_err(|e| {
-            // Fire-and-forget log — don't block on it in the error path.
             let db = state.db.clone();
             let err_msg = e.clone();
             tokio::spawn(async move {
@@ -246,6 +267,155 @@ pub async fn grab_release(
         &form.url,
     )
     .await;
+
+    // Library linkage (#6d) — fire-and-forget so the user sees
+    // "grabbed" immediately while the library bookkeeping runs in the
+    // background. Only runs when the frontend passed a title (so we
+    // have something to match) and info_hash (so grabbed_torrents has
+    // a stable primary key). Matching against the existing library
+    // reuses the RSS matcher — no AniList calls, no HTTP, just the
+    // alias/fuzzy-match pass.
+    if let (Some(title), hash) = (form.title.clone(), info_hash.clone())
+        && !title.is_empty()
+        && !hash.is_empty()
+    {
+        let is_batch = form.is_batch.unwrap_or(false);
+        let state_task = state.clone();
+        let client_task = client.clone();
+        let url_task = form.url.clone();
+        tokio::spawn(async move {
+            let Some((series, eps)) =
+                crate::services::rss::match_library_title(&state_task.db, &title, is_batch).await
+            else {
+                // No library match. Grab succeeds without series
+                // attribution. Auto-adding the series via AniList is
+                // scoped out for this pass — it needs care around
+                // rate limits, duplicate detection, and provider
+                // fallbacks.
+                return;
+            };
+            // Record the grab against the matched series. Episode
+            // numbers come from the RSS matcher's resolved_eps
+            // (absolute or season-relative, whichever fired).
+            let grab_id = crate::models::grabbed_torrents::record_grab(
+                &state_task.db,
+                &hash,
+                &title,
+                series.id,
+                &eps,
+                is_batch,
+            )
+            .await
+            .ok()
+            .flatten();
+
+            // Populate episode_quality_tags so the series page shows
+            // each grabbed episode in 'grabbed' state right away.
+            let classification = crate::services::source::classify_release(
+                &state_task.db,
+                &title,
+                None,
+                Some(crate::services::source::NyaaContext {
+                    info_hash: &hash,
+                    view_url: "",
+                    is_batch,
+                }),
+                Some(crate::services::source::SeriesContext {
+                    status: &series.status,
+                    season_year: series.season_year,
+                    end_year: series.end_year,
+                }),
+            )
+            .await;
+            for ep in &eps {
+                let _ = crate::models::episode_tags::record_grab(
+                    &state_task.db,
+                    series.id,
+                    *ep,
+                    &classification,
+                    &title,
+                    "",
+                    0,
+                    is_batch,
+                )
+                .await;
+            }
+
+            logger::info(
+                &state_task.db,
+                LogCategory::Grab,
+                &format!(
+                    "Manual grab linked to series: {} ({} ep{})",
+                    series.title,
+                    eps.len(),
+                    if eps.len() == 1 { "" } else { "s" }
+                ),
+                &title,
+            )
+            .await;
+
+            // Batch grabs get sibling-series detection via auto_expand
+            // at metadata-available time — same path RSS + auto-search
+            // use. Skipped when the series's provider_id is negative
+            // (Jikan-fallback sentinel, no AL graph to walk).
+            if is_batch
+                && series.anilist_id > 0
+                && let Some(grab_id) = grab_id
+            {
+                let db_expand = state_task.db.clone();
+                let client_expand = client_task.clone();
+                let hash_expand = hash.clone();
+                let title_expand = title.clone();
+                let series_id_expand = series.id;
+                let provider_id_expand = series.anilist_id;
+                let ep_list_expand = eps.clone();
+                let classification_expand = classification.clone();
+                tokio::spawn(async move {
+                    let detail = match crate::models::metadata_cache::get_by_provider_id(
+                        &db_expand,
+                        provider_id_expand,
+                    )
+                    .await
+                    {
+                        Ok(Some(row)) => row.detail,
+                        _ => return,
+                    };
+                    let files = match crate::services::download_client::wait_for_files(
+                        &*client_expand,
+                        &hash_expand,
+                        std::time::Duration::from_secs(180),
+                    )
+                    .await
+                    {
+                        Ok(files) => files,
+                        Err(_) => return,
+                    };
+                    let filenames: Vec<String> = files.into_iter().map(|f| f.name).collect();
+                    let ctx = crate::services::auto_expand::AutoExpandGrabContext {
+                        classification: classification_expand,
+                        release_group: String::new(),
+                        size_bytes: 0,
+                    };
+                    crate::services::auto_expand::expand_from_files(
+                        &db_expand,
+                        &filenames,
+                        &detail,
+                        series_id_expand,
+                        &ep_list_expand,
+                        grab_id,
+                        &title_expand,
+                        &ctx,
+                    )
+                    .await;
+                });
+            }
+
+            // Suppress unused-variable warning when grab_id is None
+            // (record_grab returned Err) — the if-let above already
+            // guards auto_expand on it.
+            let _ = url_task;
+        });
+    }
 
     Ok(Json(serde_json::json!({"ok": true})))
 }

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -8,7 +8,7 @@ use serde::Deserialize;
 
 use crate::AppState;
 use crate::models::log::LogCategory;
-use crate::services::{logger, nyaa};
+use crate::services::{logger, nyaa, scoring};
 
 #[derive(Template)]
 #[template(path = "search.html")]
@@ -144,7 +144,7 @@ pub async fn search_submit(
     )
     .await;
 
-    let response = match nyaa::search(&opts, 1).await {
+    let mut response = match nyaa::search(&opts, 1).await {
         Ok(resp) => {
             logger::debug(
                 &state.db,
@@ -170,6 +170,19 @@ pub async fn search_submit(
             }
         }
     };
+
+    // #1.3.0 — augment the base-score breakdown with Custom Format
+    // contributions so the search-page expander shows both the base
+    // rules and the CF deltas. SeaDex specs never fire here (no
+    // series context = empty hash set), which is deliberate: the
+    // manual search page is a generic Nyaa search surface, not a
+    // per-series auto-grab path.
+    let cfs = state.custom_formats.read().await.clone();
+    scoring::apply_cf_breakdown(
+        &mut response.results,
+        &cfs,
+        &std::collections::HashSet::new(),
+    );
 
     let template = SearchTemplate {
         page: "search".to_string(),
@@ -207,9 +220,18 @@ pub async fn search_page_api(
     )
     .await;
 
-    let response = nyaa::search(&opts, params.p)
+    let mut response = nyaa::search(&opts, params.p)
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e))?;
+
+    // Mirror search_submit — keep the expander/scores consistent across
+    // page 1 (server-rendered) and page 2+ (JSON-appended via loadMore).
+    let cfs = state.custom_formats.read().await.clone();
+    scoring::apply_cf_breakdown(
+        &mut response.results,
+        &cfs,
+        &std::collections::HashSet::new(),
+    );
 
     Ok(Json(response))
 }

--- a/src/handlers/settings/custom_formats.rs
+++ b/src/handlers/settings/custom_formats.rs
@@ -1304,6 +1304,7 @@ pub async fn settings_custom_formats_test(
         is_trusted: false,
         score: 0,
         info_hash: String::new(),
+        score_breakdown: Vec::new(),
     };
     let seadex: std::collections::HashSet<String> = std::collections::HashSet::new();
     let ctx = EvalContext {

--- a/src/handlers/settings/custom_formats.rs
+++ b/src/handlers/settings/custom_formats.rs
@@ -1305,6 +1305,7 @@ pub async fn settings_custom_formats_test(
         score: 0,
         info_hash: String::new(),
         score_breakdown: Vec::new(),
+        upload_date: String::new(),
     };
     let seadex: std::collections::HashSet<String> = std::collections::HashSet::new();
     let ctx = EvalContext {

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -208,6 +208,9 @@ pub struct SettingsForm {
     rss_interval_minutes: i32,
     post_processing_enabled: Option<String>,
     post_processing_mode: String,
+    /// #1.3.0 — opt-in: trigger auto-search when a series's
+    /// monitoring mode changes. Default off. Settings → General.
+    search_on_monitoring_change: Option<String>,
     prefer_subs: String,
     sonarr_enabled: Option<String>,
     sonarr_api_key: Option<String>,
@@ -530,6 +533,7 @@ pub async fn settings_submit(
             .as_ref()
             .map(|c| c.auto_grab_on_add)
             .unwrap_or(true),
+        search_on_monitoring_change: form.search_on_monitoring_change.is_some(),
         prefer_subs: form.prefer_subs == "1",
         allow_non_english: existing_cfg
             .as_ref()

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -78,6 +78,11 @@ pub struct Config {
     pub post_processing_enabled: bool,
     pub post_processing_mode: String,
     pub auto_grab_on_add: bool,
+    /// #1.3.0 UX pass — when true, any update to a series's
+    /// monitoring mode triggers an auto-search over the newly-
+    /// monitored-and-airable episodes. Default off to preserve
+    /// existing behavior.
+    pub search_on_monitoring_change: bool,
     pub prefer_subs: bool,
     pub allow_non_english: bool,
     pub sonarr_enabled: bool,
@@ -155,6 +160,7 @@ impl Default for Config {
             post_processing_enabled: false,
             post_processing_mode: "hardlink".to_string(),
             auto_grab_on_add: true,
+            search_on_monitoring_change: false,
             prefer_subs: true,
             allow_non_english: false,
             sonarr_enabled: false,
@@ -212,6 +218,7 @@ struct ConfigRow {
     post_processing_enabled: i64,
     post_processing_mode: String,
     auto_grab_on_add: i64,
+    search_on_monitoring_change: i64,
     prefer_subs: i64,
     allow_non_english: i64,
     sonarr_enabled: i64,
@@ -228,7 +235,7 @@ struct ConfigRow {
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
+        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -274,6 +281,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         post_processing_enabled: r.post_processing_enabled != 0,
         post_processing_mode: r.post_processing_mode,
         auto_grab_on_add: r.auto_grab_on_add != 0,
+        search_on_monitoring_change: r.search_on_monitoring_change != 0,
         prefer_subs: r.prefer_subs != 0,
         allow_non_english: r.allow_non_english != 0,
         sonarr_enabled: r.sonarr_enabled != 0,
@@ -292,8 +300,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             active_client = excluded.active_client,
             qbit_url = excluded.qbit_url,
@@ -335,6 +343,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             post_processing_enabled = excluded.post_processing_enabled,
             post_processing_mode = excluded.post_processing_mode,
             auto_grab_on_add = excluded.auto_grab_on_add,
+            search_on_monitoring_change = excluded.search_on_monitoring_change,
             prefer_subs = excluded.prefer_subs,
             allow_non_english = excluded.allow_non_english,
             sonarr_enabled = excluded.sonarr_enabled,
@@ -388,6 +397,11 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(if config.post_processing_enabled { 1_i64 } else { 0_i64 })
     .bind(&config.post_processing_mode)
     .bind(if config.auto_grab_on_add { 1_i64 } else { 0_i64 })
+    .bind(if config.search_on_monitoring_change {
+        1_i64
+    } else {
+        0_i64
+    })
     .bind(if config.prefer_subs { 1_i64 } else { 0_i64 })
     .bind(if config.allow_non_english { 1_i64 } else { 0_i64 })
     .bind(if config.sonarr_enabled { 1_i64 } else { 0_i64 })

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -722,6 +722,39 @@ pub async fn clear_episode_tag(
     Ok(())
 }
 
+/// Flip the latest `completed` grab_history row for (series_id, ep) to
+/// `replaced` — the per-episode counterpart of
+/// `grabbed_torrents::mark_replaced`. Called by post-processing when an
+/// upgrade lands on an episode that already had an import, so the
+/// episode detail modal can distinguish "the old grab was superseded"
+/// from "the old grab was user-cancelled" (which stays `removed`).
+///
+/// Only touches the most recent `completed` row — older entries from
+/// prior grab cycles stay as-is (they've already gone through their
+/// own lifecycle). If no `completed` row exists (orphan upgrade case
+/// covered by post_processing's disk-as-truth path), this is a no-op.
+pub async fn mark_grab_history_replaced(
+    db: &SqlitePool,
+    series_id: i64,
+    episode_number: i32,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE episode_grab_history
+         SET state = 'replaced', updated_at = CURRENT_TIMESTAMP
+         WHERE id = (
+             SELECT id FROM episode_grab_history
+             WHERE series_id = ? AND episode_number = ? AND state = 'completed'
+             ORDER BY grabbed_at DESC
+             LIMIT 1
+         )",
+    )
+    .bind(series_id)
+    .bind(episode_number)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
 /// Clear episode quality tags and mark grab history as "removed" for all episodes
 /// associated with a grabbed torrent (identified by series_id + episode_numbers).
 ///

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -437,23 +437,48 @@ pub async fn mark_removed(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
+/// Build the `series_title` SELECT expression honoring the user's
+/// `title_language` preference. Mirrors the fallback order in
+/// `services::nfo::title_for_preference` — `NULLIF(col, '')` is needed
+/// because `series` columns are `NOT NULL DEFAULT ''` rather than
+/// nullable, so a plain COALESCE would return the first empty string
+/// instead of skipping to the next field.
+///
+/// Fallback order (must match nfo::title_for_preference):
+/// - `romaji`  → english → native → title
+/// - `native`  → english → romaji → title
+/// - english / anything else → romaji → native → title
+fn title_select_expr(preference: &str) -> &'static str {
+    match preference {
+        "romaji" => {
+            "COALESCE(NULLIF(s.title_romaji, ''), NULLIF(s.title_english, ''), NULLIF(s.title_native, ''), s.title, '') AS series_title"
+        }
+        "native" => {
+            "COALESCE(NULLIF(s.title_native, ''), NULLIF(s.title_english, ''), NULLIF(s.title_romaji, ''), s.title, '') AS series_title"
+        }
+        _ => {
+            "COALESCE(NULLIF(s.title_english, ''), NULLIF(s.title_romaji, ''), NULLIF(s.title_native, ''), s.title, '') AS series_title"
+        }
+    }
+}
+
 /// Get all grabbed torrents with series title, ordered by most recent first.
 pub async fn get_all_with_series(
     db: &SqlitePool,
     limit: i64,
+    title_language: &str,
 ) -> Result<Vec<GrabbedTorrentWithSeries>, sqlx::Error> {
-    let rows = sqlx::query(
+    let sql = format!(
         r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.state, g.grabbed_at, g.imported_at,
-                  COALESCE(s.title_english, s.title_romaji, s.title, '') AS series_title,
+                  {title_expr},
                   COALESCE(s.anilist_id, 0) AS anilist_id
            FROM grabbed_torrents g
            LEFT JOIN series s ON s.id = g.series_id
            ORDER BY g.grabbed_at DESC
            LIMIT ?"#,
-    )
-    .bind(limit)
-    .fetch_all(db)
-    .await?;
+        title_expr = title_select_expr(title_language),
+    );
+    let rows = sqlx::query(&sql).bind(limit).fetch_all(db).await?;
 
     Ok(rows
         .iter()
@@ -477,18 +502,21 @@ pub async fn get_all_with_series(
 }
 
 /// Get all failed/blocked torrents.
-pub async fn get_blocked(db: &SqlitePool) -> Result<Vec<GrabbedTorrentWithSeries>, sqlx::Error> {
-    let rows = sqlx::query(
+pub async fn get_blocked(
+    db: &SqlitePool,
+    title_language: &str,
+) -> Result<Vec<GrabbedTorrentWithSeries>, sqlx::Error> {
+    let sql = format!(
         r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.state, g.grabbed_at, g.imported_at,
-                  COALESCE(s.title_english, s.title_romaji, s.title, '') AS series_title,
+                  {title_expr},
                   COALESCE(s.anilist_id, 0) AS anilist_id
            FROM grabbed_torrents g
            LEFT JOIN series s ON s.id = g.series_id
            WHERE g.state = 'failed'
            ORDER BY g.grabbed_at DESC"#,
-    )
-    .fetch_all(db)
-    .await?;
+        title_expr = title_select_expr(title_language),
+    );
+    let rows = sqlx::query(&sql).fetch_all(db).await?;
 
     Ok(rows
         .iter()

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -437,6 +437,31 @@ pub async fn mark_removed(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     Ok(())
 }
 
+/// Flip a previously-imported grab to the `replaced` state and stamp
+/// `replaced_by_grab_id` with the id of the new grab that took its
+/// place. Called by post-processing when a higher-scoring upgrade
+/// lands on the same episode(s) as an existing import — distinct from
+/// `mark_removed`, which is the user-cancel / cleanup path.
+///
+/// The history UI reads both columns: `replaced` rows show a "replaced
+/// by <new release>" tooltip + link so users can see why an earlier
+/// download disappeared, and the replacing grab's row surfaces a
+/// "superseded N grabs" note derived from the reverse lookup.
+pub async fn mark_replaced(
+    db: &SqlitePool,
+    id: i64,
+    replaced_by_grab_id: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE grabbed_torrents SET state = 'replaced', replaced_by_grab_id = ? WHERE id = ?",
+    )
+    .bind(replaced_by_grab_id)
+    .bind(id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
 /// Build the `series_title` SELECT expression honoring the user's
 /// `title_language` preference. Mirrors the fallback order in
 /// `services::nfo::title_for_preference` — `NULLIF(col, '')` is needed
@@ -471,9 +496,13 @@ pub async fn get_all_with_series(
     let sql = format!(
         r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.state, g.grabbed_at, g.imported_at,
                   {title_expr},
-                  COALESCE(s.anilist_id, 0) AS anilist_id
+                  COALESCE(s.anilist_id, 0) AS anilist_id,
+                  g.replaced_by_grab_id,
+                  COALESCE(rby.torrent_name, '') AS replaced_by_torrent_name,
+                  (SELECT COUNT(*) FROM grabbed_torrents rp WHERE rp.replaced_by_grab_id = g.id) AS replaces_count
            FROM grabbed_torrents g
            LEFT JOIN series s ON s.id = g.series_id
+           LEFT JOIN grabbed_torrents rby ON rby.id = g.replaced_by_grab_id
            ORDER BY g.grabbed_at DESC
            LIMIT ?"#,
         title_expr = title_select_expr(title_language),
@@ -496,6 +525,9 @@ pub async fn get_all_with_series(
                 imported_at: row.get("imported_at"),
                 series_title: row.get("series_title"),
                 anilist_id: row.get("anilist_id"),
+                replaced_by_grab_id: row.get("replaced_by_grab_id"),
+                replaced_by_torrent_name: row.get("replaced_by_torrent_name"),
+                replaces_count: row.get("replaces_count"),
             }
         })
         .collect())
@@ -509,7 +541,10 @@ pub async fn get_blocked(
     let sql = format!(
         r#"SELECT g.id, g.hash, g.torrent_name, g.series_id, g.episode_numbers, g.state, g.grabbed_at, g.imported_at,
                   {title_expr},
-                  COALESCE(s.anilist_id, 0) AS anilist_id
+                  COALESCE(s.anilist_id, 0) AS anilist_id,
+                  g.replaced_by_grab_id,
+                  '' AS replaced_by_torrent_name,
+                  0 AS replaces_count
            FROM grabbed_torrents g
            LEFT JOIN series s ON s.id = g.series_id
            WHERE g.state = 'failed'
@@ -534,6 +569,9 @@ pub async fn get_blocked(
                 imported_at: row.get("imported_at"),
                 series_title: row.get("series_title"),
                 anilist_id: row.get("anilist_id"),
+                replaced_by_grab_id: row.get("replaced_by_grab_id"),
+                replaced_by_torrent_name: row.get("replaced_by_torrent_name"),
+                replaces_count: row.get("replaces_count"),
             }
         })
         .collect())
@@ -791,6 +829,21 @@ pub struct GrabbedTorrentWithSeries {
     pub imported_at: Option<String>,
     pub series_title: String,
     pub anilist_id: i64,
+    /// When `state = 'replaced'`, the id of the grab that superseded
+    /// this one (upgrade-driven replacement from post-processing).
+    /// `None` for any other state and for replaced rows written before
+    /// the column was introduced.
+    pub replaced_by_grab_id: Option<i64>,
+    /// Title of the grab referenced by `replaced_by_grab_id`, resolved
+    /// via a LEFT JOIN at query time so the UI can render a "replaced
+    /// by <release>" tooltip without a second round-trip. Empty when
+    /// the pointer is NULL or dangles.
+    pub replaced_by_torrent_name: String,
+    /// Count of rows that carry `replaced_by_grab_id = this.id` — i.e.
+    /// how many prior grabs this one superseded. Drives the
+    /// "superseded N grabs" note on the replacing row. Zero for the
+    /// common case.
+    pub replaces_count: i64,
 }
 
 #[cfg(test)]
@@ -1225,6 +1278,96 @@ mod tests {
         assert!(
             hits_after_remove.is_empty(),
             "removed grabs must not reappear in pending lookup"
+        );
+    }
+
+    #[tokio::test]
+    async fn mark_replaced_flips_state_and_stamps_back_pointer() {
+        use sqlx::Row;
+        let db = SqlitePool::connect("sqlite::memory:")
+            .await
+            .expect("memory db");
+        crate::models::migrate(&db).await.expect("migrate");
+
+        let (series_id, _) = series::upsert(
+            &db,
+            series::SeriesCore {
+                anilist_id: 424242,
+                mal_id: None,
+                title: "Show",
+                title_romaji: "Show",
+                title_english: "Show",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2024),
+                end_year: Some(2024),
+            },
+        )
+        .await
+        .expect("series upsert");
+
+        let old_id = record_grab(
+            &db,
+            "old00000000000000000000000000000000000001",
+            "[OldGroup] Show - 01",
+            series_id,
+            &[1],
+            false,
+        )
+        .await
+        .expect("old")
+        .expect("id");
+        mark_imported(&db, old_id).await.expect("mark imported");
+
+        let new_id = record_grab(
+            &db,
+            "new00000000000000000000000000000000000001",
+            "[BetterGroup] Show - Batch [BD]",
+            series_id,
+            &[1, 2, 3],
+            true,
+        )
+        .await
+        .expect("new")
+        .expect("id");
+
+        mark_replaced(&db, old_id, new_id)
+            .await
+            .expect("mark replaced");
+
+        let row =
+            sqlx::query("SELECT state, replaced_by_grab_id FROM grabbed_torrents WHERE id = ?")
+                .bind(old_id)
+                .fetch_one(&db)
+                .await
+                .expect("lookup");
+        let state: String = row.get("state");
+        let replaced_by: Option<i64> = row.get("replaced_by_grab_id");
+        assert_eq!(state, "replaced");
+        assert_eq!(replaced_by, Some(new_id));
+
+        // The replacing grab's row surfaces via replaces_count in the
+        // with_series query — verify end-to-end.
+        let history = get_all_with_series(&db, 10, "english")
+            .await
+            .expect("history");
+        let new_row = history
+            .iter()
+            .find(|r| r.id == new_id)
+            .expect("new grab present");
+        assert_eq!(new_row.replaces_count, 1);
+        let old_row = history
+            .iter()
+            .find(|r| r.id == old_id)
+            .expect("old grab present");
+        assert_eq!(old_row.state, "replaced");
+        assert_eq!(old_row.replaced_by_grab_id, Some(new_id));
+        assert_eq!(
+            old_row.replaced_by_torrent_name,
+            "[BetterGroup] Show - Batch [BD]"
         );
     }
 }

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -1105,6 +1105,21 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .ok();
 
+    // `replaced_by_grab_id` — nullable back-pointer set when an
+    // upgrade-driven import supersedes this grab. Paired with a new
+    // `state='replaced'` value (distinct from `removed`, which is the
+    // generic "gone from download client" state reserved for user
+    // cancels and cleanup). No FK: an `ON DELETE SET NULL` would need
+    // a schema rebuild under SQLite and pruning a new grab shouldn't
+    // dangle old replaced rows in a way that breaks queries — the
+    // history handler tolerates `NULL` here. History filter and the
+    // replaced-by tooltip in the Downloads tab key off this column to
+    // show the replacement chain.
+    sqlx::query("ALTER TABLE grabbed_torrents ADD COLUMN replaced_by_grab_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
     // `active_client` on config — lowercase-snake discriminator for
     // the download client currently in use. Phase 1 only has
     // 'qbittorrent'; Phase 2+ will branch on this at AppState init.

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -914,6 +914,17 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // search_on_monitoring_change (#1.3.0 UX pass): when true, any
+    // update to a series's monitoring mode triggers a background
+    // auto-search over the newly-monitored-and-airable episodes.
+    // Default off to preserve existing behavior on upgrade.
+    sqlx::query(
+        "ALTER TABLE config ADD COLUMN search_on_monitoring_change INTEGER NOT NULL DEFAULT 0",
+    )
+    .execute(db)
+    .await
+    .ok();
+
     // prefer_subs: when true (default), penalize dual audio / dub releases in scoring.
     sqlx::query("ALTER TABLE config ADD COLUMN prefer_subs INTEGER NOT NULL DEFAULT 1")
         .execute(db)

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -42,7 +42,10 @@ pub use release_parse::{
 use release_parse::{
     normalize_subtitle, season_mismatch, trailing_subtitle_of, within_episode_slack,
 };
-use scoring::{apply_cf_seadex_overlay, rescore_for_auto_search};
+use scoring::{
+    apply_cf_seadex_overlay, apply_cf_seadex_overlay_with_breakdown, rescore_for_auto_search,
+    rescore_for_auto_search_with_breakdown,
+};
 pub use search_target::{
     SearchTarget, build_missing_targets, build_monitored_targets, build_upgrade_targets,
 };
@@ -257,7 +260,11 @@ pub async fn find_all_for_target(
             }),
         )
         .await;
-        let base = rescore_for_auto_search(
+        // Interactive search uses the breakdown variants so each
+        // candidate's `score_breakdown` stays in sync with its final
+        // displayed score — the UI expander wants the full trail of
+        // alias match / season penalty / CF contributions visible.
+        let (base, mut auto_parts) = rescore_for_auto_search_with_breakdown(
             &c,
             &classification,
             config,
@@ -273,7 +280,7 @@ pub async fn find_all_for_target(
             series_ctx.absolute_offset,
         );
         // No CF floor on the interactive path — see comment above.
-        if let Some(final_score) = apply_cf_seadex_overlay(
+        if let Some((final_score, cf_parts)) = apply_cf_seadex_overlay_with_breakdown(
             base,
             &c,
             &classification,
@@ -283,6 +290,8 @@ pub async fn find_all_for_target(
             i32::MIN,
         ) {
             c.score = final_score;
+            c.score_breakdown.append(&mut auto_parts);
+            c.score_breakdown.extend(cf_parts);
             scored.push(c);
         }
     }
@@ -492,7 +501,13 @@ pub async fn collect_scored_batches_for_target(
             continue;
         }
 
-        let base = rescore_for_auto_search(
+        // `collect_scored_batches_for_target` feeds both the user-facing
+        // `interactive_search_batches` and the auto-grab
+        // `find_best_batch_for_target`. Populating the breakdown here
+        // costs a small Vec allocation per candidate on the auto path
+        // too, which is cheap enough vs. the classify+network work that
+        // already dominates the per-candidate cost.
+        let (base, mut auto_parts) = rescore_for_auto_search_with_breakdown(
             &c,
             &classification,
             config,
@@ -507,7 +522,7 @@ pub async fn collect_scored_batches_for_target(
             cutoff_resolution_enum,
             series_ctx.absolute_offset,
         );
-        if let Some(final_score) = apply_cf_seadex_overlay(
+        if let Some((final_score, cf_parts)) = apply_cf_seadex_overlay_with_breakdown(
             base,
             &c,
             &classification,
@@ -517,6 +532,8 @@ pub async fn collect_scored_batches_for_target(
             config.custom_format_minimum_score,
         ) {
             c.score = final_score;
+            c.score_breakdown.append(&mut auto_parts);
+            c.score_breakdown.extend(cf_parts);
             scored.push(c);
         }
     }

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -278,6 +278,7 @@ pub async fn find_all_for_target(
             cutoff_source_enum,
             cutoff_resolution_enum,
             series_ctx.absolute_offset,
+            false, // batch_search_mode — episode target, single-unit penalty applies
         );
         // No CF floor on the interactive path — see comment above.
         if let Some((final_score, cf_parts)) = apply_cf_seadex_overlay_with_breakdown(
@@ -521,6 +522,7 @@ pub async fn collect_scored_batches_for_target(
             cutoff_source_enum,
             cutoff_resolution_enum,
             series_ctx.absolute_offset,
+            true, // batch_search_mode — every candidate is a batch here
         );
         if let Some((final_score, cf_parts)) = apply_cf_seadex_overlay_with_breakdown(
             base,

--- a/src/services/auto_search/release_parse.rs
+++ b/src/services/auto_search/release_parse.rs
@@ -427,6 +427,27 @@ fn pick_by_part_number(
     part: i32,
     detail: &AnimeDetail,
 ) -> Option<Vec<usize>> {
+    // Part-number narrowing is for trilogies / multi-part OVAs where
+    // each "part" is a single file inside a grouped pack (Kizumonogatari
+    // I/II/III, Rebuild of Evangelion 1/2/3, etc.). Those AniList
+    // entries all have a single-digit `episodes` count because each
+    // part is itself one film.
+    //
+    // A season whose title happens to end in a Roman numeral ("Mob
+    // Psycho 100 III", "Overlord IV") ALSO triggers
+    // `extract_part_number` — but its SeaDex batch is 12 per-episode
+    // files named "...III - 01" … "...III - 12". Part-number narrowing
+    // there picks the one file whose parsed ep number equals the
+    // Roman numeral (file 3 for "III"), which is catastrophically
+    // wrong — the user wants the whole season, not one episode that
+    // happens to share the season index. Gate the strategy on a small
+    // episode count so seasons fall through to the (correct) full-pack
+    // grab + auto_expand path.
+    const MAX_EPISODES_FOR_PART_NARROWING: i32 = 3;
+    if detail.effective_episode_count() > MAX_EPISODES_FOR_PART_NARROWING {
+        return None;
+    }
+
     let mut matches: Vec<usize> = Vec::new();
     let mut media_count = 0usize;
     for (idx, name) in filenames.iter().enumerate() {
@@ -925,6 +946,43 @@ mod tests {
         ];
         let d = detail_with_titles("JoJo's Bizarre Adventure", "JoJo no Kimyou na Bouken");
         assert_eq!(pick_wanted_file_indices(&files, &d), None);
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_skips_part_narrowing_on_multi_episode_season() {
+        // Regression: Mob Psycho 100 III is a 12-episode season whose
+        // AniList title ends in a Roman numeral. Without the episode-
+        // count gate, `extract_part_number` returns 3 and
+        // `pick_by_part_number` latches onto the "...III - 03" file —
+        // narrowing a whole-season SeaDex batch to a single-ep pick.
+        // The auto-search grab then records episode_numbers=[1] (the
+        // target) while qBit only downloads ep 3's file. Gate fix:
+        // detail.episodes > 3 → skip part-number narrowing entirely
+        // so the full season downloads as intended.
+        let files: Vec<String> = (1..=12)
+            .map(|i| format!("[SeaDex] Mob Psycho 100 III - {:02}.mkv", i))
+            .collect();
+        let mut d = detail_with_titles("Mob Psycho 100 III", "Mob Psycho 100 III");
+        d.episodes = Some(12);
+        assert_eq!(
+            pick_wanted_file_indices(&files, &d),
+            None,
+            "multi-episode season with Roman-numeral title must not be part-narrowed",
+        );
+    }
+
+    #[test]
+    fn pick_wanted_file_indices_still_narrows_trilogy_part() {
+        // Counterpart to the regression test above — the Kizumonogatari
+        // trilogy (episodes=1 per AniList part) must still narrow.
+        let files = vec![
+            "[smol] Monogatari - S09E01 - Kizumonogatari Tekketsu-hen.mkv".to_string(),
+            "[smol] Monogatari - S09E02 - Kizumonogatari Nekketsu-hen.mkv".to_string(),
+            "[smol] Monogatari - S09E03 - Kizumonogatari Reiketsu-hen.mkv".to_string(),
+        ];
+        let mut d = detail_with_titles("Kizumonogatari II: Nekketsu-hen", "Kizumonogatari II");
+        d.episodes = Some(1);
+        assert_eq!(pick_wanted_file_indices(&files, &d), Some(vec![1]));
     }
 
     #[test]

--- a/src/services/auto_search/scoring.rs
+++ b/src/services/auto_search/scoring.rs
@@ -206,6 +206,7 @@ pub(super) fn rescore_for_auto_search(
         cutoff_source,
         cutoff_resolution,
         absolute_offset,
+        false, // batch_search_mode — non-batch callers
     )
     .0
 }
@@ -214,6 +215,14 @@ pub(super) fn rescore_for_auto_search(
 /// score components added on top of the scraper's base score. Used by
 /// the interactive search path so each candidate's breakdown in the UI
 /// stays in sync with its final displayed score.
+///
+/// `batch_search_mode` is `true` when the caller is explicitly
+/// collecting batch-only candidates (`collect_scored_batches_for_
+/// target`, powering both interactive batch search and auto-search's
+/// batch grab path). In that mode the single-target batch penalty is
+/// suppressed — penalizing a batch for being a batch when the user
+/// explicitly asked for batches is nonsense, and surfaced in the
+/// breakdown as a confusing "-5 Batch Penalty" on every row.
 #[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
 pub(super) fn rescore_for_auto_search_with_breakdown(
     result: &SearchResult,
@@ -229,6 +238,7 @@ pub(super) fn rescore_for_auto_search_with_breakdown(
     cutoff_source: Source,
     cutoff_resolution: Resolution,
     absolute_offset: i32,
+    batch_search_mode: bool,
 ) -> (i32, Vec<ScoreComponent>) {
     let mut score = result.score;
     let mut parts: Vec<ScoreComponent> = Vec::new();
@@ -285,7 +295,12 @@ pub(super) fn rescore_for_auto_search_with_breakdown(
             if lower.contains("movie") || lower.contains("special") || lower.contains("ova") {
                 add(&mut parts, "Movie / Special / OVA", 8, None);
             }
-            if result.is_batch {
+            // Only penalize batches when the user is looking for a
+            // single-unit target (movie, OVA, single-episode special).
+            // Suppress on explicit batch-search paths — every candidate
+            // is a batch there, so the penalty is meaningless and just
+            // pollutes the displayed breakdown.
+            if result.is_batch && !batch_search_mode {
                 add(&mut parts, "Batch Penalty (single target)", -5, None);
             }
         }

--- a/src/services/auto_search/scoring.rs
+++ b/src/services/auto_search/scoring.rs
@@ -292,14 +292,19 @@ pub(super) fn rescore_for_auto_search_with_breakdown(
 
     match target {
         SearchTarget::Single => {
-            if lower.contains("movie") || lower.contains("special") || lower.contains("ova") {
+            // Movie / Special / OVA bonus and Batch penalty both
+            // assume the user is looking for a single-unit target.
+            // In explicit batch-search mode every candidate is a batch
+            // for the same series, so both signals are meaningless
+            // and would uniformly lift or lower the whole slate. Gate
+            // both on `!batch_search_mode` so batch-grab rankings are
+            // driven by quality + alias match + seeders, not by the
+            // presence of "Movie" / "OVA" keywords in the batch title.
+            if !batch_search_mode
+                && (lower.contains("movie") || lower.contains("special") || lower.contains("ova"))
+            {
                 add(&mut parts, "Movie / Special / OVA", 8, None);
             }
-            // Only penalize batches when the user is looking for a
-            // single-unit target (movie, OVA, single-episode special).
-            // Suppress on explicit batch-search paths — every candidate
-            // is a batch there, so the penalty is meaningless and just
-            // pollutes the displayed breakdown.
             if result.is_batch && !batch_search_mode {
                 add(&mut parts, "Batch Penalty (single target)", -5, None);
             }

--- a/src/services/auto_search/scoring.rs
+++ b/src/services/auto_search/scoring.rs
@@ -15,6 +15,7 @@ use crate::models::config::Config;
 use crate::services::custom_formats::{self, CompiledCustomFormat, EvalContext};
 use crate::services::nyaa::SearchResult;
 use crate::services::quality;
+use crate::services::scoring::ScoreComponent;
 use crate::services::seadex;
 use crate::services::source::{self, ClassificationResult, Resolution, Source};
 
@@ -48,6 +49,33 @@ pub(super) fn apply_cf_seadex_overlay(
     seadex_boost_enabled: bool,
     minimum_score: i32,
 ) -> Option<i32> {
+    apply_cf_seadex_overlay_with_breakdown(
+        base,
+        result,
+        classification,
+        cfs,
+        seadex_hashes,
+        seadex_boost_enabled,
+        minimum_score,
+    )
+    .map(|(score, _)| score)
+}
+
+/// Same as [`apply_cf_seadex_overlay`] but also returns the per-CF and
+/// SeaDex breakdown entries so the caller can fold them into the
+/// `SearchResult`'s `score_breakdown` for UI display. Used by the
+/// interactive search path where each candidate's breakdown needs to
+/// stay in sync with its final score.
+#[allow(clippy::too_many_arguments)]
+pub(super) fn apply_cf_seadex_overlay_with_breakdown(
+    base: i32,
+    result: &SearchResult,
+    classification: &ClassificationResult,
+    cfs: &[CompiledCustomFormat],
+    seadex_hashes: &HashSet<String>,
+    seadex_boost_enabled: bool,
+    minimum_score: i32,
+) -> Option<(i32, Vec<ScoreComponent>)> {
     let ctx = EvalContext {
         result,
         classification,
@@ -89,7 +117,27 @@ pub(super) fn apply_cf_seadex_overlay(
         detail
     );
 
-    if below_floor { None } else { Some(final_score) }
+    if below_floor {
+        return None;
+    }
+
+    let mut components: Vec<ScoreComponent> = breakdown
+        .into_iter()
+        .map(|(name, delta)| ScoreComponent {
+            label: format!("CF: {name}"),
+            delta,
+            detail: None,
+        })
+        .collect();
+    if seadex_bonus != 0 {
+        components.push(ScoreComponent {
+            label: "SeaDex Best".to_string(),
+            delta: seadex_bonus,
+            detail: Some("release flagged isBest by releases.moe".to_string()),
+        });
+    }
+
+    Some((final_score, components))
 }
 
 /// Build the structured scoring detail string that lands in the
@@ -144,7 +192,58 @@ pub(super) fn rescore_for_auto_search(
     cutoff_resolution: Resolution,
     absolute_offset: i32,
 ) -> i32 {
+    rescore_for_auto_search_with_breakdown(
+        result,
+        classification,
+        config,
+        aliases,
+        target,
+        expected_season,
+        is_finished,
+        finished_mode,
+        preferred_source,
+        preferred_resolution,
+        cutoff_source,
+        cutoff_resolution,
+        absolute_offset,
+    )
+    .0
+}
+
+/// Same as [`rescore_for_auto_search`] but also returns the list of
+/// score components added on top of the scraper's base score. Used by
+/// the interactive search path so each candidate's breakdown in the UI
+/// stays in sync with its final displayed score.
+#[allow(clippy::too_many_arguments, clippy::cognitive_complexity)]
+pub(super) fn rescore_for_auto_search_with_breakdown(
+    result: &SearchResult,
+    classification: &ClassificationResult,
+    config: &Config,
+    aliases: &[String],
+    target: &SearchTarget,
+    expected_season: i32,
+    is_finished: bool,
+    finished_mode: quality::FinishedSeriesMode,
+    preferred_source: Source,
+    preferred_resolution: Resolution,
+    cutoff_source: Source,
+    cutoff_resolution: Resolution,
+    absolute_offset: i32,
+) -> (i32, Vec<ScoreComponent>) {
     let mut score = result.score;
+    let mut parts: Vec<ScoreComponent> = Vec::new();
+    let mut add =
+        |parts: &mut Vec<ScoreComponent>, label: &str, delta: i32, detail: Option<String>| {
+            if delta == 0 {
+                return;
+            }
+            score += delta;
+            parts.push(ScoreComponent {
+                label: label.to_string(),
+                delta,
+                detail,
+            });
+        };
     let lower = result.title.to_lowercase();
     let normalized_title = normalize_title(&result.title);
     let title_tokens = token_set(&normalized_title);
@@ -160,68 +259,101 @@ pub(super) fn rescore_for_auto_search(
             }
         })
         .fold(0.0f32, f32::max);
-    score += (best_overlap * 40.0) as i32;
+    let overlap_delta = (best_overlap * 40.0) as i32;
+    add(
+        &mut parts,
+        "Title Alias Match",
+        overlap_delta,
+        Some(format!(
+            "{:.0}% of best alias tokens matched",
+            best_overlap * 100.0
+        )),
+    );
 
     // Season mismatch penalty (explicit season markers like S03, "3rd Season")
     if season_mismatch(&result.title, expected_season) {
-        score -= 100;
+        add(
+            &mut parts,
+            "Season Mismatch",
+            -100,
+            Some(format!("release season ≠ expected S{expected_season:02}")),
+        );
     }
 
     match target {
         SearchTarget::Single => {
             if lower.contains("movie") || lower.contains("special") || lower.contains("ova") {
-                score += 8;
+                add(&mut parts, "Movie / Special / OVA", 8, None);
             }
             if result.is_batch {
-                score -= 5;
+                add(&mut parts, "Batch Penalty (single target)", -5, None);
             }
         }
         SearchTarget::Episode(ep) => {
             if result.is_batch {
-                score -= 20;
+                add(
+                    &mut parts,
+                    "Batch Penalty (episode target)",
+                    -20,
+                    Some("single-episode grab preferred".to_string()),
+                );
             } else {
-                score += 10;
+                add(&mut parts, "Single-Episode Target", 10, None);
             }
             let parsed = parse_release_numbers(&result.title);
             let relative_match = parsed.contains(ep);
             let absolute_match =
                 absolute_offset > 0 && parsed.contains(&ep.saturating_add(absolute_offset));
             if relative_match || absolute_match {
-                score += 40;
+                add(
+                    &mut parts,
+                    "Episode Number Match",
+                    40,
+                    Some(format!("release covers episode {ep}")),
+                );
             } else if absolute_offset > 0 && !parsed.is_empty() {
-                // #30 — Phase 2 lets candidates through the franchise-alias
-                // pass even when their parsed number doesn't match either
-                // the relative or the absolute target. Those are false
-                // positives (e.g. "[Asahi-Anime Land] Jujutsu Kaisen 04"
-                // surfacing for a JJK S3 E9 absolute-56 target). Bury
-                // them with a large penalty so they sort to the bottom
-                // of the interactive list and drop below any realistic
-                // auto-search `custom_format_minimum_score` floor,
-                // without hard-rejecting in case the user actually wants
-                // a different episode that the parser mis-reads.
-                score -= 1000;
+                // #30 — franchise-alias fallback surfaces candidates
+                // whose parsed number matches neither target. Bury them.
+                add(
+                    &mut parts,
+                    "Wrong Episode Number",
+                    -1000,
+                    Some("franchise-pass release doesn't match target ep".to_string()),
+                );
             } else if absolute_offset > 0 && parsed.is_empty() {
-                // Unparseable episode number through the franchise pass
-                // ("Jujutsu Kaisen 04" with no dash separator) — smaller
-                // penalty than a wrong-number, since "can't tell" is
-                // less clearly wrong than "explicitly wrong."
-                score -= 500;
+                add(
+                    &mut parts,
+                    "Unparseable Episode Number",
+                    -500,
+                    Some("franchise-pass release with no parseable ep".to_string()),
+                );
             }
         }
     }
 
-    score += quality::preferred_group_bonus(
+    let group_bonus = quality::preferred_group_bonus(
         &result.group,
         &quality::parse_group_list(&config.preferred_groups),
     );
+    add(&mut parts, "Preferred Group (auto)", group_bonus, None);
 
     // Classification-aware quality scoring.
-    score += source::score_classification(
+    let classification_delta = source::score_classification(
         classification,
         preferred_source,
         preferred_resolution,
         cutoff_source,
         cutoff_resolution,
+    );
+    add(
+        &mut parts,
+        "Source / Resolution Fit",
+        classification_delta,
+        Some(format!(
+            "{} {}",
+            classification.source.as_str(),
+            classification.resolution.as_str()
+        )),
     );
 
     // For finished series with BD preference, give BD releases a significant boost.
@@ -229,10 +361,15 @@ pub(super) fn rescore_for_auto_search(
         && finished_mode == quality::FinishedSeriesMode::PreferBd
         && classification.source == Source::BluRay
     {
-        score += 35;
+        add(
+            &mut parts,
+            "Finished Series BD Bonus",
+            35,
+            Some("finished series + prefer_bd + BluRay source".to_string()),
+        );
     }
 
-    score
+    (score, parts)
 }
 
 #[cfg(test)]

--- a/src/services/custom_formats/mod.rs
+++ b/src/services/custom_formats/mod.rs
@@ -227,6 +227,7 @@ pub(super) mod test_helpers {
             score: 0,
             info_hash: info_hash.to_string(),
             score_breakdown: Vec::new(),
+            upload_date: String::new(),
         }
     }
 

--- a/src/services/custom_formats/mod.rs
+++ b/src/services/custom_formats/mod.rs
@@ -226,6 +226,7 @@ pub(super) mod test_helpers {
             is_trusted: false,
             score: 0,
             info_hash: info_hash.to_string(),
+            score_breakdown: Vec::new(),
         }
     }
 

--- a/src/services/nyaa/mod.rs
+++ b/src/services/nyaa/mod.rs
@@ -68,6 +68,13 @@ pub struct SearchResult {
     /// tracked separately at the auto-search site.
     #[serde(default)]
     pub score_breakdown: Vec<crate::services::scoring::ScoreComponent>,
+    /// #1.3.0 — upload date as Nyaa renders it in the table ("YYYY-
+    /// MM-DD HH:MM" UTC). Empty string when the column couldn't be
+    /// parsed (e.g. for releases fetched via the view page rather
+    /// than the listing). Surfaced to the UI so the search-results
+    /// table matches Nyaa's own listing shape.
+    #[serde(default)]
+    pub upload_date: String,
 }
 
 #[derive(Clone)]

--- a/src/services/nyaa/mod.rs
+++ b/src/services/nyaa/mod.rs
@@ -60,6 +60,14 @@ pub struct SearchResult {
     pub is_trusted: bool,
     pub score: i32,
     pub info_hash: String,
+    /// #1.3.0 — per-component breakdown of the base score (what rules
+    /// fired, with what delta and a human-readable detail). Populated
+    /// by the search scraper alongside `score` so the UI can render a
+    /// "why this score" expansion on search results. Note this covers
+    /// only the base scoring rules; Custom Format contributions are
+    /// tracked separately at the auto-search site.
+    #[serde(default)]
+    pub score_breakdown: Vec<crate::services::scoring::ScoreComponent>,
 }
 
 #[derive(Clone)]

--- a/src/services/nyaa/scraper.rs
+++ b/src/services/nyaa/scraper.rs
@@ -161,6 +161,12 @@ pub(super) fn parse_results(html: &str, opts: &SearchOptions) -> (Vec<SearchResu
         let size = tds[3].text().collect::<String>().trim().to_string();
         let size_bytes = parse_size(&size);
 
+        // Upload date (td index 4) — Nyaa renders "YYYY-MM-DD HH:MM"
+        // in UTC. Some cells also carry a `data-timestamp` attribute
+        // with the Unix epoch; we prefer the text since it's already
+        // display-ready.
+        let upload_date = tds[4].text().collect::<String>().trim().to_string();
+
         // Seeders, leechers, downloads (td indices 5, 6, 7).
         let seeders = parse_int(&tds[5].text().collect::<String>());
         let leechers = parse_int(&tds[6].text().collect::<String>());
@@ -200,6 +206,7 @@ pub(super) fn parse_results(html: &str, opts: &SearchOptions) -> (Vec<SearchResu
             score: 0,
             info_hash,
             score_breakdown: Vec::new(),
+            upload_date: upload_date.clone(),
         };
 
         let (total, breakdown) =
@@ -493,6 +500,9 @@ pub(super) fn parse_view_page(
         score: 0,
         info_hash,
         score_breakdown: Vec::new(),
+        // The view page doesn't render the listing-table date column.
+        // Callers on this path (SeaDex-bypass) get an empty string.
+        upload_date: String::new(),
     };
 
     let (total, breakdown) =
@@ -967,6 +977,7 @@ mod tests {
             score: 0,
             info_hash: String::new(),
             score_breakdown: Vec::new(),
+            upload_date: String::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;
@@ -1009,6 +1020,7 @@ mod tests {
             score: 0,
             info_hash: String::new(),
             score_breakdown: Vec::new(),
+            upload_date: String::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;

--- a/src/services/nyaa/scraper.rs
+++ b/src/services/nyaa/scraper.rs
@@ -199,10 +199,13 @@ pub(super) fn parse_results(html: &str, opts: &SearchOptions) -> (Vec<SearchResu
             is_trusted,
             score: 0,
             info_hash,
+            score_breakdown: Vec::new(),
         };
 
-        result.score =
-            crate::services::scoring::score_result_with_sub_pref(&result, opts, opts.prefer_subs);
+        let (total, breakdown) =
+            crate::services::scoring::score_result_with_breakdown(&result, opts, opts.prefer_subs);
+        result.score = total;
+        result.score_breakdown = breakdown;
         results.push(result);
     }
 
@@ -489,10 +492,13 @@ pub(super) fn parse_view_page(
         is_trusted: false,
         score: 0,
         info_hash,
+        score_breakdown: Vec::new(),
     };
 
-    result.score =
-        crate::services::scoring::score_result_with_sub_pref(&result, opts, opts.prefer_subs);
+    let (total, breakdown) =
+        crate::services::scoring::score_result_with_breakdown(&result, opts, opts.prefer_subs);
+    result.score = total;
+    result.score_breakdown = breakdown;
 
     Some(result)
 }
@@ -960,6 +966,7 @@ mod tests {
             is_trusted: false,
             score: 0,
             info_hash: String::new(),
+            score_breakdown: Vec::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;
@@ -1001,6 +1008,7 @@ mod tests {
             is_trusted: false,
             score: 0,
             info_hash: String::new(),
+            score_breakdown: Vec::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -756,6 +756,15 @@ async fn import_torrent(
                 }
                 let _ = grabbed_torrents::mark_replaced(&state.db, old_grab.id, grab.id).await;
             }
+
+            // Per-episode history counterpart: flip the old grab's
+            // episode_grab_history row for this specific ep from
+            // 'completed' to 'replaced' so the episode detail modal
+            // mirrors what the Downloads tab shows. Without this the
+            // old Kaizoku row and the new SubsPlease row both read
+            // 'completed' in grab history, hiding the upgrade chain.
+            let _ =
+                episode_tags::mark_grab_history_replaced(&state.db, target_series_id, ep_num).await;
         }
 
         match do_file_op(&cfg.post_processing_mode, &src, &dest_video).await {

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -661,7 +661,38 @@ async fn import_torrent(
                     .unwrap_or_default();
 
             if old_grabs.is_empty() {
-                // No older import record — likely a re-run of the same grab. Skip.
+                // On-disk file exists with the same SxxExx tag but no
+                // prior grabbed_torrents row in state='imported' covers
+                // this episode. Three common shapes here:
+                //   1. User re-ran the same grab (file was just put
+                //      there by an earlier tick of this same grab).
+                //   2. The original grab's row sits in state='pending'
+                //      because it never cleared import (torrent stuck,
+                //      ffprobe timeout, crash, etc.) — find_imported
+                //      skips it and we can't tell an upgrade apart
+                //      from the re-run case.
+                //   3. The original import came from outside Ryokan
+                //      (manual drop into the library) so no row
+                //      existed to find.
+                // In every case we skip — writing do_file_op would
+                // overwrite the existing file silently. But log so the
+                // user can tell it's the why-not-importing path
+                // instead of a totally silent drop.
+                logger::info(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!(
+                        "Skipping '{}' — S{:02}E{:02} already on disk but no imported grab to replace",
+                        filename_only, season, ep_num
+                    ),
+                    &format!(
+                        "series_id={}, existing_files={}, grab_id={}",
+                        target_series_id,
+                        existing_for_ep.len(),
+                        grab.id
+                    ),
+                )
+                .await;
                 continue;
             }
 

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -965,6 +965,15 @@ async fn import_torrent(
     // during the file loop. One UPDATE per distinct old grab instead
     // of one-per-episode so a batch that covered 12 episodes doesn't
     // run 12 identical write-identical-row UPDATEs.
+    //
+    // Deliberately placed AFTER the `imported_count == 0` early return
+    // above: if zero files actually landed (cross-fs copy failure, disk
+    // full, permission denied across the whole set), we don't flip old
+    // grabs to 'replaced' — they stay 'imported' and the upgrade chain
+    // isn't misrepresented. A pre-earlier version ran the marks inline
+    // with each file op, which would flip old grabs even on a total
+    // failure. Net effect of this placement: orphaned-replace rows
+    // can't appear when the replacement never materialized.
     for old_grab_id in &grabs_to_mark_replaced {
         let _ = grabbed_torrents::mark_replaced(&state.db, *old_grab_id, grab.id).await;
     }

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -445,6 +445,14 @@ async fn import_torrent(
         std::collections::BTreeMap::new();
     let mut imported_count = 0_usize;
 
+    // Old grab ids we've marked as replaced during this import pass,
+    // paired with the new `grab.id` that superseded them. Deduped via
+    // HashSet so a batch that covers 12 episodes doesn't issue 12
+    // identical UPDATEs against the same old grab row. Flushed once
+    // after the file loop.
+    let mut grabs_to_mark_replaced: std::collections::HashSet<i64> =
+        std::collections::HashSet::new();
+
     for (file_idx, file) in &video_files {
         // Route this file: prefer the routes table (Phase 2 batch
         // auto-expansion), fall back to `grab.series_id` for legacy
@@ -750,11 +758,19 @@ async fn import_torrent(
             // swapped out by a Kaizoku batch had no way to tell the
             // upgrade actually happened — old rows looked identical to
             // user-cancelled grabs.
+            // `client.delete` still runs inside the per-episode loop
+            // because it's cheap-ish (one RPC per torrent) and the old
+            // hash may repeat across per-episode finds — but qBit's
+            // delete is idempotent on an already-removed hash, so the
+            // repeat is harmless. The expensive SQL UPDATE for
+            // `mark_replaced` is deferred to a post-loop flush so a
+            // batch grab that covers 12 episodes doesn't UPDATE the
+            // same old grab 12 times.
             for old_grab in &old_grabs {
                 if !old_grab.hash.is_empty() {
                     let _ = client.delete(&old_grab.hash, true).await;
                 }
-                let _ = grabbed_torrents::mark_replaced(&state.db, old_grab.id, grab.id).await;
+                grabs_to_mark_replaced.insert(old_grab.id);
             }
 
             // Per-episode history counterpart: flip the old grab's
@@ -763,6 +779,9 @@ async fn import_torrent(
             // mirrors what the Downloads tab shows. Without this the
             // old Kaizoku row and the new SubsPlease row both read
             // 'completed' in grab history, hiding the upgrade chain.
+            // Stays inside the loop since episode_grab_history is
+            // keyed on (series_id, episode_number) — one UPDATE per
+            // episode is correct, not redundant.
             let _ =
                 episode_tags::mark_grab_history_replaced(&state.db, target_series_id, ep_num).await;
         }
@@ -940,6 +959,14 @@ async fn import_torrent(
 
     if imported_count == 0 {
         return Ok(false);
+    }
+
+    // Flush the `grabbed_torrents.state = 'replaced'` updates collected
+    // during the file loop. One UPDATE per distinct old grab instead
+    // of one-per-episode so a batch that covered 12 episodes doesn't
+    // run 12 identical write-identical-row UPDATEs.
+    for old_grab_id in &grabs_to_mark_replaced {
+        let _ = grabbed_torrents::mark_replaced(&state.db, *old_grab_id, grab.id).await;
     }
 
     // Series-level artifacts (tvshow.nfo + poster) run once per unique

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -707,11 +707,19 @@ async fn import_torrent(
             // upgrade with many old grabs the per-iteration lock acquire
             // was serializing against any other task touching
             // `state.download_client`.
+            //
+            // `mark_replaced` (not `mark_removed`) so the Downloads
+            // history keeps the upgrade chain: state='replaced' with
+            // `replaced_by_grab_id = grab.id`. Without this distinction
+            // users who got their existing SubsPlease episodes silently
+            // swapped out by a Kaizoku batch had no way to tell the
+            // upgrade actually happened — old rows looked identical to
+            // user-cancelled grabs.
             for old_grab in &old_grabs {
                 if !old_grab.hash.is_empty() {
                     let _ = client.delete(&old_grab.hash, true).await;
                 }
-                let _ = grabbed_torrents::mark_removed(&state.db, old_grab.id).await;
+                let _ = grabbed_torrents::mark_replaced(&state.db, old_grab.id, grab.id).await;
             }
         }
 

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -660,29 +660,34 @@ async fn import_torrent(
                     .await
                     .unwrap_or_default();
 
+            // No matching prior grab row but disk has a file for this
+            // SxxExx slot — treat it as an **orphan upgrade**. The disk
+            // state is ground truth: a file exists, the user is grabbing
+            // something new, they expect the new file to replace what's
+            // there. Covers three historical shapes where the DB row
+            // doesn't line up:
+            //   1. Legacy batch grabs whose `episode_numbers` was
+            //      mis-parsed from the release title before the current
+            //      batch_episode_numbers logic existed (e.g. Kaizoku
+            //      Season 3 packs stored as [3] instead of [1..12] —
+            //      `find_imported_for_episode(series, 1)` misses them).
+            //   2. Files manually dropped into the library from outside
+            //      Ryokan (pre-existing rips, migration from another
+            //      PVR) — no grab row ever existed.
+            //   3. The original grab's row is in state='pending'
+            //      (torrent stuck, crash mid-import) — not 'imported',
+            //      so find_imported skips it.
+            // The `mark_replaced` step is skipped when old_grabs is
+            // empty — the new row simply replaces on disk without a
+            // chain pointer. The replacing grab still shows up as
+            // 'imported' in history; there's just no "replaced by"
+            // backlink because nothing in the DB was the predecessor.
             if old_grabs.is_empty() {
-                // On-disk file exists with the same SxxExx tag but no
-                // prior grabbed_torrents row in state='imported' covers
-                // this episode. Three common shapes here:
-                //   1. User re-ran the same grab (file was just put
-                //      there by an earlier tick of this same grab).
-                //   2. The original grab's row sits in state='pending'
-                //      because it never cleared import (torrent stuck,
-                //      ffprobe timeout, crash, etc.) — find_imported
-                //      skips it and we can't tell an upgrade apart
-                //      from the re-run case.
-                //   3. The original import came from outside Ryokan
-                //      (manual drop into the library) so no row
-                //      existed to find.
-                // In every case we skip — writing do_file_op would
-                // overwrite the existing file silently. But log so the
-                // user can tell it's the why-not-importing path
-                // instead of a totally silent drop.
                 logger::info(
                     &state.db,
                     LogCategory::PostProcess,
                     &format!(
-                        "Skipping '{}' — S{:02}E{:02} already on disk but no imported grab to replace",
+                        "Orphan upgrade: '{}' replacing S{:02}E{:02} file on disk (no prior imported grab)",
                         filename_only, season, ep_num
                     ),
                     &format!(
@@ -693,7 +698,6 @@ async fn import_torrent(
                     ),
                 )
                 .await;
-                continue;
             }
 
             // Remove old file(s) and their NFOs to make way for the upgrade.

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -937,6 +937,43 @@ async fn load_canonical_history(
     keys
 }
 
+/// Match a release title against every tracked series in the library
+/// and return the best match's series id + resolved episode set, or
+/// `None` if no series cleared the matcher's confidence threshold.
+/// Used by the manual-search grab path (#1.3.0 plan item 6d) to
+/// link grabs to existing library entries without re-implementing
+/// the RSS matcher.
+///
+/// `is_batch` comes from the caller (the search UI already knows),
+/// so we don't need to re-run `detect_batch` here. Returns the
+/// resolved episode numbers so the grab recorder can populate
+/// episode_grab_history correctly.
+pub async fn match_library_title(
+    db: &sqlx::SqlitePool,
+    title: &str,
+    is_batch: bool,
+) -> Option<(series::Series, Vec<i32>)> {
+    let all_series = series::get_all(db).await.ok()?;
+    if all_series.is_empty() {
+        return None;
+    }
+    let all_meta: Vec<SeriesMeta> = all_series.iter().map(SeriesMeta::from_series).collect();
+    let pseudo = RssItem {
+        title: title.to_string(),
+        link: String::new(),
+        guid: String::new(),
+        torrent: String::new(),
+        magnet: String::new(),
+        info_hash: String::new(),
+        group: extract_group(title),
+        resolution: extract_resolution(title),
+        is_batch,
+    };
+    let found = best_series_match(&pseudo, &all_meta)?;
+    let eps: Vec<i32> = found.resolved_eps.iter().copied().collect();
+    Some((found.series, eps))
+}
+
 fn canonical_key_for_title(title: &str, all_meta: &[SeriesMeta]) -> Option<String> {
     let pseudo = RssItem {
         title: title.to_string(),

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -1,6 +1,7 @@
 use std::sync::LazyLock;
 
 use regex_lite::Regex;
+use serde::Serialize;
 
 use crate::services::nyaa::{SearchOptions, SearchResult};
 
@@ -10,6 +11,37 @@ use crate::services::nyaa::{SearchOptions, SearchResult};
 static DUB_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b(?:dub|dubbed)\b").expect("dub regex compiles"));
 
+/// One line of a score breakdown: what fired, what it contributed,
+/// and an optional human-readable detail (which group matched, how
+/// many seeders, what threshold crossed, etc.). Surfaced on the
+/// /api/search response and persisted alongside grab history so the
+/// "why this score" UI can show users exactly what happened.
+#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+pub struct ScoreComponent {
+    /// Short label — displayed as the left-column "what" in the UI
+    /// breakdown table (e.g. "Seeders", "Preferred Group",
+    /// "Resolution Match").
+    pub label: String,
+    /// Signed point contribution. Positive = bonus, negative =
+    /// penalty. Sum of all `delta`s in a breakdown equals the total
+    /// score — invariant pinned by tests.
+    pub delta: i32,
+    /// Optional free-text detail for the UI tooltip / secondary row
+    /// ("3 of N preferred", "1000+ seeders", etc.). Keeps the label
+    /// concise while still giving users the full picture.
+    pub detail: Option<String>,
+}
+
+impl ScoreComponent {
+    fn new(label: &str, delta: i32, detail: Option<String>) -> Self {
+        Self {
+            label: label.to_string(),
+            delta,
+            detail,
+        }
+    }
+}
+
 /// Score a search result based on multiple factors.
 /// `prefer_subs` controls whether dual audio/dub releases are penalized (default true).
 #[allow(dead_code)]
@@ -17,24 +49,50 @@ pub fn score_result(r: &SearchResult, opts: &SearchOptions) -> i32 {
     score_result_with_sub_pref(r, opts, true)
 }
 
+/// Scalar score. Delegates to `score_result_with_breakdown` and
+/// discards the component list — use the breakdown variant directly
+/// when you need both total and per-component detail.
 pub fn score_result_with_sub_pref(
     r: &SearchResult,
     opts: &SearchOptions,
     prefer_subs: bool,
 ) -> i32 {
-    let mut score: i32 = 0;
+    score_result_with_breakdown(r, opts, prefer_subs).0
+}
+
+/// Same total as `score_result_with_sub_pref`, plus the ordered
+/// list of components that contributed to the score. Invariant:
+/// `breakdown.iter().map(|c| c.delta).sum::<i32>() == total`.
+///
+/// Components are emitted in the evaluation order (seeders first,
+/// then group, resolution, and so on). Zero-delta checks are
+/// omitted — a "no preferred group configured, didn't penalize"
+/// non-event doesn't add noise to the UI. The invariant holds
+/// because we only push when we actually mutate `score`.
+#[allow(clippy::cognitive_complexity)]
+pub fn score_result_with_breakdown(
+    r: &SearchResult,
+    opts: &SearchOptions,
+    prefer_subs: bool,
+) -> (i32, Vec<ScoreComponent>) {
+    let mut total: i32 = 0;
+    let mut parts: Vec<ScoreComponent> = Vec::new();
+    let mut add = |label: &str, delta: i32, detail: Option<String>| {
+        total += delta;
+        parts.push(ScoreComponent::new(label, delta, detail));
+    };
 
     // Seeders.
     if r.seeders > 100 {
-        score += 30;
+        add("Seeders", 30, Some(format!("{} seeders (>100)", r.seeders)));
     } else if r.seeders > 50 {
-        score += 25;
+        add("Seeders", 25, Some(format!("{} seeders (>50)", r.seeders)));
     } else if r.seeders > 10 {
-        score += 20;
+        add("Seeders", 20, Some(format!("{} seeders (>10)", r.seeders)));
     } else if r.seeders > 0 {
-        score += 10;
+        add("Seeders", 10, Some(format!("{} seeders", r.seeders)));
     } else {
-        score -= 10;
+        add("Seeders", -10, Some("zero seeders".to_string()));
     }
 
     // Preferred group. Earlier entries are stronger preferences.
@@ -48,28 +106,45 @@ pub fn score_result_with_sub_pref(
                 }
             }
             if let Some(idx) = matched_index {
-                score += 140 - (idx * 20);
+                let delta = 140 - (idx * 20);
+                add(
+                    "Preferred Group",
+                    delta,
+                    Some(format!("[{}] rank {} of preferred list", r.group, idx + 1)),
+                );
             } else {
-                score -= 15;
+                add(
+                    "Non-Preferred Group",
+                    -15,
+                    Some(format!("[{}] not in preferred list", r.group)),
+                );
             }
         } else {
-            score -= 10;
+            add(
+                "No Group Tag",
+                -10,
+                Some("release title has no [Group] prefix".to_string()),
+            );
         }
     }
 
     // Preferred resolution.
     if !opts.preferred_resolution.is_empty() && r.resolution == opts.preferred_resolution {
-        score += 20;
+        add(
+            "Preferred Resolution",
+            20,
+            Some(format!("{} matches preferred", r.resolution)),
+        );
     }
 
     // Batch bonus.
     if r.is_batch {
-        score += 15;
+        add("Batch Release", 15, None);
     }
 
     // Trusted bonus.
     if r.is_trusted {
-        score += 10;
+        add("Trusted Uploader", 10, None);
     }
 
     // Encoding/source quality.
@@ -86,7 +161,11 @@ pub fn score_result_with_sub_pref(
         || lower.contains("[bd")
         || lower.contains("(bd")
     {
-        score += 5;
+        add(
+            "Encoding / Source Quality",
+            5,
+            Some("10bit / x265 / HEVC / BluRay keyword in title".to_string()),
+        );
     }
 
     // Dub vs Sub scoring.
@@ -110,30 +189,180 @@ pub fn score_result_with_sub_pref(
     // substring because the space anchors it.
     let is_dub = is_dual || DUB_RE.is_match(&lower) || lower.contains("english dub");
     if prefer_subs {
-        // Penalize dub/dual audio releases when user prefers subs.
         if is_dub {
-            score -= 15;
+            add(
+                "Dub / Dual Audio Penalty",
+                -15,
+                Some("user prefers subs; release flagged as dub/dual".to_string()),
+            );
         }
-    } else {
-        // Boost dub/dual audio when user prefers dubs.
-        if is_dub {
-            score += 15;
-        }
+    } else if is_dub {
+        add(
+            "Dub / Dual Audio Bonus",
+            15,
+            Some("user prefers dubs".to_string()),
+        );
     }
 
     // Downloads popularity.
     if r.downloads > 10000 {
-        score += 15;
+        add(
+            "Downloads",
+            15,
+            Some(format!("{} downloads (>10k)", r.downloads)),
+        );
     } else if r.downloads > 5000 {
-        score += 10;
+        add(
+            "Downloads",
+            10,
+            Some(format!("{} downloads (>5k)", r.downloads)),
+        );
     } else if r.downloads > 1000 {
-        score += 5;
+        add(
+            "Downloads",
+            5,
+            Some(format!("{} downloads (>1k)", r.downloads)),
+        );
     }
 
     // Small batch bonus (under ~25GB).
     if r.is_batch && r.size_bytes > 0 && r.size_bytes < 25 * 1024 * 1024 * 1024 {
-        score += 10;
+        add("Compact Batch", 10, Some("batch under 25 GiB".to_string()));
     }
 
-    score
+    (total, parts)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::nyaa::{SearchOptions, SearchResult};
+
+    fn result(seeders: i32, title: &str) -> SearchResult {
+        SearchResult {
+            title: title.to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            torrent: String::new(),
+            size: String::new(),
+            size_bytes: 0,
+            seeders,
+            leechers: 0,
+            downloads: 0,
+            group: String::new(),
+            resolution: "1080p".to_string(),
+            quality_label: String::new(),
+            source: String::new(),
+            web_kind: String::new(),
+            is_remux: false,
+            is_bdmv: false,
+            is_batch: false,
+            is_trusted: false,
+            score: 0,
+            info_hash: String::new(),
+        }
+    }
+
+    fn opts() -> SearchOptions {
+        SearchOptions::default()
+    }
+
+    #[test]
+    fn breakdown_sum_equals_total_always() {
+        // Invariant: components[].delta.sum() == total_score.
+        // Exercise a handful of realistic shapes to pin it.
+        let cases: Vec<(SearchResult, SearchOptions, bool)> = vec![
+            (
+                result(150, "[SubsPlease] Frieren - 01 (1080p)"),
+                opts(),
+                true,
+            ),
+            (result(0, "No Seeders Release"), opts(), true),
+            (
+                {
+                    let mut r = result(55, "[Kaizoku] Series - Batch [1080p BluRay x265]");
+                    r.is_batch = true;
+                    r.is_trusted = true;
+                    r.size_bytes = 10 * 1024 * 1024 * 1024;
+                    r.downloads = 15_000;
+                    r.group = "Kaizoku".to_string();
+                    r
+                },
+                SearchOptions {
+                    preferred_groups: vec!["Kaizoku".to_string(), "smol".to_string()],
+                    preferred_resolution: "1080p".to_string(),
+                    ..SearchOptions::default()
+                },
+                true,
+            ),
+            (
+                {
+                    let mut r = result(5, "[Group] Series - 01 Dual Audio (1080p)");
+                    r.group = "Group".to_string();
+                    r
+                },
+                SearchOptions {
+                    preferred_groups: vec!["smol".to_string()],
+                    preferred_resolution: "1080p".to_string(),
+                    ..SearchOptions::default()
+                },
+                true,
+            ),
+        ];
+        for (r, opts_case, prefer_subs) in cases {
+            let (total, parts) = score_result_with_breakdown(&r, &opts_case, prefer_subs);
+            let sum: i32 = parts.iter().map(|c| c.delta).sum();
+            assert_eq!(
+                total, sum,
+                "invariant violated for {:?} — total={} sum={} parts={:?}",
+                r.title, total, sum, parts
+            );
+            // Every component should have a non-zero delta (we don't
+            // emit no-op entries).
+            for p in &parts {
+                assert_ne!(p.delta, 0, "zero-delta component: {:?}", p);
+            }
+        }
+    }
+
+    #[test]
+    fn scalar_score_matches_breakdown_total() {
+        // The two public APIs must agree on the total.
+        let mut r = result(75, "[Group] Cool Series - 01 (1080p) [BD].mkv");
+        r.group = "Group".to_string();
+        r.is_batch = false;
+        r.downloads = 3000;
+        let opts = SearchOptions {
+            preferred_groups: vec!["Group".to_string()],
+            preferred_resolution: "1080p".to_string(),
+            ..SearchOptions::default()
+        };
+        let scalar = score_result_with_sub_pref(&r, &opts, true);
+        let (breakdown_total, _) = score_result_with_breakdown(&r, &opts, true);
+        assert_eq!(scalar, breakdown_total);
+    }
+
+    #[test]
+    fn preferred_group_rank_appears_in_detail() {
+        let mut r = result(10, "[Beatrice-Raws] Series - 01 (1080p)");
+        r.group = "Beatrice-Raws".to_string();
+        let opts = SearchOptions {
+            preferred_groups: vec!["smol".to_string(), "Beatrice-Raws".to_string()],
+            preferred_resolution: String::new(),
+            ..SearchOptions::default()
+        };
+        let (_, parts) = score_result_with_breakdown(&r, &opts, true);
+        let group_comp = parts
+            .iter()
+            .find(|c| c.label == "Preferred Group")
+            .expect("preferred group component missing");
+        assert_eq!(group_comp.delta, 120); // 140 - (1 * 20)
+        assert!(
+            group_comp
+                .detail
+                .as_deref()
+                .unwrap_or("")
+                .contains("rank 2")
+        );
+    }
 }

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -261,6 +261,7 @@ mod tests {
             score: 0,
             info_hash: String::new(),
             score_breakdown: Vec::new(),
+            upload_date: String::new(),
         }
     }
 

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -1,9 +1,12 @@
+use std::collections::HashSet;
 use std::sync::LazyLock;
 
 use regex_lite::Regex;
 use serde::{Deserialize, Serialize};
 
+use crate::services::custom_formats::{self, CompiledCustomFormat, EvalContext};
 use crate::services::nyaa::{SearchOptions, SearchResult};
+use crate::services::source::{ClassificationResult, Resolution, Source, WebKind};
 
 // Word-boundary "dub" / "dubbed" — anchors prevent the prior bare-
 // substring match from false-positiving on "redub", "dubsoon",
@@ -233,6 +236,76 @@ pub fn score_result_with_breakdown(
     (total, parts)
 }
 
+/// Rehydrate a `ClassificationResult` from the already-populated source
+/// fields on a `SearchResult`. The scraper stores `source` / `resolution`
+/// / `web_kind` as display strings plus `is_remux` / `is_bdmv` booleans;
+/// the CF evaluator wants the typed enums. `evidence` / `confidence` /
+/// `needs_review` / `decision_rule` aren't available at manual-search
+/// time, so they default — CF evaluation doesn't read them.
+fn classification_from_search_result(r: &SearchResult) -> ClassificationResult {
+    let web_kind = if r.web_kind.is_empty() {
+        WebKind::Unknown
+    } else {
+        WebKind::from_str(&r.web_kind)
+    };
+    ClassificationResult {
+        source: Source::from_str(&r.source),
+        resolution: Resolution::from_str(&r.resolution),
+        is_remux: r.is_remux,
+        web_kind,
+        is_bdmv: r.is_bdmv,
+        confidence: 1.0,
+        needs_review: false,
+        evidence: Vec::new(),
+        decision_rule: crate::services::source::DecisionRule::Empty,
+    }
+}
+
+/// Evaluate the compiled CF set against each result in `results`,
+/// adding matching CF contributions to both `result.score` and
+/// `result.score_breakdown`. Used by the manual-search path so the
+/// "why this score" expander shows CF deltas alongside the base rules.
+///
+/// `seadex_hashes` can be empty — the manual search has no series
+/// context, so SeaDex specs simply never fire. That's fine for now;
+/// the manual search isn't the SeaDex surface.
+///
+/// Appends one `ScoreComponent` per matching CF with a non-zero score,
+/// labeled `"CF: <name>"` so the UI can distinguish them from the
+/// base-score rules at a glance.
+pub fn apply_cf_breakdown(
+    results: &mut [SearchResult],
+    cfs: &[CompiledCustomFormat],
+    seadex_hashes: &HashSet<String>,
+) {
+    if cfs.is_empty() {
+        return;
+    }
+    for r in results.iter_mut() {
+        let classification = classification_from_search_result(r);
+        // Borrowed ctx needs the result to live for the whole call,
+        // but we're about to mutate the result's score. Capture the
+        // breakdown first with an immutable borrow, drop it, then
+        // mutate.
+        let (cf_total, breakdown) = {
+            let ctx = EvalContext {
+                result: r,
+                classification: &classification,
+                seadex_hashes,
+            };
+            custom_formats::total_cf_score_with_breakdown(cfs, &ctx)
+        };
+        if cf_total == 0 && breakdown.is_empty() {
+            continue;
+        }
+        r.score = r.score.saturating_add(cf_total);
+        for (name, delta) in breakdown {
+            r.score_breakdown
+                .push(ScoreComponent::new(&format!("CF: {name}"), delta, None));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +415,56 @@ mod tests {
         let scalar = score_result_with_sub_pref(&r, &opts, true);
         let (breakdown_total, _) = score_result_with_breakdown(&r, &opts, true);
         assert_eq!(scalar, breakdown_total);
+    }
+
+    #[test]
+    fn apply_cf_breakdown_noop_with_empty_cf_list() {
+        let mut r = result(30, "[Group] Series - 01 (1080p)");
+        r.score = 42;
+        let before_breakdown = r.score_breakdown.len();
+        let mut batch = vec![r];
+        apply_cf_breakdown(&mut batch, &[], &HashSet::new());
+        assert_eq!(batch[0].score, 42);
+        assert_eq!(batch[0].score_breakdown.len(), before_breakdown);
+    }
+
+    #[test]
+    fn apply_cf_breakdown_appends_cf_prefixed_entries_and_bumps_score() {
+        // Compile a tiny CF that matches any release whose title
+        // contains "x265". Using the real parser so this test stays
+        // honest about how CF scoring actually fires.
+        let cf = crate::services::custom_formats::compile_from_json(
+            r#"{
+                "name": "x265 bonus",
+                "specifications": [{
+                    "implementation": "ReleaseTitleSpecification",
+                    "fields": [{"name": "value", "value": "x265"}]
+                }]
+            }"#,
+            50,
+            1,
+        )
+        .expect("test CF compiles");
+
+        let mut hit = result(10, "[Group] Series - 01 (1080p) [x265].mkv");
+        hit.score = 20;
+        let base_breakdown_len = hit.score_breakdown.len();
+
+        let mut miss = result(10, "[Group] Series - 02 (1080p).mkv");
+        miss.score = 20;
+
+        let mut batch = vec![hit, miss];
+        apply_cf_breakdown(&mut batch, std::slice::from_ref(&cf), &HashSet::new());
+
+        // Hit: score bumped, one new "CF: x265 bonus" entry.
+        assert_eq!(batch[0].score, 70);
+        assert_eq!(batch[0].score_breakdown.len(), base_breakdown_len + 1);
+        let added = batch[0].score_breakdown.last().expect("new entry");
+        assert_eq!(added.label, "CF: x265 bonus");
+        assert_eq!(added.delta, 50);
+
+        // Miss: untouched.
+        assert_eq!(batch[1].score, 20);
     }
 
     #[test]

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -1,7 +1,7 @@
 use std::sync::LazyLock;
 
 use regex_lite::Regex;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::services::nyaa::{SearchOptions, SearchResult};
 
@@ -16,7 +16,7 @@ static DUB_RE: LazyLock<Regex> =
 /// many seeders, what threshold crossed, etc.). Surfaced on the
 /// /api/search response and persisted alongside grab history so the
 /// "why this score" UI can show users exactly what happened.
-#[derive(Debug, Clone, Serialize, utoipa::ToSchema)]
+#[derive(Debug, Clone, Serialize, Deserialize, utoipa::ToSchema)]
 pub struct ScoreComponent {
     /// Short label — displayed as the left-column "what" in the UI
     /// breakdown table (e.g. "Seeders", "Preferred Group",
@@ -260,6 +260,7 @@ mod tests {
             is_trusted: false,
             score: 0,
             info_hash: String::new(),
+            score_breakdown: Vec::new(),
         }
     }
 

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -58,7 +58,12 @@
     border: 1px solid var(--border);
     border-radius: var(--radius);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
-    z-index: 30;
+    /* 5 keeps the panel above normal table rows but below the sticky
+       results-table thead th (z-index: 15 on the search page) — so
+       scrolling past an open breakdown slides the panel under the
+       header bar instead of painting over it. The fixed-positioning
+       escape path (inside modals) overrides this inline. */
+    z-index: 5;
     text-align: left;
     font-size: 12px;
 }

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -15,6 +15,88 @@
 
 .score-low { background: rgba(211, 125, 125, 0.12); color: var(--red); }
 
+/* #1.3.0 — score breakdown expander. Used by both the manual Nyaa
+   search page and the per-series interactive search picker, so the
+   styles live here next to .score-badge rather than on any one page's
+   stylesheet. Clicking the score badge expands a panel with per-rule
+   deltas. Panel absolutely-positions under the badge so it doesn't
+   push table layout around. */
+.score-details {
+    position: relative;
+    display: inline-block;
+    vertical-align: middle;
+}
+.score-details > summary {
+    cursor: pointer;
+    list-style: none;
+    /* Override the browser default `display: list-item` on <summary>.
+       list-item's baseline behavior interacts awkwardly with the
+       containing td's vertical-align and pins the badge high.
+       Forcing inline-block gives a simple box model. */
+    display: inline-block;
+    vertical-align: middle;
+}
+.score-details > summary::-webkit-details-marker {
+    display: none;
+}
+.score-details > summary::marker {
+    display: none;
+    content: "";
+}
+.score-details[open] > summary {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+.score-components {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    min-width: 280px;
+    max-width: 360px;
+    padding: 10px 12px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    z-index: 30;
+    text-align: left;
+    font-size: 12px;
+}
+.score-components-title {
+    font-weight: 600;
+    color: var(--text-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+}
+.score-components ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.score-components li {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    column-gap: 8px;
+    align-items: baseline;
+    padding: 3px 0;
+}
+.sc-delta {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    text-align: right;
+}
+.sc-delta-pos { color: var(--green); }
+.sc-delta-neg { color: var(--red); }
+.sc-label { color: var(--text); }
+.sc-detail {
+    grid-column: 2;
+    color: var(--text-dim);
+    font-size: 11px;
+    margin-top: 1px;
+}
+
 .tag-batch { background: var(--blue-bg); color: var(--blue); }
 
 .tag-trusted { background: var(--green-bg); color: var(--green); }

--- a/static/css/pages/downloads.css
+++ b/static/css/pages/downloads.css
@@ -12,3 +12,30 @@
     white-space: nowrap;
 }
 
+/* Secondary info line under a History row's torrent name, used for
+   upgrade-chain hints. `.dl-replaced-note` is the generic "this row
+   was superseded" style; `.dl-replaced-note-upgrade` colors the other
+   side of the chain — the replacing row's "upgraded N" summary — so
+   the two kinds of note are visually distinct at a glance. */
+.dl-replaced-note {
+    font-size: 11px;
+    color: var(--text-dim);
+    margin-top: 2px;
+    font-style: italic;
+    max-width: 420px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.dl-replaced-note-upgrade {
+    color: var(--accent);
+    font-style: normal;
+    font-weight: 500;
+}
+
+.dl-replaced-target {
+    font-style: normal;
+    color: var(--text);
+}
+

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -124,6 +124,27 @@
     flex-shrink: 0;
 }
 
+.anilist-cover-link {
+    flex-shrink: 0;
+    display: block;
+    line-height: 0;
+}
+
+.anilist-cover-link:hover .anilist-cover {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+
+.anilist-title-link {
+    color: inherit;
+    text-decoration: none;
+}
+
+.anilist-title-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
 .anilist-info {
     flex: 1;
     min-width: 0;

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -320,17 +320,25 @@
 
 /* Sortable column headers (#6a). Click a header to sort asc, click
    again to flip desc. Arrows rendered via pseudo-elements so they
-   don't steal click targets from the label. */
+   don't steal click targets from the label.
+   `white-space: nowrap` is load-bearing: without it, the pseudo-
+   element arrow on narrow columns like .col-score (55px) wrapped to
+   a second line below the text, which inflated the whole column's
+   <th> height and visually shifted the cells in that column down
+   relative to the other columns — read as "the score badge is
+   higher than the rest of the row." Keeping the label + arrow on
+   one line keeps every column's header the same height. */
 .results-table .sortable {
     cursor: pointer;
     user-select: none;
+    white-space: nowrap;
 }
 .results-table .sortable::after {
     content: "";
     display: inline-block;
     width: 0;
     height: 0;
-    margin-left: 6px;
+    margin-left: 4px;
     border-left: 4px solid transparent;
     border-right: 4px solid transparent;
     opacity: 0.3;

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -218,19 +218,19 @@
     vertical-align: middle;
 }
 
-/* Sticky search-bar (#6c). Keeps the query/filters/submit row
-   reachable when scrolling a long result list. Only on desktop;
-   the mobile card view is tall enough that sticky positioning gets
-   in the way. */
+/* Sticky results-table header (#6c). Mirror the interactive-search
+   table on the series page: the column headers stay pinned as the
+   result list scrolls, so score/name/size/etc. labels remain visible.
+   `bg-elevated` background matches the interactive picker, so users
+   learn one sticky-row pattern across both surfaces. Only applies on
+   desktop — on mobile the table is replaced by `.results-cards` so
+   there's no header row to pin. */
 @media (min-width: 641px) {
-    .search-bar {
+    .results-table thead th {
         position: sticky;
         top: 0;
         z-index: 15;
-        background: var(--bg);
-        padding-top: 8px;
-        padding-bottom: 8px;
-        margin-top: -8px;
+        background: var(--bg-elevated);
     }
 }
 

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -259,11 +259,15 @@
     min-width: 280px;
     max-width: 360px;
     padding: 10px 12px;
-    background: var(--panel);
+    /* --panel isn't defined in the theme — fell through to transparent,
+       which made the expanded breakdown render as floating text over
+       the rows below. --bg-elevated is the correct overlay surface
+       (same var used by log panels and other popovers). */
+    background: var(--bg-elevated);
     border: 1px solid var(--border);
     border-radius: var(--radius);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
-    z-index: 10;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
+    z-index: 30;
     text-align: left;
     font-size: 12px;
 }

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -226,13 +226,27 @@
 .score-details {
     position: relative;
     display: inline-block;
+    vertical-align: middle;
 }
 .score-details > summary {
     cursor: pointer;
     list-style: none;
+    /* Override the browser default `display: list-item` on <summary>.
+       list-item's baseline behavior interacts awkwardly with the
+       containing td's vertical-align and was keeping the badge
+       pinned high even after the td switched to middle. Forcing
+       inline-block gives us the simple "this sits where I put it"
+       box model. */
+    display: inline-block;
+    vertical-align: middle;
 }
 .score-details > summary::-webkit-details-marker {
     display: none;
+}
+/* Firefox uses a different pseudo for the disclosure marker. */
+.score-details > summary::marker {
+    display: none;
+    content: "";
 }
 .score-details[open] > summary {
     outline: 2px solid var(--accent);

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -277,3 +277,54 @@
     margin-top: 1px;
 }
 
+/* Sticky search-bar (#6c). Keeps the query/filters/submit row
+   reachable when scrolling a long result list. Only on desktop;
+   the mobile card view is tall enough that sticky positioning gets
+   in the way. */
+@media (min-width: 641px) {
+    .search-bar {
+        position: sticky;
+        top: 0;
+        z-index: 15;
+        background: var(--bg);
+        padding-top: 8px;
+        padding-bottom: 8px;
+        margin-top: -8px;
+    }
+}
+
+/* Sortable column headers (#6a). Click a header to sort asc, click
+   again to flip desc. Arrows rendered via pseudo-elements so they
+   don't steal click targets from the label. */
+.results-table .sortable {
+    cursor: pointer;
+    user-select: none;
+}
+.results-table .sortable::after {
+    content: "";
+    display: inline-block;
+    width: 0;
+    height: 0;
+    margin-left: 6px;
+    border-left: 4px solid transparent;
+    border-right: 4px solid transparent;
+    opacity: 0.3;
+    vertical-align: middle;
+}
+.results-table .sortable.sort-asc::after {
+    border-bottom: 5px solid var(--text);
+    opacity: 1;
+}
+.results-table .sortable.sort-desc::after {
+    border-top: 5px solid var(--text);
+    opacity: 1;
+}
+.results-table .sortable:hover { color: var(--accent); }
+.col-date {
+    width: 96px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-dim);
+    white-space: nowrap;
+}
+

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -207,3 +207,73 @@
     }
 }
 
+/* Score breakdown expander (#17). The <details>/<summary> is inside
+   the score column; clicking the score badge expands the panel with
+   per-component deltas. Panel absolutely-positions under the cell
+   so it doesn't push the table layout around, and uses a small z-
+   index so it overlays subsequent rows. */
+.score-details {
+    position: relative;
+    display: inline-block;
+}
+.score-details > summary {
+    cursor: pointer;
+    list-style: none;
+}
+.score-details > summary::-webkit-details-marker {
+    display: none;
+}
+.score-details[open] > summary {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+}
+.score-components {
+    position: absolute;
+    top: calc(100% + 6px);
+    left: 0;
+    min-width: 280px;
+    max-width: 360px;
+    padding: 10px 12px;
+    background: var(--panel);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+    z-index: 10;
+    text-align: left;
+    font-size: 12px;
+}
+.score-components-title {
+    font-weight: 600;
+    color: var(--text-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    margin-bottom: 6px;
+}
+.score-components ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+.score-components li {
+    display: grid;
+    grid-template-columns: 44px 1fr;
+    column-gap: 8px;
+    align-items: baseline;
+    padding: 3px 0;
+}
+.sc-delta {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    text-align: right;
+}
+.sc-delta-pos { color: var(--green); }
+.sc-delta-neg { color: var(--red); }
+.sc-label { color: var(--text); }
+.sc-detail {
+    grid-column: 2;
+    color: var(--text-dim);
+    font-size: 11px;
+    margin-top: 1px;
+}
+

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -211,7 +211,18 @@
    the score column; clicking the score badge expands the panel with
    per-component deltas. Panel absolutely-positions under the cell
    so it doesn't push the table layout around, and uses a small z-
-   index so it overlays subsequent rows. */
+   index so it overlays subsequent rows.
+
+   Score column overrides the td default `vertical-align: top` to
+   `middle` so the badge sits at the same visual height as the
+   effectively-centered single-line metadata columns (size / date /
+   seed / leech / dl / Grab) in rows where the Name column wraps to
+   two lines. Without this the badge pins to the top of the cell
+   while everything else looks centered, which reads as the badge
+   being "higher than" the text rows. */
+.results-table .col-score {
+    vertical-align: middle;
+}
 .score-details {
     position: relative;
     display: inline-block;

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -207,103 +207,15 @@
     }
 }
 
-/* Score breakdown expander (#17). The <details>/<summary> is inside
-   the score column; clicking the score badge expands the panel with
-   per-component deltas. Panel absolutely-positions under the cell
-   so it doesn't push the table layout around, and uses a small z-
-   index so it overlays subsequent rows.
-
-   Score column overrides the td default `vertical-align: top` to
-   `middle` so the badge sits at the same visual height as the
-   effectively-centered single-line metadata columns (size / date /
-   seed / leech / dl / Grab) in rows where the Name column wraps to
-   two lines. Without this the badge pins to the top of the cell
-   while everything else looks centered, which reads as the badge
-   being "higher than" the text rows. */
+/* Keep the results-table column alignment override here — the generic
+   expander styles live in badges.css (shared with the series page's
+   interactive search), but the table td vertical-align override is
+   specific to this page's table layout. Badge needs to sit at the
+   same visual height as the single-line metadata columns; without
+   this override it pins to the top of the cell in rows where the
+   Name column wraps. */
 .results-table .col-score {
     vertical-align: middle;
-}
-.score-details {
-    position: relative;
-    display: inline-block;
-    vertical-align: middle;
-}
-.score-details > summary {
-    cursor: pointer;
-    list-style: none;
-    /* Override the browser default `display: list-item` on <summary>.
-       list-item's baseline behavior interacts awkwardly with the
-       containing td's vertical-align and was keeping the badge
-       pinned high even after the td switched to middle. Forcing
-       inline-block gives us the simple "this sits where I put it"
-       box model. */
-    display: inline-block;
-    vertical-align: middle;
-}
-.score-details > summary::-webkit-details-marker {
-    display: none;
-}
-/* Firefox uses a different pseudo for the disclosure marker. */
-.score-details > summary::marker {
-    display: none;
-    content: "";
-}
-.score-details[open] > summary {
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
-}
-.score-components {
-    position: absolute;
-    top: calc(100% + 6px);
-    left: 0;
-    min-width: 280px;
-    max-width: 360px;
-    padding: 10px 12px;
-    /* --panel isn't defined in the theme — fell through to transparent,
-       which made the expanded breakdown render as floating text over
-       the rows below. --bg-elevated is the correct overlay surface
-       (same var used by log panels and other popovers). */
-    background: var(--bg-elevated);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.35);
-    z-index: 30;
-    text-align: left;
-    font-size: 12px;
-}
-.score-components-title {
-    font-weight: 600;
-    color: var(--text-dim);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    margin-bottom: 6px;
-}
-.score-components ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-}
-.score-components li {
-    display: grid;
-    grid-template-columns: 44px 1fr;
-    column-gap: 8px;
-    align-items: baseline;
-    padding: 3px 0;
-}
-.sc-delta {
-    font-family: var(--font-mono);
-    font-weight: 600;
-    text-align: right;
-}
-.sc-delta-pos { color: var(--green); }
-.sc-delta-neg { color: var(--red); }
-.sc-label { color: var(--text); }
-.sc-detail {
-    grid-column: 2;
-    color: var(--text-dim);
-    font-size: 11px;
-    margin-top: 1px;
 }
 
 /* Sticky search-bar (#6c). Keeps the query/filters/submit row

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -10,7 +10,15 @@
 
 .results-table {
     width: 100%;
-    border-collapse: collapse;
+    /* `separate` (not `collapse`) is load-bearing for the sticky header
+       below: with collapsed borders the browser can't apply
+       `position: sticky` to <th> because collapsed borders are a shared
+       resource between adjacent cells, so the th is layout-bound to
+       the row beneath it. `border-spacing: 0` keeps the visual
+       identical to the old collapsed layout; the row-separator lines
+       come from `td { border-bottom }` below, same as before. */
+    border-collapse: separate;
+    border-spacing: 0;
     font-size: 13px;
 }
 

--- a/static/css/pages/search.css
+++ b/static/css/pages/search.css
@@ -236,7 +236,11 @@
 @media (min-width: 641px) {
     .results-table thead th {
         position: sticky;
-        top: 0;
+        /* The top nav is `position: sticky; top: 0; height: 56px` on
+           desktop (topbar.css), so our header must pin BELOW it or it
+           vanishes behind the nav as you scroll. Matching 56px keeps
+           the header edge-to-edge with the nav bottom. */
+        top: 56px;
         z-index: 15;
         background: var(--bg-elevated);
     }

--- a/static/css/pages/series.css
+++ b/static/css/pages/series.css
@@ -1066,6 +1066,21 @@
 
 .interactive-search-table .col-quality { width: 120px; white-space: nowrap; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
 
+/* Release-title link in each row. Matches the manual search page's
+   `.col-name a:hover` treatment so hovering a row makes it obvious
+   the title opens the Nyaa view page. Without this, the inline
+   `color:var(--text); text-decoration:none` styling gave zero hover
+   affordance. */
+.isearch-release-link {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.isearch-release-link:hover {
+    color: var(--accent);
+    text-decoration: underline;
+}
+
 .is-modal-scroll {
     overflow-y: auto;
     max-height: 480px;

--- a/static/css/pages/series.css
+++ b/static/css/pages/series.css
@@ -1008,6 +1008,8 @@
 
 .grab-state-removed { color: var(--text-dim); font-weight: 600; }
 
+.grab-state-replaced { color: var(--orange); font-weight: 600; }
+
 .btn-mark-failed {
     font-size: 11px;
     padding: 3px 8px;

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -72,23 +72,28 @@ function searchAnilist() {
                 const isMal = r.source === 'mal';
                 const sourceLabel = isMal ? 'MAL' : 'AniList';
                 // External link to the provider page matching whichever
-                // source served the row. MAL uses id_mal (always set for
-                // Jikan-served rows); AL uses the AniList id. Stops
-                // click-propagation to the row so clicking the title
-                // link doesn't also fire an accidental Add if we add a
-                // row-click later.
+                // source served the row. AL rows use the AniList id.
+                // MAL rows need `id_mal` — if a MAL-served row somehow
+                // arrives without one (shouldn't happen from Jikan, but
+                // defensively), fall back to rendering the cover/title
+                // as plain non-link markup rather than an href pointing
+                // at myanimelist.net with an AL id, which 404s.
                 const externalHref = isMal
-                    ? `https://myanimelist.net/anime/${r.id_mal || r.id}`
+                    ? (r.id_mal ? `https://myanimelist.net/anime/${r.id_mal}` : null)
                     : `https://anilist.co/anime/${r.id}`;
+                const coverMarkup = externalHref
+                    ? `<a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-cover-link" title="Open on ${escAttr(sourceLabel)}">
+                            <img src="${escAttr(r.cover_url)}" alt="" class="anilist-cover" loading="lazy">
+                        </a>`
+                    : `<img src="${escAttr(r.cover_url)}" alt="" class="anilist-cover" loading="lazy">`;
+                const titleMarkup = externalHref
+                    ? `<a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-title-link" title="Open on ${escAttr(sourceLabel)}">${escHtml(title)}</a>`
+                    : escHtml(title);
                 return `
                     <div class="anilist-result">
-                        <a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-cover-link" title="Open on ${escAttr(sourceLabel)}">
-                            <img src="${escAttr(r.cover_url)}" alt="" class="anilist-cover" loading="lazy">
-                        </a>
+                        ${coverMarkup}
                         <div class="anilist-info">
-                            <p class="anilist-title">
-                                <a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-title-link" title="Open on ${escAttr(sourceLabel)}">${escHtml(title)}</a>
-                            </p>
+                            <p class="anilist-title">${titleMarkup}</p>
                             <p class="anilist-subtitle">${escHtml(subtitle)}</p>
                             <div class="anilist-meta">
                                 <span class="tag tag-res">${escHtml((r.format || 'TBA').replace(/_/g, ' '))}</span>

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -69,12 +69,26 @@ function searchAnilist() {
                     ? (r.title_romaji || r.title_native || '')
                     : (r.title_english || r.title_romaji || r.title_native || '');
                 const eps = r.episodes ? `${r.episodes} eps` : '?';
-                const sourceLabel = r.source === 'mal' ? 'MAL' : 'AniList';
+                const isMal = r.source === 'mal';
+                const sourceLabel = isMal ? 'MAL' : 'AniList';
+                // External link to the provider page matching whichever
+                // source served the row. MAL uses id_mal (always set for
+                // Jikan-served rows); AL uses the AniList id. Stops
+                // click-propagation to the row so clicking the title
+                // link doesn't also fire an accidental Add if we add a
+                // row-click later.
+                const externalHref = isMal
+                    ? `https://myanimelist.net/anime/${r.id_mal || r.id}`
+                    : `https://anilist.co/anime/${r.id}`;
                 return `
                     <div class="anilist-result">
-                        <img src="${escAttr(r.cover_url)}" alt="" class="anilist-cover" loading="lazy">
+                        <a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-cover-link" title="Open on ${escAttr(sourceLabel)}">
+                            <img src="${escAttr(r.cover_url)}" alt="" class="anilist-cover" loading="lazy">
+                        </a>
                         <div class="anilist-info">
-                            <p class="anilist-title">${escHtml(title)}</p>
+                            <p class="anilist-title">
+                                <a href="${escAttr(externalHref)}" target="_blank" rel="noopener" class="anilist-title-link" title="Open on ${escAttr(sourceLabel)}">${escHtml(title)}</a>
+                            </p>
                             <p class="anilist-subtitle">${escHtml(subtitle)}</p>
                             <div class="anilist-meta">
                                 <span class="tag tag-res">${escHtml((r.format || 'TBA').replace(/_/g, ' '))}</span>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -255,7 +255,7 @@ function renderScoreBreakdown(r) {
             </li>`;
         }).join('');
         inner = `<ul>${lis}</ul>
-            <div class="form-hint">Custom Format contributions (if any) are applied on top of this base score at grab time — test via Settings → Custom Formats.</div>`;
+            <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page — open the series page's interactive search for the full breakdown.</div>`;
     }
     return `<div class="score-components">
         <div class="score-components-title">Base score breakdown</div>

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -411,5 +411,19 @@ function renderScoreBreakdown(r) {
                 sortRows(tbody, key, dir);
             });
         });
+
+        // Template ships `sort-desc` on the Score column as the default
+        // visual state, but the server hands us rows in Nyaa's natural
+        // order (upload date descending) — not sorted by score. Without
+        // this initial sort the arrow lies about the column state,
+        // which read as "sort-by-score gives weird results" on page
+        // load. Run the same sort the click handler would so the
+        // rendered rows match whatever initial class the server set.
+        const initial = table.querySelector('th.sortable.sort-asc, th.sortable.sort-desc');
+        if (initial) {
+            const key = initial.dataset.sortKey;
+            const dir = initial.classList.contains('sort-asc') ? 'asc' : 'desc';
+            sortRows(tbody, key, dir);
+        }
     });
 })();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -297,6 +297,31 @@ function renderScoreBreakdown(r) {
     function positionPanel(details) {
         const panel = details.querySelector('.score-components');
         if (!panel) return;
+        // Only lift the panel to fixed-positioning when it lives
+        // inside an overflow-clipping ancestor (e.g. the interactive-
+        // search modal). On the plain /search page the results table
+        // is a direct descendant of the viewport, so CSS
+        // `position: absolute; top: calc(100% + 6px); left: 0` anchored
+        // to the `.score-details` summary is the correct placement —
+        // it rides scroll with the row and keeps the CSS max-width
+        // cap intact. An earlier blanket fixed-positioning here
+        // stretched the panel to the full viewport width and left it
+        // floating in place after a scroll.
+        let clipped = false;
+        let node = details.parentElement;
+        while (node && node !== document.body) {
+            const cs = window.getComputedStyle(node);
+            if (cs.overflow !== 'visible' || cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
+                clipped = true;
+                break;
+            }
+            node = node.parentElement;
+        }
+        if (!clipped) {
+            resetPanelPosition(panel);
+            return;
+        }
+
         const GAP = 6;
         const MARGIN = 8;
         const rect = details.getBoundingClientRect();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -195,3 +195,74 @@ function escHtml(s) {
 function escAttr(s) {
     return s.replace(/'/g, "\\'").replace(/"/g, '&quot;');
 }
+
+// #6a — click-to-sort columns on the results table. Each row carries
+// data-* attributes populated server-side (data-score, data-name,
+// data-size, data-date, data-seeders, data-leechers, data-downloads).
+// Clicking a sortable header toggles between asc/desc and re-orders
+// the tbody rows in place. State is purely client-side — no URL
+// params, no server round-trip.
+(function () {
+    function parseValue(raw, key) {
+        if (raw == null) return null;
+        // Numeric columns.
+        if (key === 'score' || key === 'size' || key === 'seeders' || key === 'leechers' || key === 'downloads') {
+            const n = parseFloat(raw);
+            return isNaN(n) ? 0 : n;
+        }
+        // Date is sortable as a string in "YYYY-MM-DD HH:MM" shape;
+        // empty → sort last.
+        if (key === 'date') {
+            return raw || '';
+        }
+        // Name — case-insensitive string compare.
+        return String(raw).toLowerCase();
+    }
+
+    function sortRows(tbody, key, dir) {
+        const rows = Array.from(tbody.children);
+        const sign = dir === 'asc' ? 1 : -1;
+        rows.sort(function (a, b) {
+            const av = parseValue(a.dataset[key], key);
+            const bv = parseValue(b.dataset[key], key);
+            // Empty-date rows sort to the end regardless of direction.
+            if (key === 'date') {
+                if (!av && !bv) return 0;
+                if (!av) return 1;
+                if (!bv) return -1;
+            }
+            if (av < bv) return -1 * sign;
+            if (av > bv) return 1 * sign;
+            return 0;
+        });
+        const frag = document.createDocumentFragment();
+        rows.forEach(function (r) { frag.appendChild(r); });
+        tbody.appendChild(frag);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        const table = document.getElementById('results-table');
+        if (!table) return;
+        const tbody = document.getElementById('results-body');
+        if (!tbody) return;
+        table.querySelectorAll('th.sortable').forEach(function (th) {
+            th.addEventListener('click', function () {
+                const key = th.dataset.sortKey;
+                const wasAsc = th.classList.contains('sort-asc');
+                const wasDesc = th.classList.contains('sort-desc');
+                // Clear other headers.
+                table.querySelectorAll('th.sortable').forEach(function (other) {
+                    other.classList.remove('sort-asc', 'sort-desc');
+                });
+                // Flip direction: no current sort → desc for numeric
+                // columns (more is usually better), asc for name/date.
+                let dir;
+                if (wasAsc) dir = 'desc';
+                else if (wasDesc) dir = 'asc';
+                else dir = (key === 'name' || key === 'date') ? 'asc' : 'desc';
+                th.classList.add(dir === 'asc' ? 'sort-asc' : 'sort-desc');
+                sortRows(tbody, key, dir);
+            });
+        });
+    });
+})();

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -166,10 +166,23 @@ function loadMore() {
 function grabRelease(url, btn) {
     btn.disabled = true;
     btn.textContent = '...';
+    // Pull the row's data-* attributes so the backend can link the
+    // grab to a library series (#6d). Falls back to a URL-only grab
+    // when the button wasn't mounted inside a result row — e.g. a
+    // caller from a different template.
+    const row = btn.closest('tr[data-score]') || btn.closest('.result-card');
+    const payload = {url: url};
+    if (row) {
+        // data-name carries the release title; is_batch is inferred
+        // from the row class. info_hash isn't exposed on the row
+        // today — the backend re-derives it from the URL when absent.
+        if (row.dataset.name) payload.title = row.dataset.name;
+        payload.is_batch = row.classList.contains('is-batch');
+    }
     fetch('/api/grab', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify({url: url})
+        body: JSON.stringify(payload),
     })
     .then(resp => {
         if (resp.ok) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -103,16 +103,36 @@ function loadMore() {
                 const grabUrl = r.magnet || r.torrent || '';
                 const grabBtn = grabUrl ? `<button class="btn btn-grab" onclick="grabRelease('${escAttr(grabUrl)}', this)">Grab</button>` : '';
 
+                const scoreBreakdownHtml = renderScoreBreakdown(r);
+                const dateCell = r.upload_date
+                    ? `<span data-ts="${escAttr(r.upload_date)}">${escHtml(r.upload_date)}</span>`
+                    : '—';
+
                 // Table row (desktop).
                 const tr = document.createElement('tr');
                 if (rowClass) tr.className = rowClass;
+                // data-* attrs mirror the server-rendered rows so the
+                // client-side column sort picks up paginated rows too.
+                tr.dataset.score = r.score;
+                tr.dataset.name = r.title;
+                tr.dataset.size = r.size_bytes;
+                tr.dataset.date = r.upload_date || '';
+                tr.dataset.seeders = r.seeders;
+                tr.dataset.leechers = r.leechers;
+                tr.dataset.downloads = r.downloads;
                 tr.innerHTML = `
-                    <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
+                    <td class="col-score">
+                        <details class="score-details" name="score-breakdown">
+                            <summary class="score-badge ${scoreClass}" title="Click to see breakdown">${r.score}</summary>
+                            ${scoreBreakdownHtml}
+                        </details>
+                    </td>
                     <td class="col-name">
                         <a href="${escAttr(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>
                         <div class="result-tags">${tags}</div>
                     </td>
                     <td class="col-size">${escHtml(r.size)}</td>
+                    <td class="col-date">${dateCell}</td>
                     <td class="col-seed"><span class="seed-count">${r.seeders}</span></td>
                     <td class="col-leech"><span class="leech-count">${r.leechers}</span></td>
                     <td class="col-dl"><span class="dl-count">${r.downloads}</span></td>
@@ -128,7 +148,10 @@ function loadMore() {
                     card.className = `result-card${rowClass ? ' ' + rowClass : ''}`;
                     card.innerHTML = `
                         <div class="result-card-header">
-                            <span class="score-badge ${scoreClass}">${r.score}</span>
+                            <details class="score-details" name="score-breakdown">
+                                <summary class="score-badge ${scoreClass}" title="Click to see breakdown">${r.score}</summary>
+                                ${scoreBreakdownHtml}
+                            </details>
                             <a class="result-card-title" href="${escAttr(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>
                         </div>
                         <div class="result-card-tags">${tags}</div>
@@ -201,13 +224,71 @@ function grabRelease(url, btn) {
 
 function escHtml(s) {
     const d = document.createElement('div');
-    d.textContent = s;
+    d.textContent = s == null ? '' : s;
     return d.innerHTML;
 }
 
 function escAttr(s) {
-    return s.replace(/'/g, "\\'").replace(/"/g, '&quot;');
+    return String(s == null ? '' : s).replace(/'/g, "\\'").replace(/"/g, '&quot;');
 }
+
+// Build the <div class="score-components"> panel content for a result,
+// matching the server-rendered shape in templates/search.html so a row
+// appended via loadMore() behaves identically to a page-1 row. Keeping
+// the two paths in lockstep is load-bearing for the sort+expand UX.
+function renderScoreBreakdown(r) {
+    const parts = r.score_breakdown || [];
+    let inner;
+    if (parts.length === 0) {
+        inner = `<div class="form-hint">No components fired (score stayed at 0).</div>`;
+    } else {
+        const lis = parts.map(function (c) {
+            const deltaClass = c.delta > 0 ? 'sc-delta-pos' : 'sc-delta-neg';
+            const sign = c.delta > 0 ? '+' : '';
+            const detail = c.detail
+                ? `<span class="sc-detail">${escHtml(c.detail)}</span>`
+                : '';
+            return `<li>
+                <span class="sc-delta ${deltaClass}">${sign}${c.delta}</span>
+                <span class="sc-label">${escHtml(c.label)}</span>
+                ${detail}
+            </li>`;
+        }).join('');
+        inner = `<ul>${lis}</ul>
+            <div class="form-hint">Custom Format contributions (if any) are applied on top of this base score at grab time — test via Settings → Custom Formats.</div>`;
+    }
+    return `<div class="score-components">
+        <div class="score-components-title">Base score breakdown</div>
+        ${inner}
+    </div>`;
+}
+
+// #1.3.0 — close any open <details class="score-details"> when the user
+// clicks outside it or presses Escape. Without these, the only way to
+// dismiss the expander is to click the score badge itself, which is a
+// footgun on the mobile card layout where the score sits in a small
+// target at the card's top-left corner.
+(function () {
+    function closeAllOpenBreakdowns(except) {
+        document.querySelectorAll('details.score-details[open]').forEach(function (d) {
+            if (d !== except) d.removeAttribute('open');
+        });
+    }
+    document.addEventListener('click', function (evt) {
+        // If the click landed inside any score-details, leave it alone —
+        // the <details> element handles toggling its own state. Only
+        // close *other* open breakdowns (the `name=` attribute on the
+        // <details> already enforces accordion behavior, but this also
+        // covers any unnamed future callers).
+        const inside = evt.target.closest('details.score-details');
+        closeAllOpenBreakdowns(inside);
+    });
+    document.addEventListener('keydown', function (evt) {
+        if (evt.key === 'Escape') {
+            closeAllOpenBreakdowns(null);
+        }
+    });
+})();
 
 // #6a — click-to-sort columns on the results table. Each row carries
 // data-* attributes populated server-side (data-score, data-name,

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -268,18 +268,60 @@ function renderScoreBreakdown(r) {
 // dismiss the expander is to click the score badge itself, which is a
 // footgun on the mobile card layout where the score sits in a small
 // target at the card's top-left corner.
+//
+// Scroll-only edge handling: when the panel opens near the viewport
+// edge we apply `position: fixed` with a viewport-aware `max-height` +
+// internal `overflow-y: auto` so long breakdowns scroll inside the
+// panel instead of falling off-screen. Width is capped to the viewport
+// so mobile layouts don't overflow horizontally either. No flip-above
+// logic — one direction is easier to reason about and predictable for
+// both keyboard and touch users.
 (function () {
     function closeAllOpenBreakdowns(except) {
         document.querySelectorAll('details.score-details[open]').forEach(function (d) {
             if (d !== except) d.removeAttribute('open');
+            const panel = d.querySelector('.score-components');
+            if (panel && d !== except) resetPanelPosition(panel);
         });
     }
+    function resetPanelPosition(panel) {
+        panel.style.position = '';
+        panel.style.top = '';
+        panel.style.left = '';
+        panel.style.width = '';
+        panel.style.minWidth = '';
+        panel.style.maxWidth = '';
+        panel.style.maxHeight = '';
+        panel.style.overflowY = '';
+    }
+    function positionPanel(details) {
+        const panel = details.querySelector('.score-components');
+        if (!panel) return;
+        const GAP = 6;
+        const MARGIN = 8;
+        const rect = details.getBoundingClientRect();
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+
+        const top = rect.bottom + GAP;
+        const maxHeight = Math.max(120, vh - top - MARGIN);
+        const maxWidth = Math.max(240, vw - 2 * MARGIN);
+        const desiredWidth = Math.min(360, maxWidth);
+        let left = rect.left;
+        if (left + desiredWidth + MARGIN > vw) {
+            left = Math.max(MARGIN, vw - desiredWidth - MARGIN);
+        }
+        if (left < MARGIN) left = MARGIN;
+
+        panel.style.position = 'fixed';
+        panel.style.top = top + 'px';
+        panel.style.left = left + 'px';
+        panel.style.minWidth = '240px';
+        panel.style.maxWidth = maxWidth + 'px';
+        panel.style.maxHeight = maxHeight + 'px';
+        panel.style.overflowY = 'auto';
+    }
     document.addEventListener('click', function (evt) {
-        // If the click landed inside any score-details, leave it alone —
-        // the <details> element handles toggling its own state. Only
-        // close *other* open breakdowns (the `name=` attribute on the
-        // <details> already enforces accordion behavior, but this also
-        // covers any unnamed future callers).
         const inside = evt.target.closest('details.score-details');
         closeAllOpenBreakdowns(inside);
     });
@@ -288,6 +330,17 @@ function renderScoreBreakdown(r) {
             closeAllOpenBreakdowns(null);
         }
     });
+    // `toggle` doesn't bubble, so we capture it.
+    document.addEventListener('toggle', function (evt) {
+        const d = evt.target;
+        if (!(d instanceof HTMLDetailsElement)) return;
+        if (!d.classList.contains('score-details')) return;
+        if (d.open) positionPanel(d);
+        else {
+            const panel = d.querySelector('.score-components');
+            if (panel) resetPanelPosition(panel);
+        }
+    }, true);
 })();
 
 // #6a — click-to-sort columns on the results table. Each row carries

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -521,11 +521,57 @@ function renderScoreDetails(r, scoreClass) {
 // outside it or presses Escape. Registered once at module load; applies
 // to both the interactive-search table and the batch table since they
 // share the same markup shape.
+//
+// Also rewrites the panel's positioning to `fixed` on open when the
+// expander lives inside an overflow-clipping ancestor (the interactive-
+// search modal has `overflow:hidden` on `.modal` and `overflow-y:auto`
+// on `.modal-body`, which would otherwise clip the absolutely-
+// positioned `.score-components` panel out of sight). Without this the
+// breakdown silently opened offscreen and looked like nothing happened
+// when you clicked the score badge.
 (function () {
     function closeAllOpenBreakdowns(except) {
         document.querySelectorAll('details.score-details[open]').forEach(function (d) {
             if (d !== except) d.removeAttribute('open');
+            // Clear any inline fixed-position styles we applied on open.
+            const panel = d.querySelector('.score-components');
+            if (panel && d !== except) resetPanelPosition(panel);
         });
+    }
+    function resetPanelPosition(panel) {
+        panel.style.position = '';
+        panel.style.top = '';
+        panel.style.left = '';
+        panel.style.minWidth = '';
+    }
+    function positionPanelIfClipped(details) {
+        const panel = details.querySelector('.score-components');
+        if (!panel) return;
+        // Only lift to fixed-positioning when the details is inside an
+        // overflow-clipping ancestor. Outside a modal the regular CSS
+        // `position:absolute` works fine.
+        let clipped = false;
+        let node = details.parentElement;
+        while (node && node !== document.body) {
+            const cs = window.getComputedStyle(node);
+            if (cs.overflow !== 'visible' || cs.overflowX !== 'visible' || cs.overflowY !== 'visible') {
+                clipped = true;
+                break;
+            }
+            node = node.parentElement;
+        }
+        if (!clipped) {
+            resetPanelPosition(panel);
+            return;
+        }
+        const rect = details.getBoundingClientRect();
+        panel.style.position = 'fixed';
+        panel.style.top = (rect.bottom + 6) + 'px';
+        panel.style.left = rect.left + 'px';
+        // Constrain the minimum width to avoid flowing off the right
+        // edge of a narrow viewport; the max-width from the shared CSS
+        // still caps it at 360px.
+        panel.style.minWidth = '240px';
     }
     document.addEventListener('click', function (evt) {
         const inside = evt.target.closest('details.score-details');
@@ -536,6 +582,17 @@ function renderScoreDetails(r, scoreClass) {
             closeAllOpenBreakdowns(null);
         }
     });
+    // `toggle` doesn't bubble, so we capture it at the document level.
+    document.addEventListener('toggle', function (evt) {
+        const d = evt.target;
+        if (!(d instanceof HTMLDetailsElement)) return;
+        if (!d.classList.contains('score-details')) return;
+        if (d.open) positionPanelIfClipped(d);
+        else {
+            const panel = d.querySelector('.score-components');
+            if (panel) resetPanelPosition(panel);
+        }
+    }, true);
 })();
 
 function searchBatchReleases(btn) {

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -483,6 +483,61 @@ function renderPeers(seeders, leechers) {
     return `<span class="seed-count">${s}</span><span class="peer-sep">/</span><span class="leech-count">${l}</span>`;
 }
 
+// #1.3.0 — score breakdown expander for the interactive search tables.
+// Parallel to the server-rendered <details> in templates/search.html, so
+// the UX is identical between the generic Nyaa search and the per-series
+// interactive picker. Panel content lives in a named accordion group so
+// opening a second breakdown auto-closes the first.
+function renderScoreDetails(r, scoreClass) {
+    const parts = r.score_breakdown || [];
+    let inner;
+    if (parts.length === 0) {
+        inner = `<div class="form-hint">No components fired.</div>`;
+    } else {
+        const lis = parts.map(function (c) {
+            const deltaClass = c.delta > 0 ? 'sc-delta-pos' : 'sc-delta-neg';
+            const sign = c.delta > 0 ? '+' : '';
+            const detail = c.detail
+                ? `<span class="sc-detail">${escHtml(c.detail)}</span>`
+                : '';
+            return `<li>
+                <span class="sc-delta ${deltaClass}">${sign}${c.delta}</span>
+                <span class="sc-label">${escHtml(c.label)}</span>
+                ${detail}
+            </li>`;
+        }).join('');
+        inner = `<ul>${lis}</ul>`;
+    }
+    return `<details class="score-details" name="isearch-score-breakdown">
+        <summary class="score-badge ${scoreClass}" title="Click to see breakdown">${r.score}</summary>
+        <div class="score-components">
+            <div class="score-components-title">Score breakdown</div>
+            ${inner}
+        </div>
+    </details>`;
+}
+
+// Close any open <details class="score-details"> when the user clicks
+// outside it or presses Escape. Registered once at module load; applies
+// to both the interactive-search table and the batch table since they
+// share the same markup shape.
+(function () {
+    function closeAllOpenBreakdowns(except) {
+        document.querySelectorAll('details.score-details[open]').forEach(function (d) {
+            if (d !== except) d.removeAttribute('open');
+        });
+    }
+    document.addEventListener('click', function (evt) {
+        const inside = evt.target.closest('details.score-details');
+        closeAllOpenBreakdowns(inside);
+    });
+    document.addEventListener('keydown', function (evt) {
+        if (evt.key === 'Escape') {
+            closeAllOpenBreakdowns(null);
+        }
+    });
+})();
+
 function searchBatchReleases(btn) {
     setBusyButton(btn, true, 'Searching…');
     const pid = window.ryokanNewProgressId();
@@ -555,7 +610,7 @@ function renderInteractiveResults(results, epNum) {
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
         html += `<tr>
-            <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
+            <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
             <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>
@@ -666,7 +721,7 @@ function renderInteractiveBatchResults(results) {
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
         html += `<tr>
-            <td class="col-score"><span class="score-badge ${scoreClass}">${r.score}</span></td>
+            <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
             <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -202,6 +202,7 @@ function renderGrabHistory(entries, epNum) {
     for (const e of entries) {
         const stateClass = e.state === 'failed' ? 'grab-state-failed'
             : e.state === 'removed' ? 'grab-state-removed'
+            : e.state === 'replaced' ? 'grab-state-replaced'
             : e.state === 'completed' ? 'grab-state-completed'
             : 'grab-state-grabbed';
         // Only active 'grabbed' rows can be manually failed — once

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -697,7 +697,7 @@ function renderInteractiveResults(results, epNum) {
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
         html += `<tr>
             <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
-            <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
+            <td><a class="isearch-release-link" href="${escHtml(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>
@@ -808,7 +808,7 @@ function renderInteractiveBatchResults(results) {
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
         html += `<tr>
             <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
-            <td><a href="${escHtml(r.link)}" target="_blank" rel="noopener" style="color:var(--text);text-decoration:none">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
+            <td><a class="isearch-release-link" href="${escHtml(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -542,7 +542,11 @@ function renderScoreDetails(r, scoreClass) {
         panel.style.position = '';
         panel.style.top = '';
         panel.style.left = '';
+        panel.style.width = '';
         panel.style.minWidth = '';
+        panel.style.maxWidth = '';
+        panel.style.maxHeight = '';
+        panel.style.overflowY = '';
     }
     function positionPanelIfClipped(details) {
         const panel = details.querySelector('.score-components');
@@ -564,14 +568,38 @@ function renderScoreDetails(r, scoreClass) {
             resetPanelPosition(panel);
             return;
         }
+        // Scrolling-only strategy — no flip-above fallback. The panel
+        // always opens below the badge; vertical fit is handled by
+        // `max-height` + internal scroll, horizontal fit by clamping
+        // `left` and capping width to the viewport. Works the same on
+        // desktop and mobile: narrow viewports just get a narrower
+        // panel with more internal scroll.
+        const GAP = 6;
+        const MARGIN = 8;
         const rect = details.getBoundingClientRect();
+        const vw = window.innerWidth;
+        const vh = window.innerHeight;
+
+        const top = rect.bottom + GAP;
+        const maxHeight = Math.max(120, vh - top - MARGIN);
+        const maxWidth = Math.max(240, vw - 2 * MARGIN);
+        // Clamp left edge to stay within the viewport; on phones the
+        // panel's full width often exceeds badge.left + panel.width,
+        // so also cap the width when it would otherwise overflow.
+        let left = rect.left;
+        const desiredWidth = Math.min(360, maxWidth);
+        if (left + desiredWidth + MARGIN > vw) {
+            left = Math.max(MARGIN, vw - desiredWidth - MARGIN);
+        }
+        if (left < MARGIN) left = MARGIN;
+
         panel.style.position = 'fixed';
-        panel.style.top = (rect.bottom + 6) + 'px';
-        panel.style.left = rect.left + 'px';
-        // Constrain the minimum width to avoid flowing off the right
-        // edge of a narrow viewport; the max-width from the shared CSS
-        // still caps it at 360px.
+        panel.style.top = top + 'px';
+        panel.style.left = left + 'px';
         panel.style.minWidth = '240px';
+        panel.style.maxWidth = maxWidth + 'px';
+        panel.style.maxHeight = maxHeight + 'px';
+        panel.style.overflowY = 'auto';
     }
     document.addEventListener('click', function (evt) {
         const inside = evt.target.closest('details.score-details');

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -39,7 +39,7 @@
         </tr></thead><tbody>
         {% for t in queue %}
         <tr data-hash="{{ t.hash }}">
-            <td><div class="dl-torrent-name">{{ t.name }}</div></td>
+            <td><div class="dl-torrent-name" title="{{ t.name }}">{{ t.name }}</div></td>
             <td>{{ t.size_display }}</td>
             <td><div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:{{ t.progress_pct }}%"></div></div><span class="dl-progress-text">{{ t.progress_pct }}%</span></div></td>
             <td>{{ t.speed_display }}</td>
@@ -91,8 +91,8 @@
                 {% for entry in history %}
                 <tr data-state="{{ entry.state }}" data-text="{{ entry.series_title }} {{ entry.torrent_name }}">
                     <td><span data-ts="{{ entry.grabbed_at }}">{{ entry.grabbed_at }}</span></td>
-                    <td>{% if entry.anilist_id > 0 %}<a href="/series/{{ entry.anilist_id }}">{{ entry.series_title }}</a>{% else %}{{ entry.series_title }}{% endif %}</td>
-                    <td><div class="dl-torrent-name">{{ entry.torrent_name }}</div></td>
+                    <td title="{{ entry.series_title }}">{% if entry.anilist_id > 0 %}<a href="/series/{{ entry.anilist_id }}">{{ entry.series_title }}</a>{% else %}{{ entry.series_title }}{% endif %}</td>
+                    <td><div class="dl-torrent-name" title="{{ entry.torrent_name }}">{{ entry.torrent_name }}</div></td>
                     <td>{% for ep in entry.episode_numbers %}{% if !loop.first %}, {% endif %}{{ ep }}{% endfor %}</td>
                     <td>
                         {% if entry.state == "imported" %}
@@ -135,8 +135,8 @@
                 {% for entry in blocklist %}
                 <tr id="blocklist-row-{{ entry.id }}">
                     <td><span data-ts="{{ entry.grabbed_at }}">{{ entry.grabbed_at }}</span></td>
-                    <td>{% if entry.anilist_id > 0 %}<a href="/series/{{ entry.anilist_id }}">{{ entry.series_title }}</a>{% else %}{{ entry.series_title }}{% endif %}</td>
-                    <td><div class="dl-torrent-name">{{ entry.torrent_name }}</div></td>
+                    <td title="{{ entry.series_title }}">{% if entry.anilist_id > 0 %}<a href="/series/{{ entry.anilist_id }}">{{ entry.series_title }}</a>{% else %}{{ entry.series_title }}{% endif %}</td>
+                    <td><div class="dl-torrent-name" title="{{ entry.torrent_name }}">{{ entry.torrent_name }}</div></td>
                     <td>{% for ep in entry.episode_numbers %}{% if !loop.first %}, {% endif %}{{ ep }}{% endfor %}</td>
                     <td>
                         <button class="btn btn-ghost btn-sm" onclick="removeFromBlocklist({{ entry.id }})" title="Remove from blocklist">

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -72,6 +72,7 @@
             <option value="all">All states</option>
             <option value="pending">Pending</option>
             <option value="imported">Imported</option>
+            <option value="replaced">Replaced (upgraded)</option>
             <option value="failed">Failed</option>
             <option value="removed">Removed</option>
         </select>
@@ -92,13 +93,22 @@
                 <tr data-state="{{ entry.state }}" data-text="{{ entry.series_title }} {{ entry.torrent_name }}">
                     <td><span data-ts="{{ entry.grabbed_at }}">{{ entry.grabbed_at }}</span></td>
                     <td title="{{ entry.series_title }}">{% if entry.anilist_id > 0 %}<a href="/series/{{ entry.anilist_id }}">{{ entry.series_title }}</a>{% else %}{{ entry.series_title }}{% endif %}</td>
-                    <td><div class="dl-torrent-name" title="{{ entry.torrent_name }}">{{ entry.torrent_name }}</div></td>
+                    <td>
+                        <div class="dl-torrent-name" title="{{ entry.torrent_name }}">{{ entry.torrent_name }}</div>
+                        {% if entry.state == "replaced" && !entry.replaced_by_torrent_name.is_empty() %}
+                        <div class="dl-replaced-note" title="Superseded by upgrade: {{ entry.replaced_by_torrent_name }}">↪ replaced by <span class="dl-replaced-target">{{ entry.replaced_by_torrent_name }}</span></div>
+                        {% else if entry.replaces_count > 0 %}
+                        <div class="dl-replaced-note dl-replaced-note-upgrade" title="This grab superseded {{ entry.replaces_count }} earlier grab{% if entry.replaces_count != 1 %}s{% endif %} for the same episode(s)">↑ upgraded {{ entry.replaces_count }} earlier grab{% if entry.replaces_count != 1 %}s{% endif %}</div>
+                        {% endif %}
+                    </td>
                     <td>{% for ep in entry.episode_numbers %}{% if !loop.first %}, {% endif %}{{ ep }}{% endfor %}</td>
                     <td>
                         {% if entry.state == "imported" %}
                         <span class="log-badge log-badge-info">imported</span>
                         {% else if entry.state == "pending" %}
                         <span class="log-badge log-badge-debug">pending</span>
+                        {% else if entry.state == "replaced" %}
+                        <span class="log-badge log-badge-warn">replaced</span>
                         {% else if entry.state == "failed" %}
                         <span class="log-badge log-badge-error">failed</span>
                         {% else if entry.state == "removed" %}

--- a/templates/partials/settings/general.html
+++ b/templates/partials/settings/general.html
@@ -44,6 +44,17 @@
         </fieldset>
 
         <fieldset>
+            <legend>Monitoring</legend>
+            <div class="form-group">
+                <label class="checkbox-row">
+                    <input type="checkbox" name="search_on_monitoring_change" id="search_on_monitoring_change" {% if config.search_on_monitoring_change %}checked{% endif %}>
+                    <span>Auto-search when monitoring changes</span>
+                </label>
+                <span class="form-hint">When you change a series's monitoring mode (e.g. <code>none</code> → <code>all</code>), Ryokan will run a background auto-search for the newly-monitored aired episodes. Off by default — turn on if you want monitoring changes to immediately start grabbing. Narrowing transitions (<code>all</code> → <code>missing</code>, <code>any</code> → <code>none</code>) are a no-op.</span>
+            </div>
+        </fieldset>
+
+        <fieldset>
             <legend>Display</legend>
             <div class="form-group">
                 <label for="title_language">Preferred Title Language</label>

--- a/templates/search.html
+++ b/templates/search.html
@@ -49,7 +49,7 @@
                 {% for r in results %}
                 <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}" data-score="{{ r.score }}" data-name="{{ r.title }}" data-size="{{ r.size_bytes }}" data-date="{{ r.upload_date }}" data-seeders="{{ r.seeders }}" data-leechers="{{ r.leechers }}" data-downloads="{{ r.downloads }}">
                     <td class="col-score">
-                        <details class="score-details">
+                        <details class="score-details" name="score-breakdown">
                             <summary class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}" title="Click to see breakdown">{{ r.score }}</summary>
                             <div class="score-components">
                                 <div class="score-components-title">Base score breakdown</div>

--- a/templates/search.html
+++ b/templates/search.html
@@ -65,7 +65,7 @@
                                     </li>
                                     {% endfor %}
                                 </ul>
-                                <div class="form-hint">Custom Format contributions (if any) are applied on top of this base score at grab time — test via Settings → Custom Formats.</div>
+                                <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page — open the series page's interactive search for the full breakdown.</div>
                                 {% endif %}
                             </div>
                         </details>

--- a/templates/search.html
+++ b/templates/search.html
@@ -48,7 +48,26 @@
                 {% for r in results %}
                 <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}">
                     <td class="col-score">
-                        <span class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}">{{ r.score }}</span>
+                        <details class="score-details">
+                            <summary class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}" title="Click to see breakdown">{{ r.score }}</summary>
+                            <div class="score-components">
+                                <div class="score-components-title">Base score breakdown</div>
+                                {% if r.score_breakdown.is_empty() %}
+                                <div class="form-hint">No components fired (score stayed at 0).</div>
+                                {% else %}
+                                <ul>
+                                    {% for c in r.score_breakdown %}
+                                    <li>
+                                        <span class="sc-delta {% if c.delta > 0 %}sc-delta-pos{% else %}sc-delta-neg{% endif %}">{% if c.delta > 0 %}+{% endif %}{{ c.delta }}</span>
+                                        <span class="sc-label">{{ c.label }}</span>
+                                        {% if let Some(detail) = c.detail %}<span class="sc-detail">{{ detail }}</span>{% endif %}
+                                    </li>
+                                    {% endfor %}
+                                </ul>
+                                <div class="form-hint">Custom Format contributions (if any) are applied on top of this base score at grab time — test via Settings → Custom Formats.</div>
+                                {% endif %}
+                            </div>
+                        </details>
                     </td>
                     <td class="col-name">
                         <a href="{{ r.link }}" target="_blank" rel="noopener">{{ r.title }}</a>

--- a/templates/search.html
+++ b/templates/search.html
@@ -32,21 +32,22 @@
         </div>
     {% else %}
         <p class="results-count" id="results-count">{{ results.len() }} results</p>
-        <table class="results-table">
+        <table class="results-table" id="results-table">
             <thead>
                 <tr>
-                    <th class="col-score">Score</th>
-                    <th class="col-name">Name</th>
-                    <th class="col-size">Size</th>
-                    <th class="col-seed">S</th>
-                    <th class="col-leech">L</th>
-                    <th class="col-dl">D</th>
+                    <th class="col-score sortable sort-desc" data-sort-key="score">Score</th>
+                    <th class="col-name sortable" data-sort-key="name">Name</th>
+                    <th class="col-size sortable" data-sort-key="size">Size</th>
+                    <th class="col-date sortable" data-sort-key="date">Date</th>
+                    <th class="col-seed sortable" data-sort-key="seeders">S</th>
+                    <th class="col-leech sortable" data-sort-key="leechers">L</th>
+                    <th class="col-dl sortable" data-sort-key="downloads">D</th>
                     <th class="col-actions"></th>
                 </tr>
             </thead>
             <tbody id="results-body">
                 {% for r in results %}
-                <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}">
+                <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}" data-score="{{ r.score }}" data-name="{{ r.title }}" data-size="{{ r.size_bytes }}" data-date="{{ r.upload_date }}" data-seeders="{{ r.seeders }}" data-leechers="{{ r.leechers }}" data-downloads="{{ r.downloads }}">
                     <td class="col-score">
                         <details class="score-details">
                             <summary class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}" title="Click to see breakdown">{{ r.score }}</summary>
@@ -79,6 +80,7 @@
                         </div>
                     </td>
                     <td class="col-size">{{ r.size }}</td>
+                    <td class="col-date">{% if !r.upload_date.is_empty() %}<span data-ts="{{ r.upload_date }}">{{ r.upload_date }}</span>{% else %}—{% endif %}</td>
                     <td class="col-seed"><span class="seed-count">{{ r.seeders }}</span></td>
                     <td class="col-leech"><span class="leech-count">{{ r.leechers }}</span></td>
                     <td class="col-dl"><span class="dl-count">{{ r.downloads }}</span></td>


### PR DESCRIPTION
## Summary

Second batch of the 1.3.0 UX pass, completing the three items deferred from batch 1 (PR #81), plus the cargo-audit workflow fix that surfaced during this batch's push.

## What's in

- **Auto-search on monitoring change** (plan §14) — new `search_on_monitoring_change` config flag (default off), full Settings → General UI plumbing. When on, any monitoring-mode update fires the existing `auto_search_series` pipeline, which internally computes the exact missing-and-monitored delta the plan specified. Narrowing transitions (`all` → `missing`, `any` → `none`) are natural no-ops because the pipeline short-circuits on empty target lists.
- **"Why this score" breakdown** (plan §17) —
  - New `ScoreComponent { label, delta, detail }` struct + `score_result_with_breakdown` engine in `services::scoring`. Invariant `sum(delta) == total` pinned by tests.
  - `SearchResult.score_breakdown` rides on the `/api/search` response.
  - Click-to-expand `<details>` panel next to each row's score badge on the search page. Ordered component list with green/red deltas and optional detail rows.
  - CF contributions still stack separately at grab time; test them via Settings → Custom Formats.
  - Deferred (noted in plan): persisting the breakdown on `grabbed_torrents` so the grab-history page can show the same thing retroactively.
- **Manual search overhaul** (plan §6) — all four sub-items:
  - **6a** Sortable columns. Every row carries `data-*` attributes; click a header to sort asc/desc. Numeric columns default desc, name/date default asc. Pure client-side.
  - **6b** Upload-date column. Scraped from Nyaa's td index 4, displayed via the existing `data-ts` relative-timestamps helper.
  - **6c** Sticky search toolbar on desktop viewports.
  - **6d** Library linkage on grab. New `rss::match_library_title` helper reuses the RSS matcher to link manual grabs to existing library series. On match, grab history + `episode_quality_tags` get populated; batch grabs also fire `auto_expand_library_from_pack` in a background task. All fire-and-forget, so the Grab button still flashes "Sent" immediately. Auto-adding unknown series is deliberately scoped out (needs its own rate-limit / dedup plan).
- **CI fix** — the `cargo-audit` workflow had no `permissions:` block so the default `GITHUB_TOKEN` was read-only. The `rustsec/audit-check@v2` action's final "create check run" call 403'd with *"Resource not accessible by integration"*. Added `checks: write` + `issues: write` + `pull-requests: write`. Also bumped `rustls-webpki` 0.103.12 → 0.103.13 for **RUSTSEC-2026-0104** — a CRL-parsing panic that we're not actually vulnerable to (Ryokan doesn't use CRLs — we validate TLS via `rustls-platform-verifier` only), but the advisory still fails the audit.

## Test plan
- [x] CI green (fmt + clippy + build + test + audit)
- [x] Manual smoke: Settings → General → toggle "Auto-search when monitoring changes", flip a series from `none` → `all`, verify auto-search fires once
- [x] Manual smoke: search page, click score badge on any result, verify breakdown expansion renders with sum = score
- [x] Manual smoke: search page, click column headers, verify asc/desc reordering works; confirm date column is populated
- [x] Manual smoke: grab a single-episode release of a tracked series, verify it appears in the series page's grab history
- [x] Manual smoke: grab a batch of a tracked series, verify `grab_history` gets per-episode rows and (for multi-series packs) `auto_expand` writes sibling routes after metadata arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)