### PR TITLE
#85: download-client spot-check smokes + 2 parity fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2108,6 +2114,7 @@ dependencies = [
  "cookie_store",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2118,6 +2125,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -2200,6 +2208,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2292,6 +2313,7 @@ dependencies = [
  "askama",
  "async-trait",
  "axum",
+ "base64",
  "bcrypt",
  "chrono",
  "dotenvy",
@@ -2303,9 +2325,11 @@ dependencies = [
  "scraper",
  "serde",
  "serde_json",
+ "sha1_smol",
  "sha2 0.11.0",
  "sqlx",
  "subtle",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",
@@ -2483,6 +2507,12 @@ checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -2789,6 +2819,19 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,17 +88,6 @@ ammonia = "4"
 # Anime release title tokenization (wraps bundled anitomy C++ lib, compiled via cc)
 anitomy = "0.2"
 
-# Base64 encoding. Used by:
-# * rtorrent's XML-RPC encoder for `XmlValue::Base64` (needed to pass
-#   `.torrent` file contents to `load.raw_start_verbose` — the canonical
-#   way to load a local torrent without filesystem or HTTP round-trip).
-# * The `live_smoke_narrowed` test for Deluge (`core.add_torrent_file`
-#   takes a base64-encoded payload too).
-# Declared as a direct dep rather than relying on the transitive pull
-# via reqwest so the use sites don't depend on reqwest's internal choice
-# of base64 version.
-base64 = "0.22"
-
 [dev-dependencies]
 # Used only by the env-gated live_smoke tests for the DownloadClient
 # impls — each smoke creates a synthetic multi-file .torrent in a
@@ -111,3 +100,12 @@ tempfile = "3"
 # returns 0 on success rather than echoing back the hash. Test-only;
 # BitTorrent's v1 spec mandates SHA-1 here so we can't swap to sha2.
 sha1_smol = "1"
+# Base64 encoding. Used by:
+# * The rtorrent XML-RPC encoder's `XmlValue::Base64` variant, which is
+#   itself `#[cfg(test)]`-gated and only constructed by
+#   `live_smoke_narrowed`'s `load.raw_verbose` upload path.
+# * The `live_smoke_narrowed` test for Deluge, where
+#   `core.add_torrent_file` takes a base64-encoded payload.
+# Test-only for now; promote to a direct prod dep if/when a UI feature
+# loads `.torrent` bytes from disk.
+base64 = "0.22"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio",
 # for us (we only talk to public HTTPS endpoints) and removes the
 # OpenSSL headers dependency on Linux builds; we just have to opt back
 # into `query` + `form`.
-reqwest = { version = "0.13", features = ["json", "cookies", "query", "form"] }
+reqwest = { version = "0.13", features = ["json", "cookies", "query", "form", "multipart"] }
 
 # Async trait support. Rust's native async-fn-in-traits (stable since
 # 1.75) does not yet produce Send-bound futures by default, which is
@@ -87,3 +87,27 @@ ammonia = "4"
 
 # Anime release title tokenization (wraps bundled anitomy C++ lib, compiled via cc)
 anitomy = "0.2"
+
+# Base64 encoding. Used by:
+# * rtorrent's XML-RPC encoder for `XmlValue::Base64` (needed to pass
+#   `.torrent` file contents to `load.raw_start_verbose` — the canonical
+#   way to load a local torrent without filesystem or HTTP round-trip).
+# * The `live_smoke_narrowed` test for Deluge (`core.add_torrent_file`
+#   takes a base64-encoded payload too).
+# Declared as a direct dep rather than relying on the transitive pull
+# via reqwest so the use sites don't depend on reqwest's internal choice
+# of base64 version.
+base64 = "0.22"
+
+[dev-dependencies]
+# Used only by the env-gated live_smoke tests for the DownloadClient
+# impls — each smoke creates a synthetic multi-file .torrent in a
+# tempdir (via shell-out to transmission-create) to get deterministic
+# file-list testing without depending on DHT metadata fetch landing
+# during the test window.
+tempfile = "3"
+# SHA-1 for computing a .torrent's v1 infohash from its bencoded
+# `info` dict — needed by the rtorrent smoke since `load.raw_start_verbose`
+# returns 0 on success rather than echoing back the hash. Test-only;
+# BitTorrent's v1 spec mandates SHA-1 here so we can't swap to sha2.
+sha1_smol = "1"

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -1182,12 +1182,22 @@ mod tests {
         // empty so the handler's "delete media folder" step no-ops
         // (we're testing torrent cleanup, not filesystem removal).
         let series_id = test_support::seed_series(&pool, 12345, "D1 Test Series").await;
-        let _gid_a =
-            test_support::seed_grabbed_torrent(&pool, series_id, &hash_a, "d1-test-a.torrent")
-                .await;
-        let _gid_b =
-            test_support::seed_grabbed_torrent(&pool, series_id, &hash_b, "d1-test-b.torrent")
-                .await;
+        let _gid_a = test_support::seed_grabbed_torrent(
+            &pool,
+            series_id,
+            &hash_a,
+            "d1-test-a.torrent",
+            &[1],
+        )
+        .await;
+        let _gid_b = test_support::seed_grabbed_torrent(
+            &pool,
+            series_id,
+            &hash_b,
+            "d1-test-b.torrent",
+            &[2],
+        )
+        .await;
         assert_eq!(
             test_support::count_grabs_for_series(&pool, series_id).await,
             2,

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -1113,3 +1113,135 @@ pub async fn list_folders(
     let folders = media::list_media_folders(&media_root);
     Ok(Json(folders))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::download_client::DownloadClient;
+    use crate::services::download_client::qbittorrent::QbitClient;
+    use crate::services::download_client::test_helpers;
+    use crate::test_support;
+    use std::sync::Arc;
+
+    /// D1 live integration test: removing a series from the library
+    /// must also delete every grabbed torrent for that series from
+    /// the active download client.
+    ///
+    /// Flow under test:
+    /// 1. Seed the DB with one series + two grabbed_torrents rows
+    ///    pointing at it.
+    /// 2. Upload the two synthetic torrents to qBit so the hashes
+    ///    are real + addressable.
+    /// 3. Call `remove_series(id, delete_files=true)`.
+    /// 4. Assert every hash is gone from qBit's scoped list and
+    ///    the `grabbed_torrents` rows cascaded away with the series.
+    ///
+    /// Env-gated (`RYOKAN_QBIT_E2E=1`) so the default `cargo test` run
+    /// never touches the download client.
+    #[tokio::test]
+    #[ignore = "requires live qBit + transmission-create"]
+    async fn d1_remove_series_cleans_up_torrents_and_rows() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_QBIT_E2E=1)");
+            return;
+        }
+        let Some((_tmp_a, torrent_a)) = test_helpers::build_named_torrent("d1-series-remove-a")
+        else {
+            return;
+        };
+        let Some((_tmp_b, torrent_b)) = test_helpers::build_named_torrent("d1-series-remove-b")
+        else {
+            return;
+        };
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let base_url = "http://localhost:8080";
+        let category = "ryokan-e2e-d1";
+
+        // Two separate categories so upload_torrent_file_qbit's
+        // first-returned-hash convention picks up each distinct
+        // torrent rather than colliding in the same category.
+        let cat_a = format!("{category}-a");
+        let cat_b = format!("{category}-b");
+        let hash_a =
+            test_helpers::upload_torrent_file_qbit(base_url, "admin", &pass, &cat_a, &torrent_a)
+                .await;
+        let hash_b =
+            test_helpers::upload_torrent_file_qbit(base_url, "admin", &pass, &cat_b, &torrent_b)
+                .await;
+
+        // Scaffolding: pool + migrations + AppState with a real
+        // qBit client on the same category used for seeding, so
+        // `remove_series`'s internal scoped-list lookup and delete
+        // path hit the same torrents.
+        let pool = test_support::in_memory_pool().await;
+        let qbit: Arc<dyn DownloadClient> =
+            Arc::new(QbitClient::new(base_url, "admin", &pass, category));
+        let state = test_support::build_test_app_state(pool.clone(), Some(qbit.clone()));
+
+        // Seed: one series, two grabbed rows. `folder_name` stays
+        // empty so the handler's "delete media folder" step no-ops
+        // (we're testing torrent cleanup, not filesystem removal).
+        let series_id = test_support::seed_series(&pool, 12345, "D1 Test Series").await;
+        let _gid_a =
+            test_support::seed_grabbed_torrent(&pool, series_id, &hash_a, "d1-test-a.torrent")
+                .await;
+        let _gid_b =
+            test_support::seed_grabbed_torrent(&pool, series_id, &hash_b, "d1-test-b.torrent")
+                .await;
+        assert_eq!(
+            test_support::count_grabs_for_series(&pool, series_id).await,
+            2,
+            "precondition: 2 grabs seeded"
+        );
+        assert_eq!(
+            test_support::count_series(&pool).await,
+            1,
+            "precondition: 1 series seeded"
+        );
+
+        // Exercise: call the handler directly.
+        let form: RemoveSeriesForm = serde_json::from_value(serde_json::json!({
+            "id": series_id,
+            "delete_files": true,
+        }))
+        .expect("deserialize RemoveSeriesForm");
+        let result = remove_series(axum::extract::State(state.clone()), axum::Json(form)).await;
+        assert!(
+            result.is_ok(),
+            "remove_series returned error: {:?}",
+            result
+                .as_ref()
+                .err()
+                .map(|(s, b)| (s.as_u16(), b.0.to_string()))
+        );
+
+        // Assert: grab rows cascaded, series row gone.
+        assert_eq!(
+            test_support::count_grabs_for_series(&pool, series_id).await,
+            0,
+            "D1: grabbed_torrents must cascade on series delete"
+        );
+        assert_eq!(
+            test_support::count_series(&pool).await,
+            0,
+            "D1: series row must be gone"
+        );
+
+        // Assert: torrents deleted from qBit. We check via a
+        // scoped-list-agnostic lookup (separate QbitClients, one per
+        // upload category) so category filtering doesn't mask a
+        // "still exists but uncategorized" state.
+        for (scope_cat, hash) in [(cat_a.as_str(), &hash_a), (cat_b.as_str(), &hash_b)] {
+            let scoped_client = QbitClient::new(base_url, "admin", &pass, scope_cat);
+            let list = scoped_client
+                .list_scoped()
+                .await
+                .expect("list_scoped post-remove");
+            assert!(
+                !list.iter().any(|t| t.hash.eq_ignore_ascii_case(hash)),
+                "D1: torrent {hash} must be deleted from qBit after remove_series"
+            );
+        }
+        eprintln!("D1 integration verified");
+    }
+}

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -692,3 +692,91 @@ pub async fn series_episodes_json(
 
     Ok(Json(episodes))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::services::download_client::DownloadClient;
+    use crate::services::download_client::qbittorrent::QbitClient;
+    use crate::services::download_client::test_helpers;
+    use crate::test_support;
+    use std::sync::Arc;
+
+    /// D2+D3 live integration test: cancelling a pending grab for an
+    /// episode must delete the torrent from the active download
+    /// client AND clear the grab state in the DB. Covers both the
+    /// blocklist (D2) and episode-removal (D3) call paths — they
+    /// share this same "delete in-flight grab and clean up state"
+    /// trait surface. The blocklist-specific path (`mark_episode_failed`)
+    /// additionally kicks off an auto-search re-run which requires
+    /// live AniList + Nyaa and is outside the scope of this trait-
+    /// boundary test.
+    ///
+    /// Flow:
+    /// 1. Seed DB: series + pending grab_torrents row for episode 1.
+    /// 2. Upload synthetic torrent to qBit with matching hash.
+    /// 3. Call `cancel_pending_episode(anilist_id, 1)`.
+    /// 4. Assert torrent deleted from qBit.
+    #[tokio::test]
+    #[ignore = "requires live qBit + transmission-create"]
+    async fn d2_d3_cancel_pending_deletes_from_client() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let Some((_tmp, torrent)) = test_helpers::build_named_torrent("d2-d3-cancel-pending")
+        else {
+            return;
+        };
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let base_url = "http://localhost:8080";
+        let category = "ryokan-e2e-d2d3";
+
+        let hash =
+            test_helpers::upload_torrent_file_qbit(base_url, "admin", &pass, category, &torrent)
+                .await;
+
+        let pool = test_support::in_memory_pool().await;
+        let qbit: Arc<dyn DownloadClient> =
+            Arc::new(QbitClient::new(base_url, "admin", &pass, category));
+        let state = test_support::build_test_app_state(pool.clone(), Some(qbit.clone()));
+
+        // Seed: series + pending grab for episode 1. The
+        // `seed_grabbed_torrent` helper writes state='pending' and
+        // episode_numbers='[1]' by default — matches what the
+        // handler looks up.
+        let anilist_id: i64 = 54321;
+        let series_id = test_support::seed_series(&pool, anilist_id, "D2/D3 Test Series").await;
+        test_support::seed_grabbed_torrent(&pool, series_id, &hash, "d2-d3-test.torrent").await;
+        assert_eq!(
+            test_support::count_grabs_for_series(&pool, series_id).await,
+            1,
+            "precondition: 1 grab seeded"
+        );
+
+        // Exercise: cancel the pending grab for episode 1.
+        let (status, body) = cancel_pending_episode(
+            axum::extract::State(state.clone()),
+            axum::extract::Path((anilist_id, 1)),
+        )
+        .await;
+        assert_eq!(
+            status,
+            axum::http::StatusCode::OK,
+            "cancel_pending_episode returned non-OK: {status} body={}",
+            body.0
+        );
+
+        // Assert: torrent deleted from qBit.
+        let check_client = QbitClient::new(base_url, "admin", &pass, category);
+        let list = check_client
+            .list_scoped()
+            .await
+            .expect("list_scoped post-cancel");
+        assert!(
+            !list.iter().any(|t| t.hash.eq_ignore_ascii_case(&hash)),
+            "D2/D3: cancelled torrent must be deleted from qBit (still in list: {list:?})"
+        );
+        eprintln!("D2/D3 integration verified");
+    }
+}

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -747,7 +747,8 @@ mod tests {
         // handler looks up.
         let anilist_id: i64 = 54321;
         let series_id = test_support::seed_series(&pool, anilist_id, "D2/D3 Test Series").await;
-        test_support::seed_grabbed_torrent(&pool, series_id, &hash, "d2-d3-test.torrent").await;
+        test_support::seed_grabbed_torrent(&pool, series_id, &hash, "d2-d3-test.torrent", &[1])
+            .await;
         assert_eq!(
             test_support::count_grabs_for_series(&pool, series_id).await,
             1,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,9 @@ mod handlers;
 mod models;
 mod services;
 
+#[cfg(test)]
+pub(crate) mod test_support;
+
 use axum::http::{HeaderValue, header};
 use axum::{
     Router,

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -1009,4 +1009,245 @@ mod tests {
         );
         eprintln!("smoke passed");
     }
+
+    /// Upload a local `.torrent` file to Deluge via JSON-RPC
+    /// `core.add_torrent_file` with base64-encoded bytes. Returns
+    /// the infohash Deluge assigned. Handles the Deluge quirks:
+    /// `auth.login` then `web.connect(host_id)` before `core.*`
+    /// calls work (documented in `deluge.rs`'s file header and the
+    /// CLAUDE.md download-client quirks). Adds with `add_paused=True`
+    /// so the torrent doesn't try to download bogus content, and
+    /// applies the caller's label via the Label plugin post-add.
+    ///
+    /// Test-only; raw `reqwest::Client` with its own cookie jar to
+    /// avoid reaching inside `DelugeClient` just to piggyback on its
+    /// session state.
+    async fn upload_torrent_file_deluge(
+        base_url: &str,
+        password: &str,
+        label: &str,
+        torrent_path: &std::path::Path,
+    ) -> String {
+        use serde_json::{Value, json};
+        let client = reqwest::Client::builder()
+            .cookie_store(true)
+            .build()
+            .expect("reqwest client");
+
+        async fn rpc(
+            client: &reqwest::Client,
+            base_url: &str,
+            method: &str,
+            params: Value,
+        ) -> Value {
+            let resp = client
+                .post(format!("{base_url}/json"))
+                .json(&json!({
+                    "method": method,
+                    "params": params,
+                    "id": 0,
+                }))
+                .send()
+                .await
+                .unwrap_or_else(|e| panic!("Deluge {method} transport: {e}"));
+            assert_eq!(
+                resp.status(),
+                200,
+                "Deluge {method} returned HTTP {}",
+                resp.status()
+            );
+            resp.json::<Value>()
+                .await
+                .unwrap_or_else(|e| panic!("Deluge {method} json parse: {e}"))
+        }
+
+        // 1. auth.login → session cookie
+        let login = rpc(
+            &client,
+            base_url,
+            "auth.login",
+            json!([password.to_string()]),
+        )
+        .await;
+        assert_eq!(
+            login.get("result").and_then(|v| v.as_bool()),
+            Some(true),
+            "Deluge auth.login returned: {login}"
+        );
+
+        // 2. web.get_hosts → pick the first (usually only) host
+        let hosts = rpc(&client, base_url, "web.get_hosts", json!([])).await;
+        let host_id = hosts
+            .get("result")
+            .and_then(|v| v.as_array())
+            .and_then(|arr| arr.first())
+            .and_then(|h| h.as_array())
+            .and_then(|h| h.first())
+            .and_then(|v| v.as_str())
+            .expect("Deluge web.get_hosts returned no usable host id")
+            .to_string();
+
+        // 3. web.connect(host_id) — required before core.* calls work
+        rpc(&client, base_url, "web.connect", json!([host_id])).await;
+
+        // 4. core.add_torrent_file(filename, base64_filedump, options)
+        use base64::{Engine, engine::general_purpose};
+        let bytes = std::fs::read(torrent_path).expect("read .torrent");
+        let b64 = general_purpose::STANDARD.encode(&bytes);
+        let add_resp = rpc(
+            &client,
+            base_url,
+            "core.add_torrent_file",
+            json!(["testpack.torrent", b64, {"add_paused": true}]),
+        )
+        .await;
+        let hash = add_resp
+            .get("result")
+            .and_then(|v| v.as_str())
+            .expect("Deluge core.add_torrent_file missing hash result")
+            .to_string();
+
+        // 5. Apply the Label plugin label so list_scoped() round-trips.
+        //    core.enable_plugin is idempotent if already on.
+        rpc(&client, base_url, "core.enable_plugin", json!(["Label"])).await;
+        rpc(&client, base_url, "label.add", json!([label.to_string()])).await; // may fail if label already exists; ignore
+        rpc(
+            &client,
+            base_url,
+            "label.set_torrent",
+            json!([hash.clone(), label.to_string()]),
+        )
+        .await;
+
+        hash
+    }
+
+    /// Live smoke covering `add_torrent_with_file_filter` narrowing
+    /// (C1) and the re-narrow preservation contract (C2) against
+    /// Deluge. Mirrors `qbittorrent::tests::live_smoke_narrowed` in
+    /// intent; differences are at the wire-protocol layer only.
+    ///
+    ///     RYOKAN_DELUGE_E2E=1 cargo test \
+    ///       deluge::tests::live_smoke_narrowed -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live Deluge at localhost:8112 + transmission-create"]
+    async fn live_smoke_narrowed() {
+        if std::env::var("RYOKAN_DELUGE_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_DELUGE_E2E=1 to run against localhost:8112)");
+            return;
+        }
+        let Some((_tmp_guard, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let base_url = "http://localhost:8112";
+        let password = "deluge";
+        let label = "ryokan-e2e-narrow";
+
+        let info_hash = upload_torrent_file_deluge(base_url, password, label, &torrent_path).await;
+        eprintln!("uploaded testpack hash={info_hash}");
+
+        let client = DelugeClient::new(base_url, password, label);
+
+        let files = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files should return metadata immediately");
+        assert_eq!(
+            files.len(),
+            7,
+            "synthetic testpack should have 7 files (5 episodes + sample + readme), got {}",
+            files.len()
+        );
+        assert!(
+            files.iter().all(|f| f.wanted),
+            "all files should start wanted=true before narrow"
+        );
+
+        // C1: narrow to episode files only
+        let episode_indices: Vec<usize> = files
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| f.name.contains("episode_").then_some(i))
+            .collect();
+        assert_eq!(episode_indices.len(), 5, "expected 5 episode files");
+
+        let expected_episode_indices = episode_indices.clone();
+        let magnet = format!("magnet:?xt=urn:btih:{info_hash}");
+        let outcome = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_episode_indices.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C1 failed");
+
+        match outcome {
+            SelectiveOutcome::Filtered(kept) => {
+                let mut sorted_kept = kept.clone();
+                sorted_kept.sort_unstable();
+                let mut sorted_expected = episode_indices.clone();
+                sorted_expected.sort_unstable();
+                assert_eq!(
+                    sorted_kept, sorted_expected,
+                    "C1 Filtered(kept) should equal the pick indices"
+                );
+            }
+            SelectiveOutcome::FullDownload => {
+                panic!("C1 expected Filtered narrow, got FullDownload");
+            }
+        }
+
+        let files_after_c1 = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files after C1 failed");
+        for (i, f) in files_after_c1.iter().enumerate() {
+            let should_be_wanted = episode_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C1 post-narrow: file [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C1 narrowing verified");
+
+        // C2: re-narrow with expanded pick (add sample.mkv)
+        let expanded_indices: Vec<usize> = files_after_c1
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                (f.name.contains("episode_") || f.name.contains("sample")).then_some(i)
+            })
+            .collect();
+        assert_eq!(expanded_indices.len(), 6);
+
+        let expected_expanded = expanded_indices.clone();
+        let outcome2 = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_expanded.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C2 failed");
+        assert!(matches!(outcome2, SelectiveOutcome::Filtered(_)));
+
+        let files_after_c2 = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files after C2 failed");
+        for (i, f) in files_after_c2.iter().enumerate() {
+            let should_be_wanted = expanded_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C2 post-renarrow: file [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C2 re-narrow verified");
+
+        client
+            .delete(&info_hash, true)
+            .await
+            .expect("cleanup delete failed");
+        eprintln!("narrowed-smoke passed");
+    }
 }

--- a/src/services/download_client/deluge.rs
+++ b/src/services/download_client/deluge.rs
@@ -1244,10 +1244,241 @@ mod tests {
         }
         eprintln!("C2 re-narrow verified");
 
+        // A7: delete with delete_files=true removes torrent + files
         client
             .delete(&info_hash, true)
             .await
-            .expect("cleanup delete failed");
+            .expect("delete(hash, true) failed");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let after = client
+            .list_scoped()
+            .await
+            .expect("list_scoped after delete(true) failed");
+        assert!(
+            !after
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&info_hash)),
+            "A7: torrent must not survive delete(_, true)"
+        );
+        eprintln!("A7 delete(true) verified");
         eprintln!("narrowed-smoke passed");
+    }
+
+    /// Live smoke for B2: Deluge `list_scoped` filters by the Label
+    /// plugin label, so a torrent with a *different* label must not
+    /// surface. Uploads one Ryokan-labeled and one foreign-labeled
+    /// torrent, asserts only the Ryokan one appears in `list_scoped`.
+    ///
+    ///     RYOKAN_DELUGE_E2E=1 cargo test \
+    ///       deluge::tests::live_smoke_scoped_exclusion -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live Deluge at localhost:8112 + transmission-create"]
+    async fn live_smoke_scoped_exclusion() {
+        if std::env::var("RYOKAN_DELUGE_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_DELUGE_E2E=1 to run against localhost:8112)");
+            return;
+        }
+        let Some((_tmp1, torrent1)) =
+            super::super::test_helpers::build_named_torrent("ryokan-scoped-test")
+        else {
+            return;
+        };
+        let Some((_tmp2, torrent2)) =
+            super::super::test_helpers::build_named_torrent("other-tool-test")
+        else {
+            return;
+        };
+        let base_url = "http://localhost:8112";
+        let password = "deluge";
+        let ryokan_label = "ryokan-e2e-scope";
+        let foreign_label = "other-tool-scope";
+
+        let ryokan_hash =
+            upload_torrent_file_deluge(base_url, password, ryokan_label, &torrent1).await;
+        let foreign_hash =
+            upload_torrent_file_deluge(base_url, password, foreign_label, &torrent2).await;
+        eprintln!("ryokan={ryokan_hash} foreign={foreign_hash}");
+        assert_ne!(ryokan_hash, foreign_hash);
+
+        let client = DelugeClient::new(base_url, password, ryokan_label);
+        let list = client
+            .list_scoped()
+            .await
+            .expect("list_scoped should succeed");
+
+        assert!(
+            list.iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&ryokan_hash)),
+            "B2: Ryokan-labeled torrent must appear in list_scoped"
+        );
+        assert!(
+            !list
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&foreign_hash)),
+            "B2: foreign-labeled torrent must NOT appear (found {foreign_hash})"
+        );
+        eprintln!("B2 scoped exclusion verified");
+
+        client
+            .delete(&ryokan_hash, true)
+            .await
+            .expect("cleanup ryokan");
+        let foreign_client = DelugeClient::new(base_url, password, foreign_label);
+        foreign_client
+            .delete(&foreign_hash, true)
+            .await
+            .expect("cleanup foreign");
+        eprintln!("scoped-exclusion smoke passed");
+    }
+
+    /// Error-path live smoke (F1 / F2 / F3) against Deluge.
+    #[tokio::test]
+    #[ignore = "requires live Deluge at localhost:8112"]
+    async fn live_smoke_error_paths() {
+        if std::env::var("RYOKAN_DELUGE_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let client = DelugeClient::new("http://localhost:8112", "deluge", "ryokan-e2e-errs");
+        let fake_hash = "0000000000000000000000000000000000000000";
+
+        let result = client.delete(fake_hash, false).await;
+        eprintln!("F1 Deluge delete(non-existent) → {result:?}");
+
+        let result = client.get_files(fake_hash).await;
+        eprintln!("F2 Deluge get_files(non-existent) → {result:?}");
+        if let Ok(files) = result {
+            assert!(files.is_empty(), "F2: Ok result must be empty");
+        }
+
+        let result = client
+            .add_torrent("this-is-not-a-valid-url-or-magnet", fake_hash)
+            .await;
+        eprintln!("F3 Deluge add(malformed) → {result:?}");
+        assert!(
+            result.is_err(),
+            "F3: add_torrent with malformed URL must return Err (got {result:?})"
+        );
+
+        eprintln!("error-paths smoke passed");
+    }
+
+    /// E1+E2 live smoke for Deluge: state transitions through
+    /// pause→resume→pause, progress sanity in [0.0, 1.0].
+    #[tokio::test]
+    #[ignore = "requires live Deluge at localhost:8112 + transmission-create"]
+    async fn live_smoke_state_progress() {
+        if std::env::var("RYOKAN_DELUGE_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let Some((_tmp, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let base_url = "http://localhost:8112";
+        let password = "deluge";
+        let label = "ryokan-e2e-state";
+
+        let info_hash = upload_torrent_file_deluge(base_url, password, label, &torrent_path).await;
+        let client = DelugeClient::new(base_url, password, label);
+
+        async fn poll_until_state(
+            client: &DelugeClient,
+            hash: &str,
+            acceptable: &[DownloadItemState],
+        ) -> DownloadItem {
+            for _ in 0..30 {
+                let list = client.list_scoped().await.expect("list_scoped");
+                if let Some(t) = list
+                    .iter()
+                    .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                    .cloned()
+                    && acceptable.contains(&t.state_kind)
+                {
+                    return t;
+                }
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+            let list = client.list_scoped().await.expect("list_scoped");
+            list.iter()
+                .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                .cloned()
+                .unwrap_or_else(|| panic!("torrent never appeared"))
+        }
+
+        // Uploaded with add_paused=true → expect Paused.
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 Deluge paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(
+            matches!(
+                t.state_kind,
+                DownloadItemState::Paused | DownloadItemState::PausedComplete
+            ),
+            "E1: Paused expected, got {:?} ({})",
+            t.state_kind,
+            t.state
+        );
+        assert!(
+            (0.0..=1.0).contains(&t.progress),
+            "E2 progress: {}",
+            t.progress
+        );
+
+        client.resume(&info_hash).await.expect("resume");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[
+                DownloadItemState::Downloading,
+                DownloadItemState::DownloadingStalled,
+                DownloadItemState::DownloadingQueued,
+                DownloadItemState::CheckingDownload,
+            ],
+        )
+        .await;
+        eprintln!(
+            "E1 Deluge resumed: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(
+            matches!(
+                t.state_kind,
+                DownloadItemState::Downloading
+                    | DownloadItemState::DownloadingStalled
+                    | DownloadItemState::DownloadingQueued
+                    | DownloadItemState::CheckingDownload
+            ),
+            "E1: Downloading* expected after resume, got {:?} ({})",
+            t.state_kind,
+            t.state
+        );
+
+        client.pause(&info_hash).await.expect("pause");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 Deluge re-paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Paused | DownloadItemState::PausedComplete
+        ));
+
+        client.delete(&info_hash, true).await.expect("cleanup");
+        eprintln!("state-progress smoke passed");
     }
 }

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -21,6 +21,9 @@ use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::time::{Duration, Instant};
 
+#[cfg(test)]
+pub(crate) mod test_helpers;
+
 pub mod qbittorrent;
 
 /// Stub Deluge implementation. Exists during Phase 1 to compile-check

--- a/src/services/download_client/qbittorrent.rs
+++ b/src/services/download_client/qbittorrent.rs
@@ -659,7 +659,7 @@ fn map_qbit_state(state: &str) -> DownloadItemState {
         "stalledUP" => SeedingStalled,
         "queuedUP" => SeedingQueued,
         "checkingUP" => CheckingSeed,
-        "pausedDL" => Paused,
+        "pausedDL" | "stoppedDL" => Paused,
         "pausedUP" | "stoppedUP" => PausedComplete,
         "error" | "missingFiles" => Errored,
         // `metaDL`, `allocating`, `moving`, `unknown`, and any
@@ -957,10 +957,15 @@ mod tests {
             .file_name("testpack.torrent")
             .mime_str("application/x-bittorrent")
             .unwrap();
+        // qBit 5.x renamed `paused` → `stopped` on the add endpoint;
+        // pass both so the test works against 4.x and 5.x without
+        // version probing (matches the `add_torrent` impl's pattern
+        // of sending both pause and stop names).
         let form = reqwest::multipart::Form::new()
             .part("torrents", part)
             .text("category", category.to_string())
-            .text("paused", "true");
+            .text("paused", "true")
+            .text("stopped", "true");
         let resp = client
             .post(format!("{base_url}/api/v2/torrents/add"))
             .multipart(form)
@@ -1144,11 +1149,310 @@ mod tests {
         }
         eprintln!("C2 re-narrow verified (sample now wanted, readme still skipped)");
 
-        // --- Cleanup ---
+        // --- A7: delete with delete_files=true removes torrent + files ---
         client
             .delete(&info_hash, true)
             .await
-            .expect("cleanup delete failed");
+            .expect("delete(hash, true) failed");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let after = client
+            .list_scoped()
+            .await
+            .expect("list_scoped after delete(true) failed");
+        assert!(
+            !after
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&info_hash)),
+            "A7: torrent must not survive delete(_, true)"
+        );
+        eprintln!("A7 delete(true) verified — torrent gone from list_scoped");
         eprintln!("narrowed-smoke passed");
+    }
+
+    /// Live smoke covering B2 (`list_scoped` isolation): uploads a
+    /// Ryokan-scoped torrent alongside a non-Ryokan torrent and
+    /// asserts `list_scoped` returns exactly one (the Ryokan one).
+    /// Validates the scoping mechanism (qBit's `?category=` filter)
+    /// does the right thing when other tooling's torrents are also
+    /// present in the client.
+    ///
+    ///     RYOKAN_QBIT_E2E=1 QBIT_PASS=<pw> cargo test \
+    ///       qbittorrent::tests::live_smoke_scoped_exclusion -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live qBittorrent at localhost:8080 + transmission-create"]
+    async fn live_smoke_scoped_exclusion() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_QBIT_E2E=1 to run against localhost:8080)");
+            return;
+        }
+        let Some((_tmp1, torrent1)) =
+            super::super::test_helpers::build_named_torrent("ryokan-scoped-test")
+        else {
+            return;
+        };
+        let Some((_tmp2, torrent2)) =
+            super::super::test_helpers::build_named_torrent("other-tool-test")
+        else {
+            return;
+        };
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let base_url = "http://localhost:8080";
+        let ryokan_category = "ryokan-e2e-scope";
+        let foreign_category = "other-tool-scope";
+
+        let ryokan_hash =
+            upload_torrent_file(base_url, "admin", &pass, ryokan_category, &torrent1).await;
+        let foreign_hash =
+            upload_torrent_file(base_url, "admin", &pass, foreign_category, &torrent2).await;
+        eprintln!("ryokan={ryokan_hash} foreign={foreign_hash}");
+        assert_ne!(
+            ryokan_hash, foreign_hash,
+            "test distinct torrents must have distinct hashes"
+        );
+
+        let client = QbitClient::new(base_url, "admin", &pass, ryokan_category);
+        let list = client
+            .list_scoped()
+            .await
+            .expect("list_scoped should succeed");
+
+        assert!(
+            list.iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&ryokan_hash)),
+            "B2: Ryokan-scoped torrent must appear in list_scoped"
+        );
+        assert!(
+            !list
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&foreign_hash)),
+            "B2: foreign-categorized torrent must NOT appear in list_scoped (found foreign {foreign_hash} in scoped list)"
+        );
+        eprintln!("B2 scoped exclusion verified (Ryokan present, foreign absent)");
+
+        // Cleanup both — foreign one via a separate client instance scoped to it.
+        client
+            .delete(&ryokan_hash, true)
+            .await
+            .expect("cleanup ryokan");
+        let foreign_client = QbitClient::new(base_url, "admin", &pass, foreign_category);
+        foreign_client
+            .delete(&foreign_hash, true)
+            .await
+            .expect("cleanup foreign");
+        eprintln!("scoped-exclusion smoke passed");
+    }
+
+    /// Live smoke covering error paths (F1, F2, F3): `delete` and
+    /// `get_files` on a non-existent hash must not panic and must
+    /// surface a sensible result; `add_torrent` with a malformed URL
+    /// must return `Err`. Validates defensive behavior Ryokan's
+    /// handlers depend on (e.g. post-processing calling `get_files`
+    /// on a hash that might have been deleted by another path, or
+    /// the user pasting garbage into the interactive-search URL
+    /// field).
+    ///
+    ///     RYOKAN_QBIT_E2E=1 QBIT_PASS=<pw> cargo test \
+    ///       qbittorrent::tests::live_smoke_error_paths -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live qBittorrent at localhost:8080"]
+    async fn live_smoke_error_paths() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let client = QbitClient::new("http://localhost:8080", "admin", &pass, "ryokan-e2e-errs");
+        let fake_hash = "0000000000000000000000000000000000000000";
+
+        // F1: delete non-existent hash — should return Ok (qBit's
+        // DELETE is idempotent; deleting a hash not in the session
+        // is a no-op). Must not panic regardless.
+        let result = client.delete(fake_hash, false).await;
+        eprintln!("F1 qBit delete(non-existent) → {result:?}");
+        // qBit's actual behavior: silently succeeds. Accept both so
+        // a future qBit version that starts erroring doesn't regress
+        // the test — the essential property is "no panic".
+
+        // F2: get_files non-existent — per trait contract returns
+        // empty `Vec` or Err (qBit returns 404, which the impl maps
+        // to Err). Must not panic.
+        let result = client.get_files(fake_hash).await;
+        eprintln!("F2 qBit get_files(non-existent) → {result:?}");
+        if let Ok(files) = result {
+            assert!(
+                files.is_empty(),
+                "F2: Ok result must be empty Vec per trait contract"
+            );
+        }
+        // Err is also acceptable per trait contract; only panic is a fail.
+
+        // F3: add with malformed URL. Must return Err, not panic.
+        let result = client
+            .add_torrent("this-is-not-a-valid-url-or-magnet", fake_hash)
+            .await;
+        eprintln!("F3 qBit add(malformed) → {result:?}");
+        assert!(
+            result.is_err(),
+            "F3: add_torrent with malformed URL must return Err (got {result:?})"
+        );
+
+        eprintln!("error-paths smoke passed");
+    }
+
+    /// Live smoke for E1+E2: verifies `DownloadItemState` transitions
+    /// correctly through pause→resume→pause and that `progress` stays
+    /// in its contract range [0.0, 1.0] throughout. Uses the synthetic
+    /// testpack so there's no real content to download — the torrent
+    /// sits at ~0 progress, letting us observe state changes without
+    /// racing a real download.
+    ///
+    ///     RYOKAN_QBIT_E2E=1 QBIT_PASS=<pw> cargo test \
+    ///       qbittorrent::tests::live_smoke_state_progress -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live qBittorrent at localhost:8080 + transmission-create"]
+    async fn live_smoke_state_progress() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let Some((_tmp, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let base_url = "http://localhost:8080";
+        let category = "ryokan-e2e-state";
+
+        let info_hash =
+            upload_torrent_file(base_url, "admin", &pass, category, &torrent_path).await;
+        let client = QbitClient::new(base_url, "admin", &pass, category);
+
+        // qBit 5.x ignores the `paused` / `stopped` multipart flag on
+        // add — empirically verified against v5.1.4. Issue an explicit
+        // pause so the torrent settles into the Paused state we
+        // expect to observe. This isn't cheating the test: the
+        // `pause()` RPC round-trip is what the test would exercise on
+        // the Resume→Pause transition anyway.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        client.pause(&info_hash).await.expect("initial pause");
+
+        /// Poll list_scoped until the target hash appears AND its
+        /// state_kind matches one of `acceptable`. qBit goes through
+        /// transient states on add (e.g. `checkingResumeData` which
+        /// the state mapping surfaces as Downloading) before settling
+        /// to the requested pause/resume state — we need the stable
+        /// state, not the first observation.
+        async fn poll_until_state(
+            client: &QbitClient,
+            hash: &str,
+            acceptable: &[DownloadItemState],
+        ) -> DownloadItem {
+            for _ in 0..30 {
+                let list = client.list_scoped().await.expect("list_scoped");
+                if let Some(t) = list
+                    .iter()
+                    .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                    .cloned()
+                    && acceptable.contains(&t.state_kind)
+                {
+                    return t;
+                }
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+            // Fall through: return the last observed state so the
+            // assertion below produces a useful error message.
+            let list = client.list_scoped().await.expect("list_scoped");
+            list.iter()
+                .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                .cloned()
+                .unwrap_or_else(|| panic!("torrent never appeared in list_scoped"))
+        }
+
+        // Uploaded paused → state should settle to Paused (after qBit
+        // completes resume-data checking, typically <1s).
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 after paused-upload: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(
+            matches!(
+                t.state_kind,
+                DownloadItemState::Paused | DownloadItemState::PausedComplete
+            ),
+            "E1: expected Paused after paused-upload, got {:?} ({})",
+            t.state_kind,
+            t.state
+        );
+        assert!(
+            (0.0..=1.0).contains(&t.progress),
+            "E2: progress must be in [0.0, 1.0], got {}",
+            t.progress
+        );
+
+        // Resume → state transitions to a Downloading* variant.
+        client.resume(&info_hash).await.expect("resume");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[
+                DownloadItemState::Downloading,
+                DownloadItemState::DownloadingStalled,
+                DownloadItemState::DownloadingQueued,
+                DownloadItemState::CheckingDownload,
+            ],
+        )
+        .await;
+        eprintln!(
+            "E1 after resume: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(
+            matches!(
+                t.state_kind,
+                DownloadItemState::Downloading
+                    | DownloadItemState::DownloadingStalled
+                    | DownloadItemState::DownloadingQueued
+                    | DownloadItemState::CheckingDownload
+            ),
+            "E1: expected Downloading* after resume, got {:?} ({})",
+            t.state_kind,
+            t.state
+        );
+        assert!(
+            (0.0..=1.0).contains(&t.progress),
+            "E2 progress: {}",
+            t.progress
+        );
+
+        // Pause again → back to Paused.
+        client.pause(&info_hash).await.expect("pause");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 after re-pause: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(
+            matches!(
+                t.state_kind,
+                DownloadItemState::Paused | DownloadItemState::PausedComplete
+            ),
+            "E1: expected Paused after re-pause, got {:?} ({})",
+            t.state_kind,
+            t.state
+        );
+
+        client.delete(&info_hash, true).await.expect("cleanup");
+        eprintln!("state-progress smoke passed");
     }
 }

--- a/src/services/download_client/qbittorrent.rs
+++ b/src/services/download_client/qbittorrent.rs
@@ -925,4 +925,230 @@ mod tests {
         );
         eprintln!("smoke passed");
     }
+
+    /// Upload a local `.torrent` file to qBit via the multipart
+    /// `torrents/add` endpoint with `paused=true`, scoped to the
+    /// given category. Returns the infohash qBit assigned after
+    /// polling `list_scoped` for appearance. The existing
+    /// `add_torrent` trait method on `QbitClient` only accepts URL
+    /// strings (magnet/HTTP); this helper is how the smoke tests
+    /// inject a synthetic file-backed torrent without going through
+    /// a URL scheme the client can't resolve.
+    async fn upload_torrent_file(
+        base_url: &str,
+        user: &str,
+        pass: &str,
+        category: &str,
+        torrent_path: &std::path::Path,
+    ) -> String {
+        let client = reqwest::Client::builder()
+            .cookie_store(true)
+            .build()
+            .expect("reqwest client");
+        let login = client
+            .post(format!("{base_url}/api/v2/auth/login"))
+            .form(&[("username", user), ("password", pass)])
+            .send()
+            .await
+            .expect("qBit login");
+        assert_eq!(login.status(), 200, "qBit login failed");
+        let bytes = std::fs::read(torrent_path).expect("read .torrent");
+        let part = reqwest::multipart::Part::bytes(bytes)
+            .file_name("testpack.torrent")
+            .mime_str("application/x-bittorrent")
+            .unwrap();
+        let form = reqwest::multipart::Form::new()
+            .part("torrents", part)
+            .text("category", category.to_string())
+            .text("paused", "true");
+        let resp = client
+            .post(format!("{base_url}/api/v2/torrents/add"))
+            .multipart(form)
+            .send()
+            .await
+            .expect("qBit add");
+        assert_eq!(resp.status(), 200, "qBit add returned {}", resp.status());
+
+        // Poll list_scoped via the multipart session to find the new
+        // torrent's hash. qBit's add endpoint doesn't return the hash
+        // directly, so we look it up by category.
+        for _ in 0..10 {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let list_resp = client
+                .get(format!(
+                    "{base_url}/api/v2/torrents/info?category={category}"
+                ))
+                .send()
+                .await
+                .expect("qBit list");
+            let torrents: Vec<serde_json::Value> = list_resp.json().await.expect("qBit list json");
+            if let Some(first) = torrents.first()
+                && let Some(hash) = first.get("hash").and_then(|v| v.as_str())
+            {
+                return hash.to_string();
+            }
+        }
+        panic!("uploaded torrent never appeared in category {category}");
+    }
+
+    /// Live smoke covering `add_torrent_with_file_filter` narrowing
+    /// (C1) and the re-narrow preservation contract (C2). Uses a
+    /// synthetic multi-file `.torrent` (built via
+    /// `transmission-create`) uploaded directly via qBit's multipart
+    /// endpoint so metadata is present immediately — no DHT
+    /// dependency, no flakiness window.
+    ///
+    /// Contract verified:
+    /// * C1 — narrowing a full file list down to a proper subset
+    ///   returns `SelectiveOutcome::Filtered(kept_indices)` and
+    ///   writes `wanted=false` to every non-selected file.
+    /// * C2 — re-narrowing with an expanded pick bumps previously-
+    ///   skipped files that are now wanted, but does *not* re-skip
+    ///   files the expanded pick dropped. Matches the `already_narrowed`
+    ///   branch in `add_torrent_with_file_filter` whose contract says
+    ///   "re-narrow must not clobber user edits."
+    ///
+    /// Gated the same way as `live_smoke`:
+    ///
+    ///     RYOKAN_QBIT_E2E=1 QBIT_PASS=<pw> cargo test \
+    ///       qbittorrent::tests::live_smoke_narrowed -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live qBittorrent at localhost:8080 + transmission-create"]
+    async fn live_smoke_narrowed() {
+        if std::env::var("RYOKAN_QBIT_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_QBIT_E2E=1 to run against localhost:8080)");
+            return;
+        }
+        let Some((_tmp_guard, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let pass = std::env::var("QBIT_PASS").unwrap_or_else(|_| "adminadmin".to_string());
+        let base_url = "http://localhost:8080";
+        let category = "ryokan-e2e-narrow";
+
+        let info_hash =
+            upload_torrent_file(base_url, "admin", &pass, category, &torrent_path).await;
+        eprintln!("uploaded testpack hash={info_hash}");
+
+        let client = QbitClient::new(base_url, "admin", &pass, category);
+
+        // Cleanup-on-panic safety: if any assertion fails below, we want
+        // the torrent gone so the next test run starts clean. Accomplish
+        // via a drop-guard closure pattern — but since we can't early-
+        // return from a test with cleanup, just ensure the final delete
+        // runs and previous state is cleared at entry too.
+        let files = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files should return metadata immediately after file upload");
+        assert_eq!(
+            files.len(),
+            7,
+            "synthetic testpack should have 7 files (5 episodes + sample + readme), got {}",
+            files.len()
+        );
+        assert!(
+            files.iter().all(|f| f.wanted),
+            "all files should start wanted=true before narrow"
+        );
+
+        // --- C1: narrow to episode files only ---
+        let episode_indices: Vec<usize> = files
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| f.name.contains("episode_").then_some(i))
+            .collect();
+        assert_eq!(episode_indices.len(), 5, "expected 5 episode files");
+
+        let expected_episode_indices = episode_indices.clone();
+        let magnet = format!("magnet:?xt=urn:btih:{info_hash}");
+        let outcome = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_episode_indices.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C1 failed");
+
+        match outcome {
+            SelectiveOutcome::Filtered(kept) => {
+                let mut sorted_kept = kept.clone();
+                sorted_kept.sort_unstable();
+                let mut sorted_expected = episode_indices.clone();
+                sorted_expected.sort_unstable();
+                assert_eq!(
+                    sorted_kept, sorted_expected,
+                    "C1 Filtered(kept) should equal the pick indices"
+                );
+            }
+            SelectiveOutcome::FullDownload => {
+                panic!("C1 expected Filtered narrow, got FullDownload");
+            }
+        }
+
+        // Verify priorities actually applied to the client state.
+        let files_after_c1 = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files after C1 failed");
+        for (i, f) in files_after_c1.iter().enumerate() {
+            let should_be_wanted = episode_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C1 post-narrow: file [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C1 narrowing verified (5 episodes wanted, sample+readme skipped)");
+
+        // --- C2: re-narrow with expanded pick (add sample.mkv) ---
+        let expanded_indices: Vec<usize> = files_after_c1
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                (f.name.contains("episode_") || f.name.contains("sample")).then_some(i)
+            })
+            .collect();
+        assert_eq!(
+            expanded_indices.len(),
+            6,
+            "expected 6 files in expanded pick (5 episodes + sample)"
+        );
+
+        let expected_expanded = expanded_indices.clone();
+        let outcome2 = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_expanded.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C2 failed");
+
+        match outcome2 {
+            SelectiveOutcome::Filtered(_) => {}
+            SelectiveOutcome::FullDownload => {
+                panic!("C2 expected Filtered re-narrow, got FullDownload");
+            }
+        }
+
+        let files_after_c2 = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files after C2 failed");
+        for (i, f) in files_after_c2.iter().enumerate() {
+            let should_be_wanted = expanded_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C2 post-renarrow: file [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C2 re-narrow verified (sample now wanted, readme still skipped)");
+
+        // --- Cleanup ---
+        client
+            .delete(&info_hash, true)
+            .await
+            .expect("cleanup delete failed");
+        eprintln!("narrowed-smoke passed");
+    }
 }

--- a/src/services/download_client/qbittorrent.rs
+++ b/src/services/download_client/qbittorrent.rs
@@ -926,76 +926,6 @@ mod tests {
         eprintln!("smoke passed");
     }
 
-    /// Upload a local `.torrent` file to qBit via the multipart
-    /// `torrents/add` endpoint with `paused=true`, scoped to the
-    /// given category. Returns the infohash qBit assigned after
-    /// polling `list_scoped` for appearance. The existing
-    /// `add_torrent` trait method on `QbitClient` only accepts URL
-    /// strings (magnet/HTTP); this helper is how the smoke tests
-    /// inject a synthetic file-backed torrent without going through
-    /// a URL scheme the client can't resolve.
-    async fn upload_torrent_file(
-        base_url: &str,
-        user: &str,
-        pass: &str,
-        category: &str,
-        torrent_path: &std::path::Path,
-    ) -> String {
-        let client = reqwest::Client::builder()
-            .cookie_store(true)
-            .build()
-            .expect("reqwest client");
-        let login = client
-            .post(format!("{base_url}/api/v2/auth/login"))
-            .form(&[("username", user), ("password", pass)])
-            .send()
-            .await
-            .expect("qBit login");
-        assert_eq!(login.status(), 200, "qBit login failed");
-        let bytes = std::fs::read(torrent_path).expect("read .torrent");
-        let part = reqwest::multipart::Part::bytes(bytes)
-            .file_name("testpack.torrent")
-            .mime_str("application/x-bittorrent")
-            .unwrap();
-        // qBit 5.x renamed `paused` → `stopped` on the add endpoint;
-        // pass both so the test works against 4.x and 5.x without
-        // version probing (matches the `add_torrent` impl's pattern
-        // of sending both pause and stop names).
-        let form = reqwest::multipart::Form::new()
-            .part("torrents", part)
-            .text("category", category.to_string())
-            .text("paused", "true")
-            .text("stopped", "true");
-        let resp = client
-            .post(format!("{base_url}/api/v2/torrents/add"))
-            .multipart(form)
-            .send()
-            .await
-            .expect("qBit add");
-        assert_eq!(resp.status(), 200, "qBit add returned {}", resp.status());
-
-        // Poll list_scoped via the multipart session to find the new
-        // torrent's hash. qBit's add endpoint doesn't return the hash
-        // directly, so we look it up by category.
-        for _ in 0..10 {
-            tokio::time::sleep(Duration::from_millis(300)).await;
-            let list_resp = client
-                .get(format!(
-                    "{base_url}/api/v2/torrents/info?category={category}"
-                ))
-                .send()
-                .await
-                .expect("qBit list");
-            let torrents: Vec<serde_json::Value> = list_resp.json().await.expect("qBit list json");
-            if let Some(first) = torrents.first()
-                && let Some(hash) = first.get("hash").and_then(|v| v.as_str())
-            {
-                return hash.to_string();
-            }
-        }
-        panic!("uploaded torrent never appeared in category {category}");
-    }
-
     /// Live smoke covering `add_torrent_with_file_filter` narrowing
     /// (C1) and the re-narrow preservation contract (C2). Uses a
     /// synthetic multi-file `.torrent` (built via
@@ -1032,8 +962,14 @@ mod tests {
         let base_url = "http://localhost:8080";
         let category = "ryokan-e2e-narrow";
 
-        let info_hash =
-            upload_torrent_file(base_url, "admin", &pass, category, &torrent_path).await;
+        let info_hash = super::super::test_helpers::upload_torrent_file_qbit(
+            base_url,
+            "admin",
+            &pass,
+            category,
+            &torrent_path,
+        )
+        .await;
         eprintln!("uploaded testpack hash={info_hash}");
 
         let client = QbitClient::new(base_url, "admin", &pass, category);
@@ -1200,10 +1136,22 @@ mod tests {
         let ryokan_category = "ryokan-e2e-scope";
         let foreign_category = "other-tool-scope";
 
-        let ryokan_hash =
-            upload_torrent_file(base_url, "admin", &pass, ryokan_category, &torrent1).await;
-        let foreign_hash =
-            upload_torrent_file(base_url, "admin", &pass, foreign_category, &torrent2).await;
+        let ryokan_hash = super::super::test_helpers::upload_torrent_file_qbit(
+            base_url,
+            "admin",
+            &pass,
+            ryokan_category,
+            &torrent1,
+        )
+        .await;
+        let foreign_hash = super::super::test_helpers::upload_torrent_file_qbit(
+            base_url,
+            "admin",
+            &pass,
+            foreign_category,
+            &torrent2,
+        )
+        .await;
         eprintln!("ryokan={ryokan_hash} foreign={foreign_hash}");
         assert_ne!(
             ryokan_hash, foreign_hash,
@@ -1323,8 +1271,14 @@ mod tests {
         let base_url = "http://localhost:8080";
         let category = "ryokan-e2e-state";
 
-        let info_hash =
-            upload_torrent_file(base_url, "admin", &pass, category, &torrent_path).await;
+        let info_hash = super::super::test_helpers::upload_torrent_file_qbit(
+            base_url,
+            "admin",
+            &pass,
+            category,
+            &torrent_path,
+        )
+        .await;
         let client = QbitClient::new(base_url, "admin", &pass, category);
 
         // qBit 5.x ignores the `paused` / `stopped` multipart flag on

--- a/src/services/download_client/rtorrent.rs
+++ b/src/services/download_client/rtorrent.rs
@@ -259,8 +259,15 @@ impl DownloadClient for RtorrentClient {
         // malformed URLs with an RPC-level error; only rtorrent
         // swallowed them). Reject anything that isn't a magnet URI
         // or an http(s) URL before burning an XML-RPC round trip.
-        let looks_valid =
-            url.starts_with("magnet:") || url.starts_with("http://") || url.starts_with("https://");
+        // Lowercase the scheme first so `MAGNET:` / `HTTP://` also
+        // match — RFC 3986 schemes are case-insensitive. Internal
+        // Ryokan call sites always emit lowercase, but third-party
+        // integrations (a future torznab-pushed release, a hand-
+        // edited feed URL) might not.
+        let lowered = url.trim().to_ascii_lowercase();
+        let looks_valid = lowered.starts_with("magnet:")
+            || lowered.starts_with("http://")
+            || lowered.starts_with("https://");
         if !looks_valid {
             return Err(format!(
                 "rtorrent add rejected url={url}: expected magnet: / http:// / https:// scheme"
@@ -767,17 +774,13 @@ pub(crate) enum XmlValue {
     /// which accept an entire `.torrent` file as a base64 blob —
     /// these are the canonical ways to hand a tiny synthetic
     /// `.torrent` to rtorrent without serving it over HTTP or
-    /// sharing a filesystem mount with the rtorrent container. Value
-    /// is the raw bytes; the encoder handles base64 conversion.
-    ///
-    /// Currently constructed only by the `live_smoke_narrowed` test,
-    /// but kept in the production `XmlValue` enum (vs. a test-only
-    /// variant) because the encoder's match on `XmlValue` is
-    /// exhaustive and splitting the variant set would force ugly
-    /// cfg-gating on every match arm. The production encoder path
-    /// is test-verified and ready if a future feature (e.g. a
-    /// "load .torrent from local path" UI action) needs it.
-    #[allow(dead_code)]
+    /// sharing a filesystem mount with the rtorrent container.
+    /// Test-only for now (used by `live_smoke_narrowed` and friends);
+    /// gated behind `#[cfg(test)]` both here and in the encoder
+    /// match arm so the production binary doesn't ship a speculative
+    /// feature. Promote to unconditional if a UI feature later needs
+    /// to load `.torrent` bytes directly.
+    #[cfg(test)]
     Base64(Vec<u8>),
 }
 
@@ -841,6 +844,7 @@ fn encode_value(v: &XmlValue, out: &mut String) {
             }
             out.push_str("</data></array>");
         }
+        #[cfg(test)]
         XmlValue::Base64(bytes) => {
             use base64::{Engine, engine::general_purpose};
             out.push_str("<base64>");
@@ -1568,21 +1572,27 @@ mod tests {
         let client = RtorrentClient::new(rpc_url, "", "", label);
 
         // Compute the infohash client-side by SHA1'ing the bencoded
-        // `info` dict. Hand-parse just enough bencode to find it.
-        let info_hash = bencode_info_hash(&bytes).expect("extract infohash from .torrent");
+        // `info` dict (shared helper in test_helpers).
+        let info_hash = super::super::test_helpers::bencode_info_hash(&bytes)
+            .expect("extract infohash from .torrent");
         let hash_uc = info_hash.to_ascii_uppercase();
 
-        // `load.raw_verbose` (no `_start`) loads the torrent into the
-        // main view without auto-starting it — which is what we need
-        // for tests that verify paused state or write file priorities
-        // before any content transfer. Post-load commands (e.g. the
-        // `d.custom1.set` label) run during load. We explicitly
-        // avoid `load.raw_start_verbose` here because it races with
-        // a post-command `d.stop` — the start happens before the
-        // post-command applies.
+        // `load.raw_start_verbose` auto-starts the torrent, which is
+        // necessary for rtorrent to populate `d.base_path` — required
+        // by `add_torrent_with_file_filter`'s metadata-readiness
+        // poll (sibling smoke). Then we explicitly pause via the
+        // trait's pause method so the torrent ends up in the soft-
+        // paused state (`is_active=false`, `is_open=true`) that
+        // `client.resume()` → `d.resume` can cleanly undo.
+        //
+        // Post-load commands passed to `load.raw_start_verbose` run
+        // BEFORE the session-level auto-start scheduler fires, so a
+        // post-command `d.pause` races and sometimes doesn't stick.
+        // Pausing from the outside after a short settle is more
+        // reliable.
         client
             .call(
-                "load.raw_verbose",
+                "load.raw_start_verbose",
                 &[
                     XmlValue::String(String::new()),
                     XmlValue::Base64(bytes),
@@ -1590,18 +1600,17 @@ mod tests {
                 ],
             )
             .await
-            .expect("load.raw_verbose failed");
+            .expect("load.raw_start_verbose failed");
 
-        // Some rtorrent configs auto-start loaded torrents (via
-        // `schedule2 = load,...,d.start=` or similar). Post-load
-        // commands passed to `load.raw_verbose` run at load time but
-        // BEFORE any session-level auto-start scheduler. Call `d.stop`
-        // explicitly so the test can observe Paused state.
+        // Wait for the torrent to register in the main view, then
+        // pause it explicitly. Poll because rtorrent's post-load
+        // bookkeeping is async: the hash needs to appear via
+        // `d.multicall2` before `d.pause` addresses anything.
         let hash_uc_clone = hash_uc.clone();
-        for _ in 0..10 {
+        for _ in 0..20 {
             tokio::time::sleep(std::time::Duration::from_millis(200)).await;
             if client
-                .call("d.stop", &[XmlValue::String(hash_uc_clone.clone())])
+                .call("d.pause", &[XmlValue::String(hash_uc_clone.clone())])
                 .await
                 .is_ok()
             {
@@ -1610,58 +1619,6 @@ mod tests {
         }
 
         info_hash.to_ascii_lowercase()
-    }
-
-    /// Compute the v1 infohash of a .torrent by SHA1'ing the raw
-    /// bencoded `info` dict. Minimal hand-parse — finds the `4:info`
-    /// key at the top level, then slices the bencoded dict that
-    /// follows. Doesn't validate the rest of the .torrent structure;
-    /// assumes well-formed input from `transmission-create`.
-    fn bencode_info_hash(bytes: &[u8]) -> Option<String> {
-        // Top-level structure is `d...e`; look for `4:info` and grab
-        // the bencoded dict that follows.
-        let key = b"4:info";
-        let start = find_subslice(bytes, key)? + key.len();
-        let end = bencode_end(bytes, start)?;
-        let info_slice = &bytes[start..end];
-        let mut hasher = sha1_smol::Sha1::new();
-        hasher.update(info_slice);
-        Some(hasher.digest().to_string())
-    }
-
-    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
-        haystack.windows(needle.len()).position(|w| w == needle)
-    }
-
-    /// Given a bencoded value starting at `start`, return the index
-    /// just past its end. Handles dicts (`d...e`), lists (`l...e`),
-    /// ints (`i...e`), and byte-strings (`N:...`) — the full bencode
-    /// grammar. Returns None on malformed input.
-    fn bencode_end(bytes: &[u8], start: usize) -> Option<usize> {
-        let mut i = start;
-        if i >= bytes.len() {
-            return None;
-        }
-        match bytes[i] {
-            b'd' | b'l' => {
-                i += 1;
-                while i < bytes.len() && bytes[i] != b'e' {
-                    i = bencode_end(bytes, i)?;
-                }
-                if i < bytes.len() { Some(i + 1) } else { None }
-            }
-            b'i' => {
-                let e = find_subslice(&bytes[i..], b"e")? + i;
-                Some(e + 1)
-            }
-            b'0'..=b'9' => {
-                let colon = bytes[i..].iter().position(|&b| b == b':')? + i;
-                let len_str = std::str::from_utf8(&bytes[i..colon]).ok()?;
-                let len: usize = len_str.parse().ok()?;
-                Some(colon + 1 + len)
-            }
-            _ => None,
-        }
     }
 
     /// Live smoke covering `add_torrent_with_file_filter` narrowing

--- a/src/services/download_client/rtorrent.rs
+++ b/src/services/download_client/rtorrent.rs
@@ -746,6 +746,23 @@ pub(crate) enum XmlValue {
     Int(i64),
     Bool(bool),
     Array(Vec<XmlValue>),
+    /// Raw binary payload, encoded as XML-RPC `<base64>` on the
+    /// wire. Needed for `load.raw_start_verbose` / `load.raw_verbose`
+    /// which accept an entire `.torrent` file as a base64 blob —
+    /// these are the canonical ways to hand a tiny synthetic
+    /// `.torrent` to rtorrent without serving it over HTTP or
+    /// sharing a filesystem mount with the rtorrent container. Value
+    /// is the raw bytes; the encoder handles base64 conversion.
+    ///
+    /// Currently constructed only by the `live_smoke_narrowed` test,
+    /// but kept in the production `XmlValue` enum (vs. a test-only
+    /// variant) because the encoder's match on `XmlValue` is
+    /// exhaustive and splitting the variant set would force ugly
+    /// cfg-gating on every match arm. The production encoder path
+    /// is test-verified and ready if a future feature (e.g. a
+    /// "load .torrent from local path" UI action) needs it.
+    #[allow(dead_code)]
+    Base64(Vec<u8>),
 }
 
 impl XmlValue {
@@ -807,6 +824,12 @@ fn encode_value(v: &XmlValue, out: &mut String) {
                 encode_value(inner, out);
             }
             out.push_str("</data></array>");
+        }
+        XmlValue::Base64(bytes) => {
+            use base64::{Engine, engine::general_purpose};
+            out.push_str("<base64>");
+            out.push_str(&general_purpose::STANDARD.encode(bytes));
+            out.push_str("</base64>");
         }
     }
     out.push_str("</value>");
@@ -1506,5 +1529,225 @@ mod tests {
             "torrent must not survive delete"
         );
         eprintln!("smoke passed");
+    }
+
+    /// Upload a local `.torrent` to rtorrent via the XML-RPC
+    /// `load.raw_start_verbose` method, which accepts the entire
+    /// `.torrent` payload as a `<base64>` blob — the canonical
+    /// rtorrent pattern for loading a local torrent without a
+    /// filesystem mount or HTTP round-trip. Stops (pauses) the
+    /// torrent immediately after load so it doesn't try to download
+    /// fake content from the bogus tracker. Applies the Ryokan
+    /// label via `d.custom1.set` after load.
+    ///
+    /// Returns the infohash rtorrent assigned (extracted from the
+    /// torrent's bencode — the only way since `load.raw_start_verbose`
+    /// returns 0 on success, not the hash).
+    async fn upload_torrent_file_rtorrent(
+        rpc_url: &str,
+        label: &str,
+        torrent_path: &std::path::Path,
+    ) -> String {
+        let bytes = std::fs::read(torrent_path).expect("read .torrent");
+        let client = RtorrentClient::new(rpc_url, "", "", label);
+
+        // Compute the infohash client-side by SHA1'ing the bencoded
+        // `info` dict. Hand-parse just enough bencode to find it.
+        let info_hash = bencode_info_hash(&bytes).expect("extract infohash from .torrent");
+        let hash_uc = info_hash.to_ascii_uppercase();
+
+        // load.raw_start_verbose takes (target, raw_bytes, *commands).
+        // Commands run post-load; stop and set label atomically.
+        client
+            .call(
+                "load.raw_start_verbose",
+                &[
+                    XmlValue::String(String::new()),
+                    XmlValue::Base64(bytes),
+                    XmlValue::String(format!("d.stop={hash_uc}")),
+                    XmlValue::String(format!("d.custom1.set={label}")),
+                ],
+            )
+            .await
+            .expect("load.raw_start_verbose failed");
+
+        info_hash.to_ascii_lowercase()
+    }
+
+    /// Compute the v1 infohash of a .torrent by SHA1'ing the raw
+    /// bencoded `info` dict. Minimal hand-parse — finds the `4:info`
+    /// key at the top level, then slices the bencoded dict that
+    /// follows. Doesn't validate the rest of the .torrent structure;
+    /// assumes well-formed input from `transmission-create`.
+    fn bencode_info_hash(bytes: &[u8]) -> Option<String> {
+        // Top-level structure is `d...e`; look for `4:info` and grab
+        // the bencoded dict that follows.
+        let key = b"4:info";
+        let start = find_subslice(bytes, key)? + key.len();
+        let end = bencode_end(bytes, start)?;
+        let info_slice = &bytes[start..end];
+        let mut hasher = sha1_smol::Sha1::new();
+        hasher.update(info_slice);
+        Some(hasher.digest().to_string())
+    }
+
+    fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack.windows(needle.len()).position(|w| w == needle)
+    }
+
+    /// Given a bencoded value starting at `start`, return the index
+    /// just past its end. Handles dicts (`d...e`), lists (`l...e`),
+    /// ints (`i...e`), and byte-strings (`N:...`) — the full bencode
+    /// grammar. Returns None on malformed input.
+    fn bencode_end(bytes: &[u8], start: usize) -> Option<usize> {
+        let mut i = start;
+        if i >= bytes.len() {
+            return None;
+        }
+        match bytes[i] {
+            b'd' | b'l' => {
+                i += 1;
+                while i < bytes.len() && bytes[i] != b'e' {
+                    i = bencode_end(bytes, i)?;
+                }
+                if i < bytes.len() { Some(i + 1) } else { None }
+            }
+            b'i' => {
+                let e = find_subslice(&bytes[i..], b"e")? + i;
+                Some(e + 1)
+            }
+            b'0'..=b'9' => {
+                let colon = bytes[i..].iter().position(|&b| b == b':')? + i;
+                let len_str = std::str::from_utf8(&bytes[i..colon]).ok()?;
+                let len: usize = len_str.parse().ok()?;
+                Some(colon + 1 + len)
+            }
+            _ => None,
+        }
+    }
+
+    /// Live smoke covering `add_torrent_with_file_filter` narrowing
+    /// (C1) and the re-narrow preservation contract (C2) against
+    /// rtorrent. Mirrors the qBit/Deluge/Transmission equivalents;
+    /// differences are XML-RPC encoding and rtorrent's mandatory
+    /// `d.update_priorities` call after file-priority writes.
+    ///
+    ///     RYOKAN_RTORRENT_E2E=1 cargo test \
+    ///       rtorrent::tests::live_smoke_narrowed -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live rtorrent via ruTorrent at localhost:8081 + transmission-create"]
+    async fn live_smoke_narrowed() {
+        if std::env::var("RYOKAN_RTORRENT_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_RTORRENT_E2E=1 to run against localhost:8081)");
+            return;
+        }
+        let Some((_tmp_guard, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let rpc_url = "http://localhost:8081/RPC2";
+        let label = "ryokan-e2e-narrow";
+
+        let info_hash = upload_torrent_file_rtorrent(rpc_url, label, &torrent_path).await;
+        eprintln!("uploaded testpack hash={info_hash}");
+
+        let client = RtorrentClient::new(rpc_url, "", "", label);
+
+        // rtorrent needs a moment to register files after load — poll
+        // briefly until metadata is visible via get_files.
+        let mut files = Vec::new();
+        for _ in 0..20 {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            match client.get_files(&info_hash).await {
+                Ok(f) if !f.is_empty() => {
+                    files = f;
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        assert_eq!(
+            files.len(),
+            7,
+            "synthetic testpack should have 7 files, got {}",
+            files.len()
+        );
+        assert!(
+            files.iter().all(|f| f.wanted),
+            "all files should start wanted=true before narrow"
+        );
+
+        let episode_indices: Vec<usize> = files
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| f.name.contains("episode_").then_some(i))
+            .collect();
+        assert_eq!(episode_indices.len(), 5, "expected 5 episode files");
+
+        let expected_episode_indices = episode_indices.clone();
+        let magnet = format!("magnet:?xt=urn:btih:{info_hash}");
+        let outcome = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_episode_indices.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C1 failed");
+
+        match outcome {
+            SelectiveOutcome::Filtered(kept) => {
+                let mut sorted_kept = kept.clone();
+                sorted_kept.sort_unstable();
+                let mut sorted_expected = episode_indices.clone();
+                sorted_expected.sort_unstable();
+                assert_eq!(sorted_kept, sorted_expected);
+            }
+            SelectiveOutcome::FullDownload => panic!("C1 expected Filtered, got FullDownload"),
+        }
+
+        let files_after_c1 = client.get_files(&info_hash).await.expect("get_files C1");
+        for (i, f) in files_after_c1.iter().enumerate() {
+            let should_be_wanted = episode_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C1 post-narrow: [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C1 narrowing verified");
+
+        let expanded_indices: Vec<usize> = files_after_c1
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                (f.name.contains("episode_") || f.name.contains("sample")).then_some(i)
+            })
+            .collect();
+        assert_eq!(expanded_indices.len(), 6);
+
+        let expected_expanded = expanded_indices.clone();
+        let outcome2 = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_expanded.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C2 failed");
+        assert!(matches!(outcome2, SelectiveOutcome::Filtered(_)));
+
+        let files_after_c2 = client.get_files(&info_hash).await.expect("get_files C2");
+        for (i, f) in files_after_c2.iter().enumerate() {
+            let should_be_wanted = expanded_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C2 post-renarrow: [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C2 re-narrow verified");
+
+        client
+            .delete(&info_hash, true)
+            .await
+            .expect("cleanup delete failed");
+        eprintln!("narrowed-smoke passed");
     }
 }

--- a/src/services/download_client/rtorrent.rs
+++ b/src/services/download_client/rtorrent.rs
@@ -251,6 +251,22 @@ impl DownloadClient for RtorrentClient {
     }
 
     async fn add_torrent(&self, url: &str, info_hash: &str) -> Result<AddOutcome, String> {
+        // Up-front URL-shape validation. rtorrent's `load.start_verbose`
+        // silently accepts garbage-string inputs and returns 0 (success)
+        // without actually creating a torrent — caller can't tell a
+        // typo'd URL from a real add. Surfaced 2026-04-23 as an #85
+        // parity gap (qBit / Deluge / Transmission all reject
+        // malformed URLs with an RPC-level error; only rtorrent
+        // swallowed them). Reject anything that isn't a magnet URI
+        // or an http(s) URL before burning an XML-RPC round trip.
+        let looks_valid =
+            url.starts_with("magnet:") || url.starts_with("http://") || url.starts_with("https://");
+        if !looks_valid {
+            return Err(format!(
+                "rtorrent add rejected url={url}: expected magnet: / http:// / https:// scheme"
+            ));
+        }
+
         // Pre-check — rtorrent silently accepts duplicate adds so we
         // need to detect them ourselves. The cost is one extra
         // multicall, which is cheap relative to the magnet load that
@@ -1556,20 +1572,42 @@ mod tests {
         let info_hash = bencode_info_hash(&bytes).expect("extract infohash from .torrent");
         let hash_uc = info_hash.to_ascii_uppercase();
 
-        // load.raw_start_verbose takes (target, raw_bytes, *commands).
-        // Commands run post-load; stop and set label atomically.
+        // `load.raw_verbose` (no `_start`) loads the torrent into the
+        // main view without auto-starting it — which is what we need
+        // for tests that verify paused state or write file priorities
+        // before any content transfer. Post-load commands (e.g. the
+        // `d.custom1.set` label) run during load. We explicitly
+        // avoid `load.raw_start_verbose` here because it races with
+        // a post-command `d.stop` — the start happens before the
+        // post-command applies.
         client
             .call(
-                "load.raw_start_verbose",
+                "load.raw_verbose",
                 &[
                     XmlValue::String(String::new()),
                     XmlValue::Base64(bytes),
-                    XmlValue::String(format!("d.stop={hash_uc}")),
                     XmlValue::String(format!("d.custom1.set={label}")),
                 ],
             )
             .await
-            .expect("load.raw_start_verbose failed");
+            .expect("load.raw_verbose failed");
+
+        // Some rtorrent configs auto-start loaded torrents (via
+        // `schedule2 = load,...,d.start=` or similar). Post-load
+        // commands passed to `load.raw_verbose` run at load time but
+        // BEFORE any session-level auto-start scheduler. Call `d.stop`
+        // explicitly so the test can observe Paused state.
+        let hash_uc_clone = hash_uc.clone();
+        for _ in 0..10 {
+            tokio::time::sleep(std::time::Duration::from_millis(200)).await;
+            if client
+                .call("d.stop", &[XmlValue::String(hash_uc_clone.clone())])
+                .await
+                .is_ok()
+            {
+                break;
+            }
+        }
 
         info_hash.to_ascii_lowercase()
     }
@@ -1744,10 +1782,229 @@ mod tests {
         }
         eprintln!("C2 re-narrow verified");
 
+        // A7: delete with delete_files=true removes torrent + files
         client
             .delete(&info_hash, true)
             .await
-            .expect("cleanup delete failed");
+            .expect("delete(hash, true) failed");
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let after = client
+            .list_scoped()
+            .await
+            .expect("list_scoped after delete(true) failed");
+        assert!(
+            !after
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&info_hash)),
+            "A7: torrent must not survive delete(_, true)"
+        );
+        eprintln!("A7 delete(true) verified");
         eprintln!("narrowed-smoke passed");
+    }
+
+    /// Live smoke for B2: rtorrent `list_scoped` filters by the
+    /// `custom1` field (the ruTorrent "Label" convention).
+    /// A torrent with a different `custom1` value must not surface.
+    ///
+    ///     RYOKAN_RTORRENT_E2E=1 cargo test \
+    ///       rtorrent::tests::live_smoke_scoped_exclusion -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live rtorrent via ruTorrent at localhost:8081 + transmission-create"]
+    async fn live_smoke_scoped_exclusion() {
+        if std::env::var("RYOKAN_RTORRENT_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_RTORRENT_E2E=1 to run against localhost:8081)");
+            return;
+        }
+        let Some((_tmp1, torrent1)) =
+            super::super::test_helpers::build_named_torrent("ryokan-scoped-test")
+        else {
+            return;
+        };
+        let Some((_tmp2, torrent2)) =
+            super::super::test_helpers::build_named_torrent("other-tool-test")
+        else {
+            return;
+        };
+        let rpc_url = "http://localhost:8081/RPC2";
+        let ryokan_label = "ryokan-e2e-scope";
+        let foreign_label = "other-tool-scope";
+
+        let ryokan_hash = upload_torrent_file_rtorrent(rpc_url, ryokan_label, &torrent1).await;
+        let foreign_hash = upload_torrent_file_rtorrent(rpc_url, foreign_label, &torrent2).await;
+        eprintln!("ryokan={ryokan_hash} foreign={foreign_hash}");
+        assert_ne!(ryokan_hash, foreign_hash);
+
+        // rtorrent needs a brief moment to register custom1 labels
+        // after load.raw_start_verbose runs the post-load commands.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let client = RtorrentClient::new(rpc_url, "", "", ryokan_label);
+        let list = client.list_scoped().await.expect("list_scoped");
+
+        assert!(
+            list.iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&ryokan_hash)),
+            "B2: Ryokan-labeled torrent must appear"
+        );
+        assert!(
+            !list
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&foreign_hash)),
+            "B2: foreign-labeled torrent must NOT appear (found {foreign_hash})"
+        );
+        eprintln!("B2 scoped exclusion verified");
+
+        client
+            .delete(&ryokan_hash, true)
+            .await
+            .expect("cleanup ryokan");
+        let foreign_client = RtorrentClient::new(rpc_url, "", "", foreign_label);
+        foreign_client
+            .delete(&foreign_hash, true)
+            .await
+            .expect("cleanup foreign");
+        eprintln!("scoped-exclusion smoke passed");
+    }
+
+    /// Error-path live smoke (F1 / F2 / F3) against rtorrent.
+    #[tokio::test]
+    #[ignore = "requires live rtorrent via ruTorrent at localhost:8081"]
+    async fn live_smoke_error_paths() {
+        if std::env::var("RYOKAN_RTORRENT_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let client = RtorrentClient::new("http://localhost:8081/RPC2", "", "", "ryokan-e2e-errs");
+        let fake_hash = "0000000000000000000000000000000000000000";
+
+        let result = client.delete(fake_hash, false).await;
+        eprintln!("F1 rtorrent delete(non-existent) → {result:?}");
+
+        let result = client.get_files(fake_hash).await;
+        eprintln!("F2 rtorrent get_files(non-existent) → {result:?}");
+        if let Ok(files) = result {
+            assert!(files.is_empty(), "F2: Ok result must be empty");
+        }
+
+        let result = client
+            .add_torrent("this-is-not-a-valid-url-or-magnet", fake_hash)
+            .await;
+        eprintln!("F3 rtorrent add(malformed) → {result:?}");
+        // Fixed 2026-04-23: rtorrent's `add_torrent` now rejects
+        // non-magnet / non-http(s) URLs up front. Before the fix
+        // `load.start_verbose` silently returned 0 (success) on
+        // garbage strings, which would have let a typo'd URL appear
+        // to succeed from Ryokan's side while creating no torrent.
+        // This smoke fails regression-detection if that validation
+        // is removed.
+        assert!(
+            result.is_err(),
+            "F3: add_torrent with malformed URL must return Err (got {result:?})"
+        );
+
+        eprintln!("error-paths smoke passed");
+    }
+
+    /// E1+E2 live smoke for rtorrent.
+    #[tokio::test]
+    #[ignore = "requires live rtorrent via ruTorrent at localhost:8081 + transmission-create"]
+    async fn live_smoke_state_progress() {
+        if std::env::var("RYOKAN_RTORRENT_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let Some((_tmp, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let rpc_url = "http://localhost:8081/RPC2";
+        let label = "ryokan-e2e-state";
+
+        let info_hash = upload_torrent_file_rtorrent(rpc_url, label, &torrent_path).await;
+        let client = RtorrentClient::new(rpc_url, "", "", label);
+
+        async fn poll_until_state(
+            client: &RtorrentClient,
+            hash: &str,
+            acceptable: &[DownloadItemState],
+        ) -> DownloadItem {
+            for _ in 0..30 {
+                let list = client.list_scoped().await.expect("list_scoped");
+                if let Some(t) = list
+                    .iter()
+                    .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                    .cloned()
+                    && acceptable.contains(&t.state_kind)
+                {
+                    return t;
+                }
+                tokio::time::sleep(Duration::from_millis(250)).await;
+            }
+            let list = client.list_scoped().await.expect("list_scoped");
+            list.iter()
+                .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                .cloned()
+                .unwrap_or_else(|| panic!("torrent never appeared"))
+        }
+
+        // Uploaded with d.stop post-command → expect Paused.
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 rtorrent paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Paused | DownloadItemState::PausedComplete
+        ));
+        assert!((0.0..=1.0).contains(&t.progress));
+
+        client.resume(&info_hash).await.expect("resume");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[
+                DownloadItemState::Downloading,
+                DownloadItemState::DownloadingStalled,
+                DownloadItemState::DownloadingQueued,
+                DownloadItemState::CheckingDownload,
+            ],
+        )
+        .await;
+        eprintln!(
+            "E1 rtorrent resumed: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Downloading
+                | DownloadItemState::DownloadingStalled
+                | DownloadItemState::DownloadingQueued
+                | DownloadItemState::CheckingDownload
+        ));
+
+        client.pause(&info_hash).await.expect("pause");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 rtorrent re-paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Paused | DownloadItemState::PausedComplete
+        ));
+
+        client.delete(&info_hash, true).await.expect("cleanup");
+        eprintln!("state-progress smoke passed");
     }
 }

--- a/src/services/download_client/test_helpers.rs
+++ b/src/services/download_client/test_helpers.rs
@@ -55,6 +55,78 @@ pub(crate) fn build_named_torrent(name: &str) -> Option<(tempfile::TempDir, Path
     build_inner(name, true)
 }
 
+/// Upload a local `.torrent` file to qBit via the multipart
+/// `torrents/add` endpoint with `paused=true` and `stopped=true`
+/// (qBit 5.x renamed the flag — pass both to survive either
+/// version), scoped to the given category. Returns the infohash
+/// qBit assigned after polling `list_scoped` for appearance.
+///
+/// Shared between `qbittorrent::tests::live_smoke_*` and
+/// handler-level Wave 2 integration tests. The production
+/// `QbitClient::add_torrent` only accepts URL strings (magnet/HTTP);
+/// this helper injects a synthetic file-backed torrent via the
+/// multipart route that production code doesn't use.
+pub(crate) async fn upload_torrent_file_qbit(
+    base_url: &str,
+    user: &str,
+    pass: &str,
+    category: &str,
+    torrent_path: &std::path::Path,
+) -> String {
+    let client = reqwest::Client::builder()
+        .cookie_store(true)
+        .build()
+        .expect("reqwest client");
+    let login = client
+        .post(format!("{base_url}/api/v2/auth/login"))
+        .form(&[("username", user), ("password", pass)])
+        .send()
+        .await
+        .expect("qBit login");
+    assert_eq!(login.status(), 200, "qBit login failed");
+    let bytes = std::fs::read(torrent_path).expect("read .torrent");
+    let part = reqwest::multipart::Part::bytes(bytes)
+        .file_name("testpack.torrent")
+        .mime_str("application/x-bittorrent")
+        .unwrap();
+    let form = reqwest::multipart::Form::new()
+        .part("torrents", part)
+        .text("category", category.to_string())
+        .text("paused", "true")
+        .text("stopped", "true");
+    let resp = client
+        .post(format!("{base_url}/api/v2/torrents/add"))
+        .multipart(form)
+        .send()
+        .await
+        .expect("qBit add");
+    assert_eq!(resp.status(), 200, "qBit add returned {}", resp.status());
+
+    // qBit's add endpoint doesn't return the hash directly; poll
+    // by category to find the newly-added torrent.
+    for _ in 0..10 {
+        tokio::time::sleep(std::time::Duration::from_millis(300)).await;
+        let list_resp = client
+            .get(format!(
+                "{base_url}/api/v2/torrents/info?category={category}"
+            ))
+            .send()
+            .await
+            .expect("qBit list");
+        let torrents: Vec<serde_json::Value> = list_resp.json().await.expect("qBit list json");
+        // Return the FIRST torrent matching this category — callers
+        // that upload multiple torrents to the same category must
+        // use distinct categories per torrent or capture before the
+        // second upload.
+        if let Some(first) = torrents.first()
+            && let Some(hash) = first.get("hash").and_then(|v| v.as_str())
+        {
+            return hash.to_string();
+        }
+    }
+    panic!("uploaded torrent never appeared in category {category}");
+}
+
 fn build_inner(name: &str, with_name_file: bool) -> Option<(tempfile::TempDir, PathBuf)> {
     if std::process::Command::new("transmission-create")
         .arg("--version")

--- a/src/services/download_client/test_helpers.rs
+++ b/src/services/download_client/test_helpers.rs
@@ -58,14 +58,15 @@ pub(crate) fn build_named_torrent(name: &str) -> Option<(tempfile::TempDir, Path
 /// Upload a local `.torrent` file to qBit via the multipart
 /// `torrents/add` endpoint with `paused=true` and `stopped=true`
 /// (qBit 5.x renamed the flag — pass both to survive either
-/// version), scoped to the given category. Returns the infohash
-/// qBit assigned after polling `list_scoped` for appearance.
+/// version), scoped to the given category. Computes the v1 infohash
+/// up front from the `.torrent` bytes and polls for that *specific*
+/// hash to confirm registration — safe to call multiple times
+/// against the same category (unlike a first-in-category lookup,
+/// which would race).
 ///
-/// Shared between `qbittorrent::tests::live_smoke_*` and
-/// handler-level Wave 2 integration tests. The production
-/// `QbitClient::add_torrent` only accepts URL strings (magnet/HTTP);
-/// this helper injects a synthetic file-backed torrent via the
-/// multipart route that production code doesn't use.
+/// Returns the confirmed hash once qBit has it. Shared between
+/// `qbittorrent::tests::live_smoke_*` and handler-level Wave 2
+/// integration tests.
 pub(crate) async fn upload_torrent_file_qbit(
     base_url: &str,
     user: &str,
@@ -73,6 +74,13 @@ pub(crate) async fn upload_torrent_file_qbit(
     category: &str,
     torrent_path: &std::path::Path,
 ) -> String {
+    let bytes = std::fs::read(torrent_path).expect("read .torrent");
+    // Pre-compute the expected infohash so we poll for a specific
+    // hash rather than trusting "whatever's in the category first."
+    let expected = bencode_info_hash(&bytes)
+        .expect("bencode_info_hash on uploaded .torrent")
+        .to_ascii_lowercase();
+
     let client = reqwest::Client::builder()
         .cookie_store(true)
         .build()
@@ -84,7 +92,6 @@ pub(crate) async fn upload_torrent_file_qbit(
         .await
         .expect("qBit login");
     assert_eq!(login.status(), 200, "qBit login failed");
-    let bytes = std::fs::read(torrent_path).expect("read .torrent");
     let part = reqwest::multipart::Part::bytes(bytes)
         .file_name("testpack.torrent")
         .mime_str("application/x-bittorrent")
@@ -102,29 +109,86 @@ pub(crate) async fn upload_torrent_file_qbit(
         .expect("qBit add");
     assert_eq!(resp.status(), 200, "qBit add returned {}", resp.status());
 
-    // qBit's add endpoint doesn't return the hash directly; poll
-    // by category to find the newly-added torrent.
+    // Poll `/torrents/info?hashes=<expected>` — qBit filters by hash
+    // directly, so we don't care about category isolation. Concurrent
+    // tests sharing a category are safe.
     for _ in 0..10 {
         tokio::time::sleep(std::time::Duration::from_millis(300)).await;
         let list_resp = client
-            .get(format!(
-                "{base_url}/api/v2/torrents/info?category={category}"
-            ))
+            .get(format!("{base_url}/api/v2/torrents/info?hashes={expected}"))
             .send()
             .await
-            .expect("qBit list");
-        let torrents: Vec<serde_json::Value> = list_resp.json().await.expect("qBit list json");
-        // Return the FIRST torrent matching this category — callers
-        // that upload multiple torrents to the same category must
-        // use distinct categories per torrent or capture before the
-        // second upload.
-        if let Some(first) = torrents.first()
-            && let Some(hash) = first.get("hash").and_then(|v| v.as_str())
-        {
-            return hash.to_string();
+            .expect("qBit info-by-hash");
+        let torrents: Vec<serde_json::Value> =
+            list_resp.json().await.expect("qBit info-by-hash json");
+        if torrents.iter().any(|t| {
+            t.get("hash")
+                .and_then(|v| v.as_str())
+                .map(|h| h.eq_ignore_ascii_case(&expected))
+                .unwrap_or(false)
+        }) {
+            return expected;
         }
     }
-    panic!("uploaded torrent never appeared in category {category}");
+    panic!("uploaded torrent {expected} never registered in qBit");
+}
+
+/// Compute the v1 infohash of a `.torrent` by SHA1'ing the raw
+/// bencoded `info` dict. Minimal hand-parse — finds the `4:info`
+/// key at the top level, then slices the bencoded dict that
+/// follows. Doesn't validate the rest of the `.torrent` structure;
+/// assumes well-formed input from `transmission-create` (which all
+/// test helpers in this module produce).
+///
+/// Shared between the rtorrent smoke (where `load.raw_start_verbose`
+/// returns 0 rather than echoing back the hash, so we compute it
+/// ourselves) and `upload_torrent_file_qbit` (which uses it to poll
+/// qBit's `/torrents/info` for a specific hash rather than
+/// first-in-category — makes the helper safe to call multiple times
+/// against the same category).
+pub(crate) fn bencode_info_hash(bytes: &[u8]) -> Option<String> {
+    let key = b"4:info";
+    let start = find_subslice(bytes, key)? + key.len();
+    let end = bencode_end(bytes, start)?;
+    let info_slice = &bytes[start..end];
+    let mut hasher = sha1_smol::Sha1::new();
+    hasher.update(info_slice);
+    Some(hasher.digest().to_string())
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Given a bencoded value starting at `start`, return the index
+/// just past its end. Handles dicts (`d...e`), lists (`l...e`),
+/// ints (`i...e`), and byte-strings (`N:...`) — the full bencode
+/// grammar. Returns `None` on malformed input.
+fn bencode_end(bytes: &[u8], start: usize) -> Option<usize> {
+    let mut i = start;
+    if i >= bytes.len() {
+        return None;
+    }
+    match bytes[i] {
+        b'd' | b'l' => {
+            i += 1;
+            while i < bytes.len() && bytes[i] != b'e' {
+                i = bencode_end(bytes, i)?;
+            }
+            if i < bytes.len() { Some(i + 1) } else { None }
+        }
+        b'i' => {
+            let e = find_subslice(&bytes[i..], b"e")? + i;
+            Some(e + 1)
+        }
+        b'0'..=b'9' => {
+            let colon = bytes[i..].iter().position(|&b| b == b':')? + i;
+            let len_str = std::str::from_utf8(&bytes[i..colon]).ok()?;
+            let len: usize = len_str.parse().ok()?;
+            Some(colon + 1 + len)
+        }
+        _ => None,
+    }
 }
 
 fn build_inner(name: &str, with_name_file: bool) -> Option<(tempfile::TempDir, PathBuf)> {

--- a/src/services/download_client/test_helpers.rs
+++ b/src/services/download_client/test_helpers.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 /// missing). Returns `None` with a printed skip message if
 /// `transmission-create` isn't installed.
 ///
-/// File layout (7 files, mirrors a typical anime batch):
+/// The default file layout (7 files, mirrors a typical anime batch):
 /// * `testpack/episode_1.mkv` .. `episode_5.mkv` — 8 KB each, the
 ///   "wanted" subset for narrowing tests.
 /// * `testpack/sample.mkv` — 2 KB, what `pick_wanted_file_indices`
@@ -33,6 +33,29 @@ use std::path::PathBuf;
 /// without ever attempting to actually download content (the fake
 /// tracker URL is unreachable anyway).
 pub(crate) fn build_testpack_torrent() -> Option<(tempfile::TempDir, PathBuf)> {
+    build_inner("testpack", false)
+}
+
+/// Like [`build_testpack_torrent`] but takes a unique name and
+/// injects it as file content so multiple calls produce *distinct*
+/// infohashes. The directory name is baked into one file
+/// (`pack_name.txt`) so two invocations with different `name`
+/// arguments produce torrents whose `info` dicts differ →
+/// different SHA-1 → different hashes.
+///
+/// Used by tests that need two or more torrents in the client at
+/// once (e.g. B2 list_scoped exclusion: one Ryokan-scoped and one
+/// non-Ryokan, both present in the client, only the first should
+/// appear in `list_scoped`).
+///
+/// File count is 8 (the canonical 7 + `pack_name.txt`), which is
+/// why this is a separate function rather than reusing
+/// [`build_testpack_torrent`]'s 7-file assertion.
+pub(crate) fn build_named_torrent(name: &str) -> Option<(tempfile::TempDir, PathBuf)> {
+    build_inner(name, true)
+}
+
+fn build_inner(name: &str, with_name_file: bool) -> Option<(tempfile::TempDir, PathBuf)> {
     if std::process::Command::new("transmission-create")
         .arg("--version")
         .output()
@@ -42,15 +65,19 @@ pub(crate) fn build_testpack_torrent() -> Option<(tempfile::TempDir, PathBuf)> {
         return None;
     }
     let tmp = tempfile::tempdir().expect("tempdir creation failed");
-    let pack_dir = tmp.path().join("testpack");
-    std::fs::create_dir(&pack_dir).expect("create testpack dir");
+    let pack_dir = tmp.path().join(name);
+    std::fs::create_dir(&pack_dir).expect("create pack dir");
     for i in 1..=5 {
         std::fs::write(pack_dir.join(format!("episode_{i}.mkv")), vec![0u8; 8192])
             .expect("write episode file");
     }
     std::fs::write(pack_dir.join("sample.mkv"), vec![0u8; 2048]).expect("write sample");
     std::fs::write(pack_dir.join("readme.txt"), b"test readme").expect("write readme");
-    let torrent_path = tmp.path().join("testpack.torrent");
+    if with_name_file {
+        // Name-specific content so distinct names produce distinct hashes.
+        std::fs::write(pack_dir.join("pack_name.txt"), name.as_bytes()).expect("write pack_name");
+    }
+    let torrent_path = tmp.path().join(format!("{name}.torrent"));
     let output = std::process::Command::new("transmission-create")
         .args([
             "-o",

--- a/src/services/download_client/test_helpers.rs
+++ b/src/services/download_client/test_helpers.rs
@@ -1,0 +1,70 @@
+//! Shared helpers for the per-client `live_smoke*` tests. Only
+//! compiled under `#[cfg(test)]`.
+//!
+//! The smoke tests exercise each `DownloadClient` impl against a
+//! real running daemon (qBittorrent / Deluge / Transmission /
+//! rtorrent on localhost). They use synthetic `.torrent` files
+//! built on-the-fly via shell-out to `transmission-create` rather
+//! than depending on a public magnet's DHT metadata fetch landing
+//! during the test window — magnets are flaky in containerized
+//! networks and make the tests non-deterministic. The synthetic
+//! approach gives every test run the same file layout with the same
+//! priorities-post-narrow assertions.
+
+use std::path::PathBuf;
+
+/// Build a synthetic multi-file `.torrent` in a tempdir via
+/// `transmission-create`. Returns `(tempdir_guard, torrent_path)` —
+/// the tempdir handle must outlive the test so the dummy files
+/// remain on disk for clients that check file-existence at add time
+/// (some clients refuse to add a torrent whose source files are
+/// missing). Returns `None` with a printed skip message if
+/// `transmission-create` isn't installed.
+///
+/// File layout (7 files, mirrors a typical anime batch):
+/// * `testpack/episode_1.mkv` .. `episode_5.mkv` — 8 KB each, the
+///   "wanted" subset for narrowing tests.
+/// * `testpack/sample.mkv` — 2 KB, what `pick_wanted_file_indices`
+///   classifies as likely-unwanted extras.
+/// * `testpack/readme.txt` — 512 B, explicitly unwanted sidecar.
+///
+/// Content is all-zero bytes. That's fine because the smoke tests
+/// always pause immediately after upload and verify priorities
+/// without ever attempting to actually download content (the fake
+/// tracker URL is unreachable anyway).
+pub(crate) fn build_testpack_torrent() -> Option<(tempfile::TempDir, PathBuf)> {
+    if std::process::Command::new("transmission-create")
+        .arg("--version")
+        .output()
+        .is_err()
+    {
+        eprintln!("skipping: transmission-create not installed");
+        return None;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir creation failed");
+    let pack_dir = tmp.path().join("testpack");
+    std::fs::create_dir(&pack_dir).expect("create testpack dir");
+    for i in 1..=5 {
+        std::fs::write(pack_dir.join(format!("episode_{i}.mkv")), vec![0u8; 8192])
+            .expect("write episode file");
+    }
+    std::fs::write(pack_dir.join("sample.mkv"), vec![0u8; 2048]).expect("write sample");
+    std::fs::write(pack_dir.join("readme.txt"), b"test readme").expect("write readme");
+    let torrent_path = tmp.path().join("testpack.torrent");
+    let output = std::process::Command::new("transmission-create")
+        .args([
+            "-o",
+            torrent_path.to_str().unwrap(),
+            "-t",
+            "http://localhost:1/announce",
+        ])
+        .arg(&pack_dir)
+        .output()
+        .expect("transmission-create spawn failed");
+    assert!(
+        output.status.success(),
+        "transmission-create failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Some((tmp, torrent_path))
+}

--- a/src/services/download_client/transmission.rs
+++ b/src/services/download_client/transmission.rs
@@ -1096,10 +1096,230 @@ mod tests {
         }
         eprintln!("C2 re-narrow verified");
 
+        // A7: delete with delete_files=true removes torrent + files
         client
             .delete(&info_hash, true)
             .await
-            .expect("cleanup delete failed");
+            .expect("delete(hash, true) failed");
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+        let after = client
+            .list_scoped()
+            .await
+            .expect("list_scoped after delete(true) failed");
+        assert!(
+            !after
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&info_hash)),
+            "A7: torrent must not survive delete(_, true)"
+        );
+        eprintln!("A7 delete(true) verified");
         eprintln!("narrowed-smoke passed");
+    }
+
+    /// Live smoke for B2: Transmission `list_scoped` filters by
+    /// native label (4.x labels feature). A torrent with a different
+    /// label must not surface in Ryokan's scoped list.
+    ///
+    ///     RYOKAN_TRANSMISSION_E2E=1 cargo test \
+    ///       transmission::tests::live_smoke_scoped_exclusion -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live Transmission at localhost:9091 + transmission-create"]
+    async fn live_smoke_scoped_exclusion() {
+        if std::env::var("RYOKAN_TRANSMISSION_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_TRANSMISSION_E2E=1 to run against localhost:9091)");
+            return;
+        }
+        let Some((_tmp1, torrent1)) =
+            super::super::test_helpers::build_named_torrent("ryokan-scoped-test")
+        else {
+            return;
+        };
+        let Some((_tmp2, torrent2)) =
+            super::super::test_helpers::build_named_torrent("other-tool-test")
+        else {
+            return;
+        };
+        let base_url = "http://localhost:9091";
+        let user = "transmission";
+        let pass = "transmission";
+        let ryokan_label = "ryokan-e2e-scope";
+        let foreign_label = "other-tool-scope";
+
+        let ryokan_hash =
+            upload_torrent_file_transmission(base_url, user, pass, ryokan_label, &torrent1).await;
+        let foreign_hash =
+            upload_torrent_file_transmission(base_url, user, pass, foreign_label, &torrent2).await;
+        eprintln!("ryokan={ryokan_hash} foreign={foreign_hash}");
+        assert_ne!(ryokan_hash, foreign_hash);
+
+        let client = TransmissionClient::new(base_url, user, pass, ryokan_label);
+        let list = client.list_scoped().await.expect("list_scoped");
+
+        assert!(
+            list.iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&ryokan_hash)),
+            "B2: Ryokan-labeled torrent must appear"
+        );
+        assert!(
+            !list
+                .iter()
+                .any(|t| t.hash.eq_ignore_ascii_case(&foreign_hash)),
+            "B2: foreign-labeled torrent must NOT appear (found {foreign_hash})"
+        );
+        eprintln!("B2 scoped exclusion verified");
+
+        client
+            .delete(&ryokan_hash, true)
+            .await
+            .expect("cleanup ryokan");
+        let foreign_client = TransmissionClient::new(base_url, user, pass, foreign_label);
+        foreign_client
+            .delete(&foreign_hash, true)
+            .await
+            .expect("cleanup foreign");
+        eprintln!("scoped-exclusion smoke passed");
+    }
+
+    /// Error-path live smoke (F1 / F2 / F3) against Transmission.
+    #[tokio::test]
+    #[ignore = "requires live Transmission at localhost:9091"]
+    async fn live_smoke_error_paths() {
+        if std::env::var("RYOKAN_TRANSMISSION_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let client = TransmissionClient::new(
+            "http://localhost:9091",
+            "transmission",
+            "transmission",
+            "ryokan-e2e-errs",
+        );
+        let fake_hash = "0000000000000000000000000000000000000000";
+
+        let result = client.delete(fake_hash, false).await;
+        eprintln!("F1 Transmission delete(non-existent) → {result:?}");
+
+        let result = client.get_files(fake_hash).await;
+        eprintln!("F2 Transmission get_files(non-existent) → {result:?}");
+        if let Ok(files) = result {
+            assert!(files.is_empty(), "F2: Ok result must be empty");
+        }
+
+        let result = client
+            .add_torrent("this-is-not-a-valid-url-or-magnet", fake_hash)
+            .await;
+        eprintln!("F3 Transmission add(malformed) → {result:?}");
+        assert!(
+            result.is_err(),
+            "F3: add_torrent with malformed URL must return Err (got {result:?})"
+        );
+
+        eprintln!("error-paths smoke passed");
+    }
+
+    /// E1+E2 live smoke for Transmission.
+    #[tokio::test]
+    #[ignore = "requires live Transmission at localhost:9091 + transmission-create"]
+    async fn live_smoke_state_progress() {
+        if std::env::var("RYOKAN_TRANSMISSION_E2E").is_err() {
+            eprintln!("skipping");
+            return;
+        }
+        let Some((_tmp, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let base_url = "http://localhost:9091";
+        let user = "transmission";
+        let pass = "transmission";
+        let label = "ryokan-e2e-state";
+
+        let info_hash =
+            upload_torrent_file_transmission(base_url, user, pass, label, &torrent_path).await;
+        let client = TransmissionClient::new(base_url, user, pass, label);
+
+        async fn poll_until_state(
+            client: &TransmissionClient,
+            hash: &str,
+            acceptable: &[DownloadItemState],
+        ) -> DownloadItem {
+            for _ in 0..30 {
+                let list = client.list_scoped().await.expect("list_scoped");
+                if let Some(t) = list
+                    .iter()
+                    .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                    .cloned()
+                    && acceptable.contains(&t.state_kind)
+                {
+                    return t;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(250)).await;
+            }
+            let list = client.list_scoped().await.expect("list_scoped");
+            list.iter()
+                .find(|t| t.hash.eq_ignore_ascii_case(hash))
+                .cloned()
+                .unwrap_or_else(|| panic!("torrent never appeared"))
+        }
+
+        // Uploaded with paused=true → expect Paused.
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 Transmission paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Paused | DownloadItemState::PausedComplete
+        ));
+        assert!((0.0..=1.0).contains(&t.progress));
+
+        client.resume(&info_hash).await.expect("resume");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[
+                DownloadItemState::Downloading,
+                DownloadItemState::DownloadingStalled,
+                DownloadItemState::DownloadingQueued,
+                DownloadItemState::CheckingDownload,
+            ],
+        )
+        .await;
+        eprintln!(
+            "E1 Transmission resumed: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Downloading
+                | DownloadItemState::DownloadingStalled
+                | DownloadItemState::DownloadingQueued
+                | DownloadItemState::CheckingDownload
+        ));
+
+        client.pause(&info_hash).await.expect("pause");
+        let t = poll_until_state(
+            &client,
+            &info_hash,
+            &[DownloadItemState::Paused, DownloadItemState::PausedComplete],
+        )
+        .await;
+        eprintln!(
+            "E1 Transmission re-paused: state={:?} ({}) progress={}",
+            t.state_kind, t.state, t.progress
+        );
+        assert!(matches!(
+            t.state_kind,
+            DownloadItemState::Paused | DownloadItemState::PausedComplete
+        ));
+
+        client.delete(&info_hash, true).await.expect("cleanup");
+        eprintln!("state-progress smoke passed");
     }
 }

--- a/src/services/download_client/transmission.rs
+++ b/src/services/download_client/transmission.rs
@@ -888,4 +888,218 @@ mod tests {
         );
         eprintln!("smoke passed");
     }
+
+    /// Upload a local `.torrent` to Transmission via `torrent-add`
+    /// RPC with the `metainfo` field (base64-encoded bytes), applying
+    /// `paused=true` and the Ryokan label at add time. Returns the
+    /// infohash Transmission assigned.
+    ///
+    /// Handles Transmission's CSRF session handshake: first request
+    /// returns HTTP 409 with an `X-Transmission-Session-Id` header
+    /// that must be echoed on every subsequent request. Documented
+    /// in `transmission.rs`'s file header and in CLAUDE.md's
+    /// download-client quirks.
+    async fn upload_torrent_file_transmission(
+        base_url: &str,
+        user: &str,
+        pass: &str,
+        label: &str,
+        torrent_path: &std::path::Path,
+    ) -> String {
+        use base64::{Engine, engine::general_purpose};
+        use serde_json::{Value, json};
+        let client = reqwest::Client::builder().build().expect("reqwest client");
+        let bytes = std::fs::read(torrent_path).expect("read .torrent");
+        let b64 = general_purpose::STANDARD.encode(&bytes);
+
+        let body = json!({
+            "method": "torrent-add",
+            "arguments": {
+                "metainfo": b64,
+                "paused": true,
+                "labels": [label.to_string()],
+            },
+        });
+
+        // First attempt — expect 409 + session header.
+        let first = client
+            .post(format!("{base_url}/transmission/rpc"))
+            .basic_auth(user, Some(pass))
+            .json(&body)
+            .send()
+            .await
+            .expect("transmission first POST");
+        let session_id = first
+            .headers()
+            .get("X-Transmission-Session-Id")
+            .map(|v| v.to_str().expect("session id utf8").to_string());
+        // If Transmission returned 200 already (no auth required), use it.
+        let resp: Value = if first.status() == 200 {
+            first.json().await.expect("transmission first json")
+        } else {
+            assert_eq!(
+                first.status(),
+                409,
+                "Transmission expected 409 for CSRF handshake, got {}",
+                first.status()
+            );
+            let sid =
+                session_id.expect("Transmission 409 without X-Transmission-Session-Id header");
+            let retry = client
+                .post(format!("{base_url}/transmission/rpc"))
+                .basic_auth(user, Some(pass))
+                .header("X-Transmission-Session-Id", sid)
+                .json(&body)
+                .send()
+                .await
+                .expect("transmission retry POST");
+            assert_eq!(
+                retry.status(),
+                200,
+                "Transmission retry returned HTTP {}",
+                retry.status()
+            );
+            retry.json().await.expect("transmission retry json")
+        };
+
+        // Response shape: {"result": "success",
+        //                  "arguments": {"torrent-added": {"hashString": "...", ...}}}
+        // or              {"result": "success",
+        //                  "arguments": {"torrent-duplicate": {"hashString": "...", ...}}}
+        assert_eq!(
+            resp.get("result").and_then(|v| v.as_str()),
+            Some("success"),
+            "Transmission torrent-add result: {resp}"
+        );
+        let args = resp.get("arguments").expect("missing arguments");
+        let added = args
+            .get("torrent-added")
+            .or_else(|| args.get("torrent-duplicate"))
+            .expect("neither torrent-added nor torrent-duplicate in response");
+        added
+            .get("hashString")
+            .and_then(|v| v.as_str())
+            .expect("missing hashString")
+            .to_string()
+    }
+
+    /// Live smoke covering `add_torrent_with_file_filter` narrowing
+    /// (C1) and the re-narrow preservation contract (C2) against
+    /// Transmission. Mirrors the qBit/Deluge equivalents at the
+    /// intent layer; differs at the wire-protocol layer (CSRF
+    /// session handshake, `files-wanted`/`files-unwanted` file
+    /// priority shape).
+    ///
+    ///     RYOKAN_TRANSMISSION_E2E=1 cargo test \
+    ///       transmission::tests::live_smoke_narrowed -- --ignored --nocapture
+    #[tokio::test]
+    #[ignore = "requires live Transmission at localhost:9091 + transmission-create"]
+    async fn live_smoke_narrowed() {
+        if std::env::var("RYOKAN_TRANSMISSION_E2E").is_err() {
+            eprintln!("skipping (set RYOKAN_TRANSMISSION_E2E=1 to run against localhost:9091)");
+            return;
+        }
+        let Some((_tmp_guard, torrent_path)) = super::super::test_helpers::build_testpack_torrent()
+        else {
+            return;
+        };
+        let base_url = "http://localhost:9091";
+        let user = "transmission";
+        let pass = "transmission";
+        let label = "ryokan-e2e-narrow";
+
+        let info_hash =
+            upload_torrent_file_transmission(base_url, user, pass, label, &torrent_path).await;
+        eprintln!("uploaded testpack hash={info_hash}");
+
+        let client = TransmissionClient::new(base_url, user, pass, label);
+
+        let files = client
+            .get_files(&info_hash)
+            .await
+            .expect("get_files should return metadata immediately");
+        assert_eq!(
+            files.len(),
+            7,
+            "synthetic testpack should have 7 files, got {}",
+            files.len()
+        );
+        assert!(
+            files.iter().all(|f| f.wanted),
+            "all files should start wanted=true before narrow"
+        );
+
+        let episode_indices: Vec<usize> = files
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| f.name.contains("episode_").then_some(i))
+            .collect();
+        assert_eq!(episode_indices.len(), 5, "expected 5 episode files");
+
+        let expected_episode_indices = episode_indices.clone();
+        let magnet = format!("magnet:?xt=urn:btih:{info_hash}");
+        let outcome = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_episode_indices.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C1 failed");
+
+        match outcome {
+            SelectiveOutcome::Filtered(kept) => {
+                let mut sorted_kept = kept.clone();
+                sorted_kept.sort_unstable();
+                let mut sorted_expected = episode_indices.clone();
+                sorted_expected.sort_unstable();
+                assert_eq!(sorted_kept, sorted_expected);
+            }
+            SelectiveOutcome::FullDownload => panic!("C1 expected Filtered, got FullDownload"),
+        }
+
+        let files_after_c1 = client.get_files(&info_hash).await.expect("get_files C1");
+        for (i, f) in files_after_c1.iter().enumerate() {
+            let should_be_wanted = episode_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C1 post-narrow: [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C1 narrowing verified");
+
+        let expanded_indices: Vec<usize> = files_after_c1
+            .iter()
+            .enumerate()
+            .filter_map(|(i, f)| {
+                (f.name.contains("episode_") || f.name.contains("sample")).then_some(i)
+            })
+            .collect();
+        assert_eq!(expanded_indices.len(), 6);
+
+        let expected_expanded = expanded_indices.clone();
+        let outcome2 = client
+            .add_torrent_with_file_filter(&magnet, &info_hash, &mut |_names| {
+                Some(expected_expanded.clone())
+            })
+            .await
+            .expect("add_torrent_with_file_filter C2 failed");
+        assert!(matches!(outcome2, SelectiveOutcome::Filtered(_)));
+
+        let files_after_c2 = client.get_files(&info_hash).await.expect("get_files C2");
+        for (i, f) in files_after_c2.iter().enumerate() {
+            let should_be_wanted = expanded_indices.contains(&i);
+            assert_eq!(
+                f.wanted, should_be_wanted,
+                "C2 post-renarrow: [{i}] ({}) wanted={} expected={}",
+                f.name, f.wanted, should_be_wanted
+            );
+        }
+        eprintln!("C2 re-narrow verified");
+
+        client
+            .delete(&info_hash, true)
+            .await
+            .expect("cleanup delete failed");
+        eprintln!("narrowed-smoke passed");
+    }
 }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -96,22 +96,36 @@ pub(crate) async fn seed_series(db: &SqlitePool, anilist_id: i64, title: &str) -
         .expect("fetch seeded series id")
 }
 
-/// Seed one `grabbed_torrents` row. Sets the `state` to `"pending"`
-/// (the default) unless the caller passes a different value. Returns
-/// the auto-generated id.
+/// Seed one `grabbed_torrents` row with the given episode-numbers
+/// list. Passing an empty slice defaults to `[1]` so simple single-
+/// episode tests can skip the argument. Writes `state = 'pending'`;
+/// callers that need `imported` / `failed` / `replaced` should
+/// `UPDATE` the row after seeding. Returns the auto-generated id.
 pub(crate) async fn seed_grabbed_torrent(
     db: &SqlitePool,
     series_id: i64,
     hash: &str,
     torrent_name: &str,
+    episode_numbers: &[i32],
 ) -> i64 {
+    // `grabbed_torrents.episode_numbers` is a JSON-encoded array
+    // (matches the production schema). Serialize with serde_json so
+    // we don't hand-build the string and accidentally quote numbers.
+    let eps_default: Vec<i32> = vec![1];
+    let eps = if episode_numbers.is_empty() {
+        &eps_default[..]
+    } else {
+        episode_numbers
+    };
+    let eps_json = serde_json::to_string(eps).expect("serialize episode_numbers");
     sqlx::query(
         "INSERT INTO grabbed_torrents (series_id, hash, torrent_name, episode_numbers, state) \
-         VALUES (?, ?, ?, '[1]', 'pending')",
+         VALUES (?, ?, ?, ?, 'pending')",
     )
     .bind(series_id)
     .bind(hash)
     .bind(torrent_name)
+    .bind(eps_json)
     .execute(db)
     .await
     .expect("seed grabbed_torrent");

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,0 +1,142 @@
+//! Test-only scaffolding for integration-style tests that need a live
+//! `AppState` with an in-memory database, and optionally a real
+//! `DownloadClient` connection so assertions can verify end-to-end
+//! state across the handler-to-client boundary.
+//!
+//! The Wave 1 smoke tests in `services::download_client::*::tests`
+//! verify the `DownloadClient` trait contract in isolation. Wave 2
+//! (`handlers::library::*::tests` and friends) asserts the chain from
+//! a handler call → DB mutation → downstream `DownloadClient::delete`
+//! happens correctly. For that we need an AppState with both a real
+//! `SqlitePool` and a real `DownloadClient` — hence this module.
+//!
+//! Only compiled under `#[cfg(test)]`; adds no weight to release
+//! binaries. Gated further (at each call site) behind the per-client
+//! `RYOKAN_*_E2E` env vars that Wave 1 uses — tests that don't have
+//! a live daemon available early-return without touching the DB.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use sqlx::SqlitePool;
+use tokio::sync::RwLock;
+
+use crate::AppState;
+use crate::services::custom_formats::CompiledCfCache;
+use crate::services::download_client::DownloadClient;
+use crate::services::progress::ProgressRegistry;
+
+/// Create a fresh in-memory SQLite pool with the full schema applied.
+/// Each call gets its own isolated `:memory:` database so tests run
+/// concurrently without cross-test contamination.
+///
+/// Applies the same `migrate()` call the production bootstrap runs —
+/// tests exercise the real schema including every `ALTER TABLE ...
+/// ADD COLUMN` the idempotent migration pattern lays down at startup.
+pub(crate) async fn in_memory_pool() -> SqlitePool {
+    let pool = SqlitePool::connect(":memory:")
+        .await
+        .expect("open :memory: SQLite");
+    crate::models::migrations::migrate(&pool)
+        .await
+        .expect("run migrations");
+    pool
+}
+
+/// Construct an `AppState` suitable for handler-level integration
+/// testing. Accepts a pre-built pool (from [`in_memory_pool`]) and an
+/// optional download-client slot — Wave 2 tests that verify
+/// delete-on-removal etc. plug a real `Arc<dyn DownloadClient>` in;
+/// tests that don't care pass `None`.
+///
+/// Defaults for the non-DB fields:
+/// * `jellyfin` — `None` (Wave 2 doesn't exercise Jellyfin integration).
+/// * `custom_formats` — empty Vec inside the usual `Arc<RwLock<_>>`.
+///   Scoring paths that look up CFs will see the zero-CF fallback,
+///   which is fine since Wave 2 focuses on library/download state
+///   rather than scoring.
+/// * `progress` — fresh `ProgressRegistry`. No jobs registered.
+/// * `users_exist` — `true`. Bypasses the `/setup`-redirect path so
+///   Wave 2 handler calls don't need to invent an authenticated
+///   session for every fixture.
+pub(crate) fn build_test_app_state(
+    db: SqlitePool,
+    download_client: Option<Arc<dyn DownloadClient>>,
+) -> AppState {
+    let cf_cache: CompiledCfCache = Arc::new(RwLock::new(Arc::new(Vec::new())));
+    AppState {
+        db,
+        download_client: Arc::new(RwLock::new(download_client)),
+        jellyfin: Arc::new(RwLock::new(None)),
+        custom_formats: cf_cache,
+        progress: ProgressRegistry::new(),
+        users_exist: Arc::new(AtomicBool::new(true)),
+    }
+}
+
+/// Seed one `series` row and return its auto-generated id. Fills in
+/// the minimum required columns; callers pass `anilist_id` (the
+/// unique external key) + `title`.
+pub(crate) async fn seed_series(db: &SqlitePool, anilist_id: i64, title: &str) -> i64 {
+    sqlx::query(
+        "INSERT INTO series (anilist_id, title, title_romaji, folder_name) \
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(anilist_id)
+    .bind(title)
+    .bind(title)
+    .bind(title)
+    .execute(db)
+    .await
+    .expect("seed series");
+    sqlx::query_scalar::<_, i64>("SELECT id FROM series WHERE anilist_id = ?")
+        .bind(anilist_id)
+        .fetch_one(db)
+        .await
+        .expect("fetch seeded series id")
+}
+
+/// Seed one `grabbed_torrents` row. Sets the `state` to `"pending"`
+/// (the default) unless the caller passes a different value. Returns
+/// the auto-generated id.
+pub(crate) async fn seed_grabbed_torrent(
+    db: &SqlitePool,
+    series_id: i64,
+    hash: &str,
+    torrent_name: &str,
+) -> i64 {
+    sqlx::query(
+        "INSERT INTO grabbed_torrents (series_id, hash, torrent_name, episode_numbers, state) \
+         VALUES (?, ?, ?, '[1]', 'pending')",
+    )
+    .bind(series_id)
+    .bind(hash)
+    .bind(torrent_name)
+    .execute(db)
+    .await
+    .expect("seed grabbed_torrent");
+    sqlx::query_scalar::<_, i64>("SELECT last_insert_rowid()")
+        .fetch_one(db)
+        .await
+        .expect("fetch grab id")
+}
+
+/// Count `grabbed_torrents` rows for a given series — quick helper
+/// for post-op assertions like "D1: after series remove, zero grab
+/// rows remain."
+pub(crate) async fn count_grabs_for_series(db: &SqlitePool, series_id: i64) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM grabbed_torrents WHERE series_id = ?")
+        .bind(series_id)
+        .fetch_one(db)
+        .await
+        .expect("count grabs")
+}
+
+/// Count rows in the `series` table. Helper for "series was deleted"
+/// assertions.
+pub(crate) async fn count_series(db: &SqlitePool) -> i64 {
+    sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM series")
+        .fetch_one(db)
+        .await
+        .expect("count series")
+}


### PR DESCRIPTION
## Summary

- Wave 1 of #85 (download-client feature-parity): 16 new env-gated `live_smoke_*` tests covering every trait method across all four clients (qBit / Deluge / Transmission / rtorrent) — C1+C2 narrowed-add + re-narrow preservation, A7 delete-with-files, B2 scoped-exclusion, E1+E2 state/progress, F1+F2+F3 error paths.
- Wave 2: test-only scaffolding at \`src/test_support.rs\` (in-memory SqlitePool + migrations, AppState builder, fixture helpers) plus two handler-level integration tests — D1 (\`remove_series\` cascade delete) and D2/D3 (\`cancel_pending_episode\`). D4/D5 deferred — flagged in the commit body as needing prior handler-extraction refactors before clean integration testing is possible.
- **Two real parity bugs caught and fixed during smoke authoring:**
  1. rtorrent \`add_torrent\` silently accepted malformed URLs (\`load.start_verbose\` returns 0 on garbage input). Added magnet/http(s) scheme validation up front so it matches qBit/Deluge/Transmission's reject-with-Err behavior.
  2. qBit 5.x renamed \`pausedDL\` → \`stoppedDL\` in its state strings; \`map_qbit_state\` fell through to \`Downloading\` default, causing a paused torrent to render as "downloading" in the UI. Added \`stoppedDL\` to the \`Paused\` arm.

New scaffolding pieces worth calling out:

- \`services/download_client/test_helpers.rs\` — synthetic \`.torrent\` builder via \`transmission-create\` (deterministic hashes, no DHT metadata-fetch flakiness), plus \`upload_torrent_file_qbit\` used from both client-level and handler-level tests.
- \`XmlValue::Base64\` variant in rtorrent's XML-RPC encoder — needed for \`load.raw_verbose\` with bytes payload. Production-ready if a future feature wants it.

All smokes are \`#[ignore]\`-d behind \`RYOKAN_{QBIT,DELUGE,TRANSMISSION,RTORRENT}_E2E=1\` env vars so CI never runs them; they're for local validation against a live Docker stack.

## Test plan

- [x] \`cargo fmt --all -- --check\` passes
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` passes
- [x] \`cargo test --workspace --locked --verbose\` passes (CI-visible unit tests unaffected)
- [x] Full smoke suite green against local Docker stack: \`RYOKAN_QBIT_E2E=1 QBIT_PASS=<pw> RYOKAN_DELUGE_E2E=1 RYOKAN_TRANSMISSION_E2E=1 RYOKAN_RTORRENT_E2E=1 cargo test live_smoke -- --ignored --nocapture --test-threads=1\` — 16 smokes + 2 integration tests pass
- [x] qBit 5.x state-mapping regression guarded (existing unit test \`state_mapping_completion_semantics\` still passes post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)