### PR TITLE
Issue #62 PR C: personal ratings + score-format rendering

### DIFF
--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -16,6 +16,12 @@ struct IndexTemplate {
     page: String,
     library: Vec<series::Series>,
     title_language: String,
+    /// #62 PR C — the linked external account's `score_format`,
+    /// used by `Series::user_score_display(...)` to render per-row
+    /// "You: X" badges. Empty string when no account is linked, in
+    /// which case `user_score_display` always returns `None` and
+    /// the template renders no badge.
+    score_format: String,
 }
 
 #[derive(Template)]
@@ -82,6 +88,13 @@ struct SeriesTemplate {
     /// is following the external account (sync-tracked + override
     /// cleared); otherwise equals `monitor_mode`.
     monitor_mode_select_value: String,
+    /// #62 PR C — pre-rendered "You: X" badge text, formatted per
+    /// the linked account's `score_format`. `None` when no account
+    /// is linked, the series isn't on the user's list, or the user
+    /// hasn't rated this series. Empty in any other "no badge"
+    /// case so the template's `{% if let Some %}` reads as a clean
+    /// boolean.
+    user_score_display: Option<String>,
     monitored_count: i32,
     all_monitored: bool,
     /// Phase 4: series-level upgrade opt-in. Rendered as a checkbox on the

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -88,13 +88,13 @@ struct SeriesTemplate {
     /// is following the external account (sync-tracked + override
     /// cleared); otherwise equals `monitor_mode`.
     monitor_mode_select_value: String,
-    /// #62 PR C — pre-rendered "You: X" badge text, formatted per
-    /// the linked account's `score_format`. `None` when no account
-    /// is linked, the series isn't on the user's list, or the user
-    /// hasn't rated this series. Empty in any other "no badge"
-    /// case so the template's `{% if let Some %}` reads as a clean
-    /// boolean.
-    user_score_display: Option<String>,
+    /// #62 PR C — pre-rendered "You: X" badge for the detail page,
+    /// formatted per the linked account's `score_format`. `None`
+    /// when no account is linked, the user hasn't rated this
+    /// series, or the score is the unrated sentinel. The variant
+    /// (Text vs. Smiley) drives whether the template renders a
+    /// string or an inline SVG outline face.
+    user_score_display: Option<crate::services::user_score::FormattedUserScore>,
     monitored_count: i32,
     all_monitored: bool,
     /// Phase 4: series-level upgrade opt-in. Rendered as a checkbox on the

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -46,12 +46,24 @@ pub async fn index(State(state): State<AppState>) -> Html<String> {
     )
     .await;
 
+    // #62 PR C — pull the linked account's score_format so library
+    // cards can render "You: X" badges per row. Empty string when
+    // no account is linked, in which case Series::user_score_display
+    // returns None and no badge renders.
+    let score_format = crate::models::external_accounts::get_current(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .map(|a| a.score_format)
+        .unwrap_or_default();
+
     let template = IndexTemplate {
         page: "library".to_string(),
         library,
         title_language: cfg
             .map(|c| c.title_language)
             .unwrap_or_else(|| "english".to_string()),
+        score_format,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -180,6 +192,18 @@ pub async fn series_detail(
         } else {
             monitor_mode.clone()
         };
+
+    // #62 PR C — render the "You: X" badge string per the linked
+    // account's score_format. Hidden when no account is linked, the
+    // series has no user_score, or the score is the unrated
+    // sentinel. Computed here so the template just renders the
+    // already-formatted string.
+    let user_score_display = match (db_series.as_ref(), linked_account.as_ref()) {
+        (Some(row), Some(acct)) => {
+            crate::services::user_score::format_user_score(row.user_score, &acct.score_format)
+        }
+        _ => None,
+    };
 
     // Fan out the five independent read paths. Each one was previously
     // awaited serially — on a cold cache that meant 4+ sequential DB
@@ -358,6 +382,7 @@ pub async fn series_detail(
         can_sync_from_external_account,
         sync_provider_label,
         monitor_mode_select_value,
+        user_score_display,
         monitored_count,
         all_monitored,
         allow_upgrades,

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -319,6 +319,29 @@ pub struct ImportPreferences {
     pub skip_already_watched: bool,
 }
 
+/// Refresh the `score_format` column. Called from the AL sync path
+/// after each successful `fetch_media_list_collection` so a user
+/// changing their POINT_X preference on AL post-link takes effect on
+/// the next "You: X" badge render. No-op when `score_format` is
+/// empty (treats "AL omitted the field on this response" as "leave
+/// the known-good value alone").
+pub async fn update_score_format(
+    db: &SqlitePool,
+    id: i64,
+    score_format: &str,
+) -> Result<(), String> {
+    if score_format.is_empty() {
+        return Ok(());
+    }
+    sqlx::query("UPDATE external_accounts SET score_format = ? WHERE id = ?")
+        .bind(score_format)
+        .bind(id)
+        .execute(db)
+        .await
+        .map_err(|e| format!("update_score_format failed: {e}"))?;
+    Ok(())
+}
+
 /// Stamp the watch-list sync cursor(s) after a successful tick.
 /// `list_last_synced_at` is always written. `list_full_resync_at` is
 /// also written when `was_full_sync = true` — the sync engine sets

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -242,12 +242,31 @@ pub async fn link(db: &SqlitePool, req: LinkRequest) -> Result<i64, String> {
 }
 
 /// Remove the linked account. Per decision #8, preserves any
-/// imported series rows — this call only drops the `external_accounts`
-/// row. Callers that want to clear `series.user_score` / custom-list
-/// side tables invoke those model functions separately; keeping the
-/// concerns split so the unlink path can be composed from the UI
-/// side without this module growing a grab-bag of cleanup args.
+/// imported series rows but wipes the per-account state: `user_score`
+/// (which renders as "You: X" against the just-unlinked provider's
+/// `score_format`) and the FK-on-`series` `synced_from_external_
+/// account_id` (the ON DELETE SET NULL on the FK does this automatically
+/// once the account row is gone). Custom-list memberships will get
+/// the same treatment in PR D.
+///
+/// Without the user_score wipe, an unlink → re-link-different-provider
+/// flow would render every prior AL POINT_100 score as a MAL POINT_10
+/// integer (a literal `You: 85` for a series the user never rated on
+/// the new account). Per the plan doc: "user scores [are] lost" on
+/// re-link-different-account.
 pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
+    // Order matters: clear user_score on rows synced from THIS
+    // account BEFORE the account row goes away (the FK is set to
+    // SET NULL on cascade, so after the DELETE we'd lose the join
+    // key). Bounded to synced-from-this-account rows so a concurrent
+    // unlink-from-other-provider doesn't wipe an unrelated account's
+    // ratings.
+    sqlx::query("UPDATE series SET user_score = NULL WHERE synced_from_external_account_id = ?")
+        .bind(id)
+        .execute(db)
+        .await
+        .map_err(|e| format!("user_score wipe failed: {e}"))?;
+
     sqlx::query("DELETE FROM external_accounts WHERE id = ?")
         .bind(id)
         .execute(db)

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -890,6 +890,18 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .ok();
 
+    // #62 PR C — user's personal score on the linked AL/MAL account
+    // for this series. NULL means "no linked account" or "unrated"
+    // (the watch-list sync writes 0.0 for unrated entries; the read
+    // path treats 0.0 the same as NULL when rendering — never shows
+    // "You: 0"). REAL because AL's POINT_10_DECIMAL format stores
+    // fractional values; integer formats store as e.g. 8.0 and the
+    // render helper formats them back as integers.
+    sqlx::query("ALTER TABLE series ADD COLUMN user_score REAL")
+        .execute(db)
+        .await
+        .ok();
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS series_metadata_cache (

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -66,14 +66,19 @@ impl Series {
         MonitorMode::from_str(&self.monitor_mode)
     }
 
-    /// #62 PR C — render the "You: X" badge string for this series
-    /// using the given `score_format` (typically the linked
+    /// #62 PR C — render the "You: X" badge for this series using
+    /// the given `score_format` (typically the linked
     /// `external_accounts.score_format`). Returns `None` when no
     /// account is linked, the user hasn't rated this series, or the
-    /// score is the unrated sentinel. Library cards call this from
-    /// Askama directly so each row formats consistently with the
-    /// detail-page badge.
-    pub fn user_score_display(&self, score_format: &str) -> Option<String> {
+    /// score is the unrated sentinel. The returned
+    /// [`FormattedUserScore`] is either plain text (numbers, stars)
+    /// or a smiley enum the template renders as inline SVG. Library
+    /// cards call this from Askama directly so each row formats
+    /// consistently with the detail-page badge.
+    pub fn user_score_display(
+        &self,
+        score_format: &str,
+    ) -> Option<crate::services::user_score::FormattedUserScore> {
         crate::services::user_score::format_user_score(self.user_score, score_format)
     }
 }
@@ -531,7 +536,7 @@ pub async fn list_synced_from(
     account_id: i64,
 ) -> Result<Vec<SyncedSeriesRow>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, monitor_mode, monitor_mode_manual_override, user_score FROM series \
+        "SELECT id, anilist_id, monitor_mode, monitor_mode_manual_override FROM series \
          WHERE synced_from_external_account_id = ?",
     )
     .bind(account_id)

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -65,6 +65,17 @@ impl Series {
     pub fn monitor_mode_enum(&self) -> MonitorMode {
         MonitorMode::from_str(&self.monitor_mode)
     }
+
+    /// #62 PR C — render the "You: X" badge string for this series
+    /// using the given `score_format` (typically the linked
+    /// `external_accounts.score_format`). Returns `None` when no
+    /// account is linked, the user hasn't rated this series, or the
+    /// score is the unrated sentinel. Library cards call this from
+    /// Askama directly so each row formats consistently with the
+    /// detail-page badge.
+    pub fn user_score_display(&self, score_format: &str) -> Option<String> {
+        crate::services::user_score::format_user_score(self.user_score, score_format)
+    }
 }
 
 fn map_series_row(row: sqlx::sqlite::SqliteRow) -> Series {

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -52,6 +52,13 @@ pub struct Series {
     /// pinned across syncs. Cleared when the user picks "Sync from
     /// AL/MAL" from the dropdown.
     pub monitor_mode_manual_override: bool,
+    /// #62 PR C — user's personal score on their linked AL/MAL
+    /// account. `None` for manually-added series (no linked account
+    /// fed a score in) and for sync-imported series the user hasn't
+    /// rated. The render helper in `services::user_score` formats
+    /// this per the account's `score_format` and never shows
+    /// `You: 0` for 0.0 (AL's "unrated" sentinel).
+    pub user_score: Option<f64>,
 }
 
 impl Series {
@@ -94,13 +101,14 @@ fn map_series_row(row: sqlx::sqlite::SqliteRow) -> Series {
             .try_get::<i64, _>("monitor_mode_manual_override")
             .map(|v| v != 0)
             .unwrap_or(false),
+        user_score: row.try_get::<Option<f64>, _>("user_score").unwrap_or(None),
     }
 }
 
 /// Get all tracked series, ordered by most recently added.
 pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override FROM series ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;
@@ -110,7 +118,7 @@ pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
 
 pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override FROM series WHERE id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(db)
@@ -124,7 +132,7 @@ pub async fn get_by_anilist_id(
     anilist_id: i64,
 ) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override FROM series WHERE anilist_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE anilist_id = ?",
     )
     .bind(anilist_id)
     .fetch_optional(db)
@@ -135,7 +143,7 @@ pub async fn get_by_anilist_id(
 
 pub async fn get_by_mal_id(db: &SqlitePool, mal_id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override FROM series WHERE mal_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE mal_id = ?",
     )
     .bind(mal_id)
     .fetch_optional(db)
@@ -395,7 +403,7 @@ pub async fn refresh_core_metadata(
 
 pub async fn get_unreconciled_fallbacks(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;
@@ -428,6 +436,25 @@ pub async fn update_monitor_mode_manual_override(
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE series SET monitor_mode_manual_override = ? WHERE id = ?")
         .bind(if flag { 1_i64 } else { 0_i64 })
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// #62 PR C — write the user's personal score from the linked
+/// AL/MAL account. AL's POINT_10_DECIMAL format stores fractional
+/// values, so the column is REAL. Stored as `0.0` for unrated
+/// (matching AL's "0 means no score" convention); the render helper
+/// in `services::user_score` treats 0.0 the same as NULL and never
+/// shows `You: 0`.
+pub async fn update_user_score(
+    db: &SqlitePool,
+    id: i64,
+    score: Option<f64>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE series SET user_score = ? WHERE id = ?")
+        .bind(score)
         .bind(id)
         .execute(db)
         .await?;
@@ -493,7 +520,7 @@ pub async fn list_synced_from(
     account_id: i64,
 ) -> Result<Vec<SyncedSeriesRow>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, monitor_mode, monitor_mode_manual_override FROM series \
+        "SELECT id, anilist_id, monitor_mode, monitor_mode_manual_override, user_score FROM series \
          WHERE synced_from_external_account_id = ?",
     )
     .bind(account_id)

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -186,13 +186,29 @@ pub struct AniListMediaListEntry {
 /// Errors classify the same way other AL calls do (rate-limited /
 /// unavailable / not-found prefixes). The watch-list sync task
 /// surfaces the message verbatim under `LogCategory::ExternalSync`.
+/// Bundle returned by [`fetch_media_list_collection`] — the watch-
+/// list entries plus the user's currently-configured `scoreFormat`.
+/// The format is fetched in the same GraphQL call (rather than only
+/// at link time) so the sync engine refreshes
+/// `external_accounts.score_format` on every tick — a user changing
+/// their POINT_X preference on AL after linking takes effect on the
+/// next sync without forcing them to unlink + re-link.
+#[derive(Debug, Clone)]
+pub struct MediaListCollectionFetch {
+    pub entries: Vec<AniListMediaListEntry>,
+    pub score_format: String,
+}
+
 pub async fn fetch_media_list_collection(
     token: &str,
     user_id: i64,
-) -> Result<Vec<AniListMediaListEntry>, String> {
+) -> Result<MediaListCollectionFetch, String> {
     // Just the fields the sync engine reads. Each entry's `customLists`
     // is AL's per-entry membership map; the outer `lists[].isCustomList`
     // is the bucket flag we use to skip the custom-list duplicates.
+    // `User.mediaListOptions.scoreFormat` lets the sync refresh the
+    // local `score_format` column on every tick — that way switching
+    // POINT_X on AL post-link takes effect on the next sync.
     const QUERY: &str = r#"
         query ($userId: Int!) {
             MediaListCollection(userId: $userId, type: ANIME) {
@@ -207,6 +223,11 @@ pub async fn fetch_media_list_collection(
                         updatedAt
                         notes
                         customLists
+                    }
+                }
+                user {
+                    mediaListOptions {
+                        scoreFormat
                     }
                 }
             }
@@ -304,7 +325,20 @@ pub async fn fetch_media_list_collection(
         );
     }
 
-    Ok(out)
+    // Pull the user's current scoreFormat from the same response.
+    // Empty string fallback if AL omits the field — the sync caller
+    // treats empty as "leave the existing value alone" so we don't
+    // wipe a known-good score_format on a partial response.
+    let score_format = json
+        .pointer("/data/MediaListCollection/user/mediaListOptions/scoreFormat")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    Ok(MediaListCollectionFetch {
+        entries: out,
+        score_format,
+    })
 }
 
 /// Walk only the non-custom-list buckets to avoid double-counting

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -2117,6 +2117,7 @@ mod tests {
             restrict_to_uploader: user.to_string(),
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
+            user_score: None,
         }
     }
 

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -478,6 +478,32 @@ async fn stamp_synced_from_if_set(db: &SqlitePool, series_id: i64, account_id: O
     }
 }
 
+/// #62 PR C — write the user's personal score from the sync entry
+/// onto `series.user_score`. Skips silently when `account_id` is
+/// `None` (unit-test pathway with no live account). Normalizes AL's
+/// `0.0` "unrated" sentinel to `NULL` so the schema unambiguously
+/// means "rated" when the column is non-null; the render helper
+/// still handles 0.0 defensively for any rows that pre-date the
+/// normalization.
+///
+/// Best-effort write, same rationale as `stamp_synced_from_if_set`:
+/// a failure logs but doesn't fail the merge. A missing score just
+/// means the "You: X" badge won't render until the next tick.
+async fn stamp_user_score_if_set(
+    db: &SqlitePool,
+    series_id: i64,
+    score: f64,
+    account_id: Option<i64>,
+) {
+    if account_id.is_none() {
+        return;
+    }
+    let normalized = if score > 0.0 { Some(score) } else { None };
+    if let Err(e) = series::update_user_score(db, series_id, normalized).await {
+        tracing::warn!("series::update_user_score failed for series_id={series_id}: {e}");
+    }
+}
+
 /// Report from a removal-detection pass. `removed` is the list of
 /// `series.id` whose monitor_mode got downgraded to `None` because
 /// they were no longer in the user's AL/MAL list. Surfaces in the
@@ -605,6 +631,7 @@ async fn merge_one_jikan_entry(
         // (Watching → Dropped) must downgrade local monitor_mode
         // even when the new status's import flag is off.
         stamp_synced_from_if_set(db, row.id, account_id).await;
+        stamp_user_score_if_set(db, row.id, entry.score, account_id).await;
         // Manual override takes precedence: the user has explicitly
         // pinned this series's monitor_mode through the UI. Sync
         // honors that pin until the user clears it via "Sync from
@@ -678,6 +705,7 @@ async fn merge_one_jikan_entry(
     }
 
     stamp_synced_from_if_set(db, series_id, account_id).await;
+    stamp_user_score_if_set(db, series_id, entry.score, account_id).await;
     monitoring_service::apply_monitor_mode(db, series_id, target_mode).await?;
     Ok(MergeAction::Created(NewArtworkSpec {
         series_id,
@@ -705,6 +733,7 @@ async fn merge_one_anilist_entry(
         // even when `import_dropped = false`, otherwise the series
         // silently keeps grabbing for a show the user dropped.
         stamp_synced_from_if_set(db, row.id, account_id).await;
+        stamp_user_score_if_set(db, row.id, entry.score, account_id).await;
         // Manual override takes precedence: the user pinned this
         // series's monitor_mode through the UI. Sync honors the pin
         // until the user clears it via "Sync from AL/MAL".
@@ -767,6 +796,7 @@ async fn merge_one_anilist_entry(
     }
 
     stamp_synced_from_if_set(db, series_id, account_id).await;
+    stamp_user_score_if_set(db, series_id, entry.score, account_id).await;
     monitoring_service::apply_monitor_mode(db, series_id, target_mode).await?;
     Ok(MergeAction::Created(NewArtworkSpec {
         series_id,
@@ -2373,6 +2403,78 @@ mod tests {
         // Account 2's series is unaffected.
         let acct2 = series::get_by_id(&db, acct2_series).await.unwrap().unwrap();
         assert_eq!(acct2.monitor_mode, MonitorMode::All.as_str());
+    }
+
+    #[tokio::test]
+    async fn merge_writes_user_score_on_existing_series() {
+        // Sync brings in entry.score = 8.5; merge writes it to
+        // series.user_score so the "You: 8.5" badge renders. Doesn't
+        // need to be a status transition — score updates on every
+        // tick regardless of monitor_mode movement.
+        let db = crate::test_support::in_memory_pool().await;
+        seed_account_id(&db, 1, "anilist").await;
+        let series_id = crate::test_support::seed_series(&db, 12345, "Scored").await;
+
+        let entries = vec![SyncEntry {
+            provider: external_accounts::PROVIDER_ANILIST.to_string(),
+            provider_media_id: 12345,
+            anilist_id: 12345,
+            status: NormalizedStatus::Watching,
+            progress: 4,
+            score: 8.5,
+            updated_at: 0,
+            custom_lists: Vec::new(),
+        }];
+        let outcome =
+            merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
+        // Existing series → MonitorUpdated (the seed left monitor_mode
+        // empty so target=All differs); the test pins user_score
+        // regardless of the action variant.
+        assert!(outcome.failed.is_empty());
+
+        let row = series::get_by_id(&db, series_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.user_score,
+            Some(8.5),
+            "merge must write entry.score to user_score"
+        );
+    }
+
+    #[tokio::test]
+    async fn merge_normalizes_zero_score_to_null() {
+        // AL sends 0.0 for unrated entries. The merge normalizes that
+        // to NULL so `user_score IS NOT NULL` cleanly means "rated"
+        // for any future query. Render helper handles 0.0 defensively
+        // for older rows but new writes never produce it.
+        let db = crate::test_support::in_memory_pool().await;
+        seed_account_id(&db, 1, "anilist").await;
+        let series_id = crate::test_support::seed_series(&db, 12345, "Unrated").await;
+        // Pre-condition: user_score is non-null (e.g. user rated 7
+        // last sync, then unrated this sync).
+        sqlx::query("UPDATE series SET user_score = 7.0 WHERE id = ?")
+            .bind(series_id)
+            .execute(&db)
+            .await
+            .unwrap();
+
+        let entries = vec![SyncEntry {
+            provider: external_accounts::PROVIDER_ANILIST.to_string(),
+            provider_media_id: 12345,
+            anilist_id: 12345,
+            status: NormalizedStatus::Watching,
+            progress: 0,
+            score: 0.0,
+            updated_at: 0,
+            custom_lists: Vec::new(),
+        }];
+        let _ =
+            merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
+
+        let row = series::get_by_id(&db, series_id).await.unwrap().unwrap();
+        assert_eq!(
+            row.user_score, None,
+            "score=0.0 must normalize to NULL on write"
+        );
     }
 
     #[tokio::test]

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -2467,8 +2467,7 @@ mod tests {
             updated_at: 0,
             custom_lists: Vec::new(),
         }];
-        let _ =
-            merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
+        let _ = merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
 
         let row = series::get_by_id(&db, series_id).await.unwrap().unwrap();
         assert_eq!(

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -984,8 +984,24 @@ async fn sync_anilist(
         )
     })?;
 
-    let raw = anilist::fetch_media_list_collection(&account.access_token, user_id).await?;
+    let fetch = anilist::fetch_media_list_collection(&account.access_token, user_id).await?;
+    let raw = fetch.entries;
     let raw_total = raw.len();
+
+    // Refresh the user's score_format on the linked-account row so
+    // the "You: X" badge picks up POINT_X changes the user made on
+    // AL after their original link. Empty-string responses no-op
+    // (defensive — AL's user.mediaListOptions field has been stable
+    // for years but a partial response shouldn't blank a known-good
+    // value).
+    if let Err(e) =
+        external_accounts::update_score_format(&state.db, account.id, &fetch.score_format).await
+    {
+        tracing::warn!(
+            "update_score_format failed for account_id={}: {e}",
+            account.id
+        );
+    }
 
     let prefs = ImportPreferences {
         import_watching: account.import_watching,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -49,3 +49,5 @@ pub mod source_ffprobe;
 pub mod source_filename;
 pub mod source_groups;
 pub mod source_temporal;
+
+pub mod user_score;

--- a/src/services/nfo.rs
+++ b/src/services/nfo.rs
@@ -469,6 +469,7 @@ mod tests {
             restrict_to_uploader: String::new(),
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
+            user_score: None,
         }
     }
 

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -1997,6 +1997,7 @@ mod evaluate_candidate_tests {
             restrict_to_uploader: String::new(),
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
+            user_score: None,
         }
     }
 

--- a/src/services/user_score.rs
+++ b/src/services/user_score.rs
@@ -2,12 +2,18 @@
 //!
 //! AniList stores a single numeric score per entry; the user picks
 //! which display format they want it rendered in (POINT_10, stars,
-//! smileys, etc.). The score-format string lives on
-//! `external_accounts.score_format` and is applied at render time
-//! rather than write time — that way a user changing their format
-//! preference on AL flips every "You: X" badge in Ryokan on the
-//! next sync (which re-reads `score_format` along with the watch
-//! list) without needing to touch every series row.
+//! POINT_3 outline smiley faces, etc.). The score-format string
+//! lives on `external_accounts.score_format` and is applied at
+//! render time rather than write time — that way a user changing
+//! their format preference on AL flips every "You: X" badge in
+//! Ryokan on the next sync (which re-reads `score_format` along
+//! with the watch list) without needing to touch every series row.
+//!
+//! POINT_3 renders as inline outline-face SVGs (sad/neutral/happy),
+//! matching AL's own UI. The other formats are plain text. The
+//! [`FormattedUserScore`] enum is the type-safe split — templates
+//! call `render_html()` which emits HTML-safe text or SVG markup
+//! depending on the variant.
 //!
 //! MAL's API always returns 0..=10 integers; we treat MAL the same
 //! as AL's POINT_10. The unrated-on-AL sentinel is `0.0`, and AL's
@@ -20,46 +26,111 @@
 ///
 /// Returns `None` when:
 ///   - `score` is `None` (no linked account, or the column is NULL).
-///   - `score` is `0.0` or negative (AL's "unrated" sentinel — never
-///     show "You: 0" because that's a real AL score the user didn't
-///     pick).
+///   - `score` is `0.0`, negative, or NaN (AL's "unrated" sentinel
+///     covers the first two; NaN is theoretical defense — `(NaN as
+///     i64) = 0`, which would render `You: 0` if it slipped through).
+///   - `score_format` is empty, indicating no account is currently
+///     linked. A residual `user_score` from a previously-linked
+///     account would otherwise render through this function's
+///     POINT_10 fallback against the wrong formatter (e.g. an AL
+///     POINT_100 score of 85 surfacing as "You: 85" through MAL's
+///     POINT_10). The unlink path wipes user_score so this branch
+///     shouldn't fire in practice, but defense-in-depth keeps a
+///     buggy data-state from leaking nonsense badges.
 ///
-/// Returns `Some(display_string)` otherwise — formatted per the
-/// score-format rules:
-///   - `POINT_3` → `:(` (1) / `:|` (2) / `:)` (3). AL's smiley scale.
-///   - `POINT_5` → `★★★☆☆` style (1..=5 filled stars out of 5).
-///   - `POINT_10` (default for unknown formats + MAL) → `8` (integer).
-///   - `POINT_10_DECIMAL` → `8.5` (one decimal).
-///   - `POINT_100` → `85` (integer 1..=100).
+/// Returns `Some(formatted)` otherwise — variant per format:
+///   - `POINT_3` → `Smiley(Sad|Neutral|Happy)`. The template renders
+///     each as an inline outline-face SVG via `Smiley::svg()`.
+///   - `POINT_5` → `Text("★★★☆☆")` style (1..=5 filled out of 5).
+///   - `POINT_10` (default for unknown formats + MAL) → `Text("8")`.
+///   - `POINT_10_DECIMAL` → `Text("8.5")` (one decimal).
+///   - `POINT_100` → `Text("85")` (integer 1..=100).
 ///
-/// Unknown `score_format` strings fall through to `POINT_10` rather
-/// than returning `None` — better to show a number than hide the
-/// user's score entirely on a future format addition.
-pub fn format_user_score(score: Option<f64>, score_format: &str) -> Option<String> {
+/// Unknown non-empty `score_format` strings fall through to
+/// `POINT_10` rather than returning `None` — better to show a number
+/// than hide the user's score entirely on a future format addition.
+pub fn format_user_score(score: Option<f64>, score_format: &str) -> Option<FormattedUserScore> {
+    if score_format.is_empty() {
+        return None;
+    }
     let s = score?;
-    if s <= 0.0 {
+    if s.is_nan() || s <= 0.0 {
         return None;
     }
     Some(match score_format {
         "POINT_3" => format_point_3(s),
-        "POINT_5" => format_point_5(s),
-        "POINT_10_DECIMAL" => format!("{s:.1}"),
-        "POINT_100" => format!("{}", s.round() as i64),
-        _ => format!("{}", s.round() as i64),
+        "POINT_5" => FormattedUserScore::Text(format_point_5(s)),
+        "POINT_10_DECIMAL" => FormattedUserScore::Text(format!("{s:.1}")),
+        "POINT_100" => FormattedUserScore::Text(format!("{}", s.round() as i64)),
+        _ => FormattedUserScore::Text(format!("{}", s.round() as i64)),
     })
 }
 
-/// AL's three-point smiley scale. Stored as 1.0/2.0/3.0; rendered as
-/// the corresponding glyph. A value outside that range falls through
-/// to a numeric render so a future scale change doesn't leave the
-/// badge blank.
-fn format_point_3(s: f64) -> String {
+/// Two-shape display for the rendered user score. Most formats are
+/// plain text (numbers, stars). AL's POINT_3 is a 3-way smiley scale
+/// that AL itself renders as outlined faces; we mirror that by
+/// returning a [`Smiley`] variant the template renders as inline
+/// SVG instead of a text glyph.
+#[derive(Debug, Clone, PartialEq)]
+pub enum FormattedUserScore {
+    Text(String),
+    Smiley(Smiley),
+}
+
+/// AL's POINT_3 scale. Stored on disk as `1.0` / `2.0` / `3.0`; the
+/// template branches on this enum to render the matching outline-
+/// face SVG. Any value outside `1..=3` falls through to a numeric
+/// `Text` render so a future AL scale-shape change doesn't leave
+/// the badge blank.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Smiley {
+    Sad,
+    Neutral,
+    Happy,
+}
+
+impl FormattedUserScore {
+    /// Render-time helper for templates: HTML-safe string for the
+    /// Text variant (numbers + stars are already pre-escaped by
+    /// construction), inline SVG markup for the Smiley variant.
+    /// Templates use this with the `|safe` filter so the SVG
+    /// passes through unescaped.
+    pub fn render_html(&self) -> String {
+        match self {
+            FormattedUserScore::Text(s) => s.clone(),
+            FormattedUserScore::Smiley(s) => s.svg().to_string(),
+        }
+    }
+}
+
+impl Smiley {
+    /// Inline SVG for the smiley face. Outline-only, sized to sit on
+    /// the same baseline as the surrounding badge text. `currentColor`
+    /// stroke so it picks up the `.tag-user-score` accent tint without
+    /// a separate fill rule. `aria-label` keeps the screen-reader
+    /// behavior parity with the text formats.
+    pub fn svg(&self) -> &'static str {
+        match self {
+            Smiley::Sad => SAD_SVG,
+            Smiley::Neutral => NEUTRAL_SVG,
+            Smiley::Happy => HAPPY_SVG,
+        }
+    }
+}
+
+const SAD_SVG: &str = r#"<svg class="user-score-smiley" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Score: sad"><circle cx="12" cy="12" r="10"/><path d="M16 16s-1.5-2-4-2-4 2-4 2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>"#;
+const NEUTRAL_SVG: &str = r#"<svg class="user-score-smiley" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Score: neutral"><circle cx="12" cy="12" r="10"/><line x1="8" y1="15" x2="16" y2="15"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>"#;
+const HAPPY_SVG: &str = r#"<svg class="user-score-smiley" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-label="Score: happy"><circle cx="12" cy="12" r="10"/><path d="M8 14s1.5 2 4 2 4-2 4-2"/><line x1="9" y1="9" x2="9.01" y2="9"/><line x1="15" y1="9" x2="15.01" y2="9"/></svg>"#;
+
+fn format_point_3(s: f64) -> FormattedUserScore {
     let n = s.round() as i64;
     match n {
-        1 => ":(".to_string(),
-        2 => ":|".to_string(),
-        3 => ":)".to_string(),
-        _ => format!("{n}"),
+        1 => FormattedUserScore::Smiley(Smiley::Sad),
+        2 => FormattedUserScore::Smiley(Smiley::Neutral),
+        3 => FormattedUserScore::Smiley(Smiley::Happy),
+        // Out-of-range falls through to numeric so a future AL scale
+        // shift doesn't blank the badge.
+        _ => FormattedUserScore::Text(format!("{n}")),
     }
 }
 
@@ -113,83 +184,141 @@ mod tests {
         assert!(format_user_score(Some(-99.0), "POINT_100").is_none());
     }
 
+    fn text(s: &str) -> FormattedUserScore {
+        FormattedUserScore::Text(s.into())
+    }
+
     #[test]
     fn point_10_renders_integer() {
-        assert_eq!(format_user_score(Some(8.0), "POINT_10"), Some("8".into()));
-        // Half-points (an AL UI quirk for the integer scale) round
-        // to nearest. The user's chosen format is what matters; if
-        // they picked POINT_10 we never show "8.5".
-        assert_eq!(format_user_score(Some(8.5), "POINT_10"), Some("9".into()));
-        assert_eq!(format_user_score(Some(8.4), "POINT_10"), Some("8".into()));
+        assert_eq!(format_user_score(Some(8.0), "POINT_10"), Some(text("8")));
+        // Half-points round to nearest. If the user picked POINT_10
+        // we never show "8.5".
+        assert_eq!(format_user_score(Some(8.5), "POINT_10"), Some(text("9")));
+        assert_eq!(format_user_score(Some(8.4), "POINT_10"), Some(text("8")));
     }
 
     #[test]
     fn point_10_decimal_renders_one_fraction() {
         assert_eq!(
             format_user_score(Some(8.5), "POINT_10_DECIMAL"),
-            Some("8.5".into())
+            Some(text("8.5"))
         );
         assert_eq!(
             format_user_score(Some(7.0), "POINT_10_DECIMAL"),
-            Some("7.0".into())
+            Some(text("7.0"))
         );
     }
 
     #[test]
     fn point_100_renders_integer() {
-        assert_eq!(
-            format_user_score(Some(85.0), "POINT_100"),
-            Some("85".into())
-        );
+        assert_eq!(format_user_score(Some(85.0), "POINT_100"), Some(text("85")));
         assert_eq!(
             format_user_score(Some(99.7), "POINT_100"),
-            Some("100".into())
+            Some(text("100"))
         );
     }
 
     #[test]
-    fn point_3_smileys() {
-        assert_eq!(format_user_score(Some(1.0), "POINT_3"), Some(":(".into()));
-        assert_eq!(format_user_score(Some(2.0), "POINT_3"), Some(":|".into()));
-        assert_eq!(format_user_score(Some(3.0), "POINT_3"), Some(":)".into()));
-        // Out-of-range falls through — never blank.
-        assert_eq!(format_user_score(Some(4.0), "POINT_3"), Some("4".into()));
+    fn point_3_renders_smiley_variants() {
+        // AL's three-point scale is rendered as outlined-face SVGs
+        // by the template; the helper returns the Smiley variant so
+        // the template can branch on it. Out-of-range falls through
+        // to numeric Text.
+        assert_eq!(
+            format_user_score(Some(1.0), "POINT_3"),
+            Some(FormattedUserScore::Smiley(Smiley::Sad))
+        );
+        assert_eq!(
+            format_user_score(Some(2.0), "POINT_3"),
+            Some(FormattedUserScore::Smiley(Smiley::Neutral))
+        );
+        assert_eq!(
+            format_user_score(Some(3.0), "POINT_3"),
+            Some(FormattedUserScore::Smiley(Smiley::Happy))
+        );
+        assert_eq!(format_user_score(Some(4.0), "POINT_3"), Some(text("4")));
+    }
+
+    #[test]
+    fn smiley_svg_contains_currentcolor_stroke() {
+        // The badge inherits its color via .tag-user-score; the SVG
+        // must use stroke="currentColor" so it picks up the same
+        // accent. Pin this so a future SVG redraw doesn't accidentally
+        // hardcode a color.
+        for s in [Smiley::Sad, Smiley::Neutral, Smiley::Happy] {
+            assert!(
+                s.svg().contains(r#"stroke="currentColor""#),
+                "{:?} SVG must use currentColor stroke",
+                s
+            );
+            assert!(
+                s.svg().starts_with("<svg"),
+                "{:?} SVG must be a complete <svg> element",
+                s
+            );
+        }
+    }
+
+    #[test]
+    fn render_html_returns_text_or_svg_per_variant() {
+        // Text variant round-trips its inner string verbatim; Smiley
+        // variant emits its SVG markup. Templates use `|safe` on the
+        // result to let the SVG through.
+        assert_eq!(text("8").render_html(), "8");
+        let happy = FormattedUserScore::Smiley(Smiley::Happy);
+        assert!(happy.render_html().contains("<svg"));
+        assert!(happy.render_html().contains("Score: happy"));
     }
 
     #[test]
     fn point_5_stars() {
-        assert_eq!(
-            format_user_score(Some(1.0), "POINT_5"),
-            Some("★☆☆☆☆".into())
-        );
-        assert_eq!(
-            format_user_score(Some(3.0), "POINT_5"),
-            Some("★★★☆☆".into())
-        );
-        assert_eq!(
-            format_user_score(Some(5.0), "POINT_5"),
-            Some("★★★★★".into())
-        );
+        assert_eq!(format_user_score(Some(1.0), "POINT_5"), Some(text("★☆☆☆☆")));
+        assert_eq!(format_user_score(Some(3.0), "POINT_5"), Some(text("★★★☆☆")));
+        assert_eq!(format_user_score(Some(5.0), "POINT_5"), Some(text("★★★★★")));
         // Out-of-range falls through to numeric.
-        assert_eq!(format_user_score(Some(6.0), "POINT_5"), Some("6".into()));
+        assert_eq!(format_user_score(Some(6.0), "POINT_5"), Some(text("6")));
     }
 
     #[test]
-    fn unknown_format_falls_through_to_point_10() {
+    fn unknown_non_empty_format_falls_through_to_point_10() {
         // Future AL format addition shouldn't blank the badge — show
-        // the number until the renderer learns the new shape. The
-        // test pins the fallback so a refactor that returns None on
-        // unknown breaks visibly.
-        assert_eq!(format_user_score(Some(8.0), "POINT_NEW"), Some("8".into()));
-        assert_eq!(format_user_score(Some(8.0), ""), Some("8".into()));
+        // the number until the renderer learns the new shape.
+        assert_eq!(format_user_score(Some(8.0), "POINT_NEW"), Some(text("8")));
+        assert_eq!(
+            format_user_score(Some(8.0), "POINT_FUTURE_42"),
+            Some(text("8"))
+        );
+    }
+
+    #[test]
+    fn empty_format_returns_none_to_hide_stale_scores() {
+        // Regression for the unlink case: a user unlinks AL while
+        // series rows still carry user_score from the previous sync.
+        // The handler passes "" for score_format because no account
+        // is currently linked. Render must hide the badge — without
+        // this the renderer would fall through to POINT_10 and an
+        // AL POINT_100 score of 85 would render as "You: 85" through
+        // the wrong formatter. (The unlink path also wipes
+        // user_score; this guard is defense-in-depth.)
+        assert!(format_user_score(Some(85.0), "").is_none());
+        assert!(format_user_score(Some(8.5), "").is_none());
+    }
+
+    #[test]
+    fn nan_score_returns_none() {
+        // (NaN as i64) is 0 in Rust, so without an explicit guard a
+        // NaN slipping through (corrupt DB, buggy provider) would
+        // render as "You: 0" — exactly what the zero-sentinel guard
+        // exists to prevent. AL/MAL never send NaN today; the guard
+        // is theoretical but cheap.
+        assert!(format_user_score(Some(f64::NAN), "POINT_10").is_none());
     }
 
     #[test]
     fn mal_scores_render_via_point_10_fallback() {
         // MAL doesn't expose a score_format on its API; the sync
         // engine writes `"POINT_10"` for MAL accounts so the
-        // renderer treats them the same way. Pin the integer render
-        // to confirm the contract.
-        assert_eq!(format_user_score(Some(7.0), "POINT_10"), Some("7".into()));
+        // renderer treats them the same way.
+        assert_eq!(format_user_score(Some(7.0), "POINT_10"), Some(text("7")));
     }
 }

--- a/src/services/user_score.rs
+++ b/src/services/user_score.rs
@@ -1,0 +1,195 @@
+//! Render-time conversion for user-score badges (issue #62 PR C).
+//!
+//! AniList stores a single numeric score per entry; the user picks
+//! which display format they want it rendered in (POINT_10, stars,
+//! smileys, etc.). The score-format string lives on
+//! `external_accounts.score_format` and is applied at render time
+//! rather than write time — that way a user changing their format
+//! preference on AL flips every "You: X" badge in Ryokan on the
+//! next sync (which re-reads `score_format` along with the watch
+//! list) without needing to touch every series row.
+//!
+//! MAL's API always returns 0..=10 integers; we treat MAL the same
+//! as AL's POINT_10. The unrated-on-AL sentinel is `0.0`, and AL's
+//! own UI hides "0" — we mirror that by returning `None` from
+//! [`format_user_score`] for any non-positive value.
+
+/// Render a `series.user_score` value for badge display, applying
+/// the user's chosen `score_format` from
+/// `external_accounts.score_format`.
+///
+/// Returns `None` when:
+///   - `score` is `None` (no linked account, or the column is NULL).
+///   - `score` is `0.0` or negative (AL's "unrated" sentinel — never
+///     show "You: 0" because that's a real AL score the user didn't
+///     pick).
+///
+/// Returns `Some(display_string)` otherwise — formatted per the
+/// score-format rules:
+///   - `POINT_3` → `:(` (1) / `:|` (2) / `:)` (3). AL's smiley scale.
+///   - `POINT_5` → `★★★☆☆` style (1..=5 filled stars out of 5).
+///   - `POINT_10` (default for unknown formats + MAL) → `8` (integer).
+///   - `POINT_10_DECIMAL` → `8.5` (one decimal).
+///   - `POINT_100` → `85` (integer 1..=100).
+///
+/// Unknown `score_format` strings fall through to `POINT_10` rather
+/// than returning `None` — better to show a number than hide the
+/// user's score entirely on a future format addition.
+pub fn format_user_score(score: Option<f64>, score_format: &str) -> Option<String> {
+    let s = score?;
+    if s <= 0.0 {
+        return None;
+    }
+    Some(match score_format {
+        "POINT_3" => format_point_3(s),
+        "POINT_5" => format_point_5(s),
+        "POINT_10_DECIMAL" => format!("{s:.1}"),
+        "POINT_100" => format!("{}", s.round() as i64),
+        _ => format!("{}", s.round() as i64),
+    })
+}
+
+/// AL's three-point smiley scale. Stored as 1.0/2.0/3.0; rendered as
+/// the corresponding glyph. A value outside that range falls through
+/// to a numeric render so a future scale change doesn't leave the
+/// badge blank.
+fn format_point_3(s: f64) -> String {
+    let n = s.round() as i64;
+    match n {
+        1 => ":(".to_string(),
+        2 => ":|".to_string(),
+        3 => ":)".to_string(),
+        _ => format!("{n}"),
+    }
+}
+
+/// AL's five-star scale. Filled stars + empty stars to 5 total.
+/// Out-of-range values fall through to a numeric render.
+fn format_point_5(s: f64) -> String {
+    let n = s.round() as i64;
+    if !(1..=5).contains(&n) {
+        return format!("{n}");
+    }
+    let filled = n as usize;
+    let empty = 5 - filled;
+    format!("{}{}", "★".repeat(filled), "☆".repeat(empty))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_score_returns_none() {
+        // No linked account / NULL column → no badge.
+        assert!(format_user_score(None, "POINT_10").is_none());
+    }
+
+    #[test]
+    fn zero_score_returns_none_for_every_format() {
+        // AL's "unrated" sentinel — must never render as "You: 0".
+        // Cover every format so a renderer that handles one branch
+        // wrong gets caught.
+        for fmt in [
+            "POINT_3",
+            "POINT_5",
+            "POINT_10",
+            "POINT_10_DECIMAL",
+            "POINT_100",
+            "GARBAGE",
+        ] {
+            assert!(
+                format_user_score(Some(0.0), fmt).is_none(),
+                "format {fmt} must hide score 0"
+            );
+        }
+    }
+
+    #[test]
+    fn negative_scores_return_none() {
+        // Belt-and-braces: a buggy provider response with a negative
+        // value should also hide rather than render a confusing badge.
+        assert!(format_user_score(Some(-1.0), "POINT_10").is_none());
+        assert!(format_user_score(Some(-99.0), "POINT_100").is_none());
+    }
+
+    #[test]
+    fn point_10_renders_integer() {
+        assert_eq!(format_user_score(Some(8.0), "POINT_10"), Some("8".into()));
+        // Half-points (an AL UI quirk for the integer scale) round
+        // to nearest. The user's chosen format is what matters; if
+        // they picked POINT_10 we never show "8.5".
+        assert_eq!(format_user_score(Some(8.5), "POINT_10"), Some("9".into()));
+        assert_eq!(format_user_score(Some(8.4), "POINT_10"), Some("8".into()));
+    }
+
+    #[test]
+    fn point_10_decimal_renders_one_fraction() {
+        assert_eq!(
+            format_user_score(Some(8.5), "POINT_10_DECIMAL"),
+            Some("8.5".into())
+        );
+        assert_eq!(
+            format_user_score(Some(7.0), "POINT_10_DECIMAL"),
+            Some("7.0".into())
+        );
+    }
+
+    #[test]
+    fn point_100_renders_integer() {
+        assert_eq!(
+            format_user_score(Some(85.0), "POINT_100"),
+            Some("85".into())
+        );
+        assert_eq!(
+            format_user_score(Some(99.7), "POINT_100"),
+            Some("100".into())
+        );
+    }
+
+    #[test]
+    fn point_3_smileys() {
+        assert_eq!(format_user_score(Some(1.0), "POINT_3"), Some(":(".into()));
+        assert_eq!(format_user_score(Some(2.0), "POINT_3"), Some(":|".into()));
+        assert_eq!(format_user_score(Some(3.0), "POINT_3"), Some(":)".into()));
+        // Out-of-range falls through — never blank.
+        assert_eq!(format_user_score(Some(4.0), "POINT_3"), Some("4".into()));
+    }
+
+    #[test]
+    fn point_5_stars() {
+        assert_eq!(
+            format_user_score(Some(1.0), "POINT_5"),
+            Some("★☆☆☆☆".into())
+        );
+        assert_eq!(
+            format_user_score(Some(3.0), "POINT_5"),
+            Some("★★★☆☆".into())
+        );
+        assert_eq!(
+            format_user_score(Some(5.0), "POINT_5"),
+            Some("★★★★★".into())
+        );
+        // Out-of-range falls through to numeric.
+        assert_eq!(format_user_score(Some(6.0), "POINT_5"), Some("6".into()));
+    }
+
+    #[test]
+    fn unknown_format_falls_through_to_point_10() {
+        // Future AL format addition shouldn't blank the badge — show
+        // the number until the renderer learns the new shape. The
+        // test pins the fallback so a refactor that returns None on
+        // unknown breaks visibly.
+        assert_eq!(format_user_score(Some(8.0), "POINT_NEW"), Some("8".into()));
+        assert_eq!(format_user_score(Some(8.0), ""), Some("8".into()));
+    }
+
+    #[test]
+    fn mal_scores_render_via_point_10_fallback() {
+        // MAL doesn't expose a score_format on its API; the sync
+        // engine writes `"POINT_10"` for MAL accounts so the
+        // renderer treats them the same way. Pin the integer render
+        // to confirm the contract.
+        assert_eq!(format_user_score(Some(7.0), "POINT_10"), Some("7".into()));
+    }
+}

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -132,6 +132,18 @@
     color: var(--red);
 }
 
+/* #62 PR C — user's personal AL/MAL score badge. Distinct from the
+   community-score `.tag-score-*` colors so the user can tell their
+   own rating apart at a glance. The accent tint pulls from the same
+   --accent token Ryokan uses for active-state highlights, so it
+   reads as "this is yours" without competing with the community
+   badge's score-bucket coloring. */
+.tag-user-score {
+    background: rgba(203, 166, 247, 0.16);
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+}
+
 .tag-status-releasing,
 .tag-status-not_yet_released,
 .tag-status-currently_airing,

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -142,6 +142,18 @@
     background: rgba(203, 166, 247, 0.16);
     color: var(--accent);
     font-variant-numeric: tabular-nums;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+/* AL POINT_3 outline-face SVG sits inline with the "You:" prefix
+   and inherits the badge's accent color via `currentColor` on the
+   stroke. -1px translate centers the optical baseline against the
+   surrounding text — without it the circle bottom hangs slightly
+   below the text descender. */
+.user-score-smiley {
+    transform: translateY(-1px);
 }
 
 .tag-status-releasing,

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -650,20 +650,21 @@ fieldset legend {
     flex-wrap: wrap;
 }
 
+/* The container is `.ext-accounts-interval.form-group` — `.form-group`
+   gives the input the canonical bordered/padded treatment (forms.css
+   :36-47) so it matches every other settings input, while
+   `.ext-accounts-interval` adds the divider above and clamps the
+   numeric input to a narrow width. The label uses .form-group's
+   uppercase-eyebrow style so it lines up with the rest of the page. */
 .ext-accounts-interval {
     margin-top: 14px;
     padding-top: 14px;
     border-top: 1px solid var(--border-subtle);
 }
 
-.ext-accounts-interval label {
-    display: block;
-    font-weight: 600;
-    margin-bottom: 4px;
-}
-
 .ext-accounts-interval input[type="number"] {
-    width: 100px;
-    margin-bottom: 6px;
+    /* Override .form-group input's default 100% width — a 4-digit
+       minute count never needs the full row. */
+    width: 120px;
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -50,8 +50,8 @@
                 {# #62 PR C — user's personal score from their linked
                    AL/MAL account. Hidden when no account is linked or
                    the user hasn't rated this series. #}
-                {% if let Some(you_text) = s.user_score_display(score_format.as_str()) %}
-                <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_text }}</span>
+                {% if let Some(you_score) = s.user_score_display(score_format.as_str()) %}
+                <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_score.render_html()|safe }}</span>
                 {% endif %}
             </div>
         </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,6 +47,12 @@
                 <span class="tag tag-res">{% if !s.format.is_empty() %}{{ s.format.replace("_", " ") }}{% else %}TBA{% endif %}</span>
                 {% if let Some(eps) = s.episodes %}<span class="tag tag-res series-eps">{{ eps }} eps</span>{% endif %}
                 <span class="tag tag-status-{{ s.status|lowercase }}">{{ s.status.replace("_", " ") }}</span>
+                {# #62 PR C — user's personal score from their linked
+                   AL/MAL account. Hidden when no account is linked or
+                   the user hasn't rated this series. #}
+                {% if let Some(you_text) = s.user_score_display(score_format.as_str()) %}
+                <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_text }}</span>
+                {% endif %}
             </div>
         </div>
     </a>

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -283,7 +283,7 @@
                            outer Save Settings button (resolver coerces
                            out-of-range values back to the 30-minute
                            default). #}
-                        <div class="ext-accounts-interval">
+                        <div class="ext-accounts-interval form-group">
                             <label for="external_sync_interval_minutes">Sync interval (minutes)</label>
                             <input type="number"
                                    id="external_sync_interval_minutes"

--- a/templates/series.html
+++ b/templates/series.html
@@ -40,6 +40,15 @@
             {% if let Some(score_text) = detail.average_score_display %}
             <span class="tag tag-score {{ detail.score_class }}">{{ score_text }}</span>
             {% endif %}
+            {# #62 PR C — user's personal score from their linked AL/MAL
+               account. Hidden when no account is linked, the series
+               isn't on the user's list, or the user hasn't rated it.
+               The display string is pre-formatted per
+               external_accounts.score_format (POINT_3 smileys, POINT_5
+               stars, POINT_10/_DECIMAL/_100 numbers, MAL integer). #}
+            {% if let Some(you_text) = user_score_display %}
+            <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_text }}</span>
+            {% endif %}
         </div>
 
         <div class="detail-genres">

--- a/templates/series.html
+++ b/templates/series.html
@@ -46,8 +46,8 @@
                The display string is pre-formatted per
                external_accounts.score_format (POINT_3 smileys, POINT_5
                stars, POINT_10/_DECIMAL/_100 numbers, MAL integer). #}
-            {% if let Some(you_text) = user_score_display %}
-            <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_text }}</span>
+            {% if let Some(you_score) = user_score_display %}
+            <span class="tag tag-user-score" title="Your score on AL/MAL">You: {{ you_score.render_html()|safe }}</span>
             {% endif %}
         </div>
 

--- a/tests/external_sync_e2e.rs
+++ b/tests/external_sync_e2e.rs
@@ -44,7 +44,12 @@ fn media_list_collection_response() -> serde_json::Value {
                             }
                         ]
                     }
-                ]
+                ],
+                "user": {
+                    "mediaListOptions": {
+                        "scoreFormat": "POINT_10_DECIMAL"
+                    }
+                }
             }
         }
     })
@@ -197,6 +202,27 @@ async fn watch_list_sync_imports_series_with_resolved_monitor_mode() {
         acct.list_full_resync_at.unwrap_or(0) > 0,
         "first sync is a full sync; list_full_resync_at must also advance"
     );
+    // The fixture's MediaListCollection response carries
+    // user.mediaListOptions.scoreFormat = "POINT_10_DECIMAL"; the
+    // sync MUST persist that on every tick so the user's
+    // post-link POINT_X change takes effect on the next render.
+    // The link seed above started at "POINT_10" — assert the
+    // refresh actually happened.
+    assert_eq!(
+        acct.score_format, "POINT_10_DECIMAL",
+        "sync must refresh score_format from the AL response"
+    );
+
+    // Series row carries user_score = 8.5 from the fixture entry's
+    // `score: 8.5`. Renders via the user's POINT_10_DECIMAL format.
+    assert_eq!(row.user_score, Some(8.5));
+    let formatted =
+        ryokan::services::user_score::format_user_score(row.user_score, &acct.score_format);
+    let html = formatted
+        .as_ref()
+        .expect("badge should render")
+        .render_html();
+    assert_eq!(html, "8.5");
 
     // Cleanup: clear the override so other tests in the same process
     // (sequential within a `cargo test` invocation but separate test


### PR DESCRIPTION
## Summary

Issue #62 PR C — surface the user's personal AL/MAL score on series detail + library cards, formatted per their AL `score_format` preference.

- **Schema**: `series.user_score REAL NULL`. NULL for manually-added series + pre-PR-C rows; sync writes positive values from `SyncEntry.score`, normalizes AL's `0.0` "unrated" sentinel to NULL on write.
- **Render helper** (`services::user_score::format_user_score`): covers all 5 AL formats (POINT_3 smileys, POINT_5 stars, POINT_10, POINT_10_DECIMAL, POINT_100) + MAL fallback. Returns `None` for None / 0.0 / negative so unrated entries never render `You: 0`. Unknown formats fall through to POINT_10.
- **Sync wire**: both merge paths (AL-detail + Jikan-fallback) call `stamp_user_score_if_set` on every successful merge action — score updates on every tick, regardless of whether monitor_mode moved.
- **UI**: "You: X" badge on series detail page (next to the community-score tag) and on every library card. CSS uses an accent tint distinct from the community-score color buckets so the user can visually tell their rating apart from the community's.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- [x] `cargo build --workspace --locked --features test-support`
- [x] `cargo test --workspace --locked --features test-support` — 1208 passed, 22 ignored
- [x] Local smoke: binary boots, migrations apply (`series.user_score` added idempotently), `/login` returns 303 first-run redirect

## Follow-ups

PR D — custom-list membership (AL-only side table + per-series badge row + library filter). PR E — sort-by-user-score, error-surfacing banners, MAL mapping-failure counter, plus the carryovers from PR B (re-link banner, UA-in-builder, Connections-section redesign).

🤖 Generated with [Claude Code](https://claude.com/claude-code)