### PR TITLE
#62 PR E: deeper AL/MAL integration polish + library page UX

### DIFF
--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -32,6 +32,14 @@ struct IndexTemplate {
     /// applied the filter to `library`; this field drives the
     /// dropdown's selected-option state on render.
     custom_list_filter: String,
+    /// #62 PR E — distinct genre names across the library, sorted
+    /// alphabetically. Powers the genre filter input's `<datalist>`
+    /// autocomplete. Empty when no metadata has been cached yet
+    /// (template hides the input).
+    genre_names: Vec<String>,
+    /// Currently-active genre filter value from `?genre=<name>`.
+    /// Same shape as `custom_list_filter`.
+    genre_filter: String,
 }
 
 #[derive(Template)]

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -32,14 +32,10 @@ struct IndexTemplate {
     /// applied the filter to `library`; this field drives the
     /// dropdown's selected-option state on render.
     custom_list_filter: String,
-    /// #62 PR E — distinct genre names across the library, sorted
-    /// alphabetically. Powers the genre filter input's `<datalist>`
-    /// autocomplete. Empty when no metadata has been cached yet
-    /// (template hides the input).
-    genre_names: Vec<String>,
-    /// Currently-active genre filter value from `?genre=<name>`.
-    /// Same shape as `custom_list_filter`.
-    genre_filter: String,
+    /// Currently-active library search query from `?search=<text>`.
+    /// Echoed back so the input's `value` persists across
+    /// navigations.
+    search_query: String,
     /// #62 PR E — `recent` (default) or `score`. The handler has
     /// already applied the sort to `library`; this field drives the
     /// dropdown's selected-option state.

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -40,6 +40,10 @@ struct IndexTemplate {
     /// Currently-active genre filter value from `?genre=<name>`.
     /// Same shape as `custom_list_filter`.
     genre_filter: String,
+    /// #62 PR E — `recent` (default) or `score`. The handler has
+    /// already applied the sort to `library`; this field drives the
+    /// dropdown's selected-option state.
+    sort_value: String,
 }
 
 #[derive(Template)]

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -42,6 +42,14 @@ pub struct LibraryIndexQuery {
     /// both predicates).
     #[serde(default)]
     pub genre: Option<String>,
+    /// #62 PR E — `?sort=<key>` ordering. Currently supports
+    /// `recent` (default; SQL `ORDER BY added_at DESC`) and `score`
+    /// (user-score descending — only meaningful when an account is
+    /// linked, so the dropdown is hidden otherwise; unrated series
+    /// sink to the bottom). Anything unrecognized falls through to
+    /// `recent`.
+    #[serde(default)]
+    pub sort: Option<String>,
 }
 
 pub async fn index(
@@ -121,6 +129,34 @@ pub async fn index(
         library.retain(|s| matching_ids.contains(&s.id));
     }
 
+    // #62 PR E — sort-by-user-score. SQL already returned series
+    // ordered by added_at DESC ("recent"); this is an opt-in
+    // re-sort applied AFTER filters so the displayed order matches
+    // the displayed set. NULL / 0.0 / negative user_score values
+    // (unrated, manually-added pre-PR-C, etc.) sort to the bottom
+    // so they don't crowd out the rated ones the user is presumably
+    // looking at.
+    let sort_key = q.sort.as_deref().unwrap_or("recent");
+    let sort_value = if sort_key == "score" && !score_format.is_empty() {
+        // partial_cmp with NaN-safe ordering: any non-positive or
+        // missing score becomes -1.0 so it sinks. Tiebreaker on
+        // title_english (alphabetical) keeps the order
+        // deterministic across renders for series at the same
+        // score.
+        library.sort_by(|a, b| {
+            let av = a.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
+            let bv = b.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
+            bv.partial_cmp(&av)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.title_english.cmp(&b.title_english))
+        });
+        "score".to_string()
+    } else {
+        // Fall through to the SQL-default ordering for any
+        // unrecognized sort key.
+        "recent".to_string()
+    };
+
     let template = IndexTemplate {
         page: "library".to_string(),
         library,
@@ -132,6 +168,7 @@ pub async fn index(
         custom_list_filter,
         genre_names,
         genre_filter,
+        sort_value,
     };
     Html(template.render().unwrap_or_default())
 }

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -37,6 +37,11 @@ pub struct LibraryIndexQuery {
     /// across navigations.
     #[serde(default)]
     pub list: Option<String>,
+    /// #62 PR E — `?genre=<name>` filter. Same shape as `list`;
+    /// the two filters compose (set both → series must satisfy
+    /// both predicates).
+    #[serde(default)]
+    pub genre: Option<String>,
 }
 
 pub async fn index(
@@ -98,6 +103,24 @@ pub async fn index(
         library.retain(|s| matching_ids.contains(&s.id));
     }
 
+    // #62 PR E — genre filter. Same shape as the list filter and
+    // composes with it (when both are set, retain rows that satisfy
+    // both). distinct_genres feeds the input's <datalist> so the
+    // user sees autocomplete suggestions while typing.
+    let genre_names = crate::models::series_genres::distinct_genres(&state.db)
+        .await
+        .unwrap_or_default();
+    let genre_filter = q.genre.unwrap_or_default();
+    if !genre_filter.is_empty() {
+        let matching_ids: std::collections::HashSet<i64> =
+            crate::models::series_genres::series_ids_in_genre(&state.db, &genre_filter)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .collect();
+        library.retain(|s| matching_ids.contains(&s.id));
+    }
+
     let template = IndexTemplate {
         page: "library".to_string(),
         library,
@@ -107,6 +130,8 @@ pub async fn index(
         score_format,
         custom_list_names,
         custom_list_filter,
+        genre_names,
+        genre_filter,
     };
     Html(template.render().unwrap_or_default())
 }

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -132,25 +132,72 @@ pub async fn index(
     // (unrated, manually-added pre-PR-C, etc.) sort to the bottom
     // so they don't crowd out the rated ones the user is presumably
     // looking at.
+    // Sort selector. SQL already returned series ordered by
+    // added_at DESC ("recent"); anything else is an opt-in re-sort
+    // applied AFTER filters so the displayed order matches the
+    // displayed set. Score-based sorts gate on `!score_format.is_empty()`
+    // (an external account is linked); title sorts and oldest-first
+    // are universal. Unknown keys fall through to "recent".
     let sort_key = q.sort.as_deref().unwrap_or("recent");
-    let sort_value = if sort_key == "score" && !score_format.is_empty() {
-        // partial_cmp with NaN-safe ordering: any non-positive or
-        // missing score becomes -1.0 so it sinks. Tiebreaker on
-        // title_english (alphabetical) keeps the order
-        // deterministic across renders for series at the same
-        // score.
-        library.sort_by(|a, b| {
-            let av = a.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
-            let bv = b.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
-            bv.partial_cmp(&av)
-                .unwrap_or(std::cmp::Ordering::Equal)
-                .then_with(|| a.title_english.cmp(&b.title_english))
-        });
-        "score".to_string()
-    } else {
-        // Fall through to the SQL-default ordering for any
-        // unrecognized sort key.
-        "recent".to_string()
+    // Tiebreaker for non-title primary sorts: title_english,
+    // case-insensitive, with romaji/native fallback so an entry
+    // missing English doesn't sort under everything.
+    let title_key = |s: &series::Series| -> String {
+        let raw = if !s.title_english.is_empty() {
+            &s.title_english
+        } else if !s.title_romaji.is_empty() {
+            &s.title_romaji
+        } else {
+            &s.title_native
+        };
+        raw.to_lowercase()
+    };
+    let sort_value = match sort_key {
+        "score" if !score_format.is_empty() => {
+            // partial_cmp with NaN-safe ordering: any non-positive
+            // or missing score becomes -1.0 so it sinks. Tiebreaker
+            // on title keeps the order deterministic across renders
+            // for series at the same score.
+            library.sort_by(|a, b| {
+                let av = a.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
+                let bv = b.user_score.filter(|s| *s > 0.0).unwrap_or(-1.0);
+                bv.partial_cmp(&av)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| title_key(a).cmp(&title_key(b)))
+            });
+            "score".to_string()
+        }
+        "score_asc" if !score_format.is_empty() => {
+            // Inverse: low → high. Unrated entries still sink — a
+            // missing score isn't a 0, conceptually it's "no
+            // opinion," and surfacing those above the user's
+            // explicit ratings on either end of the range is
+            // confusing.
+            library.sort_by(|a, b| {
+                let av = a.user_score.filter(|s| *s > 0.0).unwrap_or(f64::INFINITY);
+                let bv = b.user_score.filter(|s| *s > 0.0).unwrap_or(f64::INFINITY);
+                av.partial_cmp(&bv)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| title_key(a).cmp(&title_key(b)))
+            });
+            "score_asc".to_string()
+        }
+        "title_asc" => {
+            library.sort_by_key(title_key);
+            "title_asc".to_string()
+        }
+        "title_desc" => {
+            library.sort_by_key(|s| std::cmp::Reverse(title_key(s)));
+            "title_desc".to_string()
+        }
+        "oldest" => {
+            // Inverse of the SQL default — reverse the slice in
+            // place rather than re-sorting on added_at, which we
+            // don't carry on the in-memory Series struct.
+            library.reverse();
+            "oldest".to_string()
+        }
+        _ => "recent".to_string(),
     };
 
     let template = IndexTemplate {

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -37,11 +37,12 @@ pub struct LibraryIndexQuery {
     /// across navigations.
     #[serde(default)]
     pub list: Option<String>,
-    /// #62 PR E — `?genre=<name>` filter. Same shape as `list`;
-    /// the two filters compose (set both → series must satisfy
-    /// both predicates).
+    /// `?search=<text>` library search. Case-insensitive substring
+    /// match against `title_english` / `title_romaji` /
+    /// `title_native`; composes with `list` (set both → series must
+    /// satisfy both predicates).
     #[serde(default)]
-    pub genre: Option<String>,
+    pub search: Option<String>,
     /// #62 PR E — `?sort=<key>` ordering. Currently supports
     /// `recent` (default; SQL `ORDER BY added_at DESC`) and `score`
     /// (user-score descending — only meaningful when an account is
@@ -111,22 +112,17 @@ pub async fn index(
         library.retain(|s| matching_ids.contains(&s.id));
     }
 
-    // #62 PR E — genre filter. Same shape as the list filter and
-    // composes with it (when both are set, retain rows that satisfy
-    // both). distinct_genres feeds the input's <datalist> so the
-    // user sees autocomplete suggestions while typing.
-    let genre_names = crate::models::series_genres::distinct_genres(&state.db)
-        .await
-        .unwrap_or_default();
-    let genre_filter = q.genre.unwrap_or_default();
-    if !genre_filter.is_empty() {
-        let matching_ids: std::collections::HashSet<i64> =
-            crate::models::series_genres::series_ids_in_genre(&state.db, &genre_filter)
-                .await
-                .unwrap_or_default()
-                .into_iter()
-                .collect();
-        library.retain(|s| matching_ids.contains(&s.id));
+    // Library search. Case-insensitive substring match against the
+    // three title fields. Composes with the list filter (set both →
+    // series must satisfy both predicates).
+    let search_query = q.search.unwrap_or_default();
+    if !search_query.trim().is_empty() {
+        let needle = search_query.trim().to_lowercase();
+        library.retain(|s| {
+            s.title_english.to_lowercase().contains(&needle)
+                || s.title_romaji.to_lowercase().contains(&needle)
+                || s.title_native.to_lowercase().contains(&needle)
+        });
     }
 
     // #62 PR E — sort-by-user-score. SQL already returned series
@@ -166,8 +162,7 @@ pub async fn index(
         score_format,
         custom_list_names,
         custom_list_filter,
-        genre_names,
-        genre_filter,
+        search_query,
         sort_value,
     };
     Html(template.render().unwrap_or_default())

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -191,10 +191,16 @@ pub async fn index(
             "title_desc".to_string()
         }
         "oldest" => {
-            // Inverse of the SQL default — reverse the slice in
-            // place rather than re-sorting on added_at, which we
-            // don't carry on the in-memory Series struct.
-            library.reverse();
+            // Sort directly on `added_at` (ISO-8601 from SQLite's
+            // CURRENT_TIMESTAMP, lexicographically chronological)
+            // rather than reverse-of-SQL-default — the latter would
+            // break silently if a future caller's needs reshaped
+            // `series::get_all`'s ORDER BY clause.
+            library.sort_by(|a, b| {
+                a.added_at
+                    .cmp(&b.added_at)
+                    .then_with(|| title_key(a).cmp(&title_key(b)))
+            });
             "oldest".to_string()
         }
         _ => "recent".to_string(),

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -156,6 +156,10 @@ pub(crate) struct ExternalAccountView {
     /// only when > 0 AND the linked provider is MAL (AL never
     /// produces deferred entries; the column always reads 0 there).
     pub last_sync_deferred_count: i64,
+    /// #62 PR E — sticky auth-rejection flag. Drives the
+    /// "Re-link required" red banner on the External Accounts card.
+    /// Cleared by the next successful sync.
+    pub last_sync_auth_failed: bool,
 }
 
 impl ExternalAccountView {
@@ -177,6 +181,7 @@ impl ExternalAccountView {
             import_completed: a.import_completed,
             skip_already_watched: a.skip_already_watched,
             last_sync_deferred_count: a.last_sync_deferred_count,
+            last_sync_auth_failed: a.last_sync_auth_failed,
         }
     }
 }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -165,17 +165,19 @@ pub(crate) struct ExternalAccountView {
     /// "Re-link required" red banner on the External Accounts card.
     /// Cleared by the next successful sync.
     pub last_sync_auth_failed: bool,
-    /// #62 PR E (redesign) — humanized score-format label, e.g.
-    /// "10-point with decimals" instead of the raw `POINT_10_DECIMAL`
-    /// AL enum string. Empty for unrecognized formats; the template
-    /// hides the row in that case.
-    pub score_format_label: &'static str,
     /// #62 PR E (redesign) — relative-time label for the most
     /// recent successful sync. "Never" when `list_last_synced_at`
     /// is NULL; otherwise the largest reasonable unit ("4 minutes
     /// ago", "2 hours ago", "3 days ago"). Computed server-side
     /// once per render so the template doesn't carry the time math.
     pub last_sync_label: String,
+    /// Raw unix timestamp the live-updater JS keys off via
+    /// `data-relative-time`. `None` when no sync has succeeded yet
+    /// (the JS skips the element in that case so "Never" stays
+    /// rendered as-is). Splitting this out from the label lets the
+    /// initial render stay correct when JS is disabled while the
+    /// JS path keeps the label fresh between page loads.
+    pub last_sync_unix_ts: Option<i64>,
 }
 
 impl ExternalAccountView {
@@ -184,14 +186,6 @@ impl ExternalAccountView {
             crate::models::external_accounts::PROVIDER_ANILIST => "AniList",
             crate::models::external_accounts::PROVIDER_MAL => "MyAnimeList",
             _ => "External",
-        };
-        let score_format_label = match a.score_format.as_str() {
-            "POINT_3" => "3-point smiley",
-            "POINT_5" => "5-star",
-            "POINT_10" => "10-point",
-            "POINT_10_DECIMAL" => "10-point (decimal)",
-            "POINT_100" => "100-point",
-            _ => "",
         };
         let last_sync_label = humanize_relative_time(a.list_last_synced_at);
         Self {
@@ -207,8 +201,8 @@ impl ExternalAccountView {
             skip_already_watched: a.skip_already_watched,
             last_sync_deferred_count: a.last_sync_deferred_count,
             last_sync_auth_failed: a.last_sync_auth_failed,
-            score_format_label,
             last_sync_label,
+            last_sync_unix_ts: a.list_last_synced_at,
         }
     }
 }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -144,6 +144,11 @@ pub(crate) struct ExternalAccountView {
     pub provider: String,
     pub provider_label: &'static str,
     pub username: String,
+    /// Raw `score_format` enum string (e.g. `POINT_10_DECIMAL`).
+    /// Kept distinct from `score_format_label` (the humanized form
+    /// the template renders) so a future debug surface can inspect
+    /// the canonical AL value without re-parsing the label.
+    #[allow(dead_code)]
     pub score_format: String,
     pub import_watching: bool,
     pub import_planning: bool,
@@ -160,6 +165,17 @@ pub(crate) struct ExternalAccountView {
     /// "Re-link required" red banner on the External Accounts card.
     /// Cleared by the next successful sync.
     pub last_sync_auth_failed: bool,
+    /// #62 PR E (redesign) — humanized score-format label, e.g.
+    /// "10-point with decimals" instead of the raw `POINT_10_DECIMAL`
+    /// AL enum string. Empty for unrecognized formats; the template
+    /// hides the row in that case.
+    pub score_format_label: &'static str,
+    /// #62 PR E (redesign) — relative-time label for the most
+    /// recent successful sync. "Never" when `list_last_synced_at`
+    /// is NULL; otherwise the largest reasonable unit ("4 minutes
+    /// ago", "2 hours ago", "3 days ago"). Computed server-side
+    /// once per render so the template doesn't carry the time math.
+    pub last_sync_label: String,
 }
 
 impl ExternalAccountView {
@@ -169,6 +185,15 @@ impl ExternalAccountView {
             crate::models::external_accounts::PROVIDER_MAL => "MyAnimeList",
             _ => "External",
         };
+        let score_format_label = match a.score_format.as_str() {
+            "POINT_3" => "3-point smiley",
+            "POINT_5" => "5-star",
+            "POINT_10" => "10-point",
+            "POINT_10_DECIMAL" => "10-point (decimal)",
+            "POINT_100" => "100-point",
+            _ => "",
+        };
+        let last_sync_label = humanize_relative_time(a.list_last_synced_at);
         Self {
             provider: a.provider,
             provider_label,
@@ -182,7 +207,38 @@ impl ExternalAccountView {
             skip_already_watched: a.skip_already_watched,
             last_sync_deferred_count: a.last_sync_deferred_count,
             last_sync_auth_failed: a.last_sync_auth_failed,
+            score_format_label,
+            last_sync_label,
         }
+    }
+}
+
+/// "4 minutes ago" / "2 hours ago" / "3 days ago" / "Never" from a
+/// Unix-epoch timestamp. The largest-reasonable-unit policy is the
+/// same one Sonarr/*arr use on their dashboards: pick the unit that
+/// gives a single-digit-or-low-double-digit number and drop fine
+/// granularity (the sync runs every N minutes; second-precision is
+/// noise).
+fn humanize_relative_time(unix_ts: Option<i64>) -> String {
+    let Some(ts) = unix_ts else {
+        return "Never".to_string();
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let delta = (now - ts).max(0);
+    if delta < 60 {
+        "Just now".to_string()
+    } else if delta < 60 * 60 {
+        let m = delta / 60;
+        format!("{m} minute{} ago", if m == 1 { "" } else { "s" })
+    } else if delta < 60 * 60 * 24 {
+        let h = delta / 3600;
+        format!("{h} hour{} ago", if h == 1 { "" } else { "s" })
+    } else {
+        let d = delta / 86400;
+        format!("{d} day{} ago", if d == 1 { "" } else { "s" })
     }
 }
 

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -151,6 +151,11 @@ pub(crate) struct ExternalAccountView {
     pub import_dropped: bool,
     pub import_completed: bool,
     pub skip_already_watched: bool,
+    /// #62 PR E — count of MAL→AL mapping failures from the most
+    /// recent sync. Surfaces as a "N couldn't be mapped" info banner
+    /// only when > 0 AND the linked provider is MAL (AL never
+    /// produces deferred entries; the column always reads 0 there).
+    pub last_sync_deferred_count: i64,
 }
 
 impl ExternalAccountView {
@@ -171,6 +176,7 @@ impl ExternalAccountView {
             import_dropped: a.import_dropped,
             import_completed: a.import_completed,
             skip_already_watched: a.skip_already_watched,
+            last_sync_deferred_count: a.last_sync_deferred_count,
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -351,6 +351,15 @@ async fn main() {
         .await
         .expect("Failed to run migrations");
 
+    // #62 PR E — one-shot genre backfill from existing
+    // series_metadata_cache rows so the library filter dropdown
+    // lights up immediately on first boot after upgrade. Idempotent
+    // via the `schema_migrations` ledger; subsequent boots are a
+    // single COUNT(*) probe and return.
+    if let Err(e) = models::series_genres::backfill_from_metadata_cache_once(&db).await {
+        tracing::warn!("series_genres backfill failed (filter dropdown may be empty): {e}");
+    }
+
     // Password-recovery boot path (#22). When RYOKAN_RESET_AUTH=1 or
     // --reset-auth is passed AND a `data/.reset-auth` sentinel file exists,
     // wipe users + sessions before the router mounts. `has_users()` then

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -56,6 +56,12 @@ pub struct ExternalAccount {
     pub import_dropped: bool,
     pub import_completed: bool,
     pub skip_already_watched: bool,
+    /// #62 PR E — count of entries from the most recent sync that
+    /// couldn't be mapped MAL→AL via anibridge. Always 0 for AL
+    /// accounts. Surfaces on the Settings → External Accounts card
+    /// as a banner so the user can see which subset of their MAL
+    /// list is sitting on the negated-id sentinel path.
+    pub last_sync_deferred_count: i64,
 }
 
 /// Input for [`link`] — the OAuth handler populates one of these
@@ -95,6 +101,7 @@ impl std::fmt::Debug for ExternalAccount {
             .field("import_dropped", &self.import_dropped)
             .field("import_completed", &self.import_completed)
             .field("skip_already_watched", &self.skip_already_watched)
+            .field("last_sync_deferred_count", &self.last_sync_deferred_count)
             .finish()
     }
 }
@@ -133,7 +140,8 @@ pub async fn get_current(db: &SqlitePool) -> Result<Option<ExternalAccount>, Str
                 access_token_expires_at, score_format,
                 list_last_synced_at, list_full_resync_at, linked_at,
                 import_watching, import_planning, import_paused,
-                import_dropped, import_completed, skip_already_watched
+                import_dropped, import_completed, skip_already_watched,
+                last_sync_deferred_count
            FROM external_accounts
           ORDER BY linked_at DESC
           LIMIT 1",
@@ -319,6 +327,24 @@ pub struct ImportPreferences {
     pub skip_already_watched: bool,
 }
 
+/// #62 PR E — record the count of MAL→AL mapping failures from
+/// the most recent sync. AL syncs always pass `0`. Read by the
+/// Settings → External Accounts page handler to render the
+/// "N series couldn't be mapped to AniList" banner.
+pub async fn update_last_sync_deferred_count(
+    db: &SqlitePool,
+    id: i64,
+    count: i64,
+) -> Result<(), String> {
+    sqlx::query("UPDATE external_accounts SET last_sync_deferred_count = ? WHERE id = ?")
+        .bind(count)
+        .bind(id)
+        .execute(db)
+        .await
+        .map_err(|e| format!("update_last_sync_deferred_count: {e}"))?;
+    Ok(())
+}
+
 /// Refresh the `score_format` column. Called from the AL sync path
 /// after each successful `fetch_media_list_collection` so a user
 /// changing their POINT_X preference on AL post-link takes effect on
@@ -439,6 +465,7 @@ struct ExternalAccountRaw {
     import_dropped: bool,
     import_completed: bool,
     skip_already_watched: bool,
+    last_sync_deferred_count: i64,
 }
 
 impl ExternalAccountRaw {
@@ -478,6 +505,7 @@ impl ExternalAccountRaw {
             import_dropped: self.import_dropped,
             import_completed: self.import_completed,
             skip_already_watched: self.skip_already_watched,
+            last_sync_deferred_count: self.last_sync_deferred_count,
         })
     }
 }

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -271,6 +271,15 @@ pub async fn link(db: &SqlitePool, req: LinkRequest) -> Result<i64, String> {
 /// the new account). Per the plan doc: "user scores [are] lost" on
 /// re-link-different-account.
 pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
+    // Capture the provider before the row goes away so we can scope
+    // the custom-list wipe below.
+    let provider: Option<String> =
+        sqlx::query_scalar("SELECT provider FROM external_accounts WHERE id = ?")
+            .bind(id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| format!("external_accounts read for provider: {e}"))?;
+
     // Order matters: clear user_score on rows synced from THIS
     // account BEFORE the account row goes away (the FK is set to
     // SET NULL on cascade, so after the DELETE we'd lose the join
@@ -282,6 +291,18 @@ pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
         .execute(db)
         .await
         .map_err(|e| format!("user_score wipe failed: {e}"))?;
+
+    // Drop the custom-list memberships that came from this provider.
+    // Without this, the library page's "All custom lists" dropdown
+    // keeps showing the unlinked account's list names, and a
+    // re-link to a different account inherits stale memberships
+    // until each affected series gets re-synced. Today's only
+    // producer is AL, so unlinking AL effectively clears the table.
+    if let Some(provider) = provider.as_deref() {
+        crate::models::series_custom_lists::clear_for_provider(db, provider)
+            .await
+            .map_err(|e| format!("series_custom_lists wipe failed: {e}"))?;
+    }
 
     sqlx::query("DELETE FROM external_accounts WHERE id = ?")
         .bind(id)

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -271,12 +271,21 @@ pub async fn link(db: &SqlitePool, req: LinkRequest) -> Result<i64, String> {
 /// the new account). Per the plan doc: "user scores [are] lost" on
 /// re-link-different-account.
 pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
+    // All four steps inside one tx: a crash between them would otherwise
+    // leave the account row dangling against half-cleaned per-account
+    // state (user_score NULL'd but custom_lists still referencing the
+    // unlinked provider, etc.).
+    let mut tx = db
+        .begin()
+        .await
+        .map_err(|e| format!("external_accounts unlink begin: {e}"))?;
+
     // Capture the provider before the row goes away so we can scope
     // the custom-list wipe below.
     let provider: Option<String> =
         sqlx::query_scalar("SELECT provider FROM external_accounts WHERE id = ?")
             .bind(id)
-            .fetch_optional(db)
+            .fetch_optional(&mut *tx)
             .await
             .map_err(|e| format!("external_accounts read for provider: {e}"))?;
 
@@ -288,7 +297,7 @@ pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
     // ratings.
     sqlx::query("UPDATE series SET user_score = NULL WHERE synced_from_external_account_id = ?")
         .bind(id)
-        .execute(db)
+        .execute(&mut *tx)
         .await
         .map_err(|e| format!("user_score wipe failed: {e}"))?;
 
@@ -299,16 +308,20 @@ pub async fn unlink(db: &SqlitePool, id: i64) -> Result<(), String> {
     // until each affected series gets re-synced. Today's only
     // producer is AL, so unlinking AL effectively clears the table.
     if let Some(provider) = provider.as_deref() {
-        crate::models::series_custom_lists::clear_for_provider(db, provider)
+        crate::models::series_custom_lists::clear_for_provider(&mut tx, provider)
             .await
             .map_err(|e| format!("series_custom_lists wipe failed: {e}"))?;
     }
 
     sqlx::query("DELETE FROM external_accounts WHERE id = ?")
         .bind(id)
-        .execute(db)
+        .execute(&mut *tx)
         .await
         .map_err(|e| format!("external_accounts DELETE failed: {e}"))?;
+
+    tx.commit()
+        .await
+        .map_err(|e| format!("external_accounts unlink commit: {e}"))?;
     Ok(())
 }
 

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -62,6 +62,13 @@ pub struct ExternalAccount {
     /// as a banner so the user can see which subset of their MAL
     /// list is sitting on the negated-id sentinel path.
     pub last_sync_deferred_count: i64,
+    /// #62 PR E — sticky flag set when the most recent sync tick
+    /// failed with an auth-rejection error (AL 401/403, MAL
+    /// refresh-token dead). Cleared on the next successful tick.
+    /// Drives the Settings UI's "Re-link required" banner — the
+    /// only signal a user has that their otherwise-quiet sync has
+    /// stopped working because of an expired token.
+    pub last_sync_auth_failed: bool,
 }
 
 /// Input for [`link`] — the OAuth handler populates one of these
@@ -102,6 +109,7 @@ impl std::fmt::Debug for ExternalAccount {
             .field("import_completed", &self.import_completed)
             .field("skip_already_watched", &self.skip_already_watched)
             .field("last_sync_deferred_count", &self.last_sync_deferred_count)
+            .field("last_sync_auth_failed", &self.last_sync_auth_failed)
             .finish()
     }
 }
@@ -141,7 +149,7 @@ pub async fn get_current(db: &SqlitePool) -> Result<Option<ExternalAccount>, Str
                 list_last_synced_at, list_full_resync_at, linked_at,
                 import_watching, import_planning, import_paused,
                 import_dropped, import_completed, skip_already_watched,
-                last_sync_deferred_count
+                last_sync_deferred_count, last_sync_auth_failed
            FROM external_accounts
           ORDER BY linked_at DESC
           LIMIT 1",
@@ -345,6 +353,23 @@ pub async fn update_last_sync_deferred_count(
     Ok(())
 }
 
+/// #62 PR E — flip the auth-failure flag. Set to `true` from the
+/// sync engine's auth-rejection branches (AL 401/403, MAL refresh
+/// dead); cleared back to `false` on the next successful tick.
+pub async fn update_last_sync_auth_failed(
+    db: &SqlitePool,
+    id: i64,
+    flag: bool,
+) -> Result<(), String> {
+    sqlx::query("UPDATE external_accounts SET last_sync_auth_failed = ? WHERE id = ?")
+        .bind(if flag { 1_i64 } else { 0_i64 })
+        .bind(id)
+        .execute(db)
+        .await
+        .map_err(|e| format!("update_last_sync_auth_failed: {e}"))?;
+    Ok(())
+}
+
 /// Refresh the `score_format` column. Called from the AL sync path
 /// after each successful `fetch_media_list_collection` so a user
 /// changing their POINT_X preference on AL post-link takes effect on
@@ -466,6 +491,7 @@ struct ExternalAccountRaw {
     import_completed: bool,
     skip_already_watched: bool,
     last_sync_deferred_count: i64,
+    last_sync_auth_failed: bool,
 }
 
 impl ExternalAccountRaw {
@@ -506,6 +532,7 @@ impl ExternalAccountRaw {
             import_completed: self.import_completed,
             skip_already_watched: self.skip_already_watched,
             last_sync_deferred_count: self.last_sync_deferred_count,
+            last_sync_auth_failed: self.last_sync_auth_failed,
         })
     }
 }

--- a/src/models/group_source_map.rs
+++ b/src/models/group_source_map.rs
@@ -539,7 +539,7 @@ pub async fn reconcile_seed_drift(db: &SqlitePool) -> Result<(), sqlx::Error> {
 /// idempotent `ALTER TABLE ADD COLUMN ... .ok()`. This exists solely
 /// so a repeat-on-every-boot migration can guard itself without each
 /// one inventing its own config flag.
-async fn ensure_schema_migrations_table(db: &SqlitePool) -> Result<(), sqlx::Error> {
+pub(crate) async fn ensure_schema_migrations_table(db: &SqlitePool) -> Result<(), sqlx::Error> {
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS schema_migrations (
              id TEXT PRIMARY KEY,
@@ -551,7 +551,10 @@ async fn ensure_schema_migrations_table(db: &SqlitePool) -> Result<(), sqlx::Err
     Ok(())
 }
 
-async fn migration_already_applied(db: &SqlitePool, id: &str) -> Result<bool, sqlx::Error> {
+pub(crate) async fn migration_already_applied(
+    db: &SqlitePool,
+    id: &str,
+) -> Result<bool, sqlx::Error> {
     let row = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM schema_migrations WHERE id = ?")
         .bind(id)
         .fetch_one(db)
@@ -559,7 +562,7 @@ async fn migration_already_applied(db: &SqlitePool, id: &str) -> Result<bool, sq
     Ok(row > 0)
 }
 
-async fn mark_migration_applied(
+pub(crate) async fn mark_migration_applied(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     id: &str,
 ) -> Result<(), sqlx::Error> {

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -977,6 +977,20 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .ok();
 
+    // #62 PR E — sticky flag set when a sync tick fails because
+    // the auth token was rejected (AL 401/403 or MAL refresh-token
+    // dead). Cleared on the next successful tick. Drives the
+    // "Re-link required" banner on the External Accounts card so
+    // a user whose AL token expired (1-year TTL) doesn't have to
+    // dig through System → Logs to figure out why their sync
+    // stopped working.
+    sqlx::query(
+        "ALTER TABLE external_accounts ADD COLUMN last_sync_auth_failed INTEGER NOT NULL DEFAULT 0",
+    )
+    .execute(db)
+    .await
+    .ok();
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS series_metadata_cache (

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -936,6 +936,34 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await?;
 
+    // #62 PR E — genre side table for the library filter dropdown.
+    // Genres come from AL/Jikan AnimeDetail.genres (already cached
+    // in series_metadata_cache); we extract them into their own
+    // table on every metadata refresh + sync merge so the filter +
+    // autocomplete reads can hit a small indexed scan instead of
+    // unmarshalling JSON for every series. Provider-agnostic — both
+    // AL and Jikan (MAL) emit the same genre vocabulary, so unlike
+    // custom_lists this table doesn't carry a `provider` column.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS series_genres (
+            series_id INTEGER NOT NULL,
+            genre TEXT NOT NULL,
+            PRIMARY KEY (series_id, genre),
+            FOREIGN KEY (series_id) REFERENCES series(id) ON DELETE CASCADE
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    sqlx::query(
+        "CREATE INDEX IF NOT EXISTS idx_series_genres_genre \
+         ON series_genres (genre)",
+    )
+    .execute(db)
+    .await?;
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS series_metadata_cache (

--- a/src/models/migrations.rs
+++ b/src/models/migrations.rs
@@ -964,6 +964,19 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .execute(db)
     .await?;
 
+    // #62 PR E — count of MAL→AL mapping failures from the most
+    // recent sync run. Surfaces on the Settings → External Accounts
+    // card as a "N series couldn't be mapped to AniList" banner so
+    // the user knows which subset of their MAL list is on the
+    // negated-id sentinel path (no SeaDex keying, etc.). Set on
+    // every successful MAL sync; AL syncs leave the column at 0.
+    sqlx::query(
+        "ALTER TABLE external_accounts ADD COLUMN last_sync_deferred_count INTEGER NOT NULL DEFAULT 0",
+    )
+    .execute(db)
+    .await
+    .ok();
+
     sqlx::query(
         r#"
         CREATE TABLE IF NOT EXISTS series_metadata_cache (

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -16,6 +16,7 @@ pub mod rss;
 pub mod scheduled_tasks;
 pub mod series;
 pub mod series_custom_lists;
+pub mod series_genres;
 pub mod session;
 pub mod user;
 

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -59,6 +59,15 @@ pub struct Series {
     /// this per the account's `score_format` and never shows
     /// `You: 0` for 0.0 (AL's "unrated" sentinel).
     pub user_score: Option<f64>,
+    /// ISO-8601 string the SQLite `DEFAULT CURRENT_TIMESTAMP` writes
+    /// at insert time (e.g. `"2026-04-25 12:34:56"`). Surfaced so the
+    /// library page's "oldest first" sort can `sort_by_key` against
+    /// this column directly rather than relying on a `library.reverse()`
+    /// of the SQL default `ORDER BY added_at DESC` — that pattern broke
+    /// silently any time a future caller's needs reshaped the query's
+    /// default ordering. ISO-8601 sorts lexicographically, so a plain
+    /// `String` comparison gives chronological order without a parse.
+    pub added_at: String,
 }
 
 impl Series {
@@ -118,13 +127,14 @@ fn map_series_row(row: sqlx::sqlite::SqliteRow) -> Series {
             .map(|v| v != 0)
             .unwrap_or(false),
         user_score: row.try_get::<Option<f64>, _>("user_score").unwrap_or(None),
+        added_at: row.try_get("added_at").unwrap_or_default(),
     }
 }
 
 /// Get all tracked series, ordered by most recently added.
 pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;
@@ -134,7 +144,7 @@ pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
 
 pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(db)
@@ -148,7 +158,7 @@ pub async fn get_by_anilist_id(
     anilist_id: i64,
 ) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE anilist_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id = ?",
     )
     .bind(anilist_id)
     .fetch_optional(db)
@@ -159,7 +169,7 @@ pub async fn get_by_anilist_id(
 
 pub async fn get_by_mal_id(db: &SqlitePool, mal_id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE mal_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id = ?",
     )
     .bind(mal_id)
     .fetch_optional(db)
@@ -419,7 +429,7 @@ pub async fn refresh_core_metadata(
 
 pub async fn get_unreconciled_fallbacks(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;

--- a/src/models/series_custom_lists.rs
+++ b/src/models/series_custom_lists.rs
@@ -125,10 +125,27 @@ pub async fn distinct_list_names(db: &SqlitePool) -> Result<Vec<String>, sqlx::E
 /// slate). Today's only producer is "anilist"; the schema's
 /// `provider` column scopes the wipe so a hypothetical future
 /// provider's memberships don't get cleared by another's unlink.
-pub async fn clear_for_provider(db: &SqlitePool, provider: &str) -> Result<u64, sqlx::Error> {
+///
+/// Scoped to `provider` rather than `(provider, account_id)` because
+/// `external_accounts` enforces single-account-per-provider via the
+/// uniqueness check in `link()` — at any moment there is at most one
+/// AL account, at most one MAL account, etc. If a future schema ever
+/// allows multiple accounts per provider, this wipe would need to
+/// take an `account_id` parameter (and the caller in `unlink` would
+/// need to pass it through) so a sibling account's lists aren't
+/// collateral damage on an unlink.
+///
+/// Takes a `&mut Transaction` rather than `&SqlitePool` because the
+/// only caller (`external_accounts::unlink`) needs the wipe to land
+/// atomically with the `user_score` reset and the account-row
+/// `DELETE`. Add a `_pool` variant if a non-tx caller appears.
+pub async fn clear_for_provider(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    provider: &str,
+) -> Result<u64, sqlx::Error> {
     let result = sqlx::query("DELETE FROM series_custom_lists WHERE provider = ?")
         .bind(provider)
-        .execute(db)
+        .execute(&mut **tx)
         .await?;
     Ok(result.rows_affected())
 }

--- a/src/models/series_custom_lists.rs
+++ b/src/models/series_custom_lists.rs
@@ -118,6 +118,21 @@ pub async fn distinct_list_names(db: &SqlitePool) -> Result<Vec<String>, sqlx::E
     Ok(rows)
 }
 
+/// Drop every membership row for the given provider. Used on
+/// account unlink so the library filter dropdown stops showing list
+/// names that came from an account the user no longer has linked
+/// (and so a re-link to a different AL account starts from a clean
+/// slate). Today's only producer is "anilist"; the schema's
+/// `provider` column scopes the wipe so a hypothetical future
+/// provider's memberships don't get cleared by another's unlink.
+pub async fn clear_for_provider(db: &SqlitePool, provider: &str) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM series_custom_lists WHERE provider = ?")
+        .bind(provider)
+        .execute(db)
+        .await?;
+    Ok(result.rows_affected())
+}
+
 /// Series ids that belong to `list_name`. Used by the library
 /// filter — handler reads this set, then filters the in-memory
 /// `Vec<Series>` against it. Cheaper than re-querying `series` with

--- a/src/models/series_genres.rs
+++ b/src/models/series_genres.rs
@@ -108,26 +108,18 @@ const BACKFILL_MIGRATION_ID: &str = "series_genres_backfill_from_cache_v1";
 /// one cache row logs and skips that row rather than aborting the
 /// migration.
 pub async fn backfill_from_metadata_cache_once(db: &SqlitePool) -> Result<(), String> {
-    // Ledger table is created on demand by the same `CREATE TABLE
-    // IF NOT EXISTS` pattern other one-shots use; safe to call
-    // here even if the migrations sweep ran first.
-    sqlx::query(
-        "CREATE TABLE IF NOT EXISTS schema_migrations (\
-             id TEXT PRIMARY KEY,\
-             applied_at DATETIME DEFAULT CURRENT_TIMESTAMP\
-         )",
-    )
-    .execute(db)
-    .await
-    .map_err(|e| format!("schema_migrations create: {e}"))?;
+    use crate::models::group_source_map::{
+        ensure_schema_migrations_table, migration_already_applied,
+    };
 
-    let already =
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM schema_migrations WHERE id = ?")
-            .bind(BACKFILL_MIGRATION_ID)
-            .fetch_one(db)
-            .await
-            .map_err(|e| format!("schema_migrations probe: {e}"))?;
-    if already > 0 {
+    ensure_schema_migrations_table(db)
+        .await
+        .map_err(|e| format!("schema_migrations create: {e}"))?;
+
+    if migration_already_applied(db, BACKFILL_MIGRATION_ID)
+        .await
+        .map_err(|e| format!("schema_migrations probe: {e}"))?
+    {
         return Ok(());
     }
 

--- a/src/models/series_genres.rs
+++ b/src/models/series_genres.rs
@@ -14,6 +14,15 @@
 //! shape: a metadata refresh might add or remove genres for a
 //! series whose AL classification changed, and an upsert path
 //! would leak stale rows.
+//!
+//! **Read paths currently have no consumer.** [`distinct_genres`]
+//! and [`series_ids_in_genre`] were originally written for a genre
+//! dropdown on the library page; that filter was replaced by the
+//! full-text library search before #62 PR E shipped. The write
+//! paths + the one-shot backfill are kept on so the table stays
+//! warm against a future detail-page genre row or an advanced
+//! filter. Don't delete them assuming they're orphaned — check the
+//! roadmap first.
 
 use sqlx::SqlitePool;
 

--- a/src/models/series_genres.rs
+++ b/src/models/series_genres.rs
@@ -1,0 +1,417 @@
+//! Genre side table (issue #62 PR E).
+//!
+//! AnimeDetail's `genres: Vec<String>` is the canonical source. This
+//! table extracts that into per-row form so the library filter +
+//! the per-series detail page (in the future) can query without
+//! unmarshalling the cached JSON. Populated on every metadata
+//! refresh + every successful sync merge, plus a one-shot backfill
+//! at startup against `series_metadata_cache` so existing libraries
+//! light up immediately.
+//!
+//! Provider-agnostic — both AL and Jikan emit the same genre
+//! vocabulary, so unlike `series_custom_lists` this table doesn't
+//! carry a `provider` column. Replace-on-write is again the right
+//! shape: a metadata refresh might add or remove genres for a
+//! series whose AL classification changed, and an upsert path
+//! would leak stale rows.
+
+use sqlx::SqlitePool;
+
+/// Replace this series's genre rows with the supplied list. Empty
+/// `genres` clears every row (e.g. AnimeDetail's genre field came
+/// back empty for whatever reason — the library filter shouldn't
+/// keep showing stale genre rows from a prior cache).
+///
+/// Two-step inside a transaction so a concurrent reader never sees
+/// a half-cleared set.
+pub async fn replace_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+    genres: &[String],
+) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+
+    sqlx::query("DELETE FROM series_genres WHERE series_id = ?")
+        .bind(series_id)
+        .execute(&mut *tx)
+        .await?;
+
+    for raw in genres {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        // INSERT OR IGNORE because AL has been observed to return a
+        // genre list with case-insensitive duplicates ("Action",
+        // "action") on community-edited entries; the PK collapses
+        // them rather than failing the merge.
+        sqlx::query("INSERT OR IGNORE INTO series_genres (series_id, genre) VALUES (?, ?)")
+            .bind(series_id)
+            .bind(trimmed)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Read every genre row for `series_id`. Sorted alphabetically so
+/// any future detail-page render is stable across loads.
+pub async fn list_for_series(db: &SqlitePool, series_id: i64) -> Result<Vec<String>, sqlx::Error> {
+    let rows = sqlx::query_scalar::<_, String>(
+        "SELECT genre FROM series_genres WHERE series_id = ? ORDER BY genre",
+    )
+    .bind(series_id)
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
+/// Distinct genre names across the whole library, sorted
+/// alphabetically. Powers the library filter's `<datalist>`
+/// autocomplete + the dropdown when one is shown.
+pub async fn distinct_genres(db: &SqlitePool) -> Result<Vec<String>, sqlx::Error> {
+    let rows =
+        sqlx::query_scalar::<_, String>("SELECT DISTINCT genre FROM series_genres ORDER BY genre")
+            .fetch_all(db)
+            .await?;
+    Ok(rows)
+}
+
+/// Series ids tagged with `genre`. Used by the library handler's
+/// in-memory filter step — same shape as the custom-list filter so
+/// both controls compose cleanly.
+pub async fn series_ids_in_genre(db: &SqlitePool, genre: &str) -> Result<Vec<i64>, sqlx::Error> {
+    let rows = sqlx::query_scalar::<_, i64>("SELECT series_id FROM series_genres WHERE genre = ?")
+        .bind(genre)
+        .fetch_all(db)
+        .await?;
+    Ok(rows)
+}
+
+/// Stable ID for the one-shot genre-backfill migration. The table
+/// is empty for any DB created before #62 PR E even though the
+/// canonical genre data has been sitting in `series_metadata_cache`
+/// the whole time. This pre-populates the side table from the
+/// existing cache so the library filter dropdown lights up
+/// immediately on first boot after upgrade — without it the
+/// dropdown would stay empty until the user triggers a metadata
+/// refresh or watch-list sync, which can be days away on default
+/// cadences.
+const BACKFILL_MIGRATION_ID: &str = "series_genres_backfill_from_cache_v1";
+
+/// Idempotent backfill: parses every cached AnimeDetail's
+/// `genres` field and writes one `series_genres` row per (series,
+/// genre). Skips on subsequent boots via the `schema_migrations`
+/// ledger row written at the end. Non-fatal — a parse failure on
+/// one cache row logs and skips that row rather than aborting the
+/// migration.
+pub async fn backfill_from_metadata_cache_once(db: &SqlitePool) -> Result<(), String> {
+    // Ledger table is created on demand by the same `CREATE TABLE
+    // IF NOT EXISTS` pattern other one-shots use; safe to call
+    // here even if the migrations sweep ran first.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (\
+             id TEXT PRIMARY KEY,\
+             applied_at DATETIME DEFAULT CURRENT_TIMESTAMP\
+         )",
+    )
+    .execute(db)
+    .await
+    .map_err(|e| format!("schema_migrations create: {e}"))?;
+
+    let already =
+        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM schema_migrations WHERE id = ?")
+            .bind(BACKFILL_MIGRATION_ID)
+            .fetch_one(db)
+            .await
+            .map_err(|e| format!("schema_migrations probe: {e}"))?;
+    if already > 0 {
+        return Ok(());
+    }
+
+    let rows = sqlx::query_as::<_, (i64, String)>(
+        "SELECT series_id, detail_json FROM series_metadata_cache",
+    )
+    .fetch_all(db)
+    .await
+    .map_err(|e| format!("metadata_cache scan: {e}"))?;
+
+    let mut updated = 0_usize;
+    for (series_id, detail_json) in rows {
+        let parsed: serde_json::Value = match serde_json::from_str(&detail_json) {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "series_genres backfill: skipping series_id={series_id} (parse error: {e})"
+                );
+                continue;
+            }
+        };
+        let genres: Vec<String> = parsed
+            .get("genres")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|g| g.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if genres.is_empty() {
+            continue;
+        }
+        if let Err(e) = replace_for_series(db, series_id, &genres).await {
+            tracing::warn!("series_genres backfill: replace failed for series_id={series_id}: {e}");
+            continue;
+        }
+        updated += 1;
+    }
+
+    sqlx::query("INSERT OR IGNORE INTO schema_migrations (id) VALUES (?)")
+        .bind(BACKFILL_MIGRATION_ID)
+        .execute(db)
+        .await
+        .map_err(|e| format!("schema_migrations record: {e}"))?;
+
+    tracing::info!(
+        "series_genres: backfilled genres for {updated} existing series from metadata_cache"
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::{in_memory_pool, seed_series};
+
+    #[tokio::test]
+    async fn replace_inserts_initial_genres() {
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, id, &["Action".into(), "Comedy".into()])
+            .await
+            .unwrap();
+
+        let got = list_for_series(&db, id).await.unwrap();
+        assert_eq!(got, vec!["Action", "Comedy"]);
+    }
+
+    #[tokio::test]
+    async fn replace_drops_removed_genres() {
+        // Series got reclassified on AL — used to be Romance, now
+        // listed as Drama. The replace-on-write must drop the old
+        // row; an upsert path would leak it.
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, id, &["Romance".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, id, &["Drama".into()])
+            .await
+            .unwrap();
+        assert_eq!(list_for_series(&db, id).await.unwrap(), vec!["Drama"]);
+    }
+
+    #[tokio::test]
+    async fn replace_with_empty_clears() {
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, id, &["Action".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, id, &[]).await.unwrap();
+        assert!(list_for_series(&db, id).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn replace_skips_blank_and_dedups() {
+        // Defensive: AL has emitted case-variants on community-edited
+        // entries; the PK collapses them via INSERT OR IGNORE. Blank
+        // / whitespace-only entries are dropped to avoid a useless
+        // empty-genre row.
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        replace_for_series(
+            &db,
+            id,
+            &[
+                "".into(),
+                "  ".into(),
+                "Action".into(),
+                "Action".into(),
+                "Comedy".into(),
+            ],
+        )
+        .await
+        .unwrap();
+        let got = list_for_series(&db, id).await.unwrap();
+        assert_eq!(got, vec!["Action", "Comedy"]);
+    }
+
+    #[tokio::test]
+    async fn distinct_genres_returns_sorted_unique() {
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Show 1").await;
+        let s2 = seed_series(&db, 200, "Show 2").await;
+        replace_for_series(&db, s1, &["Romance".into(), "Action".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s2, &["Comedy".into(), "Action".into()])
+            .await
+            .unwrap();
+        assert_eq!(
+            distinct_genres(&db).await.unwrap(),
+            vec!["Action", "Comedy", "Romance"]
+        );
+    }
+
+    #[tokio::test]
+    async fn series_ids_in_genre_matches_rows() {
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Show 1").await;
+        let s2 = seed_series(&db, 200, "Show 2").await;
+        let s3 = seed_series(&db, 300, "Show 3").await;
+        replace_for_series(&db, s1, &["Action".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s2, &["Comedy".into()])
+            .await
+            .unwrap();
+        replace_for_series(&db, s3, &["Action".into(), "Comedy".into()])
+            .await
+            .unwrap();
+
+        let mut action = series_ids_in_genre(&db, "Action").await.unwrap();
+        action.sort();
+        assert_eq!(action, vec![s1, s3]);
+    }
+
+    #[tokio::test]
+    async fn series_delete_cascades_to_genres() {
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        replace_for_series(&db, id, &["Action".into()])
+            .await
+            .unwrap();
+        sqlx::query("DELETE FROM series WHERE id = ?")
+            .bind(id)
+            .execute(&db)
+            .await
+            .unwrap();
+        assert!(list_for_series(&db, id).await.unwrap().is_empty());
+    }
+
+    /// Helper: insert a fake metadata_cache row with a synthesized
+    /// AnimeDetail JSON carrying the given genres. Mirrors the
+    /// shape `metadata_cache::upsert` writes (just enough fields
+    /// for the backfill's `genres` array extraction).
+    async fn seed_metadata_cache_with_genres(
+        db: &SqlitePool,
+        series_id: i64,
+        anilist_id: i64,
+        genres: &[&str],
+    ) {
+        let detail = serde_json::json!({
+            "id": anilist_id,
+            "id_mal": null,
+            "title_romaji": "",
+            "title_english": "",
+            "title_native": "",
+            "cover_url": "",
+            "banner_url": "",
+            "format": "TV",
+            "status": "FINISHED",
+            "status_display": "Finished",
+            "episodes": null,
+            "duration": null,
+            "season": "",
+            "season_year": null,
+            "description": "",
+            "genres": genres,
+            "average_score": null,
+            "average_score_display": null,
+            "score_is_ten_point": false,
+            "score_class": "",
+            "next_airing_episode": null,
+            "next_airing_at": null,
+            "synonyms": [],
+            "streaming_episodes": [],
+            "relations": []
+        });
+        sqlx::query(
+            "INSERT INTO series_metadata_cache (series_id, provider_id, mal_id, detail_json) \
+             VALUES (?, ?, NULL, ?)",
+        )
+        .bind(series_id)
+        .bind(anilist_id)
+        .bind(detail.to_string())
+        .execute(db)
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn backfill_populates_from_existing_cache_rows() {
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Show 1").await;
+        let s2 = seed_series(&db, 200, "Show 2").await;
+        seed_metadata_cache_with_genres(&db, s1, 100, &["Action", "Comedy"]).await;
+        seed_metadata_cache_with_genres(&db, s2, 200, &["Romance"]).await;
+
+        backfill_from_metadata_cache_once(&db).await.unwrap();
+
+        assert_eq!(
+            list_for_series(&db, s1).await.unwrap(),
+            vec!["Action", "Comedy"]
+        );
+        assert_eq!(list_for_series(&db, s2).await.unwrap(), vec!["Romance"]);
+    }
+
+    #[tokio::test]
+    async fn backfill_is_idempotent_via_ledger() {
+        // Second invocation must NOT touch the table (would clobber
+        // any post-backfill writes from a metadata refresh that
+        // happened between the first and second call). The ledger
+        // row written at the end of the first call short-circuits.
+        let db = in_memory_pool().await;
+        let id = seed_series(&db, 100, "Show").await;
+        seed_metadata_cache_with_genres(&db, id, 100, &["Action"]).await;
+        backfill_from_metadata_cache_once(&db).await.unwrap();
+
+        // Simulate a metadata refresh that changed the genre.
+        replace_for_series(&db, id, &["Drama".into()])
+            .await
+            .unwrap();
+
+        // Second backfill run — the ledger should short-circuit
+        // before the DELETE-then-INSERT, leaving "Drama" in place.
+        backfill_from_metadata_cache_once(&db).await.unwrap();
+        assert_eq!(list_for_series(&db, id).await.unwrap(), vec!["Drama"]);
+    }
+
+    #[tokio::test]
+    async fn backfill_skips_rows_with_corrupt_json() {
+        // A garbled detail_json shouldn't abort the migration —
+        // unaffected series should still get their genres written.
+        let db = in_memory_pool().await;
+        let s1 = seed_series(&db, 100, "Bad").await;
+        let s2 = seed_series(&db, 200, "Good").await;
+        sqlx::query(
+            "INSERT INTO series_metadata_cache (series_id, provider_id, mal_id, detail_json) \
+             VALUES (?, ?, NULL, ?)",
+        )
+        .bind(s1)
+        .bind(100_i64)
+        .bind("not json")
+        .execute(&db)
+        .await
+        .unwrap();
+        seed_metadata_cache_with_genres(&db, s2, 200, &["Action"]).await;
+
+        backfill_from_metadata_cache_once(&db).await.unwrap();
+
+        assert!(list_for_series(&db, s1).await.unwrap().is_empty());
+        assert_eq!(list_for_series(&db, s2).await.unwrap(), vec!["Action"]);
+    }
+}

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -301,14 +301,8 @@ pub async fn fetch_media_list_collection(
         return Err(format!("AniList unavailable: {err_msg}"));
     }
 
-    let lists = json
-        .pointer("/data/MediaListCollection/lists")
-        .and_then(|v| v.as_array())
-        .ok_or_else(|| {
-            "AniList MediaListCollection missing data.MediaListCollection.lists".to_string()
-        })?;
-
-    let out = parse_media_list_collection_lists(lists);
+    let lists = extract_media_list_buckets(&json)?;
+    let out = parse_media_list_collection_lists(&lists);
 
     // Sanity log: zero entries kept across all non-custom-list buckets
     // when the response actually had buckets means either the user has
@@ -318,7 +312,7 @@ pub async fn fetch_media_list_collection(
     // it shows up in the operator's logs even when the sync looks
     // "successful" with zero results. Doesn't fail the call — an
     // empty list IS a valid state for new accounts.
-    if out.is_empty() && all_buckets_are_custom_lists(lists) {
+    if out.is_empty() && all_buckets_are_custom_lists(&lists) {
         tracing::warn!(
             "AniList MediaListCollection returned {} buckets, all isCustomList=true; sync will see zero entries until the schema is investigated",
             lists.len()
@@ -339,6 +333,34 @@ pub async fn fetch_media_list_collection(
         entries: out,
         score_format,
     })
+}
+
+/// Pull the `lists` array out of an AL `MediaListCollection` response.
+///
+/// AL serves three legitimate response shapes here, and only the
+/// third is a real error:
+///   1. `{ data: { MediaListCollection: { lists: [...], user: {...} } } }`
+///      — normal populated response.
+///   2. `{ data: { MediaListCollection: null } }` — accounts with zero
+///      anime entries (brand-new users, or someone who cleared their
+///      list). AL omits the wrapping object entirely rather than
+///      returning an empty `lists` array.
+///   3. `data` missing entirely — malformed / partial response, the
+///      only case worth surfacing as an error.
+///
+/// Without the (2) branch, brand-new accounts (and anyone whose
+/// imported categories happen to all be empty) hit "missing
+/// data.MediaListCollection.lists" and the manual Sync now button
+/// fails instead of succeeding gracefully with 0 entries.
+fn extract_media_list_buckets(json: &serde_json::Value) -> Result<Vec<serde_json::Value>, String> {
+    if json.pointer("/data").is_none() {
+        return Err("AniList MediaListCollection missing data".to_string());
+    }
+    Ok(json
+        .pointer("/data/MediaListCollection/lists")
+        .and_then(|v| v.as_array())
+        .cloned()
+        .unwrap_or_default())
 }
 
 /// Walk only the non-custom-list buckets to avoid double-counting
@@ -1654,6 +1676,67 @@ mod tests {
         ]);
         let arr = lists.as_array().unwrap();
         assert!(all_buckets_are_custom_lists(arr));
+    }
+
+    #[test]
+    fn extract_media_list_buckets_succeeds_for_populated_response() {
+        // The normal shape: lists array present and non-empty.
+        let json = serde_json::json!({
+            "data": {
+                "MediaListCollection": {
+                    "lists": [
+                        {"isCustomList": false, "entries": []}
+                    ],
+                    "user": {"mediaListOptions": {"scoreFormat": "POINT_10"}}
+                }
+            }
+        });
+        let lists = extract_media_list_buckets(&json).unwrap();
+        assert_eq!(lists.len(), 1);
+    }
+
+    #[test]
+    fn extract_media_list_buckets_returns_empty_when_collection_is_null() {
+        // The empty-account shape: AL replies with MediaListCollection
+        // = null for accounts with zero anime entries. Should succeed
+        // with an empty lists array, not error.
+        let json = serde_json::json!({
+            "data": {
+                "MediaListCollection": null
+            }
+        });
+        let lists = extract_media_list_buckets(&json).unwrap();
+        assert!(
+            lists.is_empty(),
+            "null MediaListCollection should yield empty lists"
+        );
+    }
+
+    #[test]
+    fn extract_media_list_buckets_returns_empty_when_lists_field_is_missing() {
+        // Defense-in-depth: a response with the wrapper present but
+        // `lists` missing should also degrade to empty rather than
+        // erroring. The sync's downstream code handles empty inputs
+        // safely already, so being lenient here is the right move.
+        let json = serde_json::json!({
+            "data": {
+                "MediaListCollection": {
+                    "user": {"mediaListOptions": {"scoreFormat": "POINT_10"}}
+                }
+            }
+        });
+        let lists = extract_media_list_buckets(&json).unwrap();
+        assert!(lists.is_empty());
+    }
+
+    #[test]
+    fn extract_media_list_buckets_errors_when_data_field_missing() {
+        // The malformed-response shape: `data` itself missing means
+        // something is genuinely wrong upstream (rare — GraphQL errors
+        // are caught earlier via the `errors[]` branch). Surface it.
+        let json = serde_json::json!({});
+        let err = extract_media_list_buckets(&json).unwrap_err();
+        assert!(err.contains("missing data"), "got: {err}");
     }
 
     #[test]

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -2118,6 +2118,7 @@ mod tests {
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
             user_score: None,
+            added_at: String::new(),
         }
     }
 

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -2836,7 +2836,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn is_auth_rejection_matches_known_dead_token_strings() {
         // Each of these is a stable error-prefix the sync engine
         // emits on a token-dead failure; the Settings UI's

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -48,7 +48,7 @@ use crate::AppState;
 use crate::models::external_accounts::{self, ImportPreferences};
 use crate::models::log::LogCategory;
 use crate::models::monitoring::MonitorMode;
-use crate::models::{metadata_cache, series, series_custom_lists};
+use crate::models::{metadata_cache, series, series_custom_lists, series_genres};
 use crate::services::{
     anibridge, anilist, artwork, jikan, logger, mal, monitoring as monitoring_service,
 };
@@ -751,6 +751,13 @@ async fn merge_one_jikan_entry(
         );
     }
 
+    // #62 PR E — populate genre side table from Jikan-supplied genres.
+    if let Err(e) = series_genres::replace_for_series(db, series_id, &detail.genres).await {
+        tracing::warn!(
+            "series_genres::replace_for_series failed for series_id={series_id} during Jikan sync: {e}"
+        );
+    }
+
     stamp_synced_from_if_set(db, series_id, account_id).await;
     stamp_user_score_if_set(db, series_id, entry.score, account_id).await;
     stamp_custom_lists_if_set(
@@ -850,6 +857,13 @@ async fn merge_one_anilist_entry(
         metadata_cache::upsert(db, series_id, entry.anilist_id, detail.id_mal, detail).await
     {
         tracing::warn!("metadata_cache::upsert failed for series_id={series_id} during sync: {e}");
+    }
+
+    // #62 PR E — populate genre side table from AL-supplied genres.
+    if let Err(e) = series_genres::replace_for_series(db, series_id, &detail.genres).await {
+        tracing::warn!(
+            "series_genres::replace_for_series failed for series_id={series_id} during AL sync: {e}"
+        );
     }
 
     stamp_synced_from_if_set(db, series_id, account_id).await;

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -1155,6 +1155,18 @@ async fn sync_anilist(
     )
     .await;
     log_failed_entries(&state.db, &outcome).await;
+    // #62 PR E — clear any stale MAL deferred count from a prior
+    // provider on this same account row. AL syncs never produce
+    // deferred entries (no anibridge step), so always writing 0
+    // keeps the Settings UI accurate after a provider switch.
+    if let Err(e) =
+        external_accounts::update_last_sync_deferred_count(&state.db, account.id, 0).await
+    {
+        tracing::warn!(
+            "update_last_sync_deferred_count failed for account_id={}: {e}",
+            account.id
+        );
+    }
     spawn_post_merge_bulk_pass(state, outcome.new_artwork.clone()).await;
 
     Ok(format!(
@@ -1367,6 +1379,21 @@ async fn sync_mal(
     )
     .await;
     log_failed_entries(&state.db, &outcome).await;
+    // #62 PR E — persist the MAL→AL mapping-failure count so the
+    // Settings UI can render a "N series couldn't be mapped" banner
+    // without scraping the supervised-loop summary string.
+    if let Err(e) = external_accounts::update_last_sync_deferred_count(
+        &state.db,
+        account.id,
+        outcome.deferred_jikan as i64,
+    )
+    .await
+    {
+        tracing::warn!(
+            "update_last_sync_deferred_count failed for account_id={}: {e}",
+            account.id
+        );
+    }
     spawn_post_merge_bulk_pass(state, outcome.new_artwork.clone()).await;
 
     Ok(format!(

--- a/src/services/external_sync.rs
+++ b/src/services/external_sync.rs
@@ -991,6 +991,23 @@ pub async fn tick_once_or_busy(state: &AppState) -> Result<String, String> {
     tick_once_inner(state, true).await
 }
 
+/// True when the sync error string indicates the user's auth token
+/// is dead and re-linking is the fix (vs. transient rate-limits,
+/// network errors, or upstream 5xx). Matches the stable prefixes
+/// the sync engine emits — adding new wordings means updating this
+/// list, which is the project's existing string-tag convention for
+/// the AL failure taxonomy.
+fn is_auth_rejection(err: &str) -> bool {
+    const AUTH_PREFIXES: &[&str] = &[
+        "AniList rejected the watch-list token",
+        "MAL access token expired and no refresh token stored",
+        "MAL refresh failed (re-link required)",
+        "MAL rejected the token immediately after refresh",
+        "re-link required",
+    ];
+    AUTH_PREFIXES.iter().any(|p| err.contains(p))
+}
+
 async fn tick_once_inner(state: &AppState, force_full_sync: bool) -> Result<String, String> {
     let account = external_accounts::get_current(&state.db)
         .await
@@ -1017,7 +1034,7 @@ async fn tick_once_inner(state: &AppState, force_full_sync: bool) -> Result<Stri
         account.list_last_synced_at
     };
 
-    let summary = match account.provider.as_str() {
+    let raw = match account.provider.as_str() {
         external_accounts::PROVIDER_ANILIST => {
             sync_anilist(state, &account, delta_cursor, is_full_sync).await
         }
@@ -1029,12 +1046,47 @@ async fn tick_once_inner(state: &AppState, force_full_sync: bool) -> Result<Stri
             // prevent this, but surface explicitly rather than panic.
             return Err(format!("unknown external_accounts.provider: {other}"));
         }
-    }?;
+    };
+
+    let summary = match raw {
+        Ok(s) => s,
+        Err(e) => {
+            // #62 PR E — auth-rejection detection. The sync engine
+            // returns stable error-prefix strings for token-dead
+            // failures; a match flips the sticky flag so the
+            // Settings UI can render the "Re-link required" banner.
+            // Other failure modes (rate-limit, network timeout)
+            // leave the flag alone — they're transient.
+            if is_auth_rejection(&e)
+                && let Err(write_err) =
+                    external_accounts::update_last_sync_auth_failed(&state.db, account.id, true)
+                        .await
+            {
+                tracing::warn!(
+                    "failed to set last_sync_auth_failed for account_id={}: {write_err}",
+                    account.id
+                );
+            }
+            return Err(e);
+        }
+    };
 
     // Only stamp on success — a failed tick must not advance the
     // cursor or the entries it skipped fetching would be lost forever.
     external_accounts::stamp_list_synced(&state.db, account.id, tick_started_at, is_full_sync)
         .await?;
+    // Clear any stale auth-failure flag — the sync just succeeded,
+    // whatever caused the prior failure resolved (e.g. user
+    // re-linked).
+    if account.last_sync_auth_failed
+        && let Err(e) =
+            external_accounts::update_last_sync_auth_failed(&state.db, account.id, false).await
+    {
+        tracing::warn!(
+            "failed to clear last_sync_auth_failed for account_id={}: {e}",
+            account.id
+        );
+    }
 
     Ok(if is_full_sync {
         format!("{summary} [full-resync]")
@@ -2781,6 +2833,46 @@ mod tests {
 
         let row = series::get_by_id(&db, pinned_id).await.unwrap().unwrap();
         assert_eq!(row.monitor_mode, MonitorMode::All.as_str());
+    }
+
+    #[test]
+    #[test]
+    fn is_auth_rejection_matches_known_dead_token_strings() {
+        // Each of these is a stable error-prefix the sync engine
+        // emits on a token-dead failure; the Settings UI's
+        // "Re-link required" banner keys off this exact match.
+        // Adding a new wording requires updating the auth-prefix
+        // list — pinning the existing ones here so a refactor that
+        // reshapes a message gets caught.
+        assert!(is_auth_rejection(
+            "AniList rejected the watch-list token (status 401); user may need to re-link"
+        ));
+        assert!(is_auth_rejection(
+            "MAL access token expired and no refresh token stored — re-link required"
+        ));
+        assert!(is_auth_rejection(
+            "MAL refresh failed (re-link required): some upstream detail"
+        ));
+        assert!(is_auth_rejection(
+            "MAL rejected the token immediately after refresh — re-link required"
+        ));
+    }
+
+    #[test]
+    fn is_auth_rejection_does_not_match_transient_errors() {
+        // Rate-limits, network timeouts, and 5xx-shaped errors are
+        // transient; the Settings banner shouldn't fire for them.
+        assert!(!is_auth_rejection(
+            "AniList rate-limited: too many requests"
+        ));
+        assert!(!is_auth_rejection(
+            "AniList unavailable (status 503): service unavailable"
+        ));
+        assert!(!is_auth_rejection("AniList HTTP error: connection reset"));
+        assert!(!is_auth_rejection(
+            "AniList batch request failed: connection timed out"
+        ));
+        assert!(!is_auth_rejection("MAL fetch failed: 500 Internal Server"));
     }
 
     #[test]

--- a/src/services/mal.rs
+++ b/src/services/mal.rs
@@ -49,8 +49,13 @@ const MAL_REQUEST_DELAY: Duration = Duration::from_secs(1);
 const MAL_PAGE_SIZE: u32 = 1000;
 
 static HTTP_CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    // User-Agent set at the builder layer so every request the
+    // client issues carries it without per-call repetition. Matches
+    // `services::rss::feed::RSS_HTTP_CLIENT`'s shape; the static
+    // `Ryokan/0.1` UA is the project-wide default per CLAUDE.md.
     reqwest::Client::builder()
         .timeout(Duration::from_secs(30))
+        .user_agent("Ryokan/0.1")
         .build()
         .expect("MAL reqwest client build")
 });

--- a/src/services/metadata_sync.rs
+++ b/src/services/metadata_sync.rs
@@ -520,6 +520,20 @@ async fn refresh_series_metadata_inner(
             .await
             .map_err(|e| e.to_string())?;
 
+        // #62 PR E — extract genres into the per-row side table for
+        // the library filter. Best-effort: a write failure here logs
+        // but doesn't fail the whole metadata refresh — the cache
+        // upsert above is the canonical source and the side table
+        // can be rebuilt from it on the next tick.
+        if let Err(e) =
+            crate::models::series_genres::replace_for_series(db, tracked.id, &detail.genres).await
+        {
+            tracing::warn!(
+                "series_genres::replace_for_series failed for series_id={}: {e}",
+                tracked.id
+            );
+        }
+
         artwork::cache_series_detail_artwork(db, tracked.id, &detail).await;
         for related in detail
             .relations

--- a/src/services/nfo.rs
+++ b/src/services/nfo.rs
@@ -470,6 +470,7 @@ mod tests {
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
             user_score: None,
+            added_at: String::new(),
         }
     }
 

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -1998,6 +1998,7 @@ mod evaluate_candidate_tests {
             cumulative_prior_episodes: 0,
             monitor_mode_manual_override: false,
             user_score: None,
+            added_at: String::new(),
         }
     }
 

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -62,6 +62,7 @@
 .library-filter-form .folder-select {
     box-sizing: border-box;
     height: 42px;
+    width: 180px;
     padding: 0 28px 0 12px;
     font-size: 13px;
 }

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -24,17 +24,18 @@
 }
 
 /* Library search input. Sits between the custom-list dropdown and
-   the sort dropdown in the page-header filter row. Padding + font
-   size match `.folder-select` so the three controls share a visual
-   baseline; width is generous enough to read as a primary search
-   affordance without dominating the toolbar. */
+   the sort dropdown in the page-header filter row. Padding +
+   font-size + line-height match the `.btn` rule so the three
+   filter controls render at the same height as the Add Series
+   button next to them. */
 .library-search-input {
-    padding: 5px 10px;
+    padding: 10px 14px;
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
-    font-size: 12px;
+    font-size: 14px;
+    line-height: 1.6;
     font-family: var(--font-body);
     width: 220px;
     min-width: 180px;
@@ -47,6 +48,23 @@
 .library-search-input:focus {
     outline: none;
     border-color: var(--accent);
+}
+
+/* Scoped overrides on the page-header filter row so the dropdowns
+   and Clear pill match the `.btn` Add Series button's height. The
+   underlying .folder-select / .btn-pill rules stay untouched so
+   other pages (where the controls coexist with smaller affordances)
+   keep their tighter sizing. */
+.library-filter-form .folder-select {
+    padding: 10px 14px;
+    font-size: 14px;
+    line-height: 1.6;
+}
+
+.library-filter-form .library-filter-clear {
+    padding: 10px 16px;
+    font-size: 14px;
+    line-height: 1.6;
 }
 
 /* "Clear" link styled as a quiet pill; only renders when at least

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -1,5 +1,18 @@
 /* pages/index.css — auto-split from style.css. */
 
+/* Library page header overrides. Scoped to .library-header-row so
+   other pages keep their existing flex-start (page-desc-under-h2)
+   shape. We want the "Anime Library" title vertically centered on
+   the same baseline as the filter controls and Add Series button to
+   its right, since the page-desc is gone and there's nothing for
+   the second-line alignment to anchor to. */
+.library-header-row {
+    align-items: center;
+}
+.library-header-row h2 {
+    margin-bottom: 0;
+}
+
 .btn-pill {
     background: transparent;
     color: var(--text-dim);

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -11,6 +11,12 @@
 }
 .library-header-row h2 {
     margin-bottom: 0;
+    text-transform: uppercase;
+    /* All-caps wants a touch more breathing room than the base
+       Murecho letter-spacing (-0.005em was tuned for mixed-case);
+       0.06em opens the title up just enough to read as a deliberate
+       display treatment instead of a tight rendered string. */
+    letter-spacing: 0.06em;
 }
 
 .btn-pill {

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -23,29 +23,35 @@
     gap: 20px;
 }
 
-/* #62 PR E — genre filter input. Mirrors .folder-select's padding
-   and border treatment so it lines up with the list dropdown
-   beside it. The browser-native datalist autocomplete shows under
-   the input as the user types — no JS required. min-width keeps a
-   single-line placeholder visible without forcing the toolbar to
-   wrap on narrow viewports. */
-.library-genre-input {
-    padding: 5px 10px;
+/* Library search input. Sits in the middle column of the page
+   header (between the Library title and the right-side filter +
+   Add Series group). Wider min-width than the filter dropdowns
+   so it reads as a primary search affordance, not a small filter
+   field. */
+.library-search-form {
+    flex: 1 1 auto;
+    display: flex;
+    justify-content: center;
+    min-width: 0;
+}
+
+.library-search-input {
+    padding: 7px 12px;
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
-    font-size: 12px;
+    font-size: 13px;
     font-family: var(--font-body);
-    min-width: 180px;
-    max-width: 260px;
+    width: min(420px, 100%);
+    min-width: 220px;
 }
 
-.library-genre-input::placeholder {
+.library-search-input::placeholder {
     color: var(--text-dim);
 }
 
-.library-genre-input:focus {
+.library-search-input:focus {
     outline: none;
     border-color: var(--accent);
 }

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -15,8 +15,11 @@
     /* All-caps wants a touch more breathing room than the base
        Murecho letter-spacing (-0.005em was tuned for mixed-case);
        0.06em opens the title up just enough to read as a deliberate
-       display treatment instead of a tight rendered string. */
+       display treatment instead of a tight rendered string.
+       Dimmer text color reads as a quiet section label rather than
+       a bright primary headline. */
     letter-spacing: 0.06em;
+    color: var(--text-dim);
 }
 
 .btn-pill {

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -29,12 +29,19 @@
    (input, two selects, Clear pill) to the same outer dimension as
    the Add Series .btn next to them — without it, <input> and
    <select> render ~1-2px apart at the same padding/font because
-   their intrinsic-height handling differs. */
+   their intrinsic-height handling differs. The inline SVG
+   magnifier sits 12px from the left edge using --text-dim
+   (#7a7a96) baked into the stroke; left-padding (38px) clears
+   space for it so typed text doesn't run under the icon. */
 .library-search-input {
     box-sizing: border-box;
     height: 42px;
-    padding: 0 12px;
-    background: var(--bg);
+    padding: 0 12px 0 38px;
+    background-color: var(--bg);
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%237a7a96' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='11' cy='11' r='7'/%3E%3Cline x1='21' y1='21' x2='16.65' y2='16.65'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-position: 12px center;
+    background-size: 16px 16px;
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -180,8 +180,19 @@
     font-size: 13px;
 }
 
+/* Pin every card to the same total height. Cover height is already
+   fixed via `aspect-ratio: 2/3`, but `.series-info` would otherwise
+   grow to fit a 2-line title + 2-row wrapped tags vs. a 1-line
+   title + 1-row tags, leaving rows unequal. With grid-auto-rows
+   defaulting to `auto`, each row's height tracks the tallest card
+   in it — so as filters reshuffle which cards land in which row,
+   row heights would visibly jump. Fixed height + overflow:hidden
+   gives every card the same outer dimension regardless of content,
+   and the grid stays still through filter changes. */
 .series-info {
+    height: 100px;
     padding: 10px 12px 12px;
+    overflow: hidden;
 }
 
 .series-title {

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -67,6 +67,16 @@
     border-color: rgba(203, 166, 247, 0.45);
 }
 
+/* Reserve the Clear button's layout slot when no filter is active
+   so the row doesn't shift sideways the moment the user types into
+   the search box. visibility:hidden keeps the box (and the flex
+   gap) in place; pointer-events:none + the template's tabindex=-1
+   keep it out of mouse and keyboard focus. */
+.library-filter-clear-hidden {
+    visibility: hidden;
+    pointer-events: none;
+}
+
 @media (max-width: 640px) {
     .library-grid {
         grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -24,21 +24,26 @@
 }
 
 /* Library search input. Sits between the custom-list dropdown and
-   the sort dropdown in the page-header filter row. Padding +
-   font-size + line-height match the `.btn` rule so the three
-   filter controls render at the same height as the Add Series
-   button next to them. */
+   the sort dropdown in the page-header filter row. Explicit
+   `height` + `box-sizing: border-box` pins all four controls
+   (input, two selects, Clear pill) to the same outer dimension as
+   the Add Series .btn next to them — without it, <input> and
+   <select> render ~1-2px apart at the same padding/font because
+   their intrinsic-height handling differs. */
 .library-search-input {
-    padding: 10px 14px;
+    box-sizing: border-box;
+    height: 42px;
+    padding: 0 12px;
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
-    font-size: 14px;
-    line-height: 1.6;
+    font-size: 13px;
     font-family: var(--font-body);
     width: 220px;
     min-width: 180px;
+    appearance: textfield;
+    -webkit-appearance: textfield;
 }
 
 .library-search-input::placeholder {
@@ -51,20 +56,23 @@
 }
 
 /* Scoped overrides on the page-header filter row so the dropdowns
-   and Clear pill match the `.btn` Add Series button's height. The
-   underlying .folder-select / .btn-pill rules stay untouched so
-   other pages (where the controls coexist with smaller affordances)
+   and Clear pill share the search input's exact height. Underlying
+   .folder-select / .btn-pill rules stay untouched so other pages
    keep their tighter sizing. */
 .library-filter-form .folder-select {
-    padding: 10px 14px;
-    font-size: 14px;
-    line-height: 1.6;
+    box-sizing: border-box;
+    height: 42px;
+    padding: 0 28px 0 12px;
+    font-size: 13px;
 }
 
 .library-filter-form .library-filter-clear {
-    padding: 10px 16px;
-    font-size: 14px;
-    line-height: 1.6;
+    box-sizing: border-box;
+    height: 42px;
+    padding: 0 14px;
+    font-size: 13px;
+    display: inline-flex;
+    align-items: center;
 }
 
 /* "Clear" link styled as a quiet pill; only renders when at least

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -23,6 +23,51 @@
     gap: 20px;
 }
 
+/* #62 PR E — genre filter input. Mirrors .folder-select's padding
+   and border treatment so it lines up with the list dropdown
+   beside it. The browser-native datalist autocomplete shows under
+   the input as the user types — no JS required. min-width keeps a
+   single-line placeholder visible without forcing the toolbar to
+   wrap on narrow viewports. */
+.library-genre-input {
+    padding: 5px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 12px;
+    font-family: var(--font-body);
+    min-width: 180px;
+    max-width: 260px;
+}
+
+.library-genre-input::placeholder {
+    color: var(--text-dim);
+}
+
+.library-genre-input:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+/* "Clear" link styled as a quiet pill; only renders when at least
+   one filter is active. */
+.library-filter-clear {
+    background: transparent;
+    color: var(--text-dim);
+    border: 1px solid var(--border-subtle);
+    padding: 4px 12px;
+    font-size: 12px;
+    border-radius: 999px;
+    text-decoration: none;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.library-filter-clear:hover {
+    color: var(--accent);
+    border-color: rgba(203, 166, 247, 0.45);
+}
+
 @media (max-width: 640px) {
     .library-grid {
         grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -53,6 +53,14 @@
     -webkit-appearance: textfield;
 }
 
+/* When the custom-list dropdown is absent (no AL account linked yet
+   or freshly unlinked), the search input absorbs that slot's
+   footprint so the row doesn't visibly contract. 220px (own width)
+   + 180px (list dropdown) + 6px (flex gap) = 406px. */
+.library-search-input.library-search-input-wide {
+    width: 406px;
+}
+
 .library-search-input::placeholder {
     color: var(--text-dim);
 }

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -9,16 +9,19 @@
 .library-header-row {
     align-items: center;
 }
+/* Match the `.form-group label` treatment used throughout the
+   settings page (Provider / Import lists / Sync interval). Reads as
+   a section eyebrow rather than a primary headline — drops the
+   Murecho display font and the 24px size in favor of 13px Segoe at
+   the same dim-grey + uppercase + 0.5px letter-spacing the form
+   labels use. */
 .library-header-row h2 {
     margin-bottom: 0;
+    font-family: var(--font-body);
+    font-size: 13px;
+    font-weight: 600;
     text-transform: uppercase;
-    /* All-caps wants a touch more breathing room than the base
-       Murecho letter-spacing (-0.005em was tuned for mixed-case);
-       0.06em opens the title up just enough to read as a deliberate
-       display treatment instead of a tight rendered string.
-       Dimmer text color reads as a quiet section label rather than
-       a bright primary headline. */
-    letter-spacing: 0.06em;
+    letter-spacing: 0.5px;
     color: var(--text-dim);
 }
 

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -23,28 +23,21 @@
     gap: 20px;
 }
 
-/* Library search input. Sits in the middle column of the page
-   header (between the Library title and the right-side filter +
-   Add Series group). Wider min-width than the filter dropdowns
-   so it reads as a primary search affordance, not a small filter
-   field. */
-.library-search-form {
-    flex: 1 1 auto;
-    display: flex;
-    justify-content: center;
-    min-width: 0;
-}
-
+/* Library search input. Sits between the custom-list dropdown and
+   the sort dropdown in the page-header filter row. Padding + font
+   size match `.folder-select` so the three controls share a visual
+   baseline; width is generous enough to read as a primary search
+   affordance without dominating the toolbar. */
 .library-search-input {
-    padding: 7px 12px;
+    padding: 5px 10px;
     background: var(--bg);
     border: 1px solid var(--border);
     border-radius: var(--radius);
     color: var(--text);
-    font-size: 13px;
+    font-size: 12px;
     font-family: var(--font-body);
-    width: min(420px, 100%);
-    min-width: 220px;
+    width: 220px;
+    min-width: 180px;
 }
 
 .library-search-input::placeholder {

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -18,7 +18,7 @@
 .library-header-row h2 {
     margin-bottom: 0;
     font-family: var(--font-body);
-    font-size: 13px;
+    font-size: 28px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -9,20 +9,8 @@
 .library-header-row {
     align-items: center;
 }
-/* Match the `.form-group label` treatment used throughout the
-   settings page (Provider / Import lists / Sync interval). Reads as
-   a section eyebrow rather than a primary headline — drops the
-   Murecho display font and the 24px size in favor of 13px Segoe at
-   the same dim-grey + uppercase + 0.5px letter-spacing the form
-   labels use. */
 .library-header-row h2 {
     margin-bottom: 0;
-    font-family: var(--font-body);
-    font-size: 28px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-    color: var(--text-dim);
 }
 
 .btn-pill {

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -678,16 +678,17 @@ fieldset legend {
     font-variant-numeric: tabular-nums;
 }
 
-/* Grid layout for the 5 import-list checkbox-rows. Wrap-flex
-   would let the column starts drift because the labels have
-   different widths ("Plan to Watch" is wider than "Paused"); grid
-   tracks pin every checkmark to a column edge so they line up
-   vertically across rows. auto-fill on a 140px floor gives 2-3
-   columns on typical desktop and 1 on mobile. */
+/* Wrap-flex for the 5 import-list checkbox-rows, sized to content
+   with a fixed column gap. A grid with `1fr` tracks would stretch
+   each cell to the same width and leave varying empty space after
+   the shorter labels ("Paused" leaves more trailing whitespace
+   than "Plan to Watch"), so the spacing between (label end) and
+   (next checkbox start) reads as uneven. Content-sized items with
+   a uniform gap keep that visible spacing constant. */
 .ext-prefs-row {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-    gap: 8px 16px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 28px;
     margin-bottom: 6px;
 }
 

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -632,477 +632,82 @@ fieldset legend {
 
 .cf-score-zero { color: var(--text-dim); }
 
-/* ─── External Accounts card — #62 PR E redesign ─────────────────
-   The previous "list of stacked widgets" treatment didn't give
-   users a fast read of (a) which provider is linked, (b) whether
-   sync is alive, (c) what the user's preferences are. The card
-   below collapses those into one dashboard-style surface:
-     • accent stripe down the left edge identifies the provider
-       at a glance
-     • status strip surfaces "Last sync · 4 minutes ago · every
-       30 min" inline with the primary [Sync now] action
-     • banners (auth-fail / mapping-fail) live between status and
-       prefs so they read as sync-related signals
-     • prefs in a 2-column grid (less stacking, easier scan)
-     • Unlink demoted to a quiet text link in the footer corner —
-       destructive action shouldn't compete with the everyday
-       Sync now button visually
+/* ─── External Accounts — #62 PR E ────────────────────────────────
+   The fieldset itself is the standard connections-tab fieldset (no
+   bespoke surface). Just three small primitives below to support
+   the linked-state content:
+     • .ext-alert — inline alert blocks for the auth-fail / mapping-
+       fail banners. Sized to fit between fieldset's intro paragraph
+       and form-groups; same vertical rhythm as a form-hint paragraph.
+     • .ext-prefs-row — wrap-flex container for the import-list
+       checkbox-rows so they fit 2-3 per line on a wide viewport
+       instead of stacking five-deep.
+     • .form-display — read-only value text rendered inside a
+       form-group for "label / static value" rows (Provider,
+       Username, Score format). Mirrors the input padding so the
+       column lines up with the inputs in adjacent form-groups. */
 
-   Reuses Ryokan's accent/dim/border tokens; adds no new ones. */
-
-.ext-accounts-intro {
-    margin-top: -4px;
-    margin-bottom: 16px;
-}
-
-.ext-card {
-    position: relative;
-    background: var(--bg-elevated, var(--bg));
-    border: 1px solid var(--border);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-    /* Soft elevation; matches the depth of existing fieldsets without
-       drawing attention away from the legend above. */
-    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25), 0 8px 24px -16px rgba(0, 0, 0, 0.45);
-}
-
-/* Provider stripe on the left edge — 3px solid accent so the card
-   visually identifies as "linked AL/MAL" before the user reads any
-   text. Decorative; aria-hidden on the markup. */
-.ext-card-stripe {
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 3px;
-    background: linear-gradient(
-        180deg,
-        rgba(203, 166, 247, 0.65) 0%,
-        rgba(203, 166, 247, 0.18) 100%
-    );
-}
-
-.ext-card[data-provider="mal"] .ext-card-stripe {
-    /* MAL gets a slightly different hue to make a provider switch
-       visible on a glance — same family, different temperature. */
-    background: linear-gradient(
-        180deg,
-        rgba(125, 176, 211, 0.65) 0%,
-        rgba(125, 176, 211, 0.18) 100%
-    );
-}
-
-.ext-card-body {
-    padding: 18px 22px 16px 22px;
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-}
-
-/* ── 1. Identity row ─────────────────────────────────────────── */
-
-.ext-card-identity {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    flex-wrap: wrap;
-}
-
-.ext-card-dot {
-    display: inline-block;
-    width: 10px;
-    height: 10px;
-    border-radius: 50%;
-    background: var(--accent);
-    box-shadow: 0 0 0 4px rgba(203, 166, 247, 0.16);
-    flex-shrink: 0;
-}
-
-.ext-card[data-provider="mal"] .ext-card-dot {
-    background: rgb(125, 176, 211);
-    box-shadow: 0 0 0 4px rgba(125, 176, 211, 0.18);
-}
-
-.ext-card-identity-text {
-    display: flex;
-    flex-direction: column;
-    line-height: 1.2;
-    min-width: 0;
-}
-
-.ext-card-provider {
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    color: var(--text-dim);
-}
-
-.ext-card-username {
-    font-size: 17px;
-    font-weight: 600;
-    color: var(--text-bright);
-    margin-top: 2px;
-}
-
-.ext-card-meta-tag {
-    margin-left: auto;
-    padding: 3px 10px;
-    border-radius: 999px;
-    border: 1px solid var(--border-subtle);
-    font-size: 11px;
-    color: var(--text-dim);
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-}
-
-/* ── 2. Status strip ─────────────────────────────────────────── */
-
-.ext-card-status {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 12px;
-    flex-wrap: wrap;
-    padding: 10px 14px;
-    background: rgba(255, 255, 255, 0.025);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--radius);
-}
-
-.ext-card-status-meta {
-    display: flex;
-    align-items: baseline;
-    gap: 6px;
-    flex-wrap: wrap;
-    font-size: 13px;
-}
-
-.ext-card-status-label {
-    color: var(--text-dim);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.6px;
-    font-weight: 600;
-}
-
-.ext-card-status-value {
-    color: var(--text);
-    font-variant-numeric: tabular-nums;
-}
-
-.ext-card-status-sep {
-    color: var(--border);
-    margin: 0 4px;
-}
-
-.ext-card-sync-btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 6px;
-}
-
-/* The refresh glyph subtly rotates on hover. The spin-during-sync
-   class is reserved for the JS path that flips it while a manual
-   sync is in flight — wired up in static/js/settings.js if/when
-   the toast lifecycle exposes it. */
-.ext-card-sync-icon {
-    display: inline-block;
-    font-size: 14px;
-    line-height: 1;
-    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.ext-card-sync-btn:hover .ext-card-sync-icon {
-    transform: rotate(180deg);
-}
-
-/* ── 3. Banners ──────────────────────────────────────────────── */
-
-.ext-card-banner {
-    padding: 12px 14px;
+.ext-alert {
+    padding: 10px 12px;
     border-radius: var(--radius);
     font-size: 13px;
     line-height: 1.5;
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-}
-
-.ext-card-banner p {
-    margin: 0;
+    margin-bottom: 12px;
     color: var(--text);
 }
 
-.ext-card-banner-eyebrow {
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
+.ext-alert strong {
+    font-weight: 600;
 }
 
-.ext-card-banner-error {
+.ext-alert-error {
     background: rgba(211, 125, 125, 0.10);
     border: 1px solid rgba(211, 125, 125, 0.32);
 }
 
-.ext-card-banner-error .ext-card-banner-eyebrow {
+.ext-alert-error strong {
     color: var(--red);
 }
 
-.ext-card-banner-warn {
+.ext-alert-warn {
     background: rgba(211, 176, 125, 0.10);
     border: 1px solid rgba(211, 176, 125, 0.30);
 }
 
-.ext-card-banner-warn .ext-card-banner-eyebrow {
-    color: var(--orange);
-}
-
-.ext-card-banner-warn strong {
+.ext-alert-warn strong {
     color: var(--orange);
     font-variant-numeric: tabular-nums;
 }
 
-/* ── 4. Sections (prefs, interval) — eyebrow + content ───────── */
-
-.ext-card-section {
+/* Wrap-flex for the 5 import-list checkbox-rows. Default
+   checkbox-row is inline-display (set by base.css elsewhere); the
+   row gives them horizontal spacing + wraps cleanly on narrow.
+   2-3 per line on typical desktop, 1 per line on mobile. */
+.ext-prefs-row {
     display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding-top: 14px;
-    border-top: 1px solid var(--border-subtle);
+    flex-wrap: wrap;
+    gap: 6px 18px;
+    margin-bottom: 6px;
 }
 
-.ext-card-eyebrow {
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.9px;
-    color: var(--text-dim);
-}
-
-.ext-card-eyebrow label {
-    font: inherit;
-    color: inherit;
-    text-transform: inherit;
-    letter-spacing: inherit;
+.ext-prefs-row .checkbox-row {
     margin: 0;
+    /* Match the form-input padding so row height feels consistent
+       with the surrounding inputs without forcing the eye to retune. */
+    padding: 4px 0;
+    /* Minimum width keeps the longest label ("Plan to Watch") on one
+       line and prevents a checkbox from orphaning when wrapped. */
+    min-width: 130px;
 }
 
-.ext-card-prefs-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(140px, 1fr));
-    gap: 8px 24px;
-}
-
-@media (max-width: 480px) {
-    .ext-card-prefs-grid {
-        grid-template-columns: 1fr;
-    }
-}
-
-.ext-card-pref {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    cursor: pointer;
-    font-size: 13px;
-    color: var(--text);
-    user-select: none;
-    transition: color 0.12s;
-}
-
-.ext-card-pref:hover {
-    color: var(--text-bright);
-}
-
-.ext-card-pref input[type="checkbox"] {
-    width: 14px;
-    height: 14px;
-    accent-color: var(--accent);
-    cursor: pointer;
-    flex-shrink: 0;
-}
-
-/* The skip-already-watched row uses a richer pref shape: title +
-   hint stacked, with the checkbox aligned to the start so the long
-   explanatory copy doesn't push it off-axis. */
-.ext-card-pref-toggle {
-    align-items: flex-start;
-    gap: 10px;
-}
-
-.ext-card-pref-toggle input[type="checkbox"] {
-    margin-top: 2px;
-}
-
-.ext-card-pref-label {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-    min-width: 0;
-}
-
-.ext-card-pref-title {
-    font-weight: 500;
-    color: var(--text);
-}
-
-.ext-card-pref-hint {
-    font-size: 12px;
-    color: var(--text-dim);
-    line-height: 1.5;
-}
-
-.ext-card-pref-hint code {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    padding: 1px 5px;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid var(--border-subtle);
-    border-radius: 3px;
-    color: var(--text);
-}
-
-/* ── 6. Sync interval ─────────────────────────────────────────── */
-
-.ext-card-interval {
-    display: inline-flex;
-    align-items: baseline;
-    gap: 8px;
-}
-
-.ext-card-interval input[type="number"] {
-    width: 90px;
-    padding: 8px 10px;
-    background: var(--bg);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
+/* Read-only display field inside a form-group. Visually feels like
+   an input row (same padding / box) but styled as static text so
+   the user doesn't expect to edit it. */
+.form-display {
+    display: inline-block;
+    padding: 8px 0;
     color: var(--text);
     font-size: 14px;
     font-family: var(--font-body);
-    font-variant-numeric: tabular-nums;
-    appearance: textfield;
-    -moz-appearance: textfield;
-}
-
-.ext-card-interval input[type="number"]:focus {
-    outline: none;
-    border-color: var(--accent);
-}
-
-.ext-card-interval input[type="number"]::-webkit-outer-spin-button,
-.ext-card-interval input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-}
-
-.ext-card-interval-unit {
-    font-size: 13px;
-    color: var(--text-dim);
-}
-
-.ext-card-interval-hint {
-    font-size: 11px;
-    color: var(--text-dim);
-}
-
-/* ── 7. Footer (Unlink demoted to quiet link) ────────────────── */
-
-.ext-card-footer {
-    display: flex;
-    justify-content: flex-end;
-    padding-top: 10px;
-    margin-top: -4px;
-    border-top: 1px dashed var(--border-subtle);
-}
-
-.ext-card-unlink {
-    background: none;
-    border: none;
-    padding: 4px 0;
-    color: var(--text-dim);
-    font-size: 12px;
-    font-family: inherit;
-    cursor: pointer;
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    text-decoration-color: var(--border);
-    transition: color 0.12s, text-decoration-color 0.12s;
-}
-
-.ext-card-unlink:hover,
-.ext-card-unlink:focus-visible {
-    color: var(--red);
-    text-decoration-color: var(--red);
-    outline: none;
-}
-
-/* ─── Unlinked state — provider tiles ─────────────────────────── */
-
-.ext-link-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 12px;
-    margin-bottom: 12px;
-}
-
-.ext-link-tile {
-    display: flex;
-    flex-direction: column;
-    gap: 10px;
-    padding: 16px;
-    background: var(--bg-elevated, var(--bg));
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    transition: border-color 0.15s, transform 0.15s;
-}
-
-.ext-link-tile:hover {
-    border-color: rgba(203, 166, 247, 0.4);
-    transform: translateY(-1px);
-}
-
-.ext-link-tile-head {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
-.ext-link-tile-dot {
-    display: inline-block;
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-}
-
-.ext-link-tile-dot-al {
-    background: var(--accent);
-}
-
-.ext-link-tile-dot-mal {
-    background: rgb(125, 176, 211);
-}
-
-.ext-link-tile-name {
-    font-size: 14px;
-    font-weight: 600;
-    color: var(--text-bright);
-}
-
-.ext-link-tile-blurb {
-    margin: 0;
-    font-size: 12px;
-    color: var(--text-dim);
-    line-height: 1.5;
-    flex-grow: 1;
-}
-
-.ext-link-tile-cta {
-    align-self: flex-start;
-}
-
-.ext-link-attribution {
-    font-size: 11px;
-    color: var(--text-dim);
 }
 

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -634,7 +634,7 @@ fieldset legend {
 
 /* ─── External Accounts — #62 PR E ────────────────────────────────
    The fieldset itself is the standard connections-tab fieldset (no
-   bespoke surface). Just three small primitives below to support
+   bespoke surface). Just two small primitives below to support
    the linked-state content:
      • .ext-alert — inline alert blocks for the auth-fail / mapping-
        fail banners. Sized to fit between fieldset's intro paragraph
@@ -642,10 +642,9 @@ fieldset legend {
      • .ext-prefs-row — wrap-flex container for the import-list
        checkbox-rows so they fit 2-3 per line on a wide viewport
        instead of stacking five-deep.
-     • .form-display — read-only value text rendered inside a
-       form-group for "label / static value" rows (Provider,
-       Username, Score format). Mirrors the input padding so the
-       column lines up with the inputs in adjacent form-groups. */
+   Identity (provider/username) is shown via the standard
+   .log-badge primitive in the legend, matching the qBittorrent /
+   Jellyfin / Deluge / etc. health-badge pattern. */
 
 .ext-alert {
     padding: 10px 12px;

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -668,6 +668,27 @@ fieldset legend {
     width: 120px;
 }
 
+/* #62 PR E — re-link-required banner. Red-tinted because this is
+   a real error state: sync has stopped, no further entries will
+   import or update until the user unlinks + relinks. The banner
+   stays put until the next successful sync clears the flag, so a
+   user who clicks Sync now after re-linking gets immediate
+   feedback that the issue resolved. */
+.ext-accounts-relink-banner {
+    margin: 12px 0;
+    padding: 10px 12px;
+    background: rgba(211, 125, 125, 0.10);
+    color: var(--text);
+    border: 1px solid rgba(211, 125, 125, 0.35);
+    border-radius: var(--radius);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.ext-accounts-relink-banner strong {
+    color: var(--red);
+}
+
 /* #62 PR E — MAL mapping-failure info banner. Yellow-tinted to
    read as "informational warning" rather than an error (the
    library still works; the affected series just don't get AL-keyed

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -668,3 +668,23 @@ fieldset legend {
     width: 120px;
 }
 
+/* #62 PR E — MAL mapping-failure info banner. Yellow-tinted to
+   read as "informational warning" rather than an error (the
+   library still works; the affected series just don't get AL-keyed
+   scoring). Only renders when count > 0 AND provider == mal. */
+.ext-accounts-deferred-banner {
+    margin: 12px 0;
+    padding: 10px 12px;
+    background: rgba(211, 176, 125, 0.10);
+    color: var(--text);
+    border: 1px solid rgba(211, 176, 125, 0.30);
+    border-radius: var(--radius);
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.ext-accounts-deferred-banner strong {
+    color: var(--orange);
+    font-variant-numeric: tabular-nums;
+}
+

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -678,14 +678,16 @@ fieldset legend {
     font-variant-numeric: tabular-nums;
 }
 
-/* Wrap-flex for the 5 import-list checkbox-rows. Default
-   checkbox-row is inline-display (set by base.css elsewhere); the
-   row gives them horizontal spacing + wraps cleanly on narrow.
-   2-3 per line on typical desktop, 1 per line on mobile. */
+/* Grid layout for the 5 import-list checkbox-rows. Wrap-flex
+   would let the column starts drift because the labels have
+   different widths ("Plan to Watch" is wider than "Paused"); grid
+   tracks pin every checkmark to a column edge so they line up
+   vertically across rows. auto-fill on a 140px floor gives 2-3
+   columns on typical desktop and 1 on mobile. */
 .ext-prefs-row {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 6px 18px;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+    gap: 8px 16px;
     margin-bottom: 6px;
 }
 
@@ -694,9 +696,6 @@ fieldset legend {
     /* Match the form-input padding so row height feels consistent
        with the surrounding inputs without forcing the eye to retune. */
     padding: 4px 0;
-    /* Minimum width keeps the longest label ("Plan to Watch") on one
-       line and prevents a checkbox from orphaning when wrapped. */
-    min-width: 130px;
 }
 
 /* Read-only display field inside a form-group. Visually feels like

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -632,80 +632,477 @@ fieldset legend {
 
 .cf-score-zero { color: var(--text-dim); }
 
-/* External Accounts (#62 PR B): linked-account row layout. The header
-   pairs the username block on the left with the actions cluster on
-   the right; without flex they stack and the Sync now / Unlink pair
-   wraps awkwardly under long usernames. */
-.ext-accounts-linked-header {
+/* ─── External Accounts card — #62 PR E redesign ─────────────────
+   The previous "list of stacked widgets" treatment didn't give
+   users a fast read of (a) which provider is linked, (b) whether
+   sync is alive, (c) what the user's preferences are. The card
+   below collapses those into one dashboard-style surface:
+     • accent stripe down the left edge identifies the provider
+       at a glance
+     • status strip surfaces "Last sync · 4 minutes ago · every
+       30 min" inline with the primary [Sync now] action
+     • banners (auth-fail / mapping-fail) live between status and
+       prefs so they read as sync-related signals
+     • prefs in a 2-column grid (less stacking, easier scan)
+     • Unlink demoted to a quiet text link in the footer corner —
+       destructive action shouldn't compete with the everyday
+       Sync now button visually
+
+   Reuses Ryokan's accent/dim/border tokens; adds no new ones. */
+
+.ext-accounts-intro {
+    margin-top: -4px;
+    margin-bottom: 16px;
+}
+
+.ext-card {
+    position: relative;
+    background: var(--bg-elevated, var(--bg));
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    /* Soft elevation; matches the depth of existing fieldsets without
+       drawing attention away from the legend above. */
+    box-shadow: 0 1px 0 rgba(0, 0, 0, 0.25), 0 8px 24px -16px rgba(0, 0, 0, 0.45);
+}
+
+/* Provider stripe on the left edge — 3px solid accent so the card
+   visually identifies as "linked AL/MAL" before the user reads any
+   text. Decorative; aria-hidden on the markup. */
+.ext-card-stripe {
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 3px;
+    background: linear-gradient(
+        180deg,
+        rgba(203, 166, 247, 0.65) 0%,
+        rgba(203, 166, 247, 0.18) 100%
+    );
+}
+
+.ext-card[data-provider="mal"] .ext-card-stripe {
+    /* MAL gets a slightly different hue to make a provider switch
+       visible on a glance — same family, different temperature. */
+    background: linear-gradient(
+        180deg,
+        rgba(125, 176, 211, 0.65) 0%,
+        rgba(125, 176, 211, 0.18) 100%
+    );
+}
+
+.ext-card-body {
+    padding: 18px 22px 16px 22px;
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
+    gap: 16px;
+}
+
+/* ── 1. Identity row ─────────────────────────────────────────── */
+
+.ext-card-identity {
+    display: flex;
     align-items: center;
     gap: 12px;
     flex-wrap: wrap;
 }
 
-.ext-accounts-actions {
-    display: flex;
-    gap: 8px;
-    flex-wrap: wrap;
+.ext-card-dot {
+    display: inline-block;
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 0 4px rgba(203, 166, 247, 0.16);
+    flex-shrink: 0;
 }
 
-/* The container is `.ext-accounts-interval.form-group` — `.form-group`
-   gives the input the canonical bordered/padded treatment (forms.css
-   :36-47) so it matches every other settings input, while
-   `.ext-accounts-interval` adds the divider above and clamps the
-   numeric input to a narrow width. The label uses .form-group's
-   uppercase-eyebrow style so it lines up with the rest of the page. */
-.ext-accounts-interval {
-    margin-top: 14px;
+.ext-card[data-provider="mal"] .ext-card-dot {
+    background: rgb(125, 176, 211);
+    box-shadow: 0 0 0 4px rgba(125, 176, 211, 0.18);
+}
+
+.ext-card-identity-text {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.2;
+    min-width: 0;
+}
+
+.ext-card-provider {
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    color: var(--text-dim);
+}
+
+.ext-card-username {
+    font-size: 17px;
+    font-weight: 600;
+    color: var(--text-bright);
+    margin-top: 2px;
+}
+
+.ext-card-meta-tag {
+    margin-left: auto;
+    padding: 3px 10px;
+    border-radius: 999px;
+    border: 1px solid var(--border-subtle);
+    font-size: 11px;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+}
+
+/* ── 2. Status strip ─────────────────────────────────────────── */
+
+.ext-card-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.025);
+    border: 1px solid var(--border-subtle);
+    border-radius: var(--radius);
+}
+
+.ext-card-status-meta {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    flex-wrap: wrap;
+    font-size: 13px;
+}
+
+.ext-card-status-label {
+    color: var(--text-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    font-weight: 600;
+}
+
+.ext-card-status-value {
+    color: var(--text);
+    font-variant-numeric: tabular-nums;
+}
+
+.ext-card-status-sep {
+    color: var(--border);
+    margin: 0 4px;
+}
+
+.ext-card-sync-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+/* The refresh glyph subtly rotates on hover. The spin-during-sync
+   class is reserved for the JS path that flips it while a manual
+   sync is in flight — wired up in static/js/settings.js if/when
+   the toast lifecycle exposes it. */
+.ext-card-sync-icon {
+    display: inline-block;
+    font-size: 14px;
+    line-height: 1;
+    transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.ext-card-sync-btn:hover .ext-card-sync-icon {
+    transform: rotate(180deg);
+}
+
+/* ── 3. Banners ──────────────────────────────────────────────── */
+
+.ext-card-banner {
+    padding: 12px 14px;
+    border-radius: var(--radius);
+    font-size: 13px;
+    line-height: 1.5;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.ext-card-banner p {
+    margin: 0;
+    color: var(--text);
+}
+
+.ext-card-banner-eyebrow {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+}
+
+.ext-card-banner-error {
+    background: rgba(211, 125, 125, 0.10);
+    border: 1px solid rgba(211, 125, 125, 0.32);
+}
+
+.ext-card-banner-error .ext-card-banner-eyebrow {
+    color: var(--red);
+}
+
+.ext-card-banner-warn {
+    background: rgba(211, 176, 125, 0.10);
+    border: 1px solid rgba(211, 176, 125, 0.30);
+}
+
+.ext-card-banner-warn .ext-card-banner-eyebrow {
+    color: var(--orange);
+}
+
+.ext-card-banner-warn strong {
+    color: var(--orange);
+    font-variant-numeric: tabular-nums;
+}
+
+/* ── 4. Sections (prefs, interval) — eyebrow + content ───────── */
+
+.ext-card-section {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
     padding-top: 14px;
     border-top: 1px solid var(--border-subtle);
 }
 
-.ext-accounts-interval input[type="number"] {
-    /* Override .form-group input's default 100% width — a 4-digit
-       minute count never needs the full row. */
-    width: 120px;
+.ext-card-eyebrow {
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.9px;
+    color: var(--text-dim);
 }
 
-/* #62 PR E — re-link-required banner. Red-tinted because this is
-   a real error state: sync has stopped, no further entries will
-   import or update until the user unlinks + relinks. The banner
-   stays put until the next successful sync clears the flag, so a
-   user who clicks Sync now after re-linking gets immediate
-   feedback that the issue resolved. */
-.ext-accounts-relink-banner {
-    margin: 12px 0;
-    padding: 10px 12px;
-    background: rgba(211, 125, 125, 0.10);
-    color: var(--text);
-    border: 1px solid rgba(211, 125, 125, 0.35);
-    border-radius: var(--radius);
+.ext-card-eyebrow label {
+    font: inherit;
+    color: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    margin: 0;
+}
+
+.ext-card-prefs-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(140px, 1fr));
+    gap: 8px 24px;
+}
+
+@media (max-width: 480px) {
+    .ext-card-prefs-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.ext-card-pref {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    cursor: pointer;
     font-size: 13px;
+    color: var(--text);
+    user-select: none;
+    transition: color 0.12s;
+}
+
+.ext-card-pref:hover {
+    color: var(--text-bright);
+}
+
+.ext-card-pref input[type="checkbox"] {
+    width: 14px;
+    height: 14px;
+    accent-color: var(--accent);
+    cursor: pointer;
+    flex-shrink: 0;
+}
+
+/* The skip-already-watched row uses a richer pref shape: title +
+   hint stacked, with the checkbox aligned to the start so the long
+   explanatory copy doesn't push it off-axis. */
+.ext-card-pref-toggle {
+    align-items: flex-start;
+    gap: 10px;
+}
+
+.ext-card-pref-toggle input[type="checkbox"] {
+    margin-top: 2px;
+}
+
+.ext-card-pref-label {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+}
+
+.ext-card-pref-title {
+    font-weight: 500;
+    color: var(--text);
+}
+
+.ext-card-pref-hint {
+    font-size: 12px;
+    color: var(--text-dim);
     line-height: 1.5;
 }
 
-.ext-accounts-relink-banner strong {
-    color: var(--red);
-}
-
-/* #62 PR E — MAL mapping-failure info banner. Yellow-tinted to
-   read as "informational warning" rather than an error (the
-   library still works; the affected series just don't get AL-keyed
-   scoring). Only renders when count > 0 AND provider == mal. */
-.ext-accounts-deferred-banner {
-    margin: 12px 0;
-    padding: 10px 12px;
-    background: rgba(211, 176, 125, 0.10);
+.ext-card-pref-hint code {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    padding: 1px 5px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid var(--border-subtle);
+    border-radius: 3px;
     color: var(--text);
-    border: 1px solid rgba(211, 176, 125, 0.30);
-    border-radius: var(--radius);
-    font-size: 13px;
-    line-height: 1.5;
 }
 
-.ext-accounts-deferred-banner strong {
-    color: var(--orange);
+/* ── 6. Sync interval ─────────────────────────────────────────── */
+
+.ext-card-interval {
+    display: inline-flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.ext-card-interval input[type="number"] {
+    width: 90px;
+    padding: 8px 10px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 14px;
+    font-family: var(--font-body);
     font-variant-numeric: tabular-nums;
+    appearance: textfield;
+    -moz-appearance: textfield;
+}
+
+.ext-card-interval input[type="number"]:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.ext-card-interval input[type="number"]::-webkit-outer-spin-button,
+.ext-card-interval input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+
+.ext-card-interval-unit {
+    font-size: 13px;
+    color: var(--text-dim);
+}
+
+.ext-card-interval-hint {
+    font-size: 11px;
+    color: var(--text-dim);
+}
+
+/* ── 7. Footer (Unlink demoted to quiet link) ────────────────── */
+
+.ext-card-footer {
+    display: flex;
+    justify-content: flex-end;
+    padding-top: 10px;
+    margin-top: -4px;
+    border-top: 1px dashed var(--border-subtle);
+}
+
+.ext-card-unlink {
+    background: none;
+    border: none;
+    padding: 4px 0;
+    color: var(--text-dim);
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    text-decoration: underline;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--border);
+    transition: color 0.12s, text-decoration-color 0.12s;
+}
+
+.ext-card-unlink:hover,
+.ext-card-unlink:focus-visible {
+    color: var(--red);
+    text-decoration-color: var(--red);
+    outline: none;
+}
+
+/* ─── Unlinked state — provider tiles ─────────────────────────── */
+
+.ext-link-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 12px;
+    margin-bottom: 12px;
+}
+
+.ext-link-tile {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 16px;
+    background: var(--bg-elevated, var(--bg));
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    transition: border-color 0.15s, transform 0.15s;
+}
+
+.ext-link-tile:hover {
+    border-color: rgba(203, 166, 247, 0.4);
+    transform: translateY(-1px);
+}
+
+.ext-link-tile-head {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.ext-link-tile-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+}
+
+.ext-link-tile-dot-al {
+    background: var(--accent);
+}
+
+.ext-link-tile-dot-mal {
+    background: rgb(125, 176, 211);
+}
+
+.ext-link-tile-name {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-bright);
+}
+
+.ext-link-tile-blurb {
+    margin: 0;
+    font-size: 12px;
+    color: var(--text-dim);
+    line-height: 1.5;
+    flex-grow: 1;
+}
+
+.ext-link-tile-cta {
+    align-self: flex-start;
+}
+
+.ext-link-attribution {
+    font-size: 11px;
+    color: var(--text-dim);
 }
 

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -433,6 +433,10 @@ window.ryokanProgressToast = function (opts) {
                     // if it does.
                     toast.finalize({});
                 }
+                if (typeof opts.onTerminal === 'function') {
+                    try { opts.onTerminal(last || {}); }
+                    catch (e) { console.warn('[ryokanProgressToast] onTerminal threw:', e); }
+                }
                 return;
             }
             schedule(500);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3,6 +3,17 @@
 // `getTitleByLang` below still has something to compare against.
 const initialTitleLanguage = window.initialTitleLanguage || '';
 
+// Debounced auto-submit for the library search input. Submits 250ms
+// after the user stops typing so each keystroke isn't a navigation,
+// but the page refreshes quickly enough to feel live.
+let librarySearchDebounceTimer = null;
+function debouncedLibrarySearchSubmit(input) {
+    if (librarySearchDebounceTimer) clearTimeout(librarySearchDebounceTimer);
+    librarySearchDebounceTimer = setTimeout(() => {
+        if (input.form) input.form.submit();
+    }, 250);
+}
+
 function openAddModal() {
     document.getElementById('add-modal').style.display = 'flex';
     document.getElementById('anilist-query').focus();

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -3,15 +3,81 @@
 // `getTitleByLang` below still has something to compare against.
 const initialTitleLanguage = window.initialTitleLanguage || '';
 
-// Debounced auto-submit for the library search input. Submits 250ms
-// after the user stops typing so each keystroke isn't a navigation,
-// but the page refreshes quickly enough to feel live.
-let librarySearchDebounceTimer = null;
-function debouncedLibrarySearchSubmit(input) {
-    if (librarySearchDebounceTimer) clearTimeout(librarySearchDebounceTimer);
-    librarySearchDebounceTimer = setTimeout(() => {
-        if (input.form) input.form.submit();
-    }, 250);
+// Live client-side library search. The full library is in the DOM
+// after page load, so substring-matching titles + toggling display
+// is faster than a server round-trip and avoids the page reflow. We
+// only stamp `?search=foo` into the URL via replaceState so a
+// hard reload still lands the user on the same filtered view via
+// the server-side handler (no-JS fallback). The dropdowns and sort
+// still submit-on-change because list-membership and score-sort
+// genuinely need DB work.
+function liveLibrarySearch(input) {
+    const q = (input.value || '').trim().toLowerCase();
+    const grid = document.getElementById('library-grid');
+    if (!grid) return;
+
+    let visibleCount = 0;
+    grid.querySelectorAll('.series-card').forEach((card) => {
+        // Match against all three title fields. They're in the DOM
+        // as .title-option spans (title-switcher controls which one
+        // is visible via CSS, but all three are searchable).
+        const titles = card.querySelectorAll('.title-option');
+        let matches = q === '';
+        if (!matches) {
+            for (let i = 0; i < titles.length; i++) {
+                if (titles[i].textContent.toLowerCase().includes(q)) {
+                    matches = true;
+                    break;
+                }
+            }
+        }
+        card.style.display = matches ? '' : 'none';
+        if (matches) visibleCount++;
+    });
+
+    // URL update without navigation. Other params (list, sort) are
+    // preserved so a manual reload picks up everything.
+    const url = new URL(window.location.href);
+    if (q) url.searchParams.set('search', q);
+    else url.searchParams.delete('search');
+    window.history.replaceState(null, '', url);
+
+    // Clear button visibility: track whether *any* filter is active,
+    // not just search. The list filter is reflected in the URL.
+    const hasListFilter = !!url.searchParams.get('list');
+    const clear = document.querySelector('.library-filter-clear');
+    if (clear) {
+        const anyActive = !!q || hasListFilter;
+        clear.classList.toggle('library-filter-clear-hidden', !anyActive);
+        if (anyActive) {
+            clear.removeAttribute('aria-hidden');
+            clear.removeAttribute('tabindex');
+        } else {
+            clear.setAttribute('aria-hidden', 'true');
+            clear.setAttribute('tabindex', '-1');
+        }
+    }
+
+    // No-matches inline empty state. Built once and toggled — avoids
+    // navigation while still telling the user their query found
+    // nothing.
+    let empty = document.getElementById('library-search-empty');
+    if (visibleCount === 0 && q) {
+        if (!empty) {
+            empty = document.createElement('div');
+            empty.id = 'library-search-empty';
+            empty.className = 'empty-state';
+            const p = document.createElement('p');
+            p.textContent = 'No series match your search.';
+            empty.appendChild(p);
+            grid.parentNode.insertBefore(empty, grid.nextSibling);
+        }
+        empty.style.display = '';
+        grid.style.display = 'none';
+    } else if (empty) {
+        empty.style.display = 'none';
+        grid.style.display = '';
+    }
 }
 
 function openAddModal() {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -11,7 +11,22 @@ const initialTitleLanguage = window.initialTitleLanguage || '';
 // the server-side handler (no-JS fallback). The dropdowns and sort
 // still submit-on-change because list-membership and score-sort
 // genuinely need DB work.
+//
+// 250ms debounce on `input` so a fast typist doesn't trigger a
+// full grid re-walk + replaceState per keystroke. The DOM filter is
+// cheap on a few hundred series but a power user with thousands
+// would feel the per-keystroke layout thrash from the
+// `style.display = 'none'` writes.
+let _liveSearchTimer = null;
 function liveLibrarySearch(input) {
+    if (_liveSearchTimer) clearTimeout(_liveSearchTimer);
+    _liveSearchTimer = setTimeout(() => {
+        _liveSearchTimer = null;
+        _liveLibrarySearchImmediate(input);
+    }, 250);
+}
+
+function _liveLibrarySearchImmediate(input) {
     const q = (input.value || '').trim().toLowerCase();
     const grid = document.getElementById('library-grid');
     if (!grid) return;

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -858,3 +858,45 @@ function saveExternalAccountPrefs() {
         .then((r) => { if (!r.ok) console.error('[ext-accounts] prefs save failed:', r.status); });
     }, 250);
 }
+
+// #62 PR E — live updater for `[data-relative-time]` elements.
+// Mirrors the Rust-side `humanize_relative_time` policy so the
+// label that JS produces matches what a fresh page load from the
+// server would produce. Re-runs every 30 seconds; the user
+// browsing Settings sees "last sync 4 minutes ago" tick over to
+// "5 minutes ago" without reloading. Idempotent: if the page has
+// no marker elements it's a no-op + the timer is skipped.
+(function () {
+    function humanize(unixTs, nowSec) {
+        const delta = Math.max(0, nowSec - unixTs);
+        if (delta < 60) return 'Just now';
+        if (delta < 3600) {
+            const m = Math.floor(delta / 60);
+            return m + ' minute' + (m === 1 ? '' : 's') + ' ago';
+        }
+        if (delta < 86400) {
+            const h = Math.floor(delta / 3600);
+            return h + ' hour' + (h === 1 ? '' : 's') + ' ago';
+        }
+        const d = Math.floor(delta / 86400);
+        return d + ' day' + (d === 1 ? '' : 's') + ' ago';
+    }
+
+    function tick() {
+        const now = Math.floor(Date.now() / 1000);
+        document.querySelectorAll('[data-relative-time]').forEach(function (el) {
+            const ts = parseInt(el.getAttribute('data-relative-time'), 10);
+            if (!Number.isFinite(ts) || ts <= 0) return;
+            el.textContent = humanize(ts, now);
+        });
+    }
+
+    // First tick immediately so any clock drift since the
+    // server-render gets corrected on page load. Then every 30s.
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', tick);
+    } else {
+        tick();
+    }
+    setInterval(tick, 30 * 1000);
+})();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -797,6 +797,20 @@ function syncWatchListNow() {
         progressId,
         title: 'Watch-list sync starting…',
         category: 'external_sync',
+        onTerminal: (ev) => {
+            // On a successful manual sync, snap the last-sync hint to
+            // "Just now" right away so the user gets immediate
+            // feedback. The 30s `[data-relative-time]` updater takes
+            // care of subsequent ticks. A failed/warned sync leaves
+            // the previous timestamp untouched.
+            if (ev && ev.kind === 'success') {
+                const nowSec = Math.floor(Date.now() / 1000);
+                document.querySelectorAll('[data-relative-time]').forEach((el) => {
+                    el.setAttribute('data-relative-time', String(nowSec));
+                    el.textContent = 'Just now';
+                });
+            }
+        },
     });
     fetch('/settings/oauth/sync-now', {
         method: 'POST',

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,29 +10,34 @@
             <h2>Library</h2>
             <p class="page-desc">Your tracked anime series.</p>
         </div>
+        {# Middle column: the library search form. Its own GET form
+           so it can submit independently with debounced auto-submit
+           on the right side's filter/sort form. Hidden inputs mirror
+           the active list/sort values so a search submit doesn't
+           drop the user's other selections. #}
+        <form method="get" action="/" class="library-search-form">
+            <label for="library-search" class="visually-hidden">Search library</label>
+            <input type="search"
+                   id="library-search"
+                   name="search"
+                   placeholder="Search library…"
+                   class="library-search-input"
+                   value="{{ search_query }}"
+                   autocomplete="off"
+                   oninput="debouncedLibrarySearchSubmit(this)"
+                   onchange="this.form.submit()">
+            {% if !custom_list_filter.is_empty() %}<input type="hidden" name="list" value="{{ custom_list_filter }}">{% endif %}
+            {% if sort_value.as_str() != "recent" %}<input type="hidden" name="sort" value="{{ sort_value }}">{% endif %}
+        </form>
+
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-            {# #62 PR D + E — library filters. Combined into one
-               GET form so the two controls compose (set both →
-               server filters by both predicates). The form
-               submits on dropdown change AND on the genre input's
-               native `change` (fires after blur or Enter), so
-               either control standalone or in combination produces
-               a single navigation. #}
+            {% if !custom_list_names.is_empty() || !score_format.is_empty() || !search_query.is_empty() || !custom_list_filter.is_empty() %}
+            {# Right group: list + sort filters. Each onchange auto-
+               submits. A hidden `search` input carries the current
+               search query through so changing list/sort doesn't
+               drop it. #}
             <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-                {# Library search. Case-insensitive substring match
-                   against the three title fields (english/romaji/
-                   native); composes with the list filter and sort.
-                   Submits on Enter (form default) and on blur after
-                   edit (`change` event) so the user doesn't have to
-                   hit Enter explicitly. #}
-                <label for="library-search" class="visually-hidden">Search library</label>
-                <input type="search"
-                       id="library-search"
-                       name="search"
-                       placeholder="Search library…"
-                       class="library-genre-input"
-                       value="{{ search_query }}"
-                       onchange="this.form.submit()">
+                {% if !search_query.is_empty() %}<input type="hidden" name="search" value="{{ search_query }}">{% endif %}
                 {% if !custom_list_names.is_empty() %}
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
                 <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
@@ -45,8 +50,7 @@
                 {% if !score_format.is_empty() %}
                 {# #62 PR E — sort-by-user-score. Hidden when no
                    external account is linked because there'd be no
-                   user_score values to sort by. Submits the same
-                   form so the sort + active filters compose. #}
+                   user_score values to sort by. #}
                 <label for="library-sort" class="visually-hidden">Sort</label>
                 <select id="library-sort" name="sort" class="folder-select" onchange="this.form.submit()">
                     <option value="recent"{% if sort_value.as_str() == "recent" %} selected{% endif %}>Recently added</option>
@@ -57,13 +61,8 @@
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
                 {% endif %}
             </form>
-            {# Reserved width preserves the filter row's original
-               left edge after the Needs Review button was removed
-               — without it, the right-side flex box shrinks to
-               content and the filters slide right against Add
-               Series. Matches the deleted button's footprint
-               (padding + "Needs Review" label + the 8px gap). #}
-            <button class="btn btn-primary" style="margin-left: 140px;" onclick="openAddModal()">+ Add Series</button>
+            {% endif %}
+            <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,9 +5,9 @@
 
 {% block content %}
 <div class="page-header">
-    <div class="page-header-row">
+    <div class="page-header-row library-header-row">
         <div>
-            <h2>Library</h2>
+            <h2>Anime Library</h2>
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
             {# All filter controls in one form so they share state

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,6 @@
                 {% endif %}
             </form>
             {% endif %}
-            <a class="btn btn-secondary" href="/system?tab=review">Needs Review</a>
             <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -68,11 +68,18 @@
                    shift neighbors when a filter becomes active. The
                    element is also aria-hidden + tabindex=-1 in the
                    inactive state so a screen-reader / keyboard user
-                   can't reach a "Clear" link that does nothing. #}
+                   can't reach a "Clear" link that does nothing.
+
+                   The href carries the current sort through because
+                   sort is presentation, not a filter — clearing
+                   filters shouldn't snap the user back to the
+                   default "Recently added" order. The default
+                   ("recent") is omitted to keep the cleared URL
+                   tidy. #}
                 {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
-                <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
+                <a class="btn btn-pill library-filter-clear" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}" title="Clear filters">Clear</a>
                 {% else %}
-                <a class="btn btn-pill library-filter-clear library-filter-clear-hidden" href="/" tabindex="-1" aria-hidden="true">Clear</a>
+                <a class="btn btn-pill library-filter-clear library-filter-clear-hidden" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}" tabindex="-1" aria-hidden="true">Clear</a>
                 {% endif %}
             </form>
             {# Reserved width pushes the right group's left edge back
@@ -102,7 +109,7 @@
         {% endif %}
     </p>
     <div class="empty-state-actions">
-        <a class="btn btn-secondary" href="/">Clear filters</a>
+        <a class="btn btn-secondary" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}">Clear filters</a>
     </div>
     {% else %}
     <p>Your library is empty.</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,34 +10,15 @@
             <h2>Library</h2>
             <p class="page-desc">Your tracked anime series.</p>
         </div>
-        {# Middle column: the library search form. Its own GET form
-           so it can submit independently with debounced auto-submit
-           on the right side's filter/sort form. Hidden inputs mirror
-           the active list/sort values so a search submit doesn't
-           drop the user's other selections. #}
-        <form method="get" action="/" class="library-search-form">
-            <label for="library-search" class="visually-hidden">Search library</label>
-            <input type="search"
-                   id="library-search"
-                   name="search"
-                   placeholder="Search library…"
-                   class="library-search-input"
-                   value="{{ search_query }}"
-                   autocomplete="off"
-                   oninput="debouncedLibrarySearchSubmit(this)"
-                   onchange="this.form.submit()">
-            {% if !custom_list_filter.is_empty() %}<input type="hidden" name="list" value="{{ custom_list_filter }}">{% endif %}
-            {% if sort_value.as_str() != "recent" %}<input type="hidden" name="sort" value="{{ sort_value }}">{% endif %}
-        </form>
-
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-            {% if !custom_list_names.is_empty() || !score_format.is_empty() || !search_query.is_empty() || !custom_list_filter.is_empty() %}
-            {# Right group: list + sort filters. Each onchange auto-
-               submits. A hidden `search` input carries the current
-               search query through so changing list/sort doesn't
-               drop it. #}
+            {# All filter controls in one form so they share state
+               without hidden-input mirrors. Visual order is list →
+               search → sort → clear, putting the search box between
+               the two dropdowns. Each control auto-submits on its
+               own native event; the search input uses a 250ms
+               debounce on `input` so each keystroke isn't a fresh
+               navigation. #}
             <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-                {% if !search_query.is_empty() %}<input type="hidden" name="search" value="{{ search_query }}">{% endif %}
                 {% if !custom_list_names.is_empty() %}
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
                 <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
@@ -47,6 +28,16 @@
                     {% endfor %}
                 </select>
                 {% endif %}
+                <label for="library-search" class="visually-hidden">Search library</label>
+                <input type="search"
+                       id="library-search"
+                       name="search"
+                       placeholder="Search library…"
+                       class="library-search-input"
+                       value="{{ search_query }}"
+                       autocomplete="off"
+                       oninput="debouncedLibrarySearchSubmit(this)"
+                       onchange="this.form.submit()">
                 {% if !score_format.is_empty() %}
                 {# #62 PR E — sort-by-user-score. Hidden when no
                    external account is linked because there'd be no
@@ -61,7 +52,6 @@
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
                 {% endif %}
             </form>
-            {% endif %}
             <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -52,7 +52,13 @@
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
                 {% endif %}
             </form>
-            <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
+            {# Reserved width pushes the right group's left edge back
+               to where it sat before the Needs Review button was
+               removed. Without it, the right-side flex box shrinks
+               to content and the filters slide right against Add
+               Series. Matches the deleted button's footprint
+               (padding + "Needs Review" label + the 8px gap). #}
+            <button class="btn btn-primary" style="margin-left: 140px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,7 +42,7 @@
                        id="library-search"
                        name="search"
                        placeholder="Search library…"
-                       class="library-search-input"
+                       class="library-search-input{% if custom_list_names.is_empty() %} library-search-input-wide{% endif %}"
                        value="{{ search_query }}"
                        autocomplete="off"
                        oninput="liveLibrarySearch(this)"

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
                native `change` (fires after blur or Enter), so
                either control standalone or in combination produces
                a single navigation. #}
-            {% if !custom_list_names.is_empty() || !genre_names.is_empty() %}
+            {% if !custom_list_names.is_empty() || !genre_names.is_empty() || !score_format.is_empty() %}
             <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
                 {% if !custom_list_names.is_empty() %}
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
@@ -50,6 +50,17 @@
                     <option value="{{ name }}"></option>
                     {% endfor %}
                 </datalist>
+                {% endif %}
+                {% if !score_format.is_empty() %}
+                {# #62 PR E — sort-by-user-score. Hidden when no
+                   external account is linked because there'd be no
+                   user_score values to sort by. Submits the same
+                   form so the sort + active filters compose. #}
+                <label for="library-sort" class="visually-hidden">Sort</label>
+                <select id="library-sort" name="sort" class="folder-select" onchange="this.form.submit()">
+                    <option value="recent"{% if sort_value.as_str() == "recent" %} selected{% endif %}>Recently added</option>
+                    <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
+                </select>
                 {% endif %}
                 {% if !genre_filter.is_empty() || !custom_list_filter.is_empty() %}
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,13 @@
                 {% endif %}
             </form>
             {% endif %}
-            <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
+            {# Reserved width preserves the filter row's original
+               left edge after the Needs Review button was removed
+               — without it, the right-side flex box shrinks to
+               content and the filters slide right against Add
+               Series. Matches the deleted button's footprint
+               (padding + "Needs Review" label + the 8px gap). #}
+            <button class="btn btn-primary" style="margin-left: 140px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -48,8 +48,16 @@
                     <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
                 </select>
                 {% endif %}
+                {# Always rendered so its layout slot is reserved;
+                   visibility flips on/off so its presence doesn't
+                   shift neighbors when a filter becomes active. The
+                   element is also aria-hidden + tabindex=-1 in the
+                   inactive state so a screen-reader / keyboard user
+                   can't reach a "Clear" link that does nothing. #}
                 {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
+                {% else %}
+                <a class="btn btn-pill library-filter-clear library-filter-clear-hidden" href="/" tabindex="-1" aria-hidden="true">Clear</a>
                 {% endif %}
             </form>
             {# Reserved width pushes the right group's left edge back

--- a/templates/index.html
+++ b/templates/index.html
@@ -61,11 +61,11 @@
                 {% endif %}
             </form>
             {# Reserved width pushes the right group's left edge back
-               to where it sat before the Needs Review button was
-               removed. Trimmed from the original ~140px to compensate
-               for the now-always-rendered Clear link slot (≈60px
-               with its 6px flex gap). #}
-            <button class="btn btn-primary" style="margin-left: 80px;" onclick="openAddModal()">+ Add Series</button>
+               toward where it sat before the Needs Review button
+               was removed. Successively trimmed as the row grew —
+               first for the always-reserved Clear slot, then for
+               the height-matched (and so wider) dropdowns + search. #}
+            <button class="btn btn-primary" style="margin-left: 32px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,8 +18,21 @@
                native `change` (fires after blur or Enter), so
                either control standalone or in combination produces
                a single navigation. #}
-            {% if !custom_list_names.is_empty() || !genre_names.is_empty() || !score_format.is_empty() %}
             <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+                {# Library search. Case-insensitive substring match
+                   against the three title fields (english/romaji/
+                   native); composes with the list filter and sort.
+                   Submits on Enter (form default) and on blur after
+                   edit (`change` event) so the user doesn't have to
+                   hit Enter explicitly. #}
+                <label for="library-search" class="visually-hidden">Search library</label>
+                <input type="search"
+                       id="library-search"
+                       name="search"
+                       placeholder="Search library…"
+                       class="library-genre-input"
+                       value="{{ search_query }}"
+                       onchange="this.form.submit()">
                 {% if !custom_list_names.is_empty() %}
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
                 <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
@@ -28,28 +41,6 @@
                     <option value="{{ name }}"{% if name.as_str() == custom_list_filter.as_str() %} selected{% endif %}>{{ name }}</option>
                     {% endfor %}
                 </select>
-                {% endif %}
-                {% if !genre_names.is_empty() %}
-                {# #62 PR E — genre filter with HTML5 datalist
-                   autocomplete. The user types a genre name,
-                   browser shows matches from the bound datalist;
-                   on commit (blur/Enter) the form submits and the
-                   handler applies the filter. No JS required for
-                   the autocomplete; the small "✕" inside is the
-                   reset (visible only when filter is active). #}
-                <label for="library-genre-filter" class="visually-hidden">Filter by genre</label>
-                <input type="search"
-                       id="library-genre-filter"
-                       name="genre"
-                       list="library-genre-options"
-                       placeholder="Filter by genre…"
-                       class="library-genre-input"
-                       value="{{ genre_filter }}">
-                <datalist id="library-genre-options">
-                    {% for name in genre_names %}
-                    <option value="{{ name }}"></option>
-                    {% endfor %}
-                </datalist>
                 {% endif %}
                 {% if !score_format.is_empty() %}
                 {# #62 PR E — sort-by-user-score. Hidden when no
@@ -62,11 +53,10 @@
                     <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
                 </select>
                 {% endif %}
-                {% if !genre_filter.is_empty() || !custom_list_filter.is_empty() %}
+                {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
                 <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
                 {% endif %}
             </form>
-            {% endif %}
             {# Reserved width preserves the filter row's original
                left edge after the Needs Review button was removed
                — without it, the right-side flex box shrinks to
@@ -80,16 +70,16 @@
 
 {% if library.is_empty() %}
 <div class="empty-state">
-    {% if !genre_filter.is_empty() || !custom_list_filter.is_empty() %}
-    {# #62 PR E — distinguish "filter excluded everything" from
-       "library is genuinely empty." Keeps the user from thinking
-       the library was wiped. #}
+    {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
+    {# Distinguish "filter excluded everything" from "library is
+       genuinely empty." Keeps the user from thinking the library
+       was wiped. #}
     <p>No series match your current filter.</p>
     <p class="form-hint">
-        {% if !genre_filter.is_empty() && !custom_list_filter.is_empty() %}
-        Filtered by list <strong>{{ custom_list_filter }}</strong> and genre <strong>{{ genre_filter }}</strong>.
-        {% else if !genre_filter.is_empty() %}
-        Filtered by genre <strong>{{ genre_filter }}</strong>.
+        {% if !search_query.is_empty() && !custom_list_filter.is_empty() %}
+        Filtered by list <strong>{{ custom_list_filter }}</strong> and search <strong>"{{ search_query }}"</strong>.
+        {% else if !search_query.is_empty() %}
+        No matches for <strong>"{{ search_query }}"</strong>.
         {% else %}
         Filtered by list <strong>{{ custom_list_filter }}</strong>.
         {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,16 +47,19 @@
                        autocomplete="off"
                        oninput="liveLibrarySearch(this)"
                        onkeydown="if(event.key==='Enter'){event.preventDefault();}">
-                {% if !score_format.is_empty() %}
-                {# #62 PR E — sort-by-user-score. Hidden when no
-                   external account is linked because there'd be no
-                   user_score values to sort by. #}
+                {# Sort dropdown always renders so "Recently added"
+                   stays available — that ordering doesn't depend on
+                   any external linkage. The "My score" option only
+                   appears when an external account is linked
+                   (`score_format` non-empty); without one there's
+                   nothing to sort against. #}
                 <label for="library-sort" class="visually-hidden">Sort</label>
                 <select id="library-sort" name="sort" class="folder-select" onchange="this.form.submit()">
                     <option value="recent"{% if sort_value.as_str() == "recent" %} selected{% endif %}>Recently added</option>
+                    {% if !score_format.is_empty() %}
                     <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
+                    {% endif %}
                 </select>
-                {% endif %}
                 {# Always rendered so its layout slot is reserved;
                    visibility flips on/off so its presence doesn't
                    shift neighbors when a filter becomes active. The

--- a/templates/index.html
+++ b/templates/index.html
@@ -62,11 +62,10 @@
             </form>
             {# Reserved width pushes the right group's left edge back
                to where it sat before the Needs Review button was
-               removed. Without it, the right-side flex box shrinks
-               to content and the filters slide right against Add
-               Series. Matches the deleted button's footprint
-               (padding + "Needs Review" label + the 8px gap). #}
-            <button class="btn btn-primary" style="margin-left: 140px;" onclick="openAddModal()">+ Add Series</button>
+               removed. Trimmed from the original ~140px to compensate
+               for the now-always-rendered Clear link slot (≈60px
+               with its 6px flex gap). #}
+            <button class="btn btn-primary" style="margin-left: 80px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -8,7 +8,6 @@
     <div class="page-header-row">
         <div>
             <h2>Library</h2>
-            <p class="page-desc">Your tracked anime series.</p>
         </div>
         <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
             {# All filter controls in one form so they share state

--- a/templates/index.html
+++ b/templates/index.html
@@ -67,7 +67,7 @@
                 {% endif %}
             </form>
             {% endif %}
-            <a class="btn" href="/system?tab=review">Needs Review</a>
+            <a class="btn btn-secondary" href="/system?tab=review">Needs Review</a>
             <button class="btn btn-primary" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -29,6 +29,15 @@
                 </select>
                 {% endif %}
                 <label for="library-search" class="visually-hidden">Search library</label>
+                {# Search runs entirely client-side: `liveLibrarySearch`
+                   filters the already-rendered .series-card grid in
+                   place and stamps `?search=foo` into the URL via
+                   replaceState, so a reload still loads the right
+                   subset (the server handler stays as the no-JS
+                   fallback). Enter is prevented on the input so the
+                   form doesn't navigate; the dropdowns still
+                   submit-on-change because list and sort genuinely
+                   need server work. #}
                 <input type="search"
                        id="library-search"
                        name="search"
@@ -36,8 +45,8 @@
                        class="library-search-input"
                        value="{{ search_query }}"
                        autocomplete="off"
-                       oninput="debouncedLibrarySearchSubmit(this)"
-                       onchange="this.form.submit()">
+                       oninput="liveLibrarySearch(this)"
+                       onkeydown="if(event.key==='Enter'){event.preventDefault();}">
                 {% if !score_format.is_empty() %}
                 {# #62 PR E — sort-by-user-score. Hidden when no
                    external account is linked because there'd be no

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,14 +10,17 @@
             <h2>Library</h2>
             <p class="page-desc">Your tracked anime series.</p>
         </div>
-        <div style="display:flex;gap:8px;align-items:center">
-            {# #62 PR D — AL custom-list filter dropdown. Hidden
-               when no memberships have synced yet. Selecting an
-               option submits the surrounding form via the change
-               handler so the URL becomes `/?list=<name>` and the
-               server-side handler returns the filtered set. #}
-            {% if !custom_list_names.is_empty() %}
-            <form method="get" action="/" class="library-filter-form">
+        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
+            {# #62 PR D + E — library filters. Combined into one
+               GET form so the two controls compose (set both →
+               server filters by both predicates). The form
+               submits on dropdown change AND on the genre input's
+               native `change` (fires after blur or Enter), so
+               either control standalone or in combination produces
+               a single navigation. #}
+            {% if !custom_list_names.is_empty() || !genre_names.is_empty() %}
+            <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
+                {% if !custom_list_names.is_empty() %}
                 <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
                 <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
                     <option value="">All custom lists</option>
@@ -25,6 +28,32 @@
                     <option value="{{ name }}"{% if name.as_str() == custom_list_filter.as_str() %} selected{% endif %}>{{ name }}</option>
                     {% endfor %}
                 </select>
+                {% endif %}
+                {% if !genre_names.is_empty() %}
+                {# #62 PR E — genre filter with HTML5 datalist
+                   autocomplete. The user types a genre name,
+                   browser shows matches from the bound datalist;
+                   on commit (blur/Enter) the form submits and the
+                   handler applies the filter. No JS required for
+                   the autocomplete; the small "✕" inside is the
+                   reset (visible only when filter is active). #}
+                <label for="library-genre-filter" class="visually-hidden">Filter by genre</label>
+                <input type="search"
+                       id="library-genre-filter"
+                       name="genre"
+                       list="library-genre-options"
+                       placeholder="Filter by genre…"
+                       class="library-genre-input"
+                       value="{{ genre_filter }}">
+                <datalist id="library-genre-options">
+                    {% for name in genre_names %}
+                    <option value="{{ name }}"></option>
+                    {% endfor %}
+                </datalist>
+                {% endif %}
+                {% if !genre_filter.is_empty() || !custom_list_filter.is_empty() %}
+                <a class="btn btn-pill library-filter-clear" href="/" title="Clear filters">Clear</a>
+                {% endif %}
             </form>
             {% endif %}
             <a class="btn" href="/system?tab=review">Needs Review</a>
@@ -35,12 +64,31 @@
 
 {% if library.is_empty() %}
 <div class="empty-state">
+    {% if !genre_filter.is_empty() || !custom_list_filter.is_empty() %}
+    {# #62 PR E — distinguish "filter excluded everything" from
+       "library is genuinely empty." Keeps the user from thinking
+       the library was wiped. #}
+    <p>No series match your current filter.</p>
+    <p class="form-hint">
+        {% if !genre_filter.is_empty() && !custom_list_filter.is_empty() %}
+        Filtered by list <strong>{{ custom_list_filter }}</strong> and genre <strong>{{ genre_filter }}</strong>.
+        {% else if !genre_filter.is_empty() %}
+        Filtered by genre <strong>{{ genre_filter }}</strong>.
+        {% else %}
+        Filtered by list <strong>{{ custom_list_filter }}</strong>.
+        {% endif %}
+    </p>
+    <div class="empty-state-actions">
+        <a class="btn btn-secondary" href="/">Clear filters</a>
+    </div>
+    {% else %}
     <p>Your library is empty.</p>
     <p class="form-hint">Add your first series to get Ryokan watching for new episodes. You can also browse releases directly on Nyaa via the Search tab.</p>
     <div class="empty-state-actions">
         <button class="btn btn-primary" onclick="openAddModal()">Search AniList to add anime</button>
         <a class="btn btn-secondary" href="/search">Browse Nyaa</a>
     </div>
+    {% endif %}
 </div>
 {% else %}
 <div class="library-grid" id="library-grid">

--- a/templates/index.html
+++ b/templates/index.html
@@ -47,17 +47,21 @@
                        autocomplete="off"
                        oninput="liveLibrarySearch(this)"
                        onkeydown="if(event.key==='Enter'){event.preventDefault();}">
-                {# Sort dropdown always renders so "Recently added"
-                   stays available — that ordering doesn't depend on
-                   any external linkage. The "My score" option only
-                   appears when an external account is linked
-                   (`score_format` non-empty); without one there's
-                   nothing to sort against. #}
+                {# Sort dropdown always renders so the universal
+                   options (Recently added, oldest first, A→Z, Z→A)
+                   stay available regardless of linkage. The two
+                   score-based options only appear when an external
+                   account is linked (`score_format` non-empty);
+                   without one there's nothing to sort against. #}
                 <label for="library-sort" class="visually-hidden">Sort</label>
                 <select id="library-sort" name="sort" class="folder-select" onchange="this.form.submit()">
                     <option value="recent"{% if sort_value.as_str() == "recent" %} selected{% endif %}>Recently added</option>
+                    <option value="oldest"{% if sort_value.as_str() == "oldest" %} selected{% endif %}>Oldest first</option>
+                    <option value="title_asc"{% if sort_value.as_str() == "title_asc" %} selected{% endif %}>Title (A → Z)</option>
+                    <option value="title_desc"{% if sort_value.as_str() == "title_desc" %} selected{% endif %}>Title (Z → A)</option>
                     {% if !score_format.is_empty() %}
                     <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
+                    <option value="score_asc"{% if sort_value.as_str() == "score_asc" %} selected{% endif %}>My score (low → high)</option>
                     {% endif %}
                 </select>
                 {# Always rendered so its layout slot is reserved;

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -231,15 +231,26 @@
            interval → actions — but rebuilt entirely from the
            connections-tab primitives. No bespoke card surface. #}
         <fieldset>
+            {# Legend health badge — same visual primitive
+               qBittorrent / Jellyfin / Deluge / Transmission /
+               rTorrent use. Server-rendered (we have the data; JS
+               on the other sections fills theirs because they
+               require a live network probe). The badge color
+               encodes connection state:
+                 • green (.log-badge-info)  → linked + auth healthy
+                 • red   (.log-badge-error) → linked + re-link required
+                 • neutral (.log-badge)     → not linked #}
             <legend>
                 External Accounts
                 {% match external_account %}
                     {% when Some with (acct) %}
-                        {# Status hint in the legend — same shape qBit
-                           and Jellyfin use for their health spans. #}
-                        <span class="form-hint">{{ acct.provider_label }} · {{ acct.username }} · last sync {{ acct.last_sync_label }}</span>
+                        {% if acct.last_sync_auth_failed %}
+                        <span class="form-hint"><span class="log-badge log-badge-error">Re-link required</span></span>
+                        {% else %}
+                        <span class="form-hint"><span class="log-badge log-badge-info">{{ acct.provider_label }} · {{ acct.username }}</span></span>
+                        {% endif %}
                     {% when None %}
-                        <span class="form-hint">Not linked</span>
+                        <span class="form-hint"><span class="log-badge">Not linked</span></span>
                 {% endmatch %}
             </legend>
             <p class="form-hint" style="margin-bottom: 12px;">
@@ -263,26 +274,6 @@
                         on the last sync. They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.
                     </div>
                     {% endif %}
-
-                    {# Provider + score-format display row. Two
-                       form-group blocks side by side via .form-row,
-                       same primitive qBit's user/password row uses. #}
-                    <div class="form-row">
-                        <div class="form-group">
-                            <label>Provider</label>
-                            <span class="form-display">{{ acct.provider_label }}</span>
-                        </div>
-                        <div class="form-group">
-                            <label>Username</label>
-                            <span class="form-display">{{ acct.username }}</span>
-                        </div>
-                        {% if !acct.score_format_label.is_empty() %}
-                        <div class="form-group">
-                            <label>Score format</label>
-                            <span class="form-display">{{ acct.score_format_label }}</span>
-                        </div>
-                        {% endif %}
-                    </div>
 
                     {# Import-list checkboxes. Wrap-flex so 2-3 fit
                        per row on a wide viewport, falling back to
@@ -351,7 +342,24 @@
                     <div class="settings-inline-actions">
                         <button type="button" class="btn btn-primary" onclick="syncWatchListNow()">Sync now</button>
                         <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
-                        <span class="form-hint">Cadence every {{ config.external_sync_interval_minutes }} min · last sync {{ acct.last_sync_label }}</span>
+                        {# Cadence + last-sync hint. The last-sync
+                           span's `data-relative-time` is the unix-
+                           epoch the JS updater (settings.js) keys
+                           off so the label re-renders ("4 minutes
+                           ago" → "5 minutes ago") without a page
+                           reload. When `last_sync_unix_ts` is None
+                           the attribute is omitted; the JS skips
+                           those elements and the "Never" text from
+                           server-render stays. #}
+                        <span class="form-hint">
+                            Cadence every {{ config.external_sync_interval_minutes }} min · last sync
+                            {% match acct.last_sync_unix_ts %}
+                                {% when Some with (ts) %}
+                                    <span data-relative-time="{{ ts }}">{{ acct.last_sync_label }}</span>
+                                {% when None %}
+                                    {{ acct.last_sync_label }}
+                            {% endmatch %}
+                        </span>
                     </div>
                 {% when None %}
                     {# Unlinked: a single form-group whose action row

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -248,6 +248,18 @@
                                 <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
                             </div>
                         </div>
+                        {# #62 PR E — re-link-required banner. Set
+                           when the most recent sync hit an auth-
+                           rejection error (AL 401/403, MAL refresh
+                           dead). Cleared by the next successful
+                           sync, so it disappears on its own once
+                           the user re-links. #}
+                        {% if acct.last_sync_auth_failed %}
+                        <div class="ext-accounts-relink-banner">
+                            <strong>Re-link required.</strong>
+                            Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.
+                        </div>
+                        {% endif %}
                         {# #62 PR E — MAL→AL mapping-failure
                            counter. Persisted by sync_mal at the end
                            of every successful tick (cleared to 0 by

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -223,109 +223,189 @@
         </fieldset>
 
         {# Issue #62 PR A — External account linkage. Two states:
-           unlinked (Link buttons for AL + MAL) and linked (provider
-           card with username + per-list import checkboxes + Unlink
-           button). Only one account can be linked at a time per
-           decision #10 — the linked state hides both Link buttons. #}
+           unlinked (Link tiles for AL + MAL) and linked (compact
+           dashboard card with provider identity, sync state, prefs
+           grid, interval setting, and footer Unlink). Only one
+           account can be linked at a time per decision #10 — the
+           linked state hides both Link tiles.
+
+           Layout intent (PR-E redesign):
+             1. Identity row — provider name + username + score
+                format, accent-stripe down the left edge so the
+                provider visually identifies itself.
+             2. Status strip — last-sync timestamp + cadence + the
+                primary "Sync now" action, all on one line.
+             3. Banners (auth-failure / mapping-failure) anchored
+                between status and prefs so they read as
+                sync-related signals.
+             4. Preferences as a 2-column grid (uppercase eyebrow
+                label) — saves vertical, easier to scan.
+             5. Skip-already-watched as its own row with explainer.
+             6. Sync interval input.
+             7. Unlink as a quiet footer link, distanced from
+                Sync now so the destructive action doesn't compete
+                with the everyday one. #}
         <fieldset class="ext-accounts-fieldset">
             <legend>External Accounts</legend>
-            <p class="form-hint" style="margin-top:-4px;margin-bottom:12px">
+            <p class="form-hint ext-accounts-intro">
                 Link your AniList or MyAnimeList account to import your watch lists into Ryokan's library. Read-only — Ryokan never writes back to the provider. One account at a time.
             </p>
             {% match external_account %}
                 {% when Some with (acct) %}
-                    <div class="ext-accounts-linked" data-provider="{{ acct.provider }}">
-                        <div class="ext-accounts-linked-header">
-                            <div>
-                                <div class="ext-accounts-provider-name">{{ acct.provider_label }}</div>
-                                <div class="ext-accounts-username">Linked as <strong>{{ acct.username }}</strong></div>
-                                {% if !acct.score_format.is_empty() %}
-                                <div class="form-hint">Score format: {{ acct.score_format }}</div>
+                    <div class="ext-card" data-provider="{{ acct.provider }}">
+                        <div class="ext-card-stripe" aria-hidden="true"></div>
+                        <div class="ext-card-body">
+                            {# 1. Identity row. The accent-tinted dot
+                               anchors the provider visually so the
+                               user can tell at a glance which side
+                               they're on. #}
+                            <div class="ext-card-identity">
+                                <span class="ext-card-dot" aria-hidden="true"></span>
+                                <div class="ext-card-identity-text">
+                                    <div class="ext-card-provider">{{ acct.provider_label }}</div>
+                                    <div class="ext-card-username">{{ acct.username }}</div>
+                                </div>
+                                {% if !acct.score_format_label.is_empty() %}
+                                <span class="ext-card-meta-tag" title="Score format on {{ acct.provider_label }}">{{ acct.score_format_label }}</span>
                                 {% endif %}
                             </div>
-                            <div class="ext-accounts-actions">
-                                <button type="button" class="btn btn-primary" onclick="syncWatchListNow()">Sync now</button>
-                                <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
+
+                            {# 2. Status strip. last-sync timestamp on
+                               the left, primary Sync now on the
+                               right. Replaces the old "buttons in
+                               the corner" pattern that competed with
+                               the identity row visually. #}
+                            <div class="ext-card-status">
+                                <div class="ext-card-status-meta">
+                                    <span class="ext-card-status-label">Last sync</span>
+                                    <span class="ext-card-status-value">{{ acct.last_sync_label }}</span>
+                                    <span class="ext-card-status-sep" aria-hidden="true">·</span>
+                                    <span class="ext-card-status-label">Every</span>
+                                    <span class="ext-card-status-value">{{ config.external_sync_interval_minutes }} min</span>
+                                </div>
+                                <button type="button" class="btn btn-primary ext-card-sync-btn" onclick="syncWatchListNow()">
+                                    <span class="ext-card-sync-icon" aria-hidden="true">↻</span>
+                                    Sync now
+                                </button>
                             </div>
-                        </div>
-                        {# #62 PR E — re-link-required banner. Set
-                           when the most recent sync hit an auth-
-                           rejection error (AL 401/403, MAL refresh
-                           dead). Cleared by the next successful
-                           sync, so it disappears on its own once
-                           the user re-links. #}
-                        {% if acct.last_sync_auth_failed %}
-                        <div class="ext-accounts-relink-banner">
-                            <strong>Re-link required.</strong>
-                            Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.
-                        </div>
-                        {% endif %}
-                        {# #62 PR E — MAL→AL mapping-failure
-                           counter. Persisted by sync_mal at the end
-                           of every successful tick (cleared to 0 by
-                           sync_anilist so a provider switch shows
-                           accurate state). Renders only when > 0
-                           AND the linked provider is MAL. #}
-                        {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
-                        <div class="ext-accounts-deferred-banner">
-                            <strong>{{ acct.last_sync_deferred_count }}</strong>
-                            series couldn't be mapped MyAnimeList→AniList on the last sync.
-                            They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.
-                        </div>
-                        {% endif %}
-                        <div class="ext-accounts-prefs">
-                            <div class="form-hint" style="margin-bottom:6px">Import lists:</div>
-                            <label class="checkbox-row">
-                                <input type="checkbox" data-ext-pref="import_watching" {% if acct.import_watching %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                <span>Watching</span>
-                            </label>
-                            <label class="checkbox-row">
-                                <input type="checkbox" data-ext-pref="import_planning" {% if acct.import_planning %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                <span>Plan to Watch</span>
-                            </label>
-                            <label class="checkbox-row">
-                                <input type="checkbox" data-ext-pref="import_paused" {% if acct.import_paused %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                <span>Paused</span>
-                            </label>
-                            <label class="checkbox-row">
-                                <input type="checkbox" data-ext-pref="import_dropped" {% if acct.import_dropped %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                <span>Dropped</span>
-                            </label>
-                            <label class="checkbox-row">
-                                <input type="checkbox" data-ext-pref="import_completed" {% if acct.import_completed %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                <span>Completed</span>
-                            </label>
-                            <div style="margin-top:10px;padding-top:10px;border-top:1px solid var(--border-subtle)">
-                                <label class="checkbox-row">
+
+                            {# 3. Banners — anchored to status so they
+                                  read as sync-related signals. Both
+                                  are sticky-flag-driven; they clear
+                                  on the next successful sync. #}
+                            {% if acct.last_sync_auth_failed %}
+                            <div class="ext-card-banner ext-card-banner-error" role="alert">
+                                <span class="ext-card-banner-eyebrow">Re-link required</span>
+                                <p>Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.</p>
+                            </div>
+                            {% endif %}
+                            {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
+                            <div class="ext-card-banner ext-card-banner-warn">
+                                <span class="ext-card-banner-eyebrow">Mapping incomplete</span>
+                                <p><strong>{{ acct.last_sync_deferred_count }}</strong> series couldn't be mapped MyAnimeList → AniList on the last sync. They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.</p>
+                            </div>
+                            {% endif %}
+
+                            {# 4. Preferences. 2-col grid; the
+                                  Watching/Planning bias-on default
+                                  is the user's normal mental model
+                                  (active vs. passive lists). #}
+                            <div class="ext-card-section">
+                                <span class="ext-card-eyebrow">Import lists</span>
+                                <div class="ext-card-prefs-grid">
+                                    <label class="ext-card-pref">
+                                        <input type="checkbox" data-ext-pref="import_watching" {% if acct.import_watching %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                        <span>Watching</span>
+                                    </label>
+                                    <label class="ext-card-pref">
+                                        <input type="checkbox" data-ext-pref="import_planning" {% if acct.import_planning %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                        <span>Plan to Watch</span>
+                                    </label>
+                                    <label class="ext-card-pref">
+                                        <input type="checkbox" data-ext-pref="import_paused" {% if acct.import_paused %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                        <span>Paused</span>
+                                    </label>
+                                    <label class="ext-card-pref">
+                                        <input type="checkbox" data-ext-pref="import_dropped" {% if acct.import_dropped %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                        <span>Dropped</span>
+                                    </label>
+                                    <label class="ext-card-pref">
+                                        <input type="checkbox" data-ext-pref="import_completed" {% if acct.import_completed %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                        <span>Completed</span>
+                                    </label>
+                                </div>
+                            </div>
+
+                            {# 5. Skip-already-watched. Set apart with
+                                  its own row so it doesn't read as
+                                  just another import flag. #}
+                            <div class="ext-card-section">
+                                <label class="ext-card-pref ext-card-pref-toggle">
                                     <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                    <span>Skip already-watched episodes</span>
+                                    <span class="ext-card-pref-label">
+                                        <span class="ext-card-pref-title">Skip already-watched episodes</span>
+                                        <span class="ext-card-pref-hint">Honor the <code>progress</code> field and grab only episodes past what you've already watched. Off by default — airing series + a caught-up user would otherwise skip everything.</span>
+                                    </span>
                                 </label>
-                                <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off — airing-series + caught-up user would skip everything otherwise.</span>
                             </div>
-                        </div>
-                        {# #62 PR B — sync cadence. Range: 15 minutes to
-                           7 days (10080 minutes). Saved as part of the
-                           outer Save Settings button (resolver coerces
-                           out-of-range values back to the 30-minute
-                           default). #}
-                        <div class="ext-accounts-interval form-group">
-                            <label for="external_sync_interval_minutes">Sync interval (minutes)</label>
-                            <input type="number"
-                                   id="external_sync_interval_minutes"
-                                   name="external_sync_interval_minutes"
-                                   min="15"
-                                   max="10080"
-                                   step="1"
-                                   value="{{ config.external_sync_interval_minutes }}">
-                            <span class="form-hint">How often the supervised task pulls your watch list. Range: 15 minutes to 7 days. Default 30 minutes — most lists change infrequently and the delta cursor keeps each tick cheap.</span>
+
+                            {# 6. Sync interval. The shown cadence on
+                                  the status strip above mirrors this
+                                  field's value, so the user can see
+                                  the effect of their edit at a
+                                  glance after Save Settings. #}
+                            <div class="ext-card-section">
+                                <span class="ext-card-eyebrow">
+                                    <label for="external_sync_interval_minutes">Sync interval</label>
+                                </span>
+                                <div class="ext-card-interval">
+                                    <input type="number"
+                                           id="external_sync_interval_minutes"
+                                           name="external_sync_interval_minutes"
+                                           min="15"
+                                           max="10080"
+                                           step="1"
+                                           value="{{ config.external_sync_interval_minutes }}">
+                                    <span class="ext-card-interval-unit">minutes</span>
+                                </div>
+                                <span class="form-hint ext-card-interval-hint">15 minutes to 7 days. Default 30. Saved with the global Save Settings button.</span>
+                            </div>
+
+                            {# 7. Footer. Unlink demoted to a quiet
+                                  text link — destructive action away
+                                  from primary, opposite corner. #}
+                            <div class="ext-card-footer">
+                                <button type="button" class="ext-card-unlink" onclick="unlinkExternalAccount()">
+                                    Unlink {{ acct.provider_label }}
+                                </button>
+                            </div>
                         </div>
                     </div>
                 {% when None %}
-                    <div class="ext-accounts-link-row">
-                        <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('anilist')">Link AniList</button>
-                        <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('mal')">Link MyAnimeList</button>
+                    {# Unlinked state: two provider tiles side by side
+                       so the user sees both options at once. Each
+                       names the score-format quirk that distinguishes
+                       it from the other — the most useful disambig
+                       for the picker. #}
+                    <div class="ext-link-grid">
+                        <div class="ext-link-tile">
+                            <div class="ext-link-tile-head">
+                                <span class="ext-link-tile-dot ext-link-tile-dot-al" aria-hidden="true"></span>
+                                <span class="ext-link-tile-name">AniList</span>
+                            </div>
+                            <p class="ext-link-tile-blurb">Five score formats including the smiley scale, plus AniList custom lists like "Hidden Gems" sync as filterable badges.</p>
+                            <button type="button" class="btn btn-primary ext-link-tile-cta" onclick="startExternalAccountLink('anilist')">Link AniList</button>
+                        </div>
+                        <div class="ext-link-tile">
+                            <div class="ext-link-tile-head">
+                                <span class="ext-link-tile-dot ext-link-tile-dot-mal" aria-hidden="true"></span>
+                                <span class="ext-link-tile-name">MyAnimeList</span>
+                            </div>
+                            <p class="ext-link-tile-blurb">10-point scoring; entries without an AniList mapping land under the negated-id sentinel and stay outside SeaDex-driven scoring.</p>
+                            <button type="button" class="btn btn-primary ext-link-tile-cta" onclick="startExternalAccountLink('mal')">Link MyAnimeList</button>
+                        </div>
                     </div>
-                    <span class="form-hint">Attribution: AniList and MyAnimeList data used with permission under each platform's API terms. Read-only scope.</span>
+                    <p class="form-hint ext-link-attribution">AniList and MyAnimeList data used with permission under each platform's API terms. Read-only scope.</p>
             {% endmatch %}
         </fieldset>
 

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -253,9 +253,6 @@
                         <span class="form-hint"><span class="log-badge">Not linked</span></span>
                 {% endmatch %}
             </legend>
-            <p class="form-hint" style="margin-bottom: 12px;">
-                Link your AniList or MyAnimeList account to import your watch lists into Ryokan's library. Read-only; Ryokan never writes back to the provider. One account at a time.
-            </p>
             {% match external_account %}
                 {% when Some with (acct) %}
                     {# Banners — sticky flags cleared on the next
@@ -305,7 +302,6 @@
                                 <span>Completed</span>
                             </label>
                         </div>
-                        <span class="form-hint">Watching + Plan to Watch are on by default; the active and passive lists most users want imported. Other statuses are opt-in.</span>
                     </div>
 
                     <div class="form-group">
@@ -313,7 +309,6 @@
                             <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
                             <span>Skip already-watched episodes</span>
                         </label>
-                        <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off; airing series + a caught-up user would otherwise skip everything.</span>
                     </div>
 
                     {# #62 PR B — sync cadence. Range: 15 minutes to
@@ -330,7 +325,6 @@
                                max="10080"
                                step="1"
                                value="{{ config.external_sync_interval_minutes }}">
-                        <span class="form-hint">How often the supervised task pulls your watch list. Range: 15 minutes to 7 days. Default 30 minutes; most lists change infrequently and the delta cursor keeps each tick cheap.</span>
                     </div>
 
                     {# Same .settings-inline-actions row qBit/Jellyfin
@@ -365,17 +359,14 @@
                     {# Unlinked: a single form-group whose action row
                        carries both Link buttons, mirroring how the
                        Sonarr/Radarr fieldsets present their enable
-                       checkbox at the top. Provider trade-offs are
-                       summarized in the form-hint below the buttons. #}
+                       checkbox at the top. #}
                     <div class="form-group">
                         <label>Provider</label>
                         <div class="settings-inline-actions">
                             <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('anilist')">Link AniList</button>
                             <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('mal')">Link MyAnimeList</button>
                         </div>
-                        <span class="form-hint">AniList ships five score formats (including the smiley scale) and custom lists like "Hidden Gems" that sync as filterable badges. MyAnimeList is 10-point only and entries without an AniList mapping fall back to a negated-id sentinel that's invisible to SeaDex-keyed scoring.</span>
                     </div>
-                    <p class="form-hint" style="margin-top: -4px;">Attribution: AniList and MyAnimeList data used with permission under each platform's API terms.</p>
             {% endmatch %}
         </fieldset>
 

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -309,6 +309,7 @@
                             <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
                             <span>Skip already-watched episodes</span>
                         </label>
+                        <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off; airing series + a caught-up user would otherwise skip everything.</span>
                     </div>
 
                     {# #62 PR B — sync cadence. Range: 15 minutes to

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -337,12 +337,12 @@
                        use for their Test buttons. Sync now is the
                        primary; Unlink is secondary. The trailing
                        form-hint mirrors the Test-result span pattern
-                       — gives the user one more place to see sync
-                       cadence + last-sync at a glance. #}
+                       — gives the user one more place to see auto-sync
+                       interval + last-sync at a glance. #}
                     <div class="settings-inline-actions">
                         <button type="button" class="btn btn-primary" onclick="syncWatchListNow()">Sync now</button>
                         <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
-                        {# Cadence + last-sync hint. The last-sync
+                        {# Auto-syncs + last-sync hint. The last-sync
                            span's `data-relative-time` is the unix-
                            epoch the JS updater (settings.js) keys
                            off so the label re-renders ("4 minutes
@@ -352,7 +352,7 @@
                            those elements and the "Never" text from
                            server-render stays. #}
                         <span class="form-hint">
-                            Cadence every {{ config.external_sync_interval_minutes }} min · last sync
+                            Auto-syncs every {{ config.external_sync_interval_minutes }} min · last sync
                             {% match acct.last_sync_unix_ts %}
                                 {% when Some with (ts) %}
                                     <span data-relative-time="{{ ts }}">{{ acct.last_sync_label }}</span>

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -222,190 +222,152 @@
             </div>
         </fieldset>
 
-        {# Issue #62 PR A — External account linkage. Two states:
-           unlinked (Link tiles for AL + MAL) and linked (compact
-           dashboard card with provider identity, sync state, prefs
-           grid, interval setting, and footer Unlink). Only one
-           account can be linked at a time per decision #10 — the
-           linked state hides both Link tiles.
-
-           Layout intent (PR-E redesign):
-             1. Identity row — provider name + username + score
-                format, accent-stripe down the left edge so the
-                provider visually identifies itself.
-             2. Status strip — last-sync timestamp + cadence + the
-                primary "Sync now" action, all on one line.
-             3. Banners (auth-failure / mapping-failure) anchored
-                between status and prefs so they read as
-                sync-related signals.
-             4. Preferences as a 2-column grid (uppercase eyebrow
-                label) — saves vertical, easier to scan.
-             5. Skip-already-watched as its own row with explainer.
-             6. Sync interval input.
-             7. Unlink as a quiet footer link, distanced from
-                Sync now so the destructive action doesn't compete
-                with the everyday one. #}
-        <fieldset class="ext-accounts-fieldset">
-            <legend>External Accounts</legend>
-            <p class="form-hint ext-accounts-intro">
+        {# Issue #62 PR A — External account linkage. Same fieldset
+           + form-group + settings-inline-actions vocabulary as every
+           other section in this tab (Download Client, qBit, Jellyfin,
+           Seerr) so the page reads as one rhythm. The structural
+           flow from the PR-E redesign is preserved — provider
+           identity → sync state → banners → prefs → skip-watched →
+           interval → actions — but rebuilt entirely from the
+           connections-tab primitives. No bespoke card surface. #}
+        <fieldset>
+            <legend>
+                External Accounts
+                {% match external_account %}
+                    {% when Some with (acct) %}
+                        {# Status hint in the legend — same shape qBit
+                           and Jellyfin use for their health spans. #}
+                        <span class="form-hint">{{ acct.provider_label }} · {{ acct.username }} · last sync {{ acct.last_sync_label }}</span>
+                    {% when None %}
+                        <span class="form-hint">Not linked</span>
+                {% endmatch %}
+            </legend>
+            <p class="form-hint" style="margin-bottom: 12px;">
                 Link your AniList or MyAnimeList account to import your watch lists into Ryokan's library. Read-only — Ryokan never writes back to the provider. One account at a time.
             </p>
             {% match external_account %}
                 {% when Some with (acct) %}
-                    <div class="ext-card" data-provider="{{ acct.provider }}">
-                        <div class="ext-card-stripe" aria-hidden="true"></div>
-                        <div class="ext-card-body">
-                            {# 1. Identity row. The accent-tinted dot
-                               anchors the provider visually so the
-                               user can tell at a glance which side
-                               they're on. #}
-                            <div class="ext-card-identity">
-                                <span class="ext-card-dot" aria-hidden="true"></span>
-                                <div class="ext-card-identity-text">
-                                    <div class="ext-card-provider">{{ acct.provider_label }}</div>
-                                    <div class="ext-card-username">{{ acct.username }}</div>
-                                </div>
-                                {% if !acct.score_format_label.is_empty() %}
-                                <span class="ext-card-meta-tag" title="Score format on {{ acct.provider_label }}">{{ acct.score_format_label }}</span>
-                                {% endif %}
-                            </div>
+                    {# Banners — sticky flags cleared on the next
+                       successful sync. Sized + spaced like Seerr's
+                       intro paragraph so they sit naturally inside
+                       the fieldset. #}
+                    {% if acct.last_sync_auth_failed %}
+                    <div class="ext-alert ext-alert-error" role="alert">
+                        <strong>Re-link required.</strong>
+                        Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.
+                    </div>
+                    {% endif %}
+                    {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
+                    <div class="ext-alert ext-alert-warn">
+                        <strong>{{ acct.last_sync_deferred_count }} series couldn't be mapped MyAnimeList → AniList</strong>
+                        on the last sync. They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.
+                    </div>
+                    {% endif %}
 
-                            {# 2. Status strip. last-sync timestamp on
-                               the left, primary Sync now on the
-                               right. Replaces the old "buttons in
-                               the corner" pattern that competed with
-                               the identity row visually. #}
-                            <div class="ext-card-status">
-                                <div class="ext-card-status-meta">
-                                    <span class="ext-card-status-label">Last sync</span>
-                                    <span class="ext-card-status-value">{{ acct.last_sync_label }}</span>
-                                    <span class="ext-card-status-sep" aria-hidden="true">·</span>
-                                    <span class="ext-card-status-label">Every</span>
-                                    <span class="ext-card-status-value">{{ config.external_sync_interval_minutes }} min</span>
-                                </div>
-                                <button type="button" class="btn btn-primary ext-card-sync-btn" onclick="syncWatchListNow()">
-                                    <span class="ext-card-sync-icon" aria-hidden="true">↻</span>
-                                    Sync now
-                                </button>
-                            </div>
-
-                            {# 3. Banners — anchored to status so they
-                                  read as sync-related signals. Both
-                                  are sticky-flag-driven; they clear
-                                  on the next successful sync. #}
-                            {% if acct.last_sync_auth_failed %}
-                            <div class="ext-card-banner ext-card-banner-error" role="alert">
-                                <span class="ext-card-banner-eyebrow">Re-link required</span>
-                                <p>Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.</p>
-                            </div>
-                            {% endif %}
-                            {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
-                            <div class="ext-card-banner ext-card-banner-warn">
-                                <span class="ext-card-banner-eyebrow">Mapping incomplete</span>
-                                <p><strong>{{ acct.last_sync_deferred_count }}</strong> series couldn't be mapped MyAnimeList → AniList on the last sync. They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.</p>
-                            </div>
-                            {% endif %}
-
-                            {# 4. Preferences. 2-col grid; the
-                                  Watching/Planning bias-on default
-                                  is the user's normal mental model
-                                  (active vs. passive lists). #}
-                            <div class="ext-card-section">
-                                <span class="ext-card-eyebrow">Import lists</span>
-                                <div class="ext-card-prefs-grid">
-                                    <label class="ext-card-pref">
-                                        <input type="checkbox" data-ext-pref="import_watching" {% if acct.import_watching %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                        <span>Watching</span>
-                                    </label>
-                                    <label class="ext-card-pref">
-                                        <input type="checkbox" data-ext-pref="import_planning" {% if acct.import_planning %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                        <span>Plan to Watch</span>
-                                    </label>
-                                    <label class="ext-card-pref">
-                                        <input type="checkbox" data-ext-pref="import_paused" {% if acct.import_paused %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                        <span>Paused</span>
-                                    </label>
-                                    <label class="ext-card-pref">
-                                        <input type="checkbox" data-ext-pref="import_dropped" {% if acct.import_dropped %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                        <span>Dropped</span>
-                                    </label>
-                                    <label class="ext-card-pref">
-                                        <input type="checkbox" data-ext-pref="import_completed" {% if acct.import_completed %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                        <span>Completed</span>
-                                    </label>
-                                </div>
-                            </div>
-
-                            {# 5. Skip-already-watched. Set apart with
-                                  its own row so it doesn't read as
-                                  just another import flag. #}
-                            <div class="ext-card-section">
-                                <label class="ext-card-pref ext-card-pref-toggle">
-                                    <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
-                                    <span class="ext-card-pref-label">
-                                        <span class="ext-card-pref-title">Skip already-watched episodes</span>
-                                        <span class="ext-card-pref-hint">Honor the <code>progress</code> field and grab only episodes past what you've already watched. Off by default — airing series + a caught-up user would otherwise skip everything.</span>
-                                    </span>
-                                </label>
-                            </div>
-
-                            {# 6. Sync interval. The shown cadence on
-                                  the status strip above mirrors this
-                                  field's value, so the user can see
-                                  the effect of their edit at a
-                                  glance after Save Settings. #}
-                            <div class="ext-card-section">
-                                <span class="ext-card-eyebrow">
-                                    <label for="external_sync_interval_minutes">Sync interval</label>
-                                </span>
-                                <div class="ext-card-interval">
-                                    <input type="number"
-                                           id="external_sync_interval_minutes"
-                                           name="external_sync_interval_minutes"
-                                           min="15"
-                                           max="10080"
-                                           step="1"
-                                           value="{{ config.external_sync_interval_minutes }}">
-                                    <span class="ext-card-interval-unit">minutes</span>
-                                </div>
-                                <span class="form-hint ext-card-interval-hint">15 minutes to 7 days. Default 30. Saved with the global Save Settings button.</span>
-                            </div>
-
-                            {# 7. Footer. Unlink demoted to a quiet
-                                  text link — destructive action away
-                                  from primary, opposite corner. #}
-                            <div class="ext-card-footer">
-                                <button type="button" class="ext-card-unlink" onclick="unlinkExternalAccount()">
-                                    Unlink {{ acct.provider_label }}
-                                </button>
-                            </div>
+                    {# Provider + score-format display row. Two
+                       form-group blocks side by side via .form-row,
+                       same primitive qBit's user/password row uses. #}
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label>Provider</label>
+                            <span class="form-display">{{ acct.provider_label }}</span>
                         </div>
+                        <div class="form-group">
+                            <label>Username</label>
+                            <span class="form-display">{{ acct.username }}</span>
+                        </div>
+                        {% if !acct.score_format_label.is_empty() %}
+                        <div class="form-group">
+                            <label>Score format</label>
+                            <span class="form-display">{{ acct.score_format_label }}</span>
+                        </div>
+                        {% endif %}
+                    </div>
+
+                    {# Import-list checkboxes. Wrap-flex so 2-3 fit
+                       per row on a wide viewport, falling back to
+                       one-per-row on narrow without a separate media
+                       query — same physical pattern as the existing
+                       checkbox-row primitive, just laid out
+                       horizontally inside one form-group. #}
+                    <div class="form-group">
+                        <label>Import lists</label>
+                        <div class="ext-prefs-row">
+                            <label class="checkbox-row">
+                                <input type="checkbox" data-ext-pref="import_watching" {% if acct.import_watching %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                <span>Watching</span>
+                            </label>
+                            <label class="checkbox-row">
+                                <input type="checkbox" data-ext-pref="import_planning" {% if acct.import_planning %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                <span>Plan to Watch</span>
+                            </label>
+                            <label class="checkbox-row">
+                                <input type="checkbox" data-ext-pref="import_paused" {% if acct.import_paused %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                <span>Paused</span>
+                            </label>
+                            <label class="checkbox-row">
+                                <input type="checkbox" data-ext-pref="import_dropped" {% if acct.import_dropped %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                <span>Dropped</span>
+                            </label>
+                            <label class="checkbox-row">
+                                <input type="checkbox" data-ext-pref="import_completed" {% if acct.import_completed %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                                <span>Completed</span>
+                            </label>
+                        </div>
+                        <span class="form-hint">Watching + Plan to Watch are on by default — the active and passive lists most users want imported. Other statuses are opt-in.</span>
+                    </div>
+
+                    <div class="form-group">
+                        <label class="checkbox-row">
+                            <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
+                            <span>Skip already-watched episodes</span>
+                        </label>
+                        <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off — airing series + a caught-up user would otherwise skip everything.</span>
+                    </div>
+
+                    {# #62 PR B — sync cadence. Range: 15 minutes to
+                       7 days (10080 minutes). Saved as part of the
+                       outer Save Settings button (resolver coerces
+                       out-of-range values back to the 30-minute
+                       default). #}
+                    <div class="form-group">
+                        <label for="external_sync_interval_minutes">Sync interval (minutes)</label>
+                        <input type="number"
+                               id="external_sync_interval_minutes"
+                               name="external_sync_interval_minutes"
+                               min="15"
+                               max="10080"
+                               step="1"
+                               value="{{ config.external_sync_interval_minutes }}">
+                        <span class="form-hint">How often the supervised task pulls your watch list. Range: 15 minutes to 7 days. Default 30 minutes — most lists change infrequently and the delta cursor keeps each tick cheap.</span>
+                    </div>
+
+                    {# Same .settings-inline-actions row qBit/Jellyfin
+                       use for their Test buttons. Sync now is the
+                       primary; Unlink is secondary. The trailing
+                       form-hint mirrors the Test-result span pattern
+                       — gives the user one more place to see sync
+                       cadence + last-sync at a glance. #}
+                    <div class="settings-inline-actions">
+                        <button type="button" class="btn btn-primary" onclick="syncWatchListNow()">Sync now</button>
+                        <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
+                        <span class="form-hint">Cadence every {{ config.external_sync_interval_minutes }} min · last sync {{ acct.last_sync_label }}</span>
                     </div>
                 {% when None %}
-                    {# Unlinked state: two provider tiles side by side
-                       so the user sees both options at once. Each
-                       names the score-format quirk that distinguishes
-                       it from the other — the most useful disambig
-                       for the picker. #}
-                    <div class="ext-link-grid">
-                        <div class="ext-link-tile">
-                            <div class="ext-link-tile-head">
-                                <span class="ext-link-tile-dot ext-link-tile-dot-al" aria-hidden="true"></span>
-                                <span class="ext-link-tile-name">AniList</span>
-                            </div>
-                            <p class="ext-link-tile-blurb">Five score formats including the smiley scale, plus AniList custom lists like "Hidden Gems" sync as filterable badges.</p>
-                            <button type="button" class="btn btn-primary ext-link-tile-cta" onclick="startExternalAccountLink('anilist')">Link AniList</button>
+                    {# Unlinked: a single form-group whose action row
+                       carries both Link buttons, mirroring how the
+                       Sonarr/Radarr fieldsets present their enable
+                       checkbox at the top. Provider trade-offs are
+                       summarized in the form-hint below the buttons. #}
+                    <div class="form-group">
+                        <label>Provider</label>
+                        <div class="settings-inline-actions">
+                            <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('anilist')">Link AniList</button>
+                            <button type="button" class="btn btn-primary" onclick="startExternalAccountLink('mal')">Link MyAnimeList</button>
                         </div>
-                        <div class="ext-link-tile">
-                            <div class="ext-link-tile-head">
-                                <span class="ext-link-tile-dot ext-link-tile-dot-mal" aria-hidden="true"></span>
-                                <span class="ext-link-tile-name">MyAnimeList</span>
-                            </div>
-                            <p class="ext-link-tile-blurb">10-point scoring; entries without an AniList mapping land under the negated-id sentinel and stay outside SeaDex-driven scoring.</p>
-                            <button type="button" class="btn btn-primary ext-link-tile-cta" onclick="startExternalAccountLink('mal')">Link MyAnimeList</button>
-                        </div>
+                        <span class="form-hint">AniList ships five score formats (including the smiley scale) and custom lists like "Hidden Gems" that sync as filterable badges. MyAnimeList is 10-point only and entries without an AniList mapping fall back to a negated-id sentinel that's invisible to SeaDex-keyed scoring.</span>
                     </div>
-                    <p class="form-hint ext-link-attribution">AniList and MyAnimeList data used with permission under each platform's API terms. Read-only scope.</p>
+                    <p class="form-hint" style="margin-top: -4px;">Attribution: AniList and MyAnimeList data used with permission under each platform's API terms.</p>
             {% endmatch %}
         </fieldset>
 

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -248,6 +248,19 @@
                                 <button type="button" class="btn btn-secondary" onclick="unlinkExternalAccount()">Unlink</button>
                             </div>
                         </div>
+                        {# #62 PR E — MAL→AL mapping-failure
+                           counter. Persisted by sync_mal at the end
+                           of every successful tick (cleared to 0 by
+                           sync_anilist so a provider switch shows
+                           accurate state). Renders only when > 0
+                           AND the linked provider is MAL. #}
+                        {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
+                        <div class="ext-accounts-deferred-banner">
+                            <strong>{{ acct.last_sync_deferred_count }}</strong>
+                            series couldn't be mapped MyAnimeList→AniList on the last sync.
+                            They're still in your library but won't have AniList-keyed scoring (SeaDex, etc.) until the mappings catch up.
+                        </div>
+                        {% endif %}
                         <div class="ext-accounts-prefs">
                             <div class="form-hint" style="margin-bottom:6px">Import lists:</div>
                             <label class="checkbox-row">

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -254,7 +254,7 @@
                 {% endmatch %}
             </legend>
             <p class="form-hint" style="margin-bottom: 12px;">
-                Link your AniList or MyAnimeList account to import your watch lists into Ryokan's library. Read-only — Ryokan never writes back to the provider. One account at a time.
+                Link your AniList or MyAnimeList account to import your watch lists into Ryokan's library. Read-only; Ryokan never writes back to the provider. One account at a time.
             </p>
             {% match external_account %}
                 {% when Some with (acct) %}
@@ -305,7 +305,7 @@
                                 <span>Completed</span>
                             </label>
                         </div>
-                        <span class="form-hint">Watching + Plan to Watch are on by default — the active and passive lists most users want imported. Other statuses are opt-in.</span>
+                        <span class="form-hint">Watching + Plan to Watch are on by default; the active and passive lists most users want imported. Other statuses are opt-in.</span>
                     </div>
 
                     <div class="form-group">
@@ -313,7 +313,7 @@
                             <input type="checkbox" data-ext-pref="skip_already_watched" {% if acct.skip_already_watched %}checked{% endif %} onchange="saveExternalAccountPrefs()">
                             <span>Skip already-watched episodes</span>
                         </label>
-                        <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off — airing series + a caught-up user would otherwise skip everything.</span>
+                        <span class="form-hint">When on, new imports honor the <code>progress</code> field and grab only episodes past what you've already watched. Default off; airing series + a caught-up user would otherwise skip everything.</span>
                     </div>
 
                     {# #62 PR B — sync cadence. Range: 15 minutes to
@@ -330,7 +330,7 @@
                                max="10080"
                                step="1"
                                value="{{ config.external_sync_interval_minutes }}">
-                        <span class="form-hint">How often the supervised task pulls your watch list. Range: 15 minutes to 7 days. Default 30 minutes — most lists change infrequently and the delta cursor keeps each tick cheap.</span>
+                        <span class="form-hint">How often the supervised task pulls your watch list. Range: 15 minutes to 7 days. Default 30 minutes; most lists change infrequently and the delta cursor keeps each tick cheap.</span>
                     </div>
 
                     {# Same .settings-inline-actions row qBit/Jellyfin

--- a/tests/external_sync_e2e.rs
+++ b/tests/external_sync_e2e.rs
@@ -224,6 +224,28 @@ async fn watch_list_sync_imports_series_with_resolved_monitor_mode() {
         .render_html();
     assert_eq!(html, "8.5");
 
+    // Auth-flag clear-on-success invariant: a successful tick after a
+    // prior token-rejection must wipe `last_sync_auth_failed` so the
+    // Settings UI's "Re-link required" banner stops firing. Pre-flip
+    // the flag (simulating the prior failed tick that set it), run
+    // another sync, and assert it clears. Without this regression
+    // guard a stuck-true flag would silently keep showing the banner
+    // forever; the detection-side tests pin only the failure path.
+    external_accounts::update_last_sync_auth_failed(&db, acct.id, true)
+        .await
+        .expect("pre-flip last_sync_auth_failed for the regression guard");
+    external_sync::tick_once(&state)
+        .await
+        .expect("second tick should succeed against the wiremock fixture");
+    let acct_after = external_accounts::get_current(&db)
+        .await
+        .expect("get_current after second tick")
+        .expect("linked account should still exist after second tick");
+    assert!(
+        !acct_after.last_sync_auth_failed,
+        "successful tick must clear last_sync_auth_failed"
+    );
+
     // Cleanup: clear the override so other tests in the same process
     // (sequential within a `cargo test` invocation but separate test
     // crates run in parallel) don't pick up our wiremock host.


### PR DESCRIPTION
## Summary

Wraps up the #62 PR E (deeper AL/MAL integration) feature set with the remaining polish items, plus a substantial pass on the library-page UX that fell out while reviewing the overall flow.

### #62 PR E feature work
- **Genre filter** with HTML5 datalist autocomplete (later replaced by full library search; `series_genres` side table + populate + backfill stays for downstream use)
- **Library sort-by-user-score** — high → low, ascending also added; gates on a linked account
- **MAL mapping-failure counter** surfaced on the Settings card
- **"Re-link required" banner** for dead-token sync errors (sticky `last_sync_auth_failed` flag)
- **External Accounts section redesign** — rebuilt on the standard connections-tab primitives (`fieldset` + `form-group` + `settings-inline-actions`), badge-in-legend status, prose stripped to just the essentials, "Auto-syncs every N min · last sync X" line live-updates every 30s without a page reload

### Library page UX
- **Instant client-side search** — DOM-level title-substring filter, 250ms debounced URL-stamp via `replaceState`, no page navigation per keystroke. Server handler still routes `?search=` for the no-JS / hard-reload path.
- **Magnifier glyph** baked into the search input via inline-SVG background-image
- **Uniform card heights** — `.series-info` pinned at 100px so filter-induced row reshuffling can't change row heights
- **Filter-row layout pass** — list / search / sort / Clear all 42px tall, dropdowns matched at 180px width, search expands to 406px when no AL account linked, Clear slot reserved so it doesn't shift neighbors when activating
- **Six sort options** (Recently added, Oldest first, A→Z, Z→A, My score asc/desc) with score-based options gated on linkage
- **"Anime Library" header** inline-aligned with the controls row; iterated through several display treatments before reverting to the default Murecho-on-bright

### Bug fixes
- **Empty AL account sync** — `fetch_media_list_collection` was treating `data.MediaListCollection: null` (the legitimate response for accounts with zero anime entries) as a malformed-response error. Refactored bucket extraction into `extract_media_list_buckets` distinguishing populated / null-collection / missing-data shapes; sync now succeeds gracefully with 0 entries imported.
- **Unlink cleanup** — `external_accounts::unlink` now wipes `series_custom_lists` rows for the unlinked provider so the dropdown stops showing stale list names and a re-link to a different account starts clean. New `series_custom_lists::clear_for_provider` model fn.
- **Sort dropdown disappearing on unlink** — moved the `score_format` gate from the entire `<select>` down to just the score `<option>`s so universal sorts stay available
- **Invisible Needs Review button** — bare `class="btn"` was rendering page-bg-colored on the page background; later removed from the header entirely
- **Manual sync UX** — last-sync hint snaps to "Just now" via new `onTerminal` callback on `ryokanProgressToast`

### Test coverage
- 4 new unit tests on `extract_media_list_buckets` pinning each AL response shape
- Full suite green: 1241 tests passing, clippy + fmt clean

## Test plan

- [x] Link an AL account with watch-list entries; verify sync still works and the External Accounts card surfaces "X · Y" in the legend badge
- [x] Link an AL account with **zero** anime entries; verify sync succeeds with 0 imported rather than failing
- [x] Click "Sync now" and verify the last-sync line snaps to "Just now" on completion
- [x] Unlink the account; verify the custom-list dropdown disappears, the search input widens to fill the slot, and the sort dropdown stays visible with universal options
- [x] Type into the library search; verify cards filter live with no page reload, URL stamps `?search=foo`, hard reload preserves the filtered view
- [x] Filter to subsets and confirm card heights stay equal across rows after reshuffling
- [x] Try each of the six sort options
- [x] Confirm the Re-link banner fires when an AL token is revoked

🤖 Generated with [Claude Code](https://claude.com/claude-code)