### PR TITLE
feat(#83): PR C — grab-row write, auto-expand, blocklist, grab_preview_mode

### DIFF
--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -174,6 +174,25 @@ pub(crate) fn extract_release_title(release_metadata_json: &str) -> Option<Strin
     }
 }
 
+/// Pull the `is_batch` flag out of the modal's `release_metadata_json`
+/// blob. This is the authoritative source — it reflects the search-hit
+/// listing's batch classification, not the file count — so the post-
+/// download classifier's Layer 4 temporal inference (finished ≥ 1 year
+/// ago + batch ⇒ BluRay) gets the same signal as the non-interactive
+/// auto-search path. Using `files.len() > 1` as a proxy mis-flags a
+/// single-episode release delivered as `.mkv` + `.ass` + `.srt` (common
+/// with SubsPlease-style releases) as a batch, which would wrongly
+/// BluRay-infer on a finished-series WEB release during reclassification.
+/// Returns `None` when the modal posted a blob without the field; the
+/// caller's file-count fallback is fine for older modal payloads.
+pub(crate) fn extract_release_is_batch(release_metadata_json: &str) -> Option<bool> {
+    if release_metadata_json.trim().is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(release_metadata_json).ok()?;
+    value.get("is_batch").and_then(|v| v.as_bool())
+}
+
 fn generate_preview_id() -> String {
     let bytes: [u8; 16] = rand::random();
     hex::encode(bytes)
@@ -606,7 +625,11 @@ pub async fn grab_confirm(
     // no library attribution and no retry path.
     let release_title =
         extract_release_title(&row.release_metadata_json).unwrap_or_else(|| row.info_hash.clone());
-    let is_batch = total > 1;
+    // Prefer the search-hit's batch flag; fall back to file count for
+    // payloads from older modals that didn't forward it. The fallback
+    // is imperfect (`.mkv + subs` produces false positives) but only
+    // fires when a modal predating the fix reaches an updated server.
+    let is_batch = extract_release_is_batch(&row.release_metadata_json).unwrap_or(total > 1);
     let selected_filenames: Vec<String> = wanted
         .iter()
         .filter_map(|&i| files.get(i).map(|f| f.name.clone()))
@@ -1032,6 +1055,44 @@ mod tests {
         // uses the info_hash stand-in rather than writing a blank
         // `torrent_name`.
         assert_eq!(extract_release_title("{\"title\":\"   \"}"), None);
+    }
+
+    #[tokio::test]
+    async fn extract_release_is_batch_prefers_metadata_over_file_count() {
+        // Regression guard on the PR 90 review fix (§1): callers must
+        // not proxy `is_batch` off `files.len() > 1`, because a single-
+        // episode release shipped as `.mkv + .ass + .srt` has three
+        // files but is NOT a batch. Layer 4 reclassification would
+        // then wrongly infer BluRay on a finished-series WEB release.
+        // The authoritative source is the search-hit listing's batch
+        // flag, which the modal forwards through `release_metadata.is_batch`.
+
+        // `None` when no metadata → caller falls back to file count.
+        assert_eq!(extract_release_is_batch(""), None);
+        assert_eq!(extract_release_is_batch("{\"title\":\"x\"}"), None);
+
+        // Explicit `false` → single-episode release; caller MUST NOT
+        // fall back to file-count heuristic.
+        assert_eq!(
+            extract_release_is_batch("{\"title\":\"x\",\"is_batch\":false}"),
+            Some(false)
+        );
+
+        // Explicit `true` → batch.
+        assert_eq!(
+            extract_release_is_batch("{\"title\":\"Pack\",\"is_batch\":true}"),
+            Some(true)
+        );
+
+        // Garbage JSON / wrong types fall through to None so the caller
+        // falls back to the file-count proxy. Better to get a possibly-
+        // wrong default than to panic on a bad payload.
+        assert_eq!(extract_release_is_batch("not json"), None);
+        assert_eq!(
+            extract_release_is_batch("{\"is_batch\":\"yes\"}"),
+            None,
+            "string shouldn't coerce to bool"
+        );
     }
 
     #[tokio::test]

--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::models::pending_grabs;
 use crate::services::download_client::{self, AddOutcome};
+use crate::services::grab_commit;
 
 /// POST body for `/api/grab/preview`.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
@@ -94,6 +95,12 @@ pub struct GrabPreviewStatus {
     /// retry/defaults dialog.
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub error: String,
+    /// True when at least one `grabbed_torrents` row for the preview's
+    /// info_hash is in `state='failed'`. Modal renders an inline
+    /// "previously blocklisted" warning + an Unblock-and-continue
+    /// button that sends `unblock: true` on confirm (plan decision #12).
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub blocklisted: bool,
 }
 
 #[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
@@ -113,6 +120,16 @@ pub struct GrabConfirmForm {
     /// leaves every file at priority 0 and confirmation is what
     /// flips the selection back on).
     pub wanted_indices: Vec<usize>,
+    /// `true` when the user explicitly clicked "Unblock and continue"
+    /// on the inline blocklist warning in the modal. Flips every
+    /// prior `state='failed'` row for this hash to `state='replaced'`
+    /// with a back-pointer to the new grab id. Omitted / `false`
+    /// leaves the blocklist entries alone — the new grab still goes
+    /// through (the partial UNIQUE index on `(hash) WHERE state IN
+    /// ('pending', 'imported')` doesn't exclude 'failed' rows), but
+    /// the Downloads-page blocked list keeps showing the old entry.
+    #[serde(default)]
+    pub unblock: bool,
 }
 
 #[derive(Debug, Serialize, utoipa::ToSchema)]
@@ -137,6 +154,24 @@ pub struct GrabConfirmResult {
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct GrabCancelForm {
     pub preview_id: String,
+}
+
+/// Pluck the user-visible release title out of the `release_metadata_json`
+/// blob the modal posted on preview. Handles both the expected
+/// `{"title": "..."}` shape and the defensive "metadata was garbage"
+/// case by returning `None` so the caller can fall back to the
+/// info-hash as a stand-in.
+pub(crate) fn extract_release_title(release_metadata_json: &str) -> Option<String> {
+    if release_metadata_json.trim().is_empty() {
+        return None;
+    }
+    let value: serde_json::Value = serde_json::from_str(release_metadata_json).ok()?;
+    let title = value.get("title")?.as_str()?.trim();
+    if title.is_empty() {
+        None
+    } else {
+        Some(title.into())
+    }
 }
 
 fn generate_preview_id() -> String {
@@ -395,6 +430,14 @@ pub async fn grab_preview_status(
         serde_json::from_str(&row.release_metadata_json).unwrap_or(serde_json::Value::Null)
     };
 
+    // Blocklist status is read once per poll. Cheap single-row
+    // SELECT on an indexed hash; keeps the modal's "previously
+    // blocklisted" banner accurate even if the user unblocks the
+    // release from Downloads mid-poll.
+    let blocklisted = crate::models::grabbed_torrents::is_blocklisted(&state.db, &row.info_hash)
+        .await
+        .unwrap_or(false);
+
     // Error takes precedence over fetching/ready. If the spawned
     // metadata-fetch task marked an error, surface it immediately so
     // the modal can offer retry/defaults without waiting for the TTL
@@ -406,6 +449,7 @@ pub async fn grab_preview_status(
             release_metadata,
             file_list: Vec::new(),
             error: row.error_message,
+            blocklisted,
         }));
     }
 
@@ -416,6 +460,7 @@ pub async fn grab_preview_status(
             release_metadata,
             file_list: Vec::new(),
             error: String::new(),
+            blocklisted,
         }));
     }
 
@@ -426,6 +471,7 @@ pub async fn grab_preview_status(
         release_metadata,
         file_list,
         error: String::new(),
+        blocklisted,
     }))
 }
 
@@ -548,11 +594,49 @@ pub async fn grab_confirm(
     // running — resume is idempotent.
     let resume_error = client.resume(&row.info_hash).await.err();
 
+    // Library attribution (PR C). Writes the `grabbed_torrents` row
+    // and kicks off sibling auto-expand on the user-selected subset —
+    // files the user unchecked are excluded from the sibling-detection
+    // file list so a deselected sibling (user unchecked all its
+    // episodes) doesn't get a ghost library row. Decision #7.
+    //
+    // We run this BEFORE deleting the pending row so a DB panic inside
+    // commit leaves the pending row for the sweep to retry; if we
+    // deleted first, a failure mid-commit would strand the grab with
+    // no library attribution and no retry path.
+    let release_title =
+        extract_release_title(&row.release_metadata_json).unwrap_or_else(|| row.info_hash.clone());
+    let is_batch = total > 1;
+    let selected_filenames: Vec<String> = wanted
+        .iter()
+        .filter_map(|&i| files.get(i).map(|f| f.name.clone()))
+        .collect();
+    let new_grab_id = grab_commit::commit_grab_and_expand(
+        &state,
+        &row,
+        selected_filenames,
+        &release_title,
+        is_batch,
+    )
+    .await;
+
+    // Inline unblock (plan decision #12). When the user clicked
+    // "Unblock and continue" on the blocklisted-release warning,
+    // flip the old `state='failed'` rows for this hash to
+    // `state='replaced'` with a back-pointer to the fresh grab so
+    // the Downloads-page blocked list drops the stale entry. No-op
+    // when there's no new grab id (dedup hit, missing series
+    // context) — we don't want to clear the blocklist without a
+    // fresh row to point at.
+    if form.unblock
+        && let Some(new_id) = new_grab_id
+    {
+        let _ = crate::models::grabbed_torrents::unblock_by_hash(&state.db, &row.info_hash, new_id)
+            .await;
+    }
+
     // Drop the pending row — the user has committed, so the sweep
-    // should never revisit this preview_id. Grab-row write happens
-    // separately via the existing post-processing pipeline (PR C
-    // scope). For now the caller takes the confirmation as "the
-    // torrent is running with your selections applied."
+    // should never revisit this preview_id.
     pending_grabs::delete(&state.db, &form.preview_id)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
@@ -709,6 +793,7 @@ mod tests {
             Json(GrabConfirmForm {
                 preview_id: "".to_string(),
                 wanted_indices: vec![0],
+                unblock: false,
             }),
         )
         .await;
@@ -724,6 +809,7 @@ mod tests {
             Json(GrabConfirmForm {
                 preview_id: "nope".to_string(),
                 wanted_indices: vec![],
+                unblock: false,
             }),
         )
         .await;
@@ -742,6 +828,7 @@ mod tests {
             Json(GrabConfirmForm {
                 preview_id: "pid-1".to_string(),
                 wanted_indices: vec![],
+                unblock: false,
             }),
         )
         .await;
@@ -925,5 +1012,109 @@ mod tests {
             matches!(res, Err((StatusCode::BAD_REQUEST, _))),
             "error-row dedup suppression failed; got {res:?}"
         );
+    }
+
+    #[tokio::test]
+    async fn extract_release_title_handles_missing_and_present_shapes() {
+        // Defensive: modal posts release_metadata with title; a
+        // browser extension or curl probe could send garbage. We
+        // never want a bad payload to take down the grab-commit
+        // helper, so extract_release_title returns Option and
+        // callers fall back to info_hash.
+        assert_eq!(extract_release_title(""), None);
+        assert_eq!(extract_release_title("not json at all"), None);
+        assert_eq!(extract_release_title("{\"size\":\"1 GB\"}"), None);
+        assert_eq!(
+            extract_release_title("{\"title\":\"[Group] Show - 01.mkv\"}"),
+            Some("[Group] Show - 01.mkv".into())
+        );
+        // Whitespace-only title falls through to None so the caller
+        // uses the info_hash stand-in rather than writing a blank
+        // `torrent_name`.
+        assert_eq!(extract_release_title("{\"title\":\"   \"}"), None);
+    }
+
+    #[tokio::test]
+    async fn preview_status_surfaces_blocklist_flag() {
+        // A prior grab of the same hash with state='failed' should
+        // flip `blocklisted: true` on the preview response so the
+        // modal can render the inline unblock banner. Plan decision
+        // #12.
+        let db = in_memory_pool().await;
+        let series_id = crate::test_support::seed_series(&db, 101, "Test Series").await;
+        // Seed a failed grab row on the hash we're about to preview.
+        let grab_id = crate::models::grabbed_torrents::record_grab(
+            &db,
+            VALID_HASH,
+            "earlier grab",
+            series_id,
+            &[1],
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        crate::models::grabbed_torrents::mark_failed(&db, grab_id)
+            .await
+            .unwrap();
+        // Open a preview on the same hash.
+        pending_grabs::create(
+            &db,
+            "pid-blocked",
+            VALID_HASH,
+            "qbittorrent",
+            None,
+            Some(series_id),
+            "{\"title\":\"Test Release\"}",
+            true,
+        )
+        .await
+        .unwrap();
+
+        let state = build_test_app_state(db, None);
+        let resp = grab_preview_status(State(state), Path("pid-blocked".to_string()))
+            .await
+            .expect("preview status should succeed");
+        assert!(
+            resp.blocklisted,
+            "blocklisted flag should fire when a failed row exists for the hash"
+        );
+    }
+
+    #[tokio::test]
+    async fn unblock_by_hash_flips_failed_to_replaced() {
+        // Direct check on the model helper — confirm path wiring
+        // covered separately. Verifies the UPDATE targets only
+        // state='failed' rows and writes the back-pointer.
+        let db = in_memory_pool().await;
+        let series_id = crate::test_support::seed_series(&db, 202, "Other Series").await;
+        let stale = crate::models::grabbed_torrents::record_grab(
+            &db,
+            VALID_HASH,
+            "old",
+            series_id,
+            &[],
+            false,
+        )
+        .await
+        .unwrap()
+        .unwrap();
+        crate::models::grabbed_torrents::mark_failed(&db, stale)
+            .await
+            .unwrap();
+
+        let affected = crate::models::grabbed_torrents::unblock_by_hash(&db, VALID_HASH, 99999)
+            .await
+            .unwrap();
+        assert_eq!(affected, 1);
+
+        let (state, replaced_by): (String, Option<i64>) =
+            sqlx::query_as("SELECT state, replaced_by_grab_id FROM grabbed_torrents WHERE id = ?")
+                .bind(stale)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(state, "replaced");
+        assert_eq!(replaced_by, Some(99999));
     }
 }

--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -728,7 +728,61 @@ pub async fn grab_cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::services::download_client::{
+        AddOutcome, DownloadClient, DownloadFile, DownloadItem, SelectiveOutcome,
+    };
     use crate::test_support::{build_test_app_state, in_memory_pool};
+    use async_trait::async_trait;
+
+    /// Minimal DownloadClient stub that accepts every call. Used by
+    /// caller-level tests that need `grab_confirm` to clear
+    /// `require_download_client` + `set_file_wanted` + `resume`
+    /// without actually hitting a running qBittorrent.
+    struct NoopClient;
+
+    #[async_trait]
+    impl DownloadClient for NoopClient {
+        async fn test(&self) -> Result<String, String> {
+            Ok("noop".into())
+        }
+        async fn add_torrent(&self, _url: &str, _hash: &str) -> Result<AddOutcome, String> {
+            Ok(AddOutcome::Added)
+        }
+        async fn add_torrent_with_file_filter(
+            &self,
+            _url: &str,
+            _hash: &str,
+            _pick: &mut (dyn for<'a> FnMut(&'a [String]) -> Option<Vec<usize>> + Send),
+        ) -> Result<SelectiveOutcome, String> {
+            Ok(SelectiveOutcome::FullDownload)
+        }
+        async fn list_scoped(&self) -> Result<Vec<DownloadItem>, String> {
+            Ok(vec![])
+        }
+        async fn get_files(&self, _hash: &str) -> Result<Vec<DownloadFile>, String> {
+            Ok(vec![])
+        }
+        async fn pause(&self, _hash: &str) -> Result<(), String> {
+            Ok(())
+        }
+        async fn resume(&self, _hash: &str) -> Result<(), String> {
+            Ok(())
+        }
+        async fn delete(&self, _hash: &str, _delete_files: bool) -> Result<(), String> {
+            Ok(())
+        }
+        async fn set_file_wanted(
+            &self,
+            _hash: &str,
+            _files: &[usize],
+            _wanted: bool,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn sonarr_impl_name(&self) -> &'static str {
+            "QBittorrent"
+        }
+    }
 
     // Unit tests against the handler functions directly (not via a
     // live Axum router) so we can assert on concrete response types
@@ -1092,6 +1146,74 @@ mod tests {
             extract_release_is_batch("{\"is_batch\":\"yes\"}"),
             None,
             "string shouldn't coerce to bool"
+        );
+    }
+
+    #[tokio::test]
+    async fn grab_confirm_honors_release_metadata_is_batch_over_file_count() {
+        // Caller-level regression guard for the PR 90 bug fix. A future
+        // refactor could silently re-introduce `files.len() > 1` at the
+        // confirm call site without the `extract_release_is_batch` unit
+        // test failing (the helper would keep returning `Some(false)`,
+        // the caller would just ignore it). This test exercises the
+        // full path: 3 files posted (`.mkv + .ass + .srt`), explicit
+        // `is_batch: false` in release_metadata → asserts the written
+        // grabbed_torrents row has `is_batch = 0`, not 1.
+        let db = in_memory_pool().await;
+        let series_id = crate::test_support::seed_series(&db, 303, "Single Episode Series").await;
+        let hash = VALID_HASH;
+        let release_metadata = serde_json::json!({
+            "title": "[Group] Single Ep - 05 [1080p]",
+            "size": "1.2 GB",
+            "seeders": 100,
+            "group": "Group",
+            "is_batch": false,
+        });
+        let file_list = serde_json::json!([
+            {"name": "[Group] Single Ep - 05 [1080p].mkv", "size": 1_000_000_000_i64},
+            {"name": "[Group] Single Ep - 05 [1080p].en.ass", "size": 20_000},
+            {"name": "[Group] Single Ep - 05 [1080p].en.srt", "size": 18_000},
+        ]);
+        pending_grabs::create(
+            &db,
+            "pid-subs",
+            hash,
+            "qbittorrent",
+            None,
+            Some(series_id),
+            &release_metadata.to_string(),
+            true,
+        )
+        .await
+        .unwrap();
+        pending_grabs::set_file_list(&db, "pid-subs", &file_list.to_string())
+            .await
+            .unwrap();
+
+        let state = build_test_app_state(db.clone(), Some(std::sync::Arc::new(NoopClient)));
+        let res = grab_confirm(
+            State(state),
+            Json(GrabConfirmForm {
+                preview_id: "pid-subs".into(),
+                wanted_indices: vec![0, 1, 2],
+                unblock: false,
+            }),
+        )
+        .await;
+        assert!(
+            res.is_ok(),
+            "confirm should succeed with NoopClient: {res:?}"
+        );
+
+        let is_batch: i64 =
+            sqlx::query_scalar("SELECT is_batch FROM grabbed_torrents WHERE hash = ?")
+                .bind(hash)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            is_batch, 0,
+            "release_metadata.is_batch=false MUST beat the files.len()>1 proxy"
         );
     }
 

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -18,6 +18,19 @@ struct SearchTemplate {
     query: String,
     searched: bool,
     has_next: bool,
+    /// Issue #83 — `batches_only` (default) or `never`. Threaded
+    /// through to search.js via window.searchState so the Grab button
+    /// can bypass the modal when the user's set it to `never`.
+    grab_preview_mode: String,
+}
+
+async fn load_grab_preview_mode(state: &AppState) -> String {
+    crate::models::config::get_config(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .map(|c| c.grab_preview_mode)
+        .unwrap_or_else(|| "batches_only".to_string())
 }
 
 #[derive(Deserialize)]
@@ -120,13 +133,14 @@ async fn build_opts(
     }
 }
 
-pub async fn search_page(State(_state): State<AppState>) -> Html<String> {
+pub async fn search_page(State(state): State<AppState>) -> Html<String> {
     let template = SearchTemplate {
         page: "search".to_string(),
         results: Vec::new(),
         query: String::new(),
         searched: false,
         has_next: false,
+        grab_preview_mode: load_grab_preview_mode(&state).await,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -184,12 +198,14 @@ pub async fn search_submit(
         &std::collections::HashSet::new(),
     );
 
+    let grab_preview_mode = load_grab_preview_mode(&state).await;
     let template = SearchTemplate {
         page: "search".to_string(),
         results: response.results,
         query: form.query,
         searched: true,
         has_next: response.has_next,
+        grab_preview_mode,
     };
     Html(template.render().unwrap_or_default())
 }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -220,6 +220,12 @@ pub struct SettingsForm {
     seadex_enabled: Option<String>,
     default_custom_query_tokens: Option<String>,
     default_restrict_to_uploader: Option<String>,
+    /// Issue #83 — interactive file-picker trigger policy. `batches_only`
+    /// (default) opens the modal for multi-file torrents; `never`
+    /// preserves 1.3.0 one-click behavior. Omitted from forms before
+    /// PR C → falls back to the existing config value (or default).
+    #[serde(default)]
+    grab_preview_mode: Option<String>,
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -619,6 +625,20 @@ pub async fn settings_submit(
                 .as_ref()
                 .map(|c| c.default_restrict_to_uploader.clone())
                 .unwrap_or_default()
+        },
+        // #83 — Interactive file-picker lives on the Integrations tab
+        // alongside the other download-client knobs. Preserve on
+        // other-tab saves. Unknown values coerce to `batches_only`.
+        grab_preview_mode: if form.tab.as_deref() == Some("integrations") || form.tab.is_none() {
+            match form.grab_preview_mode.as_deref().unwrap_or("") {
+                "never" => "never".to_string(),
+                _ => "batches_only".to_string(),
+            }
+        } else {
+            existing_cfg
+                .as_ref()
+                .map(|c| c.grab_preview_mode.clone())
+                .unwrap_or_else(|| "batches_only".to_string())
         },
     };
 

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -115,6 +115,13 @@ pub struct Config {
     /// user has to clear the field. Per-series override takes
     /// precedence. Empty means no restriction.
     pub default_restrict_to_uploader: String,
+    /// Interactive file-picker trigger policy (issue #83). One of
+    /// `"batches_only"` (default — multi-file torrents open the modal,
+    /// single-file skip it) or `"never"` (no modal ever, legacy 1.3.0
+    /// behavior). `"always"` is deliberately not a valid value per
+    /// plan decision — single-file releases have nothing to pick. Any
+    /// other string coerces to `batches_only` on save.
+    pub grab_preview_mode: String,
 }
 
 impl Default for Config {
@@ -172,6 +179,7 @@ impl Default for Config {
             seadex_enabled: false,
             default_custom_query_tokens: String::new(),
             default_restrict_to_uploader: String::new(),
+            grab_preview_mode: "batches_only".to_string(),
         }
     }
 }
@@ -230,12 +238,13 @@ struct ConfigRow {
     seadex_enabled: i64,
     default_custom_query_tokens: String,
     default_restrict_to_uploader: String,
+    grab_preview_mode: String,
 }
 
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader FROM config WHERE id = 1",
+        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader, grab_preview_mode FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -293,6 +302,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         seadex_enabled: r.seadex_enabled != 0,
         default_custom_query_tokens: r.default_custom_query_tokens,
         default_restrict_to_uploader: r.default_restrict_to_uploader,
+        grab_preview_mode: r.grab_preview_mode,
     }))
 }
 
@@ -300,8 +310,8 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
 pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::Error> {
     sqlx::query(
         r#"
-        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader)
-        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        INSERT INTO config (id, active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader, grab_preview_mode)
+        VALUES (1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(id) DO UPDATE SET
             active_client = excluded.active_client,
             qbit_url = excluded.qbit_url,
@@ -354,7 +364,8 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
             custom_format_minimum_score = excluded.custom_format_minimum_score,
             seadex_enabled = excluded.seadex_enabled,
             default_custom_query_tokens = excluded.default_custom_query_tokens,
-            default_restrict_to_uploader = excluded.default_restrict_to_uploader
+            default_restrict_to_uploader = excluded.default_restrict_to_uploader,
+            grab_preview_mode = excluded.grab_preview_mode
         "#,
     )
     .bind(&config.active_client)
@@ -413,6 +424,7 @@ pub async fn save_config(db: &SqlitePool, config: &Config) -> Result<(), sqlx::E
     .bind(if config.seadex_enabled { 1_i64 } else { 0_i64 })
     .bind(&config.default_custom_query_tokens)
     .bind(&config.default_restrict_to_uploader)
+    .bind(&config.grab_preview_mode)
     .execute(db)
     .await?;
 

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -20,27 +20,30 @@ pub struct GrabbedTorrent {
 
 /// Record a torrent grab for post-processing.
 ///
-/// Three outcomes, all returning `Ok(Some(grab_id))` so callers can
-/// attach `grabbed_torrent_series` route rows without re-querying:
+/// Outcomes:
 ///
-///  1. **Fresh insert.** No prior active row for this hash — a new
-///     grab row is inserted at state `pending`.
-///  2. **Reactivation.** A prior row with the same non-empty hash
-///     exists in state `pending` or `imported`. That row is flipped
-///     back to `pending`, `imported_at` and `qbit_content_path` are
-///     cleared, and `series_id` / `episode_numbers` / `torrent_name`
+///  1. **Fresh insert** → `Ok(Some(new_id))`. No prior active row for
+///     this hash — a new grab row is inserted at state `pending`.
+///  2. **Reactivation** → `Ok(Some(existing_id))`. A prior row with the
+///     same non-empty hash exists in state `imported`. That row is
+///     flipped back to `pending`, `imported_at` and `qbit_content_path`
+///     are cleared, and `series_id` / `episode_numbers` / `torrent_name`
 ///     / `is_batch` are refreshed to the new request. Post-processing
 ///     will re-import the torrent as if it were fresh. This handles
 ///     the "I deleted the library file, re-grabbed the same release,
 ///     nothing happened" drift case — without it, the `INSERT OR
 ///     IGNORE` silently swallowed the second grab and the episode tag
 ///     would get stuck at `grabbed` forever.
-///  3. **Empty-hash pass-through.** Hash is empty (legacy grab
-///     paths). Partial index excludes empty-hash rows, so a fresh
-///     insert always succeeds and no dedup/reactivation happens.
-///
-/// `Ok(None)` is no longer returned — any successful path now carries
-/// the affected row's id, and a real DB error bubbles up as `Err`.
+///  3. **Pending-row dedup** → `Ok(None)`. A prior row exists in state
+///     `pending`. Another flow (typically post-processing mid-import)
+///     is actively working on this hash and we must not clobber its
+///     columns. Callers treat `None` as "in-flight, leave it alone"
+///     and skip any follow-up route/tag writes.
+///  4. **Empty-hash pass-through** → `Ok(Some(new_id))`. Hash is empty
+///     (legacy grab paths). Partial index excludes empty-hash rows, so
+///     a fresh insert always succeeds. A DB error after the empty-hash
+///     insert (e.g. FK violation on `series_id`) surfaces as
+///     `Ok(None)` so the anomaly is visible rather than papered over.
 ///
 /// `is_batch` is the caller's view (from the Nyaa listing or search
 /// hit) of whether the release is a batch/season pack. Persisted so

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -577,6 +577,52 @@ pub async fn get_blocked(
         .collect())
 }
 
+/// Is this infohash currently blocklisted? True when at least one
+/// `grabbed_torrents` row exists for the hash with `state = 'failed'`.
+/// Checked by the interactive file-picker preview endpoint so the
+/// modal can render the inline-unblock warning (plan decision #12).
+pub async fn is_blocklisted(db: &SqlitePool, hash: &str) -> Result<bool, sqlx::Error> {
+    if hash.is_empty() {
+        return Ok(false);
+    }
+    let existing: Option<i64> = sqlx::query_scalar(
+        "SELECT id FROM grabbed_torrents WHERE hash = ? AND state = 'failed' LIMIT 1",
+    )
+    .bind(hash)
+    .fetch_optional(db)
+    .await?;
+    Ok(existing.is_some())
+}
+
+/// Flip every `state='failed'` row for this hash to `state='replaced'`
+/// with a back-pointer to the new grab id. Called by the inline-unblock
+/// path in `handlers::grab::grab_confirm` after `record_grab` writes
+/// the fresh pending row.
+///
+/// Using `replaced` (rather than `removed`) preserves the hash→id
+/// audit trail: the Downloads page's blocklist view filters on
+/// `state='failed'`, and the new pending row's provenance is still
+/// walkable through `replaced_by_grab_id`.
+pub async fn unblock_by_hash(
+    db: &SqlitePool,
+    hash: &str,
+    replaced_by: i64,
+) -> Result<u64, sqlx::Error> {
+    if hash.is_empty() {
+        return Ok(0);
+    }
+    let result = sqlx::query(
+        "UPDATE grabbed_torrents \
+         SET state = 'replaced', replaced_by_grab_id = ? \
+         WHERE hash = ? AND state = 'failed'",
+    )
+    .bind(replaced_by)
+    .bind(hash)
+    .execute(db)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Mark a grabbed torrent as failed (blocklisted) by matching torrent name and series.
 pub async fn mark_failed_by_name(
     db: &SqlitePool,

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -40,10 +40,14 @@ pub struct GrabbedTorrent {
 ///     columns. Callers treat `None` as "in-flight, leave it alone"
 ///     and skip any follow-up route/tag writes.
 ///  4. **Empty-hash pass-through** → `Ok(Some(new_id))`. Hash is empty
-///     (legacy grab paths). Partial index excludes empty-hash rows, so
-///     a fresh insert always succeeds. A DB error after the empty-hash
-///     insert (e.g. FK violation on `series_id`) surfaces as
-///     `Ok(None)` so the anomaly is visible rather than papered over.
+///     (legacy grab paths). Partial UNIQUE index excludes empty-hash
+///     rows, so a fresh insert can't trip that constraint. If the
+///     INSERT OR IGNORE still returns no row id (an unexpected
+///     NOT NULL / CHECK / UNIQUE violation that OR IGNORE swallowed),
+///     we surface `Ok(None)` so the anomaly is visible rather than
+///     papered over. FK violations aren't in that set —
+///     `PRAGMA foreign_keys = ON` bubbles them up as `Err` via the
+///     `?` before reaching this branch.
 ///
 /// `is_batch` is the caller's view (from the Nyaa listing or search
 /// hit) of whether the release is a batch/season pack. Persisted so

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -1826,6 +1826,17 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await?;
 
+    // Issue #83 — interactive file-picker trigger policy. Values:
+    // `batches_only` (default) or `never`. Pre-existing DBs get the
+    // default on-read through the `NOT NULL DEFAULT 'batches_only'`
+    // column, so no per-row backfill is needed.
+    sqlx::query(
+        "ALTER TABLE config ADD COLUMN grab_preview_mode TEXT NOT NULL DEFAULT 'batches_only'",
+    )
+    .execute(db)
+    .await
+    .ok();
+
     Ok(())
 }
 

--- a/src/services/grab_commit.rs
+++ b/src/services/grab_commit.rs
@@ -253,5 +253,16 @@ async fn run_auto_expand(
             &info_hash,
         )
         .await;
+    } else {
+        // Emit a debug tombstone for the zero-sibling run too — makes
+        // "did auto-expand even fire on this grab?" answerable from
+        // logs without re-deriving from the absence of an info line.
+        logger::debug(
+            &db,
+            LogCategory::Grab,
+            &format!("grab auto-expand detected no siblings in '{title}'"),
+            &info_hash,
+        )
+        .await;
     }
 }

--- a/src/services/grab_commit.rs
+++ b/src/services/grab_commit.rs
@@ -1,0 +1,243 @@
+//! Shared grab-commit helper for issue #83's interactive file-picker.
+//!
+//! Two paths end up with a live, file-priority-applied, resumed torrent
+//! that Ryokan wants to attribute to the library:
+//!
+//!   1. **User-confirmed** — `handlers::grab::grab_confirm` applies the
+//!      user's selections and resumes the torrent. Filenames here are
+//!      the user-kept subset (decision #7).
+//!   2. **Walkaway auto-commit** — `services::grab_sweep::auto_commit_row`
+//!      marks every file wanted on a heartbeat-lapsed row (decision #3).
+//!      Filenames here are the full file list.
+//!
+//! Both paths need the same downstream work: write a `grabbed_torrents`
+//! row so post-processing picks up the download, and run sibling
+//! auto-expand so a batch pack's sequels/prequels/side-stories get
+//! their own library rows and per-file routing.
+//!
+//! The auto-search path in `handlers::library::search` already does this
+//! with a pre-computed classification from the scoring pipeline. The
+//! interactive path doesn't — the modal doesn't run source
+//! classification. We fall back to `ClassificationResult::unknown()`
+//! and let post-processing backfill the real `(source, resolution,
+//! is_remux)` verdict once files land on disk. `needs_review` flips
+//! true on the unknown row so the classifier review page surfaces it
+//! if post-processing can't confidently classify it either.
+
+use sqlx::SqlitePool;
+
+use crate::AppState;
+use crate::models::grabbed_torrents;
+use crate::models::log::LogCategory;
+use crate::models::pending_grabs::PendingGrab;
+use crate::services::anilist;
+use crate::services::auto_expand::{self, AutoExpandGrabContext};
+use crate::services::auto_search;
+use crate::services::logger;
+use crate::services::source::ClassificationResult;
+
+/// Write the `grabbed_torrents` row and kick off sibling auto-expand
+/// for a pending grab that's now live on the download client. Returns
+/// `Some(grab_id)` on success, `None` when library attribution was
+/// skipped (no series context, empty title, DB insert deduped against
+/// an in-flight row).
+///
+/// `filenames` is the file list to feed into auto-expand — the
+/// user-selected subset on the confirm path, the full list on the
+/// auto-commit path. Auto-expand writes `grabbed_torrent_series`
+/// routes only for files present in the list, so a subset here
+/// correctly limits sibling library attribution to what's actually
+/// going to import (decision #7's post-confirm timing shift).
+///
+/// Auto-expand fires as a `tokio::spawn` — the caller returns to the
+/// HTTP response before the metadata-bound relation walk completes.
+/// Post-processing has its own auto-expand safety net so a failure
+/// here doesn't prevent eventual library attribution.
+pub async fn commit_grab_and_expand(
+    state: &AppState,
+    row: &PendingGrab,
+    filenames: Vec<String>,
+    release_title: &str,
+    is_batch: bool,
+) -> Option<i64> {
+    // Bare-magnet grab from the global search page with no series
+    // context — we can't attribute the download to a library row, so
+    // skip the write. The torrent still downloads (the caller already
+    // issued the resume); it just won't show up in any series's
+    // grabbed list. Post-processing will ignore it for the same
+    // reason — no `grabbed_torrents` row to key off.
+    let Some(series_id) = row.series_id else {
+        logger::debug(
+            &state.db,
+            LogCategory::Grab,
+            "skipping grab-row write — no series_id on pending grab",
+            &row.info_hash,
+        )
+        .await;
+        return None;
+    };
+
+    if release_title.trim().is_empty() {
+        logger::warn(
+            &state.db,
+            LogCategory::Grab,
+            "skipping grab-row write — release title empty",
+            &row.info_hash,
+        )
+        .await;
+        return None;
+    }
+
+    // Derive episode numbers from the release title. `parse_release_numbers`
+    // handles single-episode (`... - 05 ...`), range (`01-12`), and
+    // absolute-numbered (`25-48` for JoJo P3 Egypt-hen) forms. If the
+    // title doesn't parse, fall back to an empty vec — post-processing
+    // still classifies imported files individually, and the series
+    // page's per-episode grab state backfills when `episode_tags` rows
+    // land via auto-expand / post-processing. Writing an empty slice
+    // matches the auto_search path's behavior for releases where the
+    // title parser returns nothing.
+    let mut ep_nums: Vec<i32> = auto_search::parse_release_numbers(release_title)
+        .into_iter()
+        .collect();
+    ep_nums.sort_unstable();
+
+    let grab_id = match grabbed_torrents::record_grab(
+        &state.db,
+        &row.info_hash,
+        release_title,
+        series_id,
+        &ep_nums,
+        is_batch,
+    )
+    .await
+    {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            // Dedup hit against an in-flight `pending` row — another
+            // flow is mid-commit on this hash. Don't stomp it; the
+            // other flow will drive auto-expand. This matches the
+            // auto_search path's `grab_id.flatten()` behavior.
+            logger::debug(
+                &state.db,
+                LogCategory::Grab,
+                "grab dedup hit — skipping auto-expand",
+                &row.info_hash,
+            )
+            .await;
+            return None;
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::Grab,
+                "record_grab failed",
+                &format!("{} ({})", e, row.info_hash),
+            )
+            .await;
+            return None;
+        }
+    };
+
+    // Fire-and-forget the sibling auto-expand. Don't block the HTTP
+    // response — the transitive relation walk can take several
+    // seconds on cold DETAIL_CACHE, and confirm / auto-commit both
+    // want to return as soon as the client-side work is done.
+    //
+    // A failed fetch or panic inside the spawn drops the auto-expand
+    // silently; the import-time call in `services::post_processing`
+    // is the safety net that guarantees siblings land eventually.
+    if !filenames.is_empty() {
+        let db_task = state.db.clone();
+        let title_task = release_title.to_string();
+        let ep_nums_task = ep_nums.clone();
+        let info_hash_task = row.info_hash.clone();
+        tokio::spawn(async move {
+            run_auto_expand(
+                db_task,
+                info_hash_task,
+                series_id,
+                ep_nums_task,
+                grab_id,
+                title_task,
+                filenames,
+            )
+            .await;
+        });
+    }
+
+    Some(grab_id)
+}
+
+/// Resolve the parent series's AL detail and invoke `expand_from_files`.
+/// Broken out of the spawn so the `?`-style control flow reads cleanly
+/// without making every step inside the spawn an `if let Some` ladder.
+async fn run_auto_expand(
+    db: SqlitePool,
+    info_hash: String,
+    series_id: i64,
+    ep_nums: Vec<i32>,
+    grab_id: i64,
+    title: String,
+    filenames: Vec<String>,
+) {
+    // Look up anilist_id from series_id. Negative AL IDs (MAL-fallback
+    // sentinel per CLAUDE.md) route to Jikan inside
+    // `get_anime_detail_with_options`, which correctly returns an
+    // AnimeDetail for display purposes but carries the negated id —
+    // sibling detection still runs against that shape since
+    // expand_from_files already filters `parent_detail.id <= 0`
+    // internally.
+    let anilist_id =
+        match sqlx::query_scalar::<_, i64>("SELECT anilist_id FROM series WHERE id = ?")
+            .bind(series_id)
+            .fetch_optional(&db)
+            .await
+        {
+            Ok(Some(id)) => id,
+            Ok(None) => {
+                logger::warn(
+                    &db,
+                    LogCategory::Grab,
+                    "auto-expand: series row vanished between grab-row write and detail fetch",
+                    &format!("series_id={} hash={}", series_id, info_hash),
+                )
+                .await;
+                return;
+            }
+            Err(e) => {
+                logger::warn(
+                    &db,
+                    LogCategory::Grab,
+                    "auto-expand: DB error resolving series_id",
+                    &format!("{} ({})", e, info_hash),
+                )
+                .await;
+                return;
+            }
+        };
+
+    let detail = match anilist::get_anime_detail_with_options(anilist_id, None, false).await {
+        Ok(d) => d,
+        Err(e) => {
+            logger::info(
+                &db,
+                LogCategory::Grab,
+                "auto-expand: AL detail fetch failed; post-processing will retry at import time",
+                &format!("{} ({})", e, info_hash),
+            )
+            .await;
+            return;
+        }
+    };
+
+    let ctx = AutoExpandGrabContext {
+        classification: ClassificationResult::unknown(),
+        release_group: String::new(),
+        size_bytes: 0,
+    };
+    let _ = auto_expand::expand_from_files(
+        &db, &filenames, &detail, series_id, &ep_nums, grab_id, &title, &ctx,
+    )
+    .await;
+}

--- a/src/services/grab_commit.rs
+++ b/src/services/grab_commit.rs
@@ -236,8 +236,22 @@ async fn run_auto_expand(
         release_group: String::new(),
         size_bytes: 0,
     };
-    let _ = auto_expand::expand_from_files(
+    // `expand_from_files` returns `newly_added_siblings: usize` and
+    // handles its own per-sibling error logging; we only surface the
+    // count here so a zero-sibling detection run is visible in the
+    // logs alongside a match-heavy one. Matches the style of the
+    // two DB fetches above which log their outcomes explicitly.
+    let newly_added = auto_expand::expand_from_files(
         &db, &filenames, &detail, series_id, &ep_nums, grab_id, &title, &ctx,
     )
     .await;
+    if newly_added > 0 {
+        logger::info(
+            &db,
+            LogCategory::Grab,
+            &format!("grab auto-expand added {newly_added} sibling series from '{title}'"),
+            &info_hash,
+        )
+        .await;
+    }
 }

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -25,8 +25,6 @@
 
 use std::time::Duration;
 
-use serde_json::Value;
-
 use crate::AppState;
 use crate::models::pending_grabs;
 
@@ -108,14 +106,12 @@ async fn auto_commit_row(state: &AppState, row: &pending_grabs::PendingGrab) {
         return;
     };
 
-    // Parse the file list just enough to count entries. The full
-    // shape (`Vec<PreviewFile>`) lives in `handlers::grab` — we
-    // don't need the filenames here, only the length so we can
-    // build the `0..len` index slice for `set_file_wanted`.
-    let file_count: usize = serde_json::from_str::<Value>(&row.file_list_json)
-        .ok()
-        .and_then(|v| v.as_array().map(|a| a.len()))
-        .unwrap_or(0);
+    // Parse the file list — we need the filenames for auto-expand
+    // and the length for the `0..len` index slice passed to
+    // `set_file_wanted`.
+    let files: Vec<crate::handlers::grab::PreviewFile> =
+        serde_json::from_str(&row.file_list_json).unwrap_or_default();
+    let file_count = files.len();
     if file_count == 0 {
         tracing::warn!(
             target: "ryokan::services::grab_sweep",
@@ -161,6 +157,24 @@ async fn auto_commit_row(state: &AppState, row: &pending_grabs::PendingGrab) {
         );
         return;
     }
+
+    // Library attribution (PR C). Walkaway means the user got every
+    // file wanted, so the full file list is passed to auto-expand —
+    // unlike the confirm path which passes only the user-selected
+    // subset. Failures inside `commit_grab_and_expand` are logged;
+    // the sweep still deletes the pending row so it doesn't loop.
+    let release_title = crate::handlers::grab::extract_release_title(&row.release_metadata_json)
+        .unwrap_or_else(|| row.info_hash.clone());
+    let is_batch = file_count > 1;
+    let all_filenames: Vec<String> = files.into_iter().map(|f| f.name).collect();
+    crate::services::grab_commit::commit_grab_and_expand(
+        state,
+        row,
+        all_filenames,
+        &release_title,
+        is_batch,
+    )
+    .await;
 
     tracing::info!(
         target: "ryokan::services::grab_sweep",

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -165,7 +165,11 @@ async fn auto_commit_row(state: &AppState, row: &pending_grabs::PendingGrab) {
     // the sweep still deletes the pending row so it doesn't loop.
     let release_title = crate::handlers::grab::extract_release_title(&row.release_metadata_json)
         .unwrap_or_else(|| row.info_hash.clone());
-    let is_batch = file_count > 1;
+    // Search-hit batch flag is the authoritative source; the
+    // file-count fallback only fires for pre-fix modal payloads
+    // (see `extract_release_is_batch`).
+    let is_batch = crate::handlers::grab::extract_release_is_batch(&row.release_metadata_json)
+        .unwrap_or(file_count > 1);
     let all_filenames: Vec<String> = files.into_iter().map(|f| f.name).collect();
     crate::services::grab_commit::commit_grab_and_expand(
         state,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -10,6 +10,7 @@ pub mod jellyfin;
 
 pub mod auto_expand;
 pub mod auto_search;
+pub mod grab_commit;
 pub mod grab_sweep;
 pub mod logger;
 pub mod progress;

--- a/static/css/pages/grab_picker.css
+++ b/static/css/pages/grab_picker.css
@@ -289,6 +289,45 @@
     gap: 8px;
 }
 
+/* Blocklist warning banner — rendered inside the file-list body when
+ * the preview response carries `blocklisted: true`. Sits above the
+ * file table, not in the toolbar, so the warning is unmissable. One-
+ * click dismissal via the primary button sets session.unblockAcked
+ * which both hides the banner and carries forward as the `unblock`
+ * flag on confirm. Per plan decision #12.
+ */
+.grab-picker-blocklist-banner {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    padding: 12px 16px;
+    margin: 12px 16px 0;
+    background: var(--bg-elevated);
+    border: 1px solid var(--red);
+    border-radius: 6px;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.grab-picker-blocklist-text {
+    flex: 1;
+    min-width: 260px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: var(--text-dim);
+}
+
+.grab-picker-blocklist-text strong {
+    color: var(--red);
+    font-weight: 600;
+    margin-right: 4px;
+}
+
+.grab-picker-blocklist-text em {
+    font-style: italic;
+    color: var(--text-bright);
+}
+
 /* Timeout dialog — sits over the file list when the GET poll flips
  * to status=error. Two buttons per plan decision #1: "Wait another
  * 30s" and "Grab with defaults". Not a separate modal — replaces the

--- a/static/js/grab_picker.js
+++ b/static/js/grab_picker.js
@@ -532,6 +532,10 @@
                 size: ctx.size || '',
                 seeders: ctx.seeders != null ? Number(ctx.seeders) : null,
                 group: ctx.group || '',
+                // Forward the search-hit's batch flag so the backend's
+                // grab-row write picks it up verbatim instead of
+                // inferring from file count.
+                is_batch: !!ctx.isBatch,
             },
         };
         if (ctx.seriesId) body.series_id = Number(ctx.seriesId);

--- a/static/js/grab_picker.js
+++ b/static/js/grab_picker.js
@@ -170,14 +170,43 @@
         if (toolbar) toolbar.style.display = 'flex';
         if (footer) footer.style.display = 'flex';
 
-        if (session.view === 'tree') {
-            body.innerHTML = renderTreeView();
-        } else {
-            body.innerHTML = renderFlatView();
-        }
+        const banner = (session.blocklisted && !session.unblockAcked)
+            ? renderBlocklistBanner()
+            : '';
+        const list = (session.view === 'tree') ? renderTreeView() : renderFlatView();
+        body.innerHTML = banner + list;
         attachRowHandlers();
+        attachBlocklistHandlers();
         updateSelectionTotal();
         updateViewToggle();
+    }
+
+    function renderBlocklistBanner() {
+        return `
+            <div class="grab-picker-blocklist-banner" role="alert">
+                <div class="grab-picker-blocklist-text">
+                    <strong>Previously blocklisted.</strong>
+                    This release is in the blocked list from an earlier grab.
+                    Clicking <em>Unblock and continue</em> will clear the old
+                    blocklist entry and start a fresh grab with your
+                    selections. Closing this modal leaves the blocklist alone.
+                </div>
+                <button type="button" class="btn btn-primary" data-grab-picker-action="unblock">
+                    Unblock and continue
+                </button>
+            </div>
+        `;
+    }
+
+    function attachBlocklistHandlers() {
+        const btn = document.querySelector('[data-grab-picker-action="unblock"]');
+        if (btn) {
+            btn.addEventListener('click', () => {
+                if (!session) return;
+                session.unblockAcked = true;
+                renderFileList();
+            });
+        }
     }
 
     function renderFlatView() {
@@ -379,6 +408,8 @@
                 }
                 if (data.status === 'ready') {
                     session.files = data.file_list || [];
+                    session.blocklisted = !!data.blocklisted;
+                    session.unblockAcked = session.unblockAcked || false;
                     session.wanted = new Set();
                     for (let i = 0; i < session.files.length; i++) session.wanted.add(i);
                     const unwanted = computeDefaultUnwanted(session.files);
@@ -421,7 +452,15 @@
         fetch('/api/grab/confirm', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
-            body: JSON.stringify({ preview_id: session.previewId, wanted_indices: wantedIndices }),
+            body: JSON.stringify({
+                preview_id: session.previewId,
+                wanted_indices: wantedIndices,
+                // Carry the user's acknowledgement of the inline
+                // blocklist warning through to the backend so it can
+                // flip the old failed rows to `replaced` alongside
+                // the fresh grab write.
+                unblock: !!session.unblockAcked,
+            }),
         })
         .then(async r => {
             const data = await r.json().catch(() => ({}));

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -203,15 +203,17 @@ function grabRelease(url, btn) {
     const row = btn.closest('tr[data-score]') || btn.closest('.result-card');
     const isBatch = !!(row && row.classList.contains('is-batch'));
 
-    // Issue #83 PR B — batch releases open the interactive file
-    // picker. Single-file releases keep the direct /api/grab path
-    // (no files to pick). `grab_preview_mode` is the long-term toggle
-    // (plan decision plan docs) but lands server-side in PR C; for
-    // now the batch-vs-single split is the whole routing decision.
-    // When the picker isn't available on this page (no modal DOM,
-    // no info_hash on the row), fall through to the direct grab so
-    // the button keeps working.
+    // Issue #83 — batch releases open the interactive file picker
+    // unless the user's `grab_preview_mode` config is `never`, in
+    // which case the Grab button takes the direct /api/grab path
+    // for 1.3.0-style one-click behavior. Single-file releases
+    // always bypass the picker (nothing to pick). If the picker
+    // isn't available on this page (no modal DOM, no info_hash
+    // on the row), fall through to the direct grab so the button
+    // keeps working.
+    const previewMode = (window.searchState && window.searchState.grabPreviewMode) || 'batches_only';
     const canPicker = isBatch
+        && previewMode !== 'never'
         && typeof window.openGrabPicker === 'function'
         && row && row.dataset.infoHash;
     if (canPicker) {

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -223,6 +223,11 @@ function grabRelease(url, btn) {
             seeders: Number(row.dataset.seeders) || 0,
             group: row.dataset.group || '',
             infoHash: row.dataset.infoHash || '',
+            // Carry the search-hit's batch classification through to
+            // the preview POST so the backend's grab-row write uses
+            // the listing's flag instead of a file-count proxy (which
+            // mis-flags .mkv+.ass+.srt single-episode releases).
+            isBatch: isBatch,
         });
         return;
     }

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -10,6 +10,14 @@
                 </select>
                 <span class="form-hint">Ryokan talks to one client at a time. Switching cancels any pending grabs queued against the previous client.</span>
             </div>
+            <div class="form-group">
+                <label for="grab_preview_mode">Interactive file picker</label>
+                <select name="grab_preview_mode" id="grab_preview_mode">
+                    <option value="batches_only" {% if config.grab_preview_mode != "never" %}selected{% endif %}>Batches only (default)</option>
+                    <option value="never" {% if config.grab_preview_mode == "never" %}selected{% endif %}>Never</option>
+                </select>
+                <span class="form-hint">When set to <em>Batches only</em>, multi-file torrents open a modal where you can uncheck files (samples, NCOPs, extras) before the grab commits. Single-file torrents always skip the modal. Set to <em>Never</em> for 1.3.0-style one-click grabs.</span>
+            </div>
         </fieldset>
 
         <fieldset id="qbit-fieldset" {% if config.active_client != "qbittorrent" %}style="display:none"{% endif %}>

--- a/templates/search.html
+++ b/templates/search.html
@@ -143,6 +143,7 @@ window.searchState = {
     hasMore: {% if searched %}{{ has_next }}{% else %}false{% endif %},
     totalResults: {% if searched %}{{ results.len() }}{% else %}0{% endif %},
     searched: {{ searched }},
+    grabPreviewMode: "{{ grab_preview_mode }}",
 };
 </script>
 <script src="/static/js/grab_picker.js" defer></script>

--- a/templates/search.html
+++ b/templates/search.html
@@ -143,7 +143,10 @@ window.searchState = {
     hasMore: {% if searched %}{{ has_next }}{% else %}false{% endif %},
     totalResults: {% if searched %}{{ results.len() }}{% else %}0{% endif %},
     searched: {{ searched }},
-    grabPreviewMode: "{{ grab_preview_mode }}",
+    // Enum of two values — emit as literal strings so a future unvalidated
+    // config value can't land inside a JS string context via template
+    // interpolation (Askama auto-escapes HTML entities, not JS sequences).
+    grabPreviewMode: {% if grab_preview_mode == "never" %}"never"{% else %}"batches_only"{% endif %},
 };
 </script>
 <script src="/static/js/grab_picker.js" defer></script>


### PR DESCRIPTION
## Summary

Issue #83 PR C — two commits on `dev` closing out the plan doc's PR C scope.

- **`85b251d`** — Backend: shared `services::grab_commit::commit_grab_and_expand` helper wires both the confirm path (user-selected subset, plan decision §7) and the sweep auto-commit path (full file list, walkaway = everything wanted) into a single grab-row write + sibling auto-expand site. Blocklist surfacing on preview GET + inline unblock flag on confirm (decision §12); `extract_release_title` defensive helper.
- **`18170c5`** — UX: `grab_preview_mode` config column (batches_only | never) with Settings → Integrations dropdown; `search.js` skips the modal when `never`; `grab_picker.js` renders the inline blocklist banner + Unblock-and-continue button.

Resolves the PR C scope markers in `grab_confirm`, `grab_sweep` module docs, and the `templates/partials/settings/integrations.html` default.

## Plan-doc decisions landed

- **§3** — auto-commit on walkaway now writes a `grabbed_torrents` row (previously: torrent resumed but library attribution was missing)
- **§7** — sibling auto-expand runs on the user-selected subset post-confirm, full list post-auto-commit
- **§12** — inline blocklist warning + single-click unblock (no Downloads-page round-trip)
- **Settings flag** — `grab_preview_mode: batches_only | never` shipped; `always` deliberately omitted per plan

## Test plan
- [x] Browser smoke: grab a batch release, confirm with a subset selected → series gets a grab row, auto-expand fires for any siblings
- [x] Browser smoke: grab a release already in the blocklist → inline warning renders, click Unblock-and-continue, confirm → old failed row flips to `replaced` with new id
- [x] Browser smoke: toggle Settings → Integrations → Interactive file picker to `Never`, then grab a batch → modal is bypassed, direct /api/grab path fires
- [x] Walkaway: open modal on batch release, close tab, wait ~2 min → sweep auto-commits with all files wanted + writes grab row + fires auto-expand
- [x] Migration: fresh DB picks up `grab_preview_mode = 'batches_only'` default; pre-PR-C DB reads default on first config load without backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)