### PR TITLE
Issue #62 PR D: AL custom-list membership

### DIFF
--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -22,6 +22,16 @@ struct IndexTemplate {
     /// which case `user_score_display` always returns `None` and
     /// the template renders no badge.
     score_format: String,
+    /// #62 PR D — distinct AL custom-list names across the whole
+    /// library. Powers the filter-dropdown next to the search box.
+    /// Empty when no memberships have synced yet, in which case the
+    /// template hides the dropdown entirely.
+    custom_list_names: Vec<String>,
+    /// Currently-active filter value from `?list=<name>`. Empty
+    /// means "no filter, show everything." The handler has already
+    /// applied the filter to `library`; this field drives the
+    /// dropdown's selected-option state on render.
+    custom_list_filter: String,
 }
 
 #[derive(Template)]
@@ -95,6 +105,12 @@ struct SeriesTemplate {
     /// (Text vs. Smiley) drives whether the template renders a
     /// string or an inline SVG outline face.
     user_score_display: Option<crate::services::user_score::FormattedUserScore>,
+    /// #62 PR D — AL custom-list names this series belongs to.
+    /// Sorted alphabetically by the model layer. Empty when no
+    /// memberships are recorded (no account linked, or sync hasn't
+    /// found this series in any custom list); the template hides
+    /// the badge row in that case.
+    custom_list_memberships: Vec<String>,
     monitored_count: i32,
     all_monitored: bool,
     /// Phase 4: series-level upgrade opt-in. Rendered as a checkbox on the

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -82,10 +82,13 @@ pub async fn index(
         // In-memory filter against the just-loaded library. Cheaper
         // than a JOIN-based query when the library is already cached
         // — the per-series ids set is small enough that the
-        // HashSet lookup on each row is sub-microsecond. Filter is
-        // dropped silently if the user passes a list name that
-        // doesn't exist (defensive against a stale tab + a sync
-        // that removed the last membership for that name).
+        // HashSet lookup on each row is sub-microsecond. A stale or
+        // unknown `?list=foo` (e.g. user bookmarked the URL, then
+        // synced away the last membership) yields an empty
+        // matching_ids set and therefore an empty library — chosen
+        // over silently dropping the filter so the dropdown's
+        // still-selected value lines up with what the user sees,
+        // making the staleness obvious instead of mysterious.
         let matching_ids: std::collections::HashSet<i64> =
             crate::models::series_custom_lists::series_ids_in_list(&state.db, &custom_list_filter)
                 .await

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -28,7 +28,21 @@ use super::reconcile::{
 };
 use super::{Episode, ErrorTemplate, IndexTemplate, RelationCard, RelationGroup, SeriesTemplate};
 
-pub async fn index(State(state): State<AppState>) -> Html<String> {
+#[derive(Default, serde::Deserialize)]
+pub struct LibraryIndexQuery {
+    /// #62 PR D — `?list=<name>` filter. When present + non-empty,
+    /// the index handler keeps only series whose
+    /// `series_custom_lists` rows match. Echoed back to the
+    /// template so the dropdown's selected-option state persists
+    /// across navigations.
+    #[serde(default)]
+    pub list: Option<String>,
+}
+
+pub async fn index(
+    State(state): State<AppState>,
+    axum::extract::Query(q): axum::extract::Query<LibraryIndexQuery>,
+) -> Html<String> {
     // Fetch the library list and config concurrently — they're independent
     // and each was previously serialized on the other. `get_all` is the
     // larger query of the two so this shaves the smaller query's RTT off
@@ -57,6 +71,30 @@ pub async fn index(State(state): State<AppState>) -> Html<String> {
         .map(|a| a.score_format)
         .unwrap_or_default();
 
+    // #62 PR D — populate the filter dropdown + apply the active
+    // filter. Distinct list names are alphabetized; empty result
+    // means no memberships synced yet (template hides the dropdown).
+    let custom_list_names = crate::models::series_custom_lists::distinct_list_names(&state.db)
+        .await
+        .unwrap_or_default();
+    let custom_list_filter = q.list.unwrap_or_default();
+    if !custom_list_filter.is_empty() {
+        // In-memory filter against the just-loaded library. Cheaper
+        // than a JOIN-based query when the library is already cached
+        // — the per-series ids set is small enough that the
+        // HashSet lookup on each row is sub-microsecond. Filter is
+        // dropped silently if the user passes a list name that
+        // doesn't exist (defensive against a stale tab + a sync
+        // that removed the last membership for that name).
+        let matching_ids: std::collections::HashSet<i64> =
+            crate::models::series_custom_lists::series_ids_in_list(&state.db, &custom_list_filter)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .collect();
+        library.retain(|s| matching_ids.contains(&s.id));
+    }
+
     let template = IndexTemplate {
         page: "library".to_string(),
         library,
@@ -64,6 +102,8 @@ pub async fn index(State(state): State<AppState>) -> Html<String> {
             .map(|c| c.title_language)
             .unwrap_or_else(|| "english".to_string()),
         score_format,
+        custom_list_names,
+        custom_list_filter,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -203,6 +243,20 @@ pub async fn series_detail(
             crate::services::user_score::format_user_score(row.user_score, &acct.score_format)
         }
         _ => None,
+    };
+
+    // #62 PR D — read AL custom-list memberships for the badge row.
+    // Empty when this series isn't on any user-defined list; the
+    // template hides the row in that case. Sorted alphabetically by
+    // the model layer so the badge order is stable across renders.
+    let custom_list_memberships = match db_id {
+        Some(id) => crate::models::series_custom_lists::list_for_series(&state.db, id)
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .map(|m| m.list_name)
+            .collect(),
+        None => Vec::new(),
     };
 
     // Fan out the five independent read paths. Each one was previously
@@ -383,6 +437,7 @@ pub async fn series_detail(
         sync_provider_label,
         monitor_mode_select_value,
         user_score_display,
+        custom_list_memberships,
         monitored_count,
         all_monitored,
         allow_upgrades,

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -902,6 +902,40 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // #62 PR D — AL custom-list membership. AL groups list entries
+    // into status buckets (CURRENT/PLANNING/etc.) plus zero or more
+    // user-named custom lists; a series can belong to many at once.
+    // The sync engine pulls per-entry membership in the same
+    // GraphQL response and reconciles this side table on every
+    // merge action.
+    //
+    // ON DELETE CASCADE so removing a series wipes its membership
+    // rows without a hand-tracked cleanup. UNIQUE (series_id, provider,
+    // list_name) enforces no-dup membership per (series, account).
+    // `provider` is on the row even though only AL emits these today
+    // (decision-doc baseline); a hypothetical future provider with
+    // its own custom-list concept gets a parallel namespace.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS series_custom_lists (
+            series_id INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            list_name TEXT NOT NULL,
+            PRIMARY KEY (series_id, provider, list_name),
+            FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_series_custom_lists_list_name \
+         ON series_custom_lists (list_name)",
+    )
+    .execute(db)
+    .await?;
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS series_metadata_cache (

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -15,6 +15,7 @@ pub mod pending_grabs;
 pub mod rss;
 pub mod scheduled_tasks;
 pub mod series;
+pub mod series_custom_lists;
 pub mod session;
 pub mod user;
 

--- a/src/models/series_custom_lists.rs
+++ b/src/models/series_custom_lists.rs
@@ -1,0 +1,333 @@
+//! AniList custom-list membership side table (issue #62 PR D).
+//!
+//! Sync writes one row per (series, provider, custom-list-name) on
+//! every merge action. The detail page renders a badge row from
+//! `list_for_series`; the library page filter dropdown reads
+//! `distinct_list_names`.
+//!
+//! AL-only by data: MAL has no custom-list concept and the sync
+//! engine's `entries_from_mal` path always returns an empty
+//! `custom_lists` Vec. The schema's `provider` column exists as
+//! future-proofing — if a provider with its own custom-list shape
+//! ever appears, its memberships get their own namespace per row.
+//!
+//! Reconciliation strategy is replace-on-merge rather than
+//! incremental upsert: AL's GraphQL response carries the FULL
+//! membership map per entry (the `customLists: { name: bool }`
+//! object), so doing a clear+insert per series is both simpler and
+//! correct against the "user removed from a custom list" case.
+//! Without the clear, a series the user moved out of "Hidden gems"
+//! would keep its stale membership row forever.
+
+use sqlx::SqlitePool;
+
+/// One row of `series_custom_lists` projected for read paths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CustomListMembership {
+    pub series_id: i64,
+    pub provider: String,
+    pub list_name: String,
+}
+
+/// Replace the full custom-list membership set for `series_id` +
+/// `provider` with the supplied `list_names`. Any existing row
+/// scoped to the same (series, provider) that isn't in the new set
+/// is dropped, and any name not yet present is inserted. Idempotent
+/// — running twice with the same input is a no-op.
+///
+/// Empty `list_names` clears all memberships for this series under
+/// this provider, which is the right behavior for "the user removed
+/// the entry from every custom list" (or unrated their entries
+/// entirely on AL).
+pub async fn replace_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+    provider: &str,
+    list_names: &[String],
+) -> Result<(), sqlx::Error> {
+    // Two-step inside a transaction so a concurrent reader never
+    // sees a half-cleared membership set. The clear is scoped to
+    // (series_id, provider) so a series synced from AL keeps any
+    // hypothetical future MAL-side list memberships intact (today
+    // MAL never writes any, but the schema supports it).
+    let mut tx = db.begin().await?;
+
+    sqlx::query("DELETE FROM series_custom_lists WHERE series_id = ? AND provider = ?")
+        .bind(series_id)
+        .bind(provider)
+        .execute(&mut *tx)
+        .await?;
+
+    for name in list_names {
+        let trimmed = name.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // INSERT OR IGNORE because the input vector might contain
+        // the same list name twice (defensive — AL's response
+        // shouldn't, but a future schema change could).
+        sqlx::query(
+            "INSERT OR IGNORE INTO series_custom_lists (series_id, provider, list_name) \
+             VALUES (?, ?, ?)",
+        )
+        .bind(series_id)
+        .bind(provider)
+        .bind(trimmed)
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Read every (series_id, provider, list_name) row for a given
+/// series. Sorted by `list_name` so the rendered badge order is
+/// stable regardless of insertion order.
+pub async fn list_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+) -> Result<Vec<CustomListMembership>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (i64, String, String)>(
+        "SELECT series_id, provider, list_name FROM series_custom_lists \
+         WHERE series_id = ? ORDER BY list_name",
+    )
+    .bind(series_id)
+    .fetch_all(db)
+    .await?;
+    Ok(rows
+        .into_iter()
+        .map(|(sid, provider, list_name)| CustomListMembership {
+            series_id: sid,
+            provider,
+            list_name,
+        })
+        .collect())
+}
+
+/// Distinct list names across the entire library, sorted
+/// alphabetically. Powers the library-page filter dropdown — only
+/// names that have at least one membership row appear, so an empty
+/// dropdown means "no custom lists synced yet."
+pub async fn distinct_list_names(db: &SqlitePool) -> Result<Vec<String>, sqlx::Error> {
+    let rows = sqlx::query_scalar::<_, String>(
+        "SELECT DISTINCT list_name FROM series_custom_lists ORDER BY list_name",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+/// Series ids that belong to `list_name`. Used by the library
+/// filter — handler reads this set, then filters the in-memory
+/// `Vec<Series>` against it. Cheaper than re-querying `series` with
+/// a join when the library is already loaded.
+pub async fn series_ids_in_list(db: &SqlitePool, list_name: &str) -> Result<Vec<i64>, sqlx::Error> {
+    let rows = sqlx::query_scalar::<_, i64>(
+        "SELECT series_id FROM series_custom_lists WHERE list_name = ?",
+    )
+    .bind(list_name)
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{in_memory_pool, seed_series};
+
+    #[tokio::test]
+    async fn replace_inserts_initial_memberships() {
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+
+        replace_for_series(
+            &db,
+            series_id,
+            "anilist",
+            &["Hidden Gems".into(), "Rewatching".into()],
+        )
+        .await
+        .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        // Sorted alphabetically by list_name.
+        assert_eq!(rows[0].list_name, "Hidden Gems");
+        assert_eq!(rows[1].list_name, "Rewatching");
+        assert_eq!(rows[0].provider, "anilist");
+    }
+
+    #[tokio::test]
+    async fn replace_drops_removed_lists() {
+        // The user moved a series out of "Hidden Gems" on AL and
+        // into "Top 10" instead. The next sync's replace-on-merge
+        // must drop the old membership; without this the stale row
+        // would persist forever.
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, series_id, "anilist", &["Hidden Gems".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, series_id, "anilist", &["Top 10".into()])
+            .await
+            .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].list_name, "Top 10");
+    }
+
+    #[tokio::test]
+    async fn replace_with_empty_list_clears_memberships() {
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, series_id, "anilist", &["Hidden Gems".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, series_id, "anilist", &[])
+            .await
+            .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn replace_skips_blank_names() {
+        // Defensive: AL shouldn't return blank custom-list keys, but
+        // a future schema bug or a user-edited list name with only
+        // whitespace shouldn't produce a useless empty row.
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(
+            &db,
+            series_id,
+            "anilist",
+            &["".into(), "   ".into(), "Real List".into()],
+        )
+        .await
+        .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].list_name, "Real List");
+    }
+
+    #[tokio::test]
+    async fn replace_dedups_repeat_names() {
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(
+            &db,
+            series_id,
+            "anilist",
+            &["Top 10".into(), "Top 10".into()],
+        )
+        .await
+        .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert_eq!(rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn replace_per_provider_is_namespaced() {
+        // Provider scope: replacing AL memberships must NOT touch a
+        // hypothetical second-provider's rows. Guards against a
+        // future provider being added and the AL replace silently
+        // wiping the other side.
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, series_id, "anilist", &["AL List".into()])
+            .await
+            .unwrap();
+        // Direct insert simulating a future provider.
+        sqlx::query(
+            "INSERT INTO series_custom_lists (series_id, provider, list_name) VALUES (?, ?, ?)",
+        )
+        .bind(series_id)
+        .bind("future_provider")
+        .bind("FP List")
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // Replace AL only — should leave the future_provider row alone.
+        replace_for_series(&db, series_id, "anilist", &["AL List 2".into()])
+            .await
+            .unwrap();
+
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert!(
+            rows.iter()
+                .any(|r| r.provider == "anilist" && r.list_name == "AL List 2")
+        );
+        assert!(rows.iter().any(|r| r.provider == "future_provider"));
+    }
+
+    #[tokio::test]
+    async fn distinct_list_names_returns_sorted_unique() {
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Show 1").await;
+        let s2 = seed_series(&db, 200, "Show 2").await;
+        replace_for_series(&db, s1, "anilist", &["B".into(), "A".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s2, "anilist", &["A".into(), "C".into()])
+            .await
+            .unwrap();
+
+        let names = distinct_list_names(&db).await.unwrap();
+        assert_eq!(names, vec!["A", "B", "C"]);
+    }
+
+    #[tokio::test]
+    async fn distinct_list_names_empty_when_nothing_synced() {
+        let db = in_memory_pool().await;
+        // No memberships → empty dropdown → library page hides the
+        // filter control entirely (handler-side gate).
+        assert!(distinct_list_names(&db).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn series_ids_in_list_returns_matching_rows() {
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Show 1").await;
+        let s2 = seed_series(&db, 200, "Show 2").await;
+        let s3 = seed_series(&db, 300, "Show 3").await;
+        replace_for_series(&db, s1, "anilist", &["Top 10".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s2, "anilist", &["Hidden Gems".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s3, "anilist", &["Top 10".into()])
+            .await
+            .unwrap();
+
+        let mut ids = series_ids_in_list(&db, "Top 10").await.unwrap();
+        ids.sort();
+        assert_eq!(ids, vec![s1, s3]);
+    }
+
+    #[tokio::test]
+    async fn series_delete_cascades_to_custom_lists() {
+        // The FK has ON DELETE CASCADE so dropping a series wipes
+        // its membership rows without a hand-tracked cleanup.
+        let db = in_memory_pool().await;
+        let series_id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, series_id, "anilist", &["Top 10".into()])
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM series WHERE id = ?")
+            .bind(series_id)
+            .execute(&db)
+            .await
+            .unwrap();
+        let rows = list_for_series(&db, series_id).await.unwrap();
+        assert!(rows.is_empty());
+    }
+}

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -2531,8 +2531,7 @@ mod tests {
             updated_at: 0,
             custom_lists: vec!["Hidden Gems".into(), "Top 10".into()],
         }];
-        let _ =
-            merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
+        let _ = merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
 
         let memberships = series_custom_lists::list_for_series(&db, series_id)
             .await

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -510,6 +510,15 @@ async fn stamp_user_score_if_set(
 /// custom-list memberships, so the call would just clear a never-
 /// populated set every tick).
 ///
+/// Called from BOTH the AL-detail and Jikan-fallback merge paths.
+/// The Jikan path is dead-by-data today — `entries_from_mal` always
+/// returns an empty `custom_lists` and the provider check short-
+/// circuits before any DB write — but keeping the call symmetric
+/// across both paths means a hypothetical future provider added to
+/// the Jikan-fallback path inherits the namespace-skip automatically
+/// instead of silently clobbering AL's rows. Two cheap branch-and-
+/// returns per Jikan merge is a fine tax for that invariant.
+///
 /// Replace-on-merge rather than incremental: the GraphQL response
 /// carries the full membership map per entry, so clear+insert is
 /// the right shape for "user moved this out of Hidden Gems" — an

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -48,7 +48,7 @@ use crate::AppState;
 use crate::models::external_accounts::{self, ImportPreferences};
 use crate::models::log::LogCategory;
 use crate::models::monitoring::MonitorMode;
-use crate::models::{metadata_cache, series};
+use crate::models::{metadata_cache, series, series_custom_lists};
 use crate::services::{
     anibridge, anilist, artwork, jikan, logger, mal, monitoring as monitoring_service,
 };
@@ -504,6 +504,42 @@ async fn stamp_user_score_if_set(
     }
 }
 
+/// #62 PR D — replace the series's AL custom-list memberships from
+/// `entry.custom_lists`. Skips when `account_id` is `None` (unit-
+/// test pathway) and when `provider` isn't AniList (MAL never emits
+/// custom-list memberships, so the call would just clear a never-
+/// populated set every tick).
+///
+/// Replace-on-merge rather than incremental: the GraphQL response
+/// carries the full membership map per entry, so clear+insert is
+/// the right shape for "user moved this out of Hidden Gems" — an
+/// upsert path would leak stale rows.
+///
+/// Best-effort: a failure logs but doesn't fail the merge. A
+/// missing membership row just means the badge / filter doesn't
+/// reflect the latest state until the next tick.
+async fn stamp_custom_lists_if_set(
+    db: &SqlitePool,
+    series_id: i64,
+    provider: &str,
+    custom_lists: &[String],
+    account_id: Option<i64>,
+) {
+    if account_id.is_none() {
+        return;
+    }
+    if provider != external_accounts::PROVIDER_ANILIST {
+        return;
+    }
+    if let Err(e) =
+        series_custom_lists::replace_for_series(db, series_id, provider, custom_lists).await
+    {
+        tracing::warn!(
+            "series_custom_lists::replace_for_series failed for series_id={series_id}: {e}"
+        );
+    }
+}
+
 /// Report from a removal-detection pass. `removed` is the list of
 /// `series.id` whose monitor_mode got downgraded to `None` because
 /// they were no longer in the user's AL/MAL list. Surfaces in the
@@ -632,6 +668,8 @@ async fn merge_one_jikan_entry(
         // even when the new status's import flag is off.
         stamp_synced_from_if_set(db, row.id, account_id).await;
         stamp_user_score_if_set(db, row.id, entry.score, account_id).await;
+        stamp_custom_lists_if_set(db, row.id, &entry.provider, &entry.custom_lists, account_id)
+            .await;
         // Manual override takes precedence: the user has explicitly
         // pinned this series's monitor_mode through the UI. Sync
         // honors that pin until the user clears it via "Sync from
@@ -706,6 +744,14 @@ async fn merge_one_jikan_entry(
 
     stamp_synced_from_if_set(db, series_id, account_id).await;
     stamp_user_score_if_set(db, series_id, entry.score, account_id).await;
+    stamp_custom_lists_if_set(
+        db,
+        series_id,
+        &entry.provider,
+        &entry.custom_lists,
+        account_id,
+    )
+    .await;
     monitoring_service::apply_monitor_mode(db, series_id, target_mode).await?;
     Ok(MergeAction::Created(NewArtworkSpec {
         series_id,
@@ -734,6 +780,8 @@ async fn merge_one_anilist_entry(
         // silently keeps grabbing for a show the user dropped.
         stamp_synced_from_if_set(db, row.id, account_id).await;
         stamp_user_score_if_set(db, row.id, entry.score, account_id).await;
+        stamp_custom_lists_if_set(db, row.id, &entry.provider, &entry.custom_lists, account_id)
+            .await;
         // Manual override takes precedence: the user pinned this
         // series's monitor_mode through the UI. Sync honors the pin
         // until the user clears it via "Sync from AL/MAL".
@@ -797,6 +845,14 @@ async fn merge_one_anilist_entry(
 
     stamp_synced_from_if_set(db, series_id, account_id).await;
     stamp_user_score_if_set(db, series_id, entry.score, account_id).await;
+    stamp_custom_lists_if_set(
+        db,
+        series_id,
+        &entry.provider,
+        &entry.custom_lists,
+        account_id,
+    )
+    .await;
     monitoring_service::apply_monitor_mode(db, series_id, target_mode).await?;
     Ok(MergeAction::Created(NewArtworkSpec {
         series_id,
@@ -2454,6 +2510,129 @@ mod tests {
             Some(8.5),
             "merge must write entry.score to user_score"
         );
+    }
+
+    #[tokio::test]
+    async fn merge_writes_custom_list_memberships_for_anilist() {
+        // AL custom-list membership is replaced on every successful
+        // merge action so the detail-page badge row + library filter
+        // stay in lockstep with the user's current AL state.
+        let db = crate::test_support::in_memory_pool().await;
+        seed_account_id(&db, 1, "anilist").await;
+        let series_id = crate::test_support::seed_series(&db, 12345, "Listed").await;
+
+        let entries = vec![SyncEntry {
+            provider: external_accounts::PROVIDER_ANILIST.to_string(),
+            provider_media_id: 12345,
+            anilist_id: 12345,
+            status: NormalizedStatus::Watching,
+            progress: 0,
+            score: 0.0,
+            updated_at: 0,
+            custom_lists: vec!["Hidden Gems".into(), "Top 10".into()],
+        }];
+        let _ =
+            merge_into_library(&db, &entries, &HashMap::new(), &prefs_default(), Some(1)).await;
+
+        let memberships = series_custom_lists::list_for_series(&db, series_id)
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 2);
+        assert!(memberships.iter().any(|m| m.list_name == "Hidden Gems"));
+        assert!(memberships.iter().any(|m| m.list_name == "Top 10"));
+        for m in &memberships {
+            assert_eq!(m.provider, external_accounts::PROVIDER_ANILIST);
+        }
+    }
+
+    #[tokio::test]
+    async fn merge_replaces_stale_custom_list_membership() {
+        // The user moved a series out of "Hidden Gems" on AL. The
+        // next sync's replace-on-merge MUST drop the old membership;
+        // an upsert-only path would leak stale rows forever.
+        let db = crate::test_support::in_memory_pool().await;
+        seed_account_id(&db, 1, "anilist").await;
+        let series_id = crate::test_support::seed_series(&db, 12345, "Moved").await;
+
+        // First sync: in Hidden Gems.
+        let entries_v1 = vec![SyncEntry {
+            provider: external_accounts::PROVIDER_ANILIST.to_string(),
+            provider_media_id: 12345,
+            anilist_id: 12345,
+            status: NormalizedStatus::Watching,
+            progress: 0,
+            score: 0.0,
+            updated_at: 0,
+            custom_lists: vec!["Hidden Gems".into()],
+        }];
+        let _ =
+            merge_into_library(&db, &entries_v1, &HashMap::new(), &prefs_default(), Some(1)).await;
+
+        // Second sync: moved to Top 10, no longer in Hidden Gems.
+        let entries_v2 = vec![SyncEntry {
+            custom_lists: vec!["Top 10".into()],
+            ..entries_v1[0].clone()
+        }];
+        let _ =
+            merge_into_library(&db, &entries_v2, &HashMap::new(), &prefs_default(), Some(1)).await;
+
+        let memberships = series_custom_lists::list_for_series(&db, series_id)
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(memberships[0].list_name, "Top 10");
+    }
+
+    #[tokio::test]
+    async fn merge_jikan_path_does_not_write_custom_lists() {
+        // MAL has no custom-list concept; entries_from_mal always
+        // returns empty custom_lists. The Jikan-fallback merge path
+        // MUST also skip the membership write so it can't ever
+        // accidentally clobber AL-side memberships.
+        let db = crate::test_support::in_memory_pool().await;
+        seed_account_id(&db, 1, "mal").await;
+        // Pre-seed a hypothetical AL-side membership for this series
+        // (e.g. user previously had AL linked, then switched to MAL).
+        let series_id = crate::test_support::seed_series(&db, -777, "Jikan series").await;
+        sqlx::query(
+            "INSERT INTO series_custom_lists (series_id, provider, list_name) VALUES (?, ?, ?)",
+        )
+        .bind(series_id)
+        .bind("anilist")
+        .bind("Old AL List")
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // Seed a Jikan detail so the merge path actually fires.
+        crate::services::jikan::seed_detail_cache_for_tests(
+            777,
+            make_detail(-777, "Jikan series", "TV", "FINISHED"),
+        )
+        .await;
+
+        let entries = vec![SyncEntry {
+            provider: external_accounts::PROVIDER_MAL.to_string(),
+            provider_media_id: 777,
+            anilist_id: -777,
+            status: NormalizedStatus::Watching,
+            progress: 0,
+            score: 0.0,
+            updated_at: 0,
+            custom_lists: Vec::new(),
+        }];
+        let _ = merge_jikan_fallback_entries(&db, &entries, &prefs_default(), Some(1)).await;
+
+        // The pre-seeded AL membership stays put — Jikan path's
+        // skip-when-not-anilist guard prevents it from being wiped.
+        let memberships = series_custom_lists::list_for_series(&db, series_id)
+            .await
+            .unwrap();
+        assert_eq!(memberships.len(), 1);
+        assert_eq!(memberships[0].list_name, "Old AL List");
+        assert_eq!(memberships[0].provider, "anilist");
+
+        crate::services::jikan::clear_detail_cache_entry_for_tests(777).await;
     }
 
     #[tokio::test]

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -156,23 +156,35 @@
     transform: translateY(-1px);
 }
 
-/* #62 PR D — AL custom-list membership badge. Distinct visual
-   from the user-score badge: muted/neutral surface so a series in
-   five lists doesn't drown out the score row. Anchor element so
-   each badge clicks through to the library filtered to that list,
-   which is the most useful one-click pivot from the detail page. */
+/* #62 PR D — AL custom-list membership badge. Pill-shaped to match
+   the genre row's visual rhythm but with an accent-tinted surface
+   so it reads as "the user's own curation" rather than "metadata
+   from AL." `display: inline-block` is mandatory: the element is
+   an `<a>` (so each badge can click through to the filtered library)
+   and inline anchors don't render padding visually. The explicit
+   text-decoration override beats the browser-default underline.
+   Doesn't piggyback on the small `.tag` shape — that's mono-9px
+   eyebrow text used for status pills, not a row of clickable badges. */
 .tag-custom-list {
-    background: var(--surface-2, rgba(255, 255, 255, 0.04));
-    color: var(--text-dim);
-    border: 1px solid var(--border-subtle);
+    display: inline-block;
+    font-size: 11px;
+    font-weight: 500;
+    padding: 3px 10px;
+    border-radius: 20px;
+    background: rgba(203, 166, 247, 0.12);
+    color: var(--accent);
+    border: 1px solid rgba(203, 166, 247, 0.30);
     text-decoration: none;
-    transition: background 0.15s, color 0.15s, border-color 0.15s;
+    line-height: 1.4;
+    transition: background 0.15s, border-color 0.15s, color 0.15s;
 }
 
-.tag-custom-list:hover {
-    background: rgba(203, 166, 247, 0.10);
+.tag-custom-list:hover,
+.tag-custom-list:focus-visible {
+    background: rgba(203, 166, 247, 0.20);
+    border-color: rgba(203, 166, 247, 0.55);
     color: var(--accent);
-    border-color: rgba(203, 166, 247, 0.35);
+    text-decoration: none;
 }
 
 .detail-custom-lists {
@@ -180,13 +192,18 @@
     align-items: center;
     flex-wrap: wrap;
     gap: 6px;
-    margin-top: 12px;
+    margin-top: 4px;
+    margin-bottom: 14px;
     font-size: 13px;
 }
 
 .detail-custom-lists-label {
     color: var(--text-dim);
-    margin-right: 2px;
+    margin-right: 4px;
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    font-weight: 600;
 }
 
 .tag-status-releasing,

--- a/static/css/badges.css
+++ b/static/css/badges.css
@@ -156,6 +156,39 @@
     transform: translateY(-1px);
 }
 
+/* #62 PR D — AL custom-list membership badge. Distinct visual
+   from the user-score badge: muted/neutral surface so a series in
+   five lists doesn't drown out the score row. Anchor element so
+   each badge clicks through to the library filtered to that list,
+   which is the most useful one-click pivot from the detail page. */
+.tag-custom-list {
+    background: var(--surface-2, rgba(255, 255, 255, 0.04));
+    color: var(--text-dim);
+    border: 1px solid var(--border-subtle);
+    text-decoration: none;
+    transition: background 0.15s, color 0.15s, border-color 0.15s;
+}
+
+.tag-custom-list:hover {
+    background: rgba(203, 166, 247, 0.10);
+    color: var(--accent);
+    border-color: rgba(203, 166, 247, 0.35);
+}
+
+.detail-custom-lists {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-top: 12px;
+    font-size: 13px;
+}
+
+.detail-custom-lists-label {
+    color: var(--text-dim);
+    margin-right: 2px;
+}
+
 .tag-status-releasing,
 .tag-status-not_yet_released,
 .tag-status-currently_airing,

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -161,6 +161,22 @@ body {
     padding: 32px 24px 80px;
 }
 
+/* Screen-reader-only utility — keeps a label in the a11y tree
+   while hiding it visually. Used by the library custom-list filter
+   where the dropdown is self-evident but assistive tech still
+   benefits from a label association. */
+.visually-hidden {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
 .page-header { margin-bottom: 28px; }
 
 .page-header h2 {

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,9 +17,9 @@
                handler so the URL becomes `/?list=<name>` and the
                server-side handler returns the filtered set. #}
             {% if !custom_list_names.is_empty() %}
-            <form method="get" action="/" class="library-filter-form" id="library-filter-form">
+            <form method="get" action="/" class="library-filter-form">
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
-                <select id="library-list-filter" name="list" class="folder-select" onchange="document.getElementById('library-filter-form').submit()">
+                <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
                     <option value="">All custom lists</option>
                     {% for name in custom_list_names %}
                     <option value="{{ name }}"{% if name.as_str() == custom_list_filter.as_str() %} selected{% endif %}>{{ name }}</option>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,23 @@
             <h2>Library</h2>
             <p class="page-desc">Your tracked anime series.</p>
         </div>
-        <div style="display:flex;gap:8px">
+        <div style="display:flex;gap:8px;align-items:center">
+            {# #62 PR D — AL custom-list filter dropdown. Hidden
+               when no memberships have synced yet. Selecting an
+               option submits the surrounding form via the change
+               handler so the URL becomes `/?list=<name>` and the
+               server-side handler returns the filtered set. #}
+            {% if !custom_list_names.is_empty() %}
+            <form method="get" action="/" class="library-filter-form" id="library-filter-form">
+                <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
+                <select id="library-list-filter" name="list" class="folder-select" onchange="document.getElementById('library-filter-form').submit()">
+                    <option value="">All custom lists</option>
+                    {% for name in custom_list_names %}
+                    <option value="{{ name }}"{% if name.as_str() == custom_list_filter.as_str() %} selected{% endif %}>{{ name }}</option>
+                    {% endfor %}
+                </select>
+            </form>
+            {% endif %}
             <a class="btn" href="/system?tab=review">Needs Review</a>
             <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
         </div>

--- a/templates/series.html
+++ b/templates/series.html
@@ -66,7 +66,7 @@
         <div class="detail-custom-lists">
             <span class="detail-custom-lists-label">Lists:</span>
             {% for list_name in custom_list_memberships %}
-            <a href="/?list={{ list_name|urlencode }}" class="tag tag-custom-list">{{ list_name }}</a>
+            <a href="/?list={{ list_name|urlencode }}" class="tag-custom-list">{{ list_name }}</a>
             {% endfor %}
         </div>
         {% endif %}

--- a/templates/series.html
+++ b/templates/series.html
@@ -57,6 +57,20 @@
             {% endfor %}
         </div>
 
+        {# #62 PR D — AL custom-list membership badges. Hidden when
+           the series isn't on any of the user's custom lists (or
+           no account is linked). Each badge links back to the
+           library filtered to that list so the user can quickly
+           pivot from "what's in this list" to "the list itself." #}
+        {% if !custom_list_memberships.is_empty() %}
+        <div class="detail-custom-lists">
+            <span class="detail-custom-lists-label">Lists:</span>
+            {% for list_name in custom_list_memberships %}
+            <a href="/?list={{ list_name|urlencode }}" class="tag tag-custom-list">{{ list_name }}</a>
+            {% endfor %}
+        </div>
+        {% endif %}
+
         <div class="detail-actions">
             <button class="btn btn-primary" id="btn-auto-search" onclick="autoSearchSeries(this)">
                 <span class="btn-label">Search Missing Episodes</span>


### PR DESCRIPTION
## Summary

Issue #62 PR D — AL custom-list membership tracking with two UI surfaces. AL-only by data: MAL has no custom-list concept and the sync engine's `entries_from_mal` always returns an empty `custom_lists` Vec.

- **Schema**: `series_custom_lists (series_id, provider, list_name)` with PK across the triple, ON DELETE CASCADE on series_id, and an index on list_name for the library-filter lookup. The `provider` column is on the row as future-proofing — only AL writes today, but a hypothetical future provider with its own list-shape gets a parallel namespace.
- **Sync**: both merge paths call `stamp_custom_lists_if_set` on every successful merge action. Helper is gated on (a) account_id is_some AND (b) provider == anilist (MAL skip prevents cross-namespace clobbering). Replace-on-merge means a series the user moved out of "Hidden Gems" gets the old membership dropped + new one inserted in one transaction — no upsert path = no stale-row leak.
- **UI**:
  - Detail page: "Lists:" badge row showing every list the series belongs to. Each badge is an `<a>` linking back to `/?list=<name>` so the user can pivot from "what's in this list" → "the list itself" with one click.
  - Library page: filter dropdown next to Needs Review / Add Series. Populated from `distinct_list_names`; hidden when no memberships have synced yet. Selection submits via onchange.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- [x] `cargo test --workspace --features test-support` — 1217 passed, 22 ignored
- [x] Migration applies idempotently on top of an existing DB
- [x] Filter dropdown is hidden by default (no memberships); shows after a sync that pulls custom-list entries

## Follow-ups

PR E carries over: sort-by-user-score, error-surfacing banners (re-link required), MAL mapping-failure counter, plus the cosmetic items from PR B (UA-in-builder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)