### PR TITLE
1.4.5: bug-fix sweep + handler test coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2531,7 +2531,6 @@ dependencies = [
  "bcrypt",
  "chacha20poly1305",
  "chrono",
- "dotenvy",
  "fancy-regex",
  "futures-util",
  "hex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,7 +2520,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "1.4.1"
+version = "1.4.5"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,7 +118,6 @@ utoipa-swagger-ui = { version = "9", features = ["axum"] }
 
 # Misc
 chrono = { version = "0.4", features = ["serde"] }
-dotenvy = "0.15"
 urlencoding = "2"
 regex-lite = "0.1"
 # fancy-regex is used only by the Custom Formats parser (Sonarr-v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "1.4.1"
+version = "1.4.5"
 edition = "2024"
 rust-version = "1.95"
 

--- a/src/handlers/arr_shared.rs
+++ b/src/handlers/arr_shared.rs
@@ -67,7 +67,13 @@ impl SystemStatus {
     /// `app_name` for the indicator pill in its UI.
     pub fn default_with_name(app_name: &str) -> Self {
         Self {
-            version: "3.0.9.1549".to_string(),
+            // Sonarr v4 is the current line; the Radarr override below
+            // bumps to a v6 string. Seerr uses `app_name` for its UI
+            // pill and `os_name` for path-separator inference, but
+            // doesn't version-gate its v3 API client off this string.
+            // Bump these alongside upstream Sonarr / Radarr stable
+            // releases so the indicator in Seerr reads as up-to-date.
+            version: "4.0.17.2952".to_string(),
             build_time: "2024-01-01T00:00:00Z".to_string(),
             is_debug: false,
             is_production: true,

--- a/src/handlers/arr_shared.rs
+++ b/src/handlers/arr_shared.rs
@@ -61,11 +61,13 @@ pub struct SystemStatus {
 }
 
 impl SystemStatus {
-    /// Fixed fake-Sonarr / fake-Radarr status payload. Only `app_name`
-    /// and `os_name` are material — Seerr uses `os_name` to decide
-    /// path separator when validating `root_folder_path`, and
-    /// `app_name` for the indicator pill in its UI.
-    pub fn default_with_name(app_name: &str) -> Self {
+    /// Fake-Sonarr / fake-Radarr status payload. Material fields:
+    /// `app_name` (Seerr's indicator-pill text), `os_name` (Seerr's
+    /// path-separator inference for `root_folder_path` validation),
+    /// `start_time` (the connected app's uptime as Seerr's UI
+    /// displays it — pass `state.start_time` so it reflects actual
+    /// process boot rather than a hardcoded long-stale timestamp).
+    pub fn default_with_name(app_name: &str, start_time: chrono::DateTime<chrono::Utc>) -> Self {
         Self {
             // Sonarr v4 is the current line; the Radarr override below
             // bumps to a v6 string. Seerr uses `app_name` for its UI
@@ -97,7 +99,7 @@ impl SystemStatus {
             url_base: String::new(),
             runtime_version: String::new(),
             runtime_name: String::new(),
-            start_time: "2024-01-01T00:00:00Z".to_string(),
+            start_time: start_time.format("%Y-%m-%dT%H:%M:%S%.fZ").to_string(),
             package_update_mechanism: "builtIn".to_string(),
             app_name: app_name.to_string(),
         }

--- a/src/handlers/auth/tests/mod.rs
+++ b/src/handlers/auth/tests/mod.rs
@@ -34,6 +34,7 @@
 mod csrf;
 mod forgot_password;
 mod proxy_headers;
+mod sanitize;
 mod sessions;
 mod setup;
 mod throttle;

--- a/src/handlers/auth/tests/sanitize.rs
+++ b/src/handlers/auth/tests/sanitize.rs
@@ -1,0 +1,89 @@
+//! `sanitize_for_log` coverage. The helper guards every log line that
+//! embeds attacker-supplied text (form usernames on failed logins).
+//! Without it, a username probe smuggling terminal escapes or ANSI
+//! sequences could clobber an admin's `tail -f`, and a multi-kilobyte
+//! probe value would land verbatim in the `logs` table.
+
+use crate::handlers::auth::sanitize_for_log;
+
+#[test]
+fn passes_through_plain_ascii_unchanged() {
+    assert_eq!(sanitize_for_log("admin"), "admin");
+    assert_eq!(
+        sanitize_for_log("user.name+tag@example.com"),
+        "user.name+tag@example.com"
+    );
+}
+
+#[test]
+fn trims_surrounding_whitespace() {
+    // Bare whitespace on either side is a noisy artifact of typed
+    // input — strip it before logging.
+    assert_eq!(sanitize_for_log("  admin  "), "admin");
+    assert_eq!(sanitize_for_log("\t\nhello\r\n"), "hello");
+}
+
+#[test]
+fn strips_ascii_control_chars() {
+    // `\x07` is BEL — would beep the terminal. `\x1b` is ESC, the
+    // start of every ANSI escape sequence (color, cursor moves,
+    // alternative-screen). A username probe carrying these would
+    // wreck a `tail -f` session.
+    assert_eq!(sanitize_for_log("hello\x07world"), "helloworld");
+    assert_eq!(sanitize_for_log("\x1b[31mRED\x1b[0m"), "[31mRED[0m");
+    // Embedded NUL inside the string also gets dropped — it would
+    // truncate the column on most logging consumers.
+    assert_eq!(sanitize_for_log("a\x00b"), "ab");
+}
+
+#[test]
+fn caps_at_64_chars_to_block_oversized_probes() {
+    // The cap stops a multi-KB probe from landing verbatim in the
+    // `logs` table. 64 chars is enough to surface a real username
+    // for diagnostics without giving a probe room to embed
+    // arbitrary content.
+    let long: String = "A".repeat(200);
+    let sanitized = sanitize_for_log(&long);
+    assert_eq!(sanitized.chars().count(), 64);
+    assert!(sanitized.chars().all(|c| c == 'A'));
+}
+
+#[test]
+fn cap_is_char_aware_not_byte_aware() {
+    // Multi-byte UTF-8 chars count as one char each — a 64-emoji
+    // username caps at 64 chars (256 bytes), not at 64 bytes (16
+    // emojis). The byte-aware variant would also need to respect
+    // a UTF-8 boundary or it would panic; char-aware sidesteps
+    // both concerns.
+    let emojis: String = "🎌".repeat(80);
+    let sanitized = sanitize_for_log(&emojis);
+    assert_eq!(sanitized.chars().count(), 64);
+}
+
+#[test]
+fn empty_input_passes_through() {
+    assert_eq!(sanitize_for_log(""), "");
+    // Whitespace-only collapses to empty after the trim step.
+    assert_eq!(sanitize_for_log("   \t\n"), "");
+}
+
+#[test]
+fn unicode_letters_pass_through_unchanged() {
+    // Non-ASCII letters are NOT control chars and shouldn't be
+    // stripped — supports usernames in non-Latin scripts. Capped
+    // by the 64-char limit but otherwise preserved.
+    assert_eq!(sanitize_for_log("ユーザー"), "ユーザー");
+    assert_eq!(sanitize_for_log("Müller"), "Müller");
+}
+
+#[test]
+fn newline_inside_input_is_stripped_not_used_as_separator() {
+    // A multi-line probe must collapse to a single line so it can't
+    // forge fake log entries by injecting `\n[FAKE LEVEL]`.
+    let injected = "real_user\n[INFO] forged log line";
+    let sanitized = sanitize_for_log(injected);
+    assert!(
+        !sanitized.contains('\n'),
+        "no newlines should survive: {sanitized:?}"
+    );
+}

--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -398,6 +398,115 @@ mod tests {
         }
     }
 
+    // ── format_size ───────────────────────────────────────────────────
+
+    #[test]
+    fn format_size_zero_or_negative_renders_zero_bytes() {
+        // Negative bytes can't physically happen, but i64 lets the
+        // value through. The defensive `<= 0` arm exists for that
+        // case; pin it with both 0 and a negative input. The string
+        // is a literal "0 B" so the queue row renders something
+        // rather than an empty cell.
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(-1), "0 B");
+    }
+
+    #[test]
+    fn format_size_under_1_kib_uses_b_with_no_decimals() {
+        // First-tier units render with no decimal — "12 B" reads more
+        // naturally than "12.0 B" for tiny values.
+        assert_eq!(format_size(1), "1 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_size_unit_boundaries_round_to_one_decimal() {
+        // 1 KB = 1024 → "1.0 KB" (note: KB unit-string, decimal on).
+        assert_eq!(format_size(1024), "1.0 KB");
+        // 1 MB.
+        assert_eq!(format_size(1024 * 1024), "1.0 MB");
+        // 1 GB.
+        assert_eq!(format_size(1024i64.pow(3)), "1.0 GB");
+        // 1 TB — top unit, larger values stay in TB.
+        assert_eq!(format_size(1024i64.pow(4)), "1.0 TB");
+    }
+
+    #[test]
+    fn format_size_clamps_at_top_unit() {
+        // Beyond TB (1024^4), the index is capped at 4 (TB) so a
+        // hypothetical PB-sized torrent doesn't underflow into an
+        // empty unit slot.
+        let huge = 1024i64.pow(5);
+        assert!(format_size(huge).ends_with(" TB"), "{}", format_size(huge));
+    }
+
+    // ── format_speed ─────────────────────────────────────────────────
+
+    #[test]
+    fn format_speed_zero_renders_blank() {
+        // 0 bps means "no transfer in flight" — surface as blank so
+        // the queue row reads cleanly rather than "0 B/s".
+        assert_eq!(format_speed(0), "");
+        assert_eq!(format_speed(-1), "");
+    }
+
+    #[test]
+    fn format_speed_appends_per_second_to_size() {
+        assert_eq!(format_speed(1024), "1.0 KB/s");
+        assert_eq!(format_speed(2 * 1024 * 1024), "2.0 MB/s");
+    }
+
+    // ── format_eta ───────────────────────────────────────────────────
+
+    #[test]
+    fn format_eta_zero_or_sentinel_renders_blank() {
+        assert_eq!(format_eta(0), "");
+        assert_eq!(format_eta(-1), "");
+        // 8_640_000s = 100 days. qBit returns this as the "infinity"
+        // sentinel; treat as unknown, render blank.
+        assert_eq!(format_eta(8_640_000), "");
+        assert_eq!(format_eta(9_999_999), "");
+    }
+
+    #[test]
+    fn format_eta_seconds_only_under_one_minute() {
+        assert_eq!(format_eta(45), "45s");
+        assert_eq!(format_eta(1), "1s");
+    }
+
+    #[test]
+    fn format_eta_minutes_and_seconds_under_one_hour() {
+        assert_eq!(format_eta(60), "1m 0s");
+        assert_eq!(format_eta(125), "2m 5s");
+    }
+
+    #[test]
+    fn format_eta_hours_and_minutes_at_or_above_one_hour() {
+        // Seconds drop out at the hour level — "1h 30m 5s" would be
+        // visual noise for an ETA estimate that's already coarse.
+        assert_eq!(format_eta(3600), "1h 0m");
+        assert_eq!(format_eta(3661), "1h 1m");
+        assert_eq!(format_eta(7320), "2h 2m");
+    }
+
+    // ── normalize_tab ────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_tab_known_tabs_pass_through() {
+        assert_eq!(normalize_tab(Some("history".into())), "history");
+        assert_eq!(normalize_tab(Some("blocklist".into())), "blocklist");
+    }
+
+    #[test]
+    fn normalize_tab_unknown_or_missing_defaults_to_queue() {
+        // Queue is the natural landing — opening /downloads with no
+        // explicit tab should show what's currently transferring.
+        assert_eq!(normalize_tab(None), "queue");
+        assert_eq!(normalize_tab(Some("garbage".into())), "queue");
+        assert_eq!(normalize_tab(Some("".into())), "queue");
+    }
+
     #[test]
     fn torrent_view_is_paused_flag_matches_enum() {
         // Drives the pause/resume button on the queue row. Reading

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -989,7 +989,7 @@ pub async fn reclassify_episode(
         ));
     }
 
-    let disk_files = media::scan_series_folder(&cfg.media_root, &series_row.folder_name);
+    let disk_files = media::scan_series_folder(&cfg.media_root, &series_row.folder_name).await;
     let file = disk_files
         .iter()
         .find(|f| {

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -65,7 +65,7 @@ pub async fn delete_episode_file(
         None => return json_err(axum::http::StatusCode::INTERNAL_SERVER_ERROR, "No config"),
     };
 
-    let files = media::scan_series_folder(&cfg.media_root, &tracked.folder_name);
+    let files = media::scan_series_folder(&cfg.media_root, &tracked.folder_name).await;
     let target = files.iter().find(|f| f.episode_number == episode_number);
 
     match target {

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -612,11 +612,7 @@ pub(super) async fn build_episodes(
     //   3. force_kitsu_fallback config flag (DB)
     //   4. monitored-episode set (DB, only when the series is tracked)
     //   5. per-episode quality tags (DB, only when the series is tracked)
-    let media_root_owned = media_root.to_string();
-    let folder_name_owned = folder_name.to_string();
-    let disk_files_fut = tokio::task::spawn_blocking(move || {
-        media::scan_series_folder(&media_root_owned, &folder_name_owned)
-    });
+    let disk_files_fut = media::scan_series_folder(media_root, folder_name);
 
     let detail_id = detail.id;
     let cached_eps_fut = async move {
@@ -660,14 +656,13 @@ pub(super) async fn build_episodes(
         }
     };
 
-    let (disk_files_res, cached_eps, force_kitsu_fallback, monitored_lookup, quality_tags) = tokio::join!(
+    let (disk_files, cached_eps, force_kitsu_fallback, monitored_lookup, quality_tags) = tokio::join!(
         disk_files_fut,
         cached_eps_fut,
         force_kitsu_fallback_enabled(db),
         monitored_fut,
         quality_tags_fut,
     );
-    let disk_files = disk_files_res.unwrap_or_default();
     let cached_matches_force =
         !force_kitsu_fallback || cached_eps.values().any(|ep| ep.source == "kitsu");
     let use_cached_eps = !cached_eps.is_empty() && cached_matches_force;

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -1742,4 +1742,406 @@ mod tests {
 
         std::fs::remove_dir_all(&media_root).ok();
     }
+
+    // ── Pure-helper coverage ──────────────────────────────────────────
+    //
+    // The async/DB-bound `build_episodes` tests above pin the heaviest
+    // user-visible flows. The helpers in this section are the small
+    // pure functions the page renderers fan out to — they're the
+    // load-bearing invariants every relation card / episode list /
+    // size-display string passes through. None had unit tests before
+    // this commit.
+
+    /// Zero-init `RelatedEntry`. Tests mutate only the fields that
+    /// matter to the case so the assertion focus is on what's being
+    /// pinned, not on a wall of empty positional args.
+    fn default_relation() -> anilist::RelatedEntry {
+        anilist::RelatedEntry {
+            id: 1,
+            id_mal: None,
+            title_romaji: String::new(),
+            title_english: String::new(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            format: String::new(),
+            status: String::new(),
+            status_display: String::new(),
+            episodes: None,
+            relation_type: String::new(),
+            season_year: None,
+            media_type: String::new(),
+        }
+    }
+
+    // ── format_relation_label ────────────────────────────────────────
+
+    #[test]
+    fn format_relation_label_known_types_get_friendly_names() {
+        assert_eq!(format_relation_label("PREQUEL"), "Prequel");
+        assert_eq!(format_relation_label("SEQUEL"), "Sequel");
+        assert_eq!(format_relation_label("SIDE_STORY"), "Side Story");
+        assert_eq!(format_relation_label("SPIN_OFF"), "Spin Off");
+    }
+
+    #[test]
+    fn format_relation_label_unknown_type_replaces_underscores() {
+        // AL adds new relation_type variants periodically (most
+        // recently `CONTAINS`). The fallback turns underscores into
+        // spaces so the new variant renders readably without a code
+        // change.
+        assert_eq!(format_relation_label("BRAND_NEW_TYPE"), "BRAND NEW TYPE");
+        assert_eq!(format_relation_label(""), "");
+    }
+
+    // ── non_empty_or ──────────────────────────────────────────────────
+
+    #[test]
+    fn non_empty_or_uses_value_when_non_empty() {
+        assert_eq!(non_empty_or("real", "fallback"), "real");
+    }
+
+    #[test]
+    fn non_empty_or_falls_back_on_whitespace() {
+        // Trim before the empty-check — `"   "` is a fallback case,
+        // not a value the user intended to display.
+        assert_eq!(non_empty_or("", "fallback"), "fallback");
+        assert_eq!(non_empty_or("   ", "fallback"), "fallback");
+        assert_eq!(non_empty_or("\t\n", "fallback"), "fallback");
+    }
+
+    // ── preferred_title ──────────────────────────────────────────────
+
+    #[test]
+    fn preferred_title_prefers_english_then_romaji_then_native() {
+        // Order is fixed: english > romaji > native. A regression in
+        // the priority would break every "Show: <title>" label across
+        // the UI.
+        assert_eq!(preferred_title("Eng", "Rom", "Nat"), "Eng");
+        assert_eq!(preferred_title("", "Rom", "Nat"), "Rom");
+        assert_eq!(preferred_title("", "", "Nat"), "Nat");
+        assert_eq!(preferred_title("", "", ""), "");
+    }
+
+    // ── format_size ──────────────────────────────────────────────────
+
+    #[test]
+    fn format_size_zero_returns_empty_string() {
+        // The "size unknown / not yet measured" sentinel renders blank
+        // rather than `"0 MiB"` which would clutter every ungrabbed
+        // episode row.
+        assert_eq!(format_size(0), "");
+    }
+
+    #[test]
+    fn format_size_uses_mib_under_1_gib() {
+        // 100 MiB → "100 MiB"; integer-rounded.
+        assert_eq!(format_size(100 * 1024 * 1024), "100 MiB");
+        // 500 MiB.
+        assert_eq!(format_size(500 * 1024 * 1024), "500 MiB");
+    }
+
+    #[test]
+    fn format_size_uses_gib_at_or_above_1_gib() {
+        // Boundary: exactly 1 GiB → "1.0 GiB". One decimal precision.
+        assert_eq!(format_size(1024 * 1024 * 1024), "1.0 GiB");
+        // Typical BD episode (~1.5 GiB).
+        assert_eq!(
+            format_size((1.5_f64 * 1024.0 * 1024.0 * 1024.0) as u64),
+            "1.5 GiB"
+        );
+        // Full season pack.
+        assert_eq!(format_size(20 * 1024 * 1024 * 1024), "20.0 GiB");
+    }
+
+    // ── relation_identity_key ────────────────────────────────────────
+
+    #[test]
+    fn relation_identity_key_prefers_mal_over_provider() {
+        // MAL ID is more stable across provider rebinds — when both
+        // are available, key on MAL so a re-link doesn't re-key the
+        // relation cache.
+        assert_eq!(relation_identity_key(42, Some(99)), "mal:99");
+    }
+
+    #[test]
+    fn relation_identity_key_falls_back_to_provider() {
+        assert_eq!(relation_identity_key(42, None), "provider:42");
+    }
+
+    #[test]
+    fn relation_identity_key_handles_negative_provider_id() {
+        // Negative-provider sentinel for MAL-fallback rows should
+        // still produce a stable key, not panic on formatting.
+        assert_eq!(relation_identity_key(-99, None), "provider:-99");
+    }
+
+    // ── relation_richness ────────────────────────────────────────────
+
+    #[test]
+    fn relation_richness_zero_for_empty_relation() {
+        assert_eq!(relation_richness(&default_relation()), 0);
+    }
+
+    #[test]
+    fn relation_richness_scores_each_field() {
+        // The formula awards: cover=4, format=2, status=2, episodes=1,
+        // title=1. Pin each via a relation that has only that field.
+        let mut cover_only = default_relation();
+        cover_only.cover_url = "url".to_string();
+        assert_eq!(relation_richness(&cover_only), 4);
+
+        let mut format_only = default_relation();
+        format_only.format = "TV".to_string();
+        assert_eq!(relation_richness(&format_only), 2);
+
+        let mut status_only = default_relation();
+        status_only.status = "FINISHED".to_string();
+        assert_eq!(relation_richness(&status_only), 2);
+
+        let mut episodes_only = default_relation();
+        episodes_only.episodes = Some(12);
+        assert_eq!(relation_richness(&episodes_only), 1);
+
+        let mut title_only = default_relation();
+        title_only.title_english = "Eng".to_string();
+        assert_eq!(relation_richness(&title_only), 1);
+    }
+
+    #[test]
+    fn relation_richness_treats_tba_as_missing() {
+        // AL emits "TBA" for unscheduled metadata; the richness
+        // function discounts it as "no signal" rather than counting
+        // it as present.
+        let mut tba = default_relation();
+        tba.title_english = "Eng".to_string();
+        tba.format = "TBA".to_string();
+        tba.status = "TBA".to_string();
+        // Only the title contributes (1).
+        assert_eq!(relation_richness(&tba), 1);
+    }
+
+    #[test]
+    fn relation_richness_zero_episodes_does_not_count() {
+        // `episodes: Some(0)` (e.g., an unscheduled cour) contributes
+        // nothing — the gate is `> 0`.
+        let mut zero_eps = default_relation();
+        zero_eps.title_english = "Eng".to_string();
+        zero_eps.episodes = Some(0);
+        assert_eq!(relation_richness(&zero_eps), 1);
+    }
+
+    // ── merge_relation_metadata ──────────────────────────────────────
+
+    #[test]
+    fn merge_relation_metadata_keeps_primary_when_complete() {
+        // Primary has every field — fallback's data is never read.
+        let mut primary = default_relation();
+        primary.title_english = "Eng".to_string();
+        primary.title_romaji = "Rom".to_string();
+        primary.cover_url = "url".to_string();
+        primary.format = "TV".to_string();
+        primary.status = "FINISHED".to_string();
+        primary.episodes = Some(12);
+        primary.season_year = Some(2024);
+        primary.id_mal = Some(99);
+        primary.media_type = "ANIME".to_string();
+
+        let mut fallback = default_relation();
+        fallback.title_english = "Other".to_string();
+        fallback.format = "OVA".to_string();
+        fallback.episodes = Some(1);
+        fallback.id_mal = Some(1);
+
+        let merged = merge_relation_metadata(&primary, &fallback);
+        assert_eq!(merged.title_english, "Eng");
+        assert_eq!(merged.format, "TV");
+        assert_eq!(merged.episodes, Some(12));
+        assert_eq!(merged.id_mal, Some(99));
+    }
+
+    #[test]
+    fn merge_relation_metadata_fills_empty_fields_from_fallback() {
+        // Primary missing every field — every fallback value lands.
+        let primary = default_relation();
+        let mut fallback = default_relation();
+        fallback.title_english = "Eng".to_string();
+        fallback.title_romaji = "Rom".to_string();
+        fallback.cover_url = "url".to_string();
+        fallback.format = "TV".to_string();
+        fallback.status = "FINISHED".to_string();
+        fallback.episodes = Some(12);
+        fallback.season_year = Some(2024);
+        fallback.id_mal = Some(99);
+        fallback.media_type = "ANIME".to_string();
+
+        let merged = merge_relation_metadata(&primary, &fallback);
+        assert_eq!(merged.title_english, "Eng");
+        assert_eq!(merged.title_romaji, "Rom");
+        assert_eq!(merged.cover_url, "url");
+        assert_eq!(merged.format, "TV");
+        assert_eq!(merged.status, "FINISHED");
+        assert_eq!(merged.episodes, Some(12));
+        assert_eq!(merged.season_year, Some(2024));
+        assert_eq!(merged.id_mal, Some(99));
+        assert_eq!(merged.media_type, "ANIME");
+    }
+
+    #[test]
+    fn merge_relation_metadata_treats_tba_as_replaceable() {
+        // TBA is a placeholder, not data. Both the format and status
+        // arms have a `|| field == "TBA"` clause so a fallback with
+        // real metadata wins over a TBA primary.
+        let mut primary = default_relation();
+        primary.title_english = "Eng".to_string();
+        primary.format = "TBA".to_string();
+        primary.status = "TBA".to_string();
+
+        let mut fallback = default_relation();
+        fallback.format = "TV".to_string();
+        fallback.status = "FINISHED".to_string();
+
+        let merged = merge_relation_metadata(&primary, &fallback);
+        assert_eq!(merged.format, "TV");
+        assert_eq!(merged.status, "FINISHED");
+    }
+
+    #[test]
+    fn merge_relation_metadata_replaces_zero_episodes_with_fallback() {
+        // `episodes == Some(0)` is treated as "unknown" for merge
+        // purposes — same as `None`. A fallback with real data wins.
+        let mut primary = default_relation();
+        primary.title_english = "Eng".to_string();
+        primary.format = "TV".to_string();
+        primary.episodes = Some(0);
+
+        let mut fallback = default_relation();
+        fallback.episodes = Some(12);
+
+        let merged = merge_relation_metadata(&primary, &fallback);
+        assert_eq!(merged.episodes, Some(12));
+    }
+
+    // ── episode_needs_kitsu_backfill ─────────────────────────────────
+
+    #[test]
+    fn episode_needs_kitsu_backfill_short_series_never_backfills() {
+        // 1-episode series (movies / OVAs) never trigger the Kitsu
+        // round-trip, even if Jikan returned nothing — the backfill
+        // overhead isn't worth it for one missing title.
+        for ep_count in [0, 1] {
+            assert!(!episode_needs_kitsu_backfill(ep_count, |_| false));
+        }
+    }
+
+    #[test]
+    fn episode_needs_kitsu_backfill_under_tolerance_skips() {
+        // 12-episode series, 5 missing — under the 10-ep tolerance.
+        // Skip the backfill: Jikan/MAL is allowed to lag a handful of
+        // recent episodes on a still-airing show without forcing the
+        // Kitsu HTTP round-trip.
+        let missing_eps: std::collections::HashSet<i32> = (1..=5).collect();
+        assert!(!episode_needs_kitsu_backfill(12, |ep| {
+            !missing_eps.contains(&ep)
+        }));
+    }
+
+    #[test]
+    fn episode_needs_kitsu_backfill_over_tolerance_triggers() {
+        // 24-episode series, 11 missing — over the 10-ep tolerance.
+        // Backfill fires.
+        let missing_eps: std::collections::HashSet<i32> = (1..=11).collect();
+        assert!(episode_needs_kitsu_backfill(24, |ep| {
+            !missing_eps.contains(&ep)
+        }));
+    }
+
+    #[test]
+    fn episode_needs_kitsu_backfill_complete_jikan_skips() {
+        // All titles present — no backfill needed.
+        assert!(!episode_needs_kitsu_backfill(24, |_| true));
+    }
+
+    // ── should_persist_detail_cache (handlers/library/reconcile) ─────
+    //
+    // Tested here rather than in reconcile.rs because the helper is
+    // private — keeping the test next to other library-handler
+    // helpers means the suite has one obvious home.
+
+    #[test]
+    fn should_persist_detail_cache_sentinel_anilist_id_always_persists() {
+        // Negative anilist_id is the Jikan-fallback sentinel
+        // (-mal_id). For these rows the AL detail can never match
+        // (the row has no AL identity yet); the cache write is the
+        // only way the metadata-cache → relations chain ever
+        // populates. Always persist.
+        let detail = empty_anime_detail(123, "Show", None);
+        assert!(super::super::reconcile::should_persist_detail_cache_for_test(-999, &detail));
+        // Zero anilist_id (theoretically impossible after the
+        // negative-ID-sentinel sweep, but defensive) also persists.
+        assert!(super::super::reconcile::should_persist_detail_cache_for_test(0, &detail));
+    }
+
+    #[test]
+    fn should_persist_detail_cache_real_anilist_id_requires_match() {
+        let detail = empty_anime_detail(42, "Show", None);
+        // Match → persist.
+        assert!(super::super::reconcile::should_persist_detail_cache_for_test(42, &detail));
+        // Mismatch → don't persist (the detail is for a different AL entry).
+        assert!(
+            !super::super::reconcile::should_persist_detail_cache_for_test(
+                42,
+                &empty_anime_detail(99, "Show", None)
+            )
+        );
+        // Detail.id = 0 → don't persist (defensive, matches the
+        // `id > 0` guard the AL parse path enforces).
+        assert!(
+            !super::super::reconcile::should_persist_detail_cache_for_test(
+                42,
+                &empty_anime_detail(0, "Show", None)
+            )
+        );
+    }
+
+    // ── normalize_system_tab (handlers/system) ───────────────────────
+
+    #[test]
+    fn normalize_system_tab_known_tabs_pass_through() {
+        for tab in ["scoring", "debug", "rss", "tasks", "review", "credits"] {
+            assert_eq!(
+                crate::handlers::system::normalize_system_tab_for_test(Some(tab.into())),
+                tab
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_system_tab_help_alias_resolves_to_scoring() {
+        // Legacy alias from when scoring rules used to live on a
+        // dedicated /system?tab=help page. Pinning the aliasing so
+        // the redirect-via-tab convention can't drift away from
+        // existing bookmarks.
+        assert_eq!(
+            crate::handlers::system::normalize_system_tab_for_test(Some("help".into())),
+            "scoring"
+        );
+    }
+
+    #[test]
+    fn normalize_system_tab_unknown_or_missing_defaults_to_logs() {
+        // Logs is the safest landing — the user can always see what's
+        // going on from the logs tab.
+        assert_eq!(
+            crate::handlers::system::normalize_system_tab_for_test(None),
+            "logs"
+        );
+        assert_eq!(
+            crate::handlers::system::normalize_system_tab_for_test(Some("garbage".into())),
+            "logs"
+        );
+        assert_eq!(
+            crate::handlers::system::normalize_system_tab_for_test(Some("".into())),
+            "logs"
+        );
+    }
 }

--- a/src/handlers/library/reconcile.rs
+++ b/src/handlers/library/reconcile.rs
@@ -452,7 +452,7 @@ pub(super) async fn resolve_series_context(
         let _ = metadata_cache::upsert_provider(db, detail.id, detail.id_mal, &detail).await;
     }
     if let Some(ref tracked) = db_series
-        && should_persist_detail_cache(tracked, &detail)
+        && should_persist_detail_cache(tracked.anilist_id, &detail)
     {
         let _ = metadata_cache::upsert(db, tracked.id, detail.id, detail.id_mal, &detail).await;
     }
@@ -464,11 +464,19 @@ pub(super) async fn resolve_series_context(
     Ok((db_series, provider_id, detail))
 }
 
-fn should_persist_detail_cache(tracked: &series::Series, detail: &anilist::AnimeDetail) -> bool {
-    if tracked.anilist_id <= 0 {
+fn should_persist_detail_cache(tracked_anilist_id: i64, detail: &anilist::AnimeDetail) -> bool {
+    if tracked_anilist_id <= 0 {
         return true;
     }
-    detail.id > 0 && detail.id == tracked.anilist_id
+    detail.id > 0 && detail.id == tracked_anilist_id
+}
+
+#[cfg(test)]
+pub(crate) fn should_persist_detail_cache_for_test(
+    tracked_anilist_id: i64,
+    detail: &anilist::AnimeDetail,
+) -> bool {
+    should_persist_detail_cache(tracked_anilist_id, detail)
 }
 
 pub(super) async fn reconcile_all_fallback_entries(db: &SqlitePool) -> ReconcileReport {

--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -695,7 +695,7 @@ pub async fn auto_search_series(
         .as_ref()
         .map(|s| s.folder_name.clone())
         .unwrap_or_default();
-    let existing_files = media::scan_series_folder(&cfg.media_root, &folder_name);
+    let existing_files = media::scan_series_folder(&cfg.media_root, &folder_name).await;
     let existing_eps: Vec<i32> = existing_files.iter().map(|f| f.episode_number).collect();
 
     let monitored_eps = if let Some(ref tracked_series) = tracked {

--- a/src/handlers/library/search/tests/mod.rs
+++ b/src/handlers/library/search/tests/mod.rs
@@ -804,3 +804,102 @@ async fn auto_expand_owari_bd_split_with_anilist_count_mismatch() {
     );
     assert_eq!(parent_route.episode_offset, 0);
 }
+
+// ── Pure-helper coverage ─────────────────────────────────────────────
+//
+// Tests below cover the small pure helpers in `auto_search.rs` that
+// don't need a DB or a download client. The async/DB-backed
+// auto-expand tests above remain the load-bearing checks; these pin
+// the small functions that feed them.
+
+mod pure_helpers {
+    use super::super::auto_search::{batch_episode_numbers, display_title_for_progress};
+    use super::empty_anime_detail;
+
+    // ── batch_episode_numbers ────────────────────────────────────────
+
+    #[test]
+    fn batch_episode_numbers_parses_ranges_from_release_titles() {
+        // Real Nyaa batch shape — episode range gets parsed into
+        // every number it covers.
+        let detail = empty_anime_detail(1, "Show");
+        let nums = batch_episode_numbers("[Group] Show 01-12 (BD 1080p)", &detail);
+        assert_eq!(nums, (1..=12).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn batch_episode_numbers_falls_back_to_anilist_count() {
+        // When the title carries no parseable range, we fall back to
+        // AL's reported episode count. The series has 26 episodes so
+        // the fallback list is 1..=26.
+        let detail = empty_anime_detail(1, "Show");
+        // empty_anime_detail seeds episodes: Some(26).
+        let nums = batch_episode_numbers("[Group] Show Complete BD", &detail);
+        assert_eq!(nums, (1..=26).collect::<Vec<_>>());
+    }
+
+    #[test]
+    fn batch_episode_numbers_no_fallback_when_episode_count_zero_or_missing() {
+        // detail.episodes == None → the fallback arm shouldn't fire
+        // (we'd produce an empty vec rather than risking a guess).
+        let mut detail = empty_anime_detail(1, "Show");
+        detail.episodes = None;
+        assert!(batch_episode_numbers("[Group] Show Complete BD", &detail).is_empty());
+
+        // detail.episodes == Some(0) is similarly defensive.
+        detail.episodes = Some(0);
+        assert!(batch_episode_numbers("[Group] Show Complete BD", &detail).is_empty());
+    }
+
+    #[test]
+    fn batch_episode_numbers_no_fallback_when_episode_count_unreasonable() {
+        // The 1000-episode cap exists so an AL parse glitch
+        // (e.g. erroneous reported episodes count for One Piece)
+        // can't blow up into a million-element vec. Pin the gate.
+        let mut detail = empty_anime_detail(1, "Show");
+        detail.episodes = Some(1001);
+        assert!(batch_episode_numbers("[Group] Show Complete BD", &detail).is_empty());
+    }
+
+    #[test]
+    fn batch_episode_numbers_returns_sorted_unique_values() {
+        // The sort guarantee matters — downstream upgrade scans
+        // bisect this list. An out-of-order vec would silently miss
+        // upgrades. The parser handles dedup itself, but pin that
+        // contract by feeding a title with overlapping ranges.
+        let detail = empty_anime_detail(1, "Show");
+        let nums = batch_episode_numbers("[Group] Show 03 + 01-05 BD", &detail);
+        // Sorted ascending; dedup handled upstream.
+        let mut sorted = nums.clone();
+        sorted.sort_unstable();
+        assert_eq!(nums, sorted, "result must come back sorted");
+    }
+
+    // ── display_title_for_progress ───────────────────────────────────
+
+    #[test]
+    fn display_title_for_progress_prefers_english() {
+        let mut detail = empty_anime_detail(1, "Show");
+        detail.title_english = "English Title".to_string();
+        detail.title_romaji = "Romaji Title".to_string();
+        assert_eq!(display_title_for_progress(&detail), "English Title");
+    }
+
+    #[test]
+    fn display_title_for_progress_falls_back_to_romaji_when_english_empty() {
+        let mut detail = empty_anime_detail(1, "Show");
+        detail.title_english = String::new();
+        detail.title_romaji = "Romaji Only".to_string();
+        assert_eq!(display_title_for_progress(&detail), "Romaji Only");
+    }
+
+    #[test]
+    fn display_title_for_progress_returns_empty_when_both_empty() {
+        // Defensive — neither title is populated. The progress toast
+        // gets an empty body but the call doesn't panic.
+        let mut detail = empty_anime_detail(1, "Show");
+        detail.title_english = String::new();
+        detail.title_romaji = String::new();
+        assert_eq!(display_title_for_progress(&detail), "");
+    }
+}

--- a/src/handlers/oauth.rs
+++ b/src/handlers/oauth.rs
@@ -769,6 +769,96 @@ mod tests {
         assert_ne!(a, b);
     }
 
+    // ── generate_state_nonce ─────────────────────────────────────────
+
+    #[test]
+    fn state_nonce_is_url_safe_and_distinct_per_call() {
+        // Same RNG-smoke check as the verifier counterpart. The state
+        // nonce gates the OAuth callback; predictability here would
+        // break the CSRF guard outright.
+        let a = generate_state_nonce();
+        let b = generate_state_nonce();
+        assert_ne!(a, b);
+        for nonce in [&a, &b] {
+            assert!(
+                nonce
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'),
+                "state nonce must be URL-safe: {nonce}"
+            );
+            assert!(!nonce.is_empty());
+        }
+    }
+
+    // ── constant_time_eq ─────────────────────────────────────────────
+
+    #[test]
+    fn constant_time_eq_matches_equal_inputs() {
+        assert!(constant_time_eq(b"", b""));
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(constant_time_eq(b"\x00\x01\xff", b"\x00\x01\xff"));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_different_inputs() {
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        // First-byte difference must not short-circuit early — `subtle`
+        // is what guarantees this; we can only smoke-test correctness
+        // here, not timing.
+        assert!(!constant_time_eq(b"X", b"Y"));
+    }
+
+    #[test]
+    fn constant_time_eq_rejects_length_mismatch() {
+        // Different-length inputs return false without a panic. Length
+        // is a public attribute (the caller's input lengths come from
+        // user-supplied strings), so this fast-path is safe.
+        assert!(!constant_time_eq(b"abc", b"abcd"));
+        assert!(!constant_time_eq(b"abc", b""));
+    }
+
+    // ── excerpt ──────────────────────────────────────────────────────
+
+    #[test]
+    fn excerpt_passes_through_short_strings_unchanged() {
+        assert_eq!(excerpt(""), "");
+        assert_eq!(excerpt("hello"), "hello");
+    }
+
+    #[test]
+    fn excerpt_caps_long_strings_with_ellipsis() {
+        // 240 chars is the cap; anything longer gets a single '…' suffix.
+        let long: String = "X".repeat(500);
+        let got = excerpt(&long);
+        // 240 X's + '…'.
+        assert!(got.starts_with(&"X".repeat(240)), "wrong prefix: {got}");
+        assert!(got.ends_with('…'));
+        assert_eq!(got.chars().count(), 241);
+    }
+
+    #[test]
+    fn excerpt_is_char_aware_does_not_panic_on_utf8_boundary() {
+        // The 240-char boundary intersects a 4-byte emoji — a byte-
+        // slice excerpt would panic at `&s[..240]`. The char-aware
+        // implementation must not.
+        let mut s = String::new();
+        s.push_str(&"a".repeat(239));
+        s.push('🎌'); // 4-byte UTF-8 char at exact char boundary 240.
+        s.push_str("trailing");
+        let got = excerpt(&s);
+        assert!(got.ends_with('…'));
+        assert_eq!(got.chars().count(), 241);
+    }
+
+    #[test]
+    fn excerpt_at_exact_cap_does_not_append_ellipsis() {
+        // Boundary: a 240-char input fits exactly — no '…' suffix.
+        let exact: String = "Y".repeat(240);
+        let got = excerpt(&exact);
+        assert_eq!(got, exact);
+        assert!(!got.ends_with('…'));
+    }
+
     #[tokio::test]
     async fn anilist_start_redirects_to_authorize_url() {
         let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();

--- a/src/handlers/oauth.rs
+++ b/src/handlers/oauth.rs
@@ -50,7 +50,7 @@ use serde::{Deserialize, Serialize};
 use crate::AppState;
 use crate::models::external_accounts::{self, LinkRequest, PROVIDER_ANILIST, PROVIDER_MAL};
 use crate::models::log::LogCategory;
-use crate::services::{external_sync, logger, oauth_state, progress};
+use crate::services::{anilist, external_sync, logger, oauth_state, progress};
 
 /// AniList public client ID. Registered 2026-04-22 against the
 /// author's AL account; the AL app page documents the redirect URI
@@ -532,12 +532,19 @@ async fn fetch_anilist_viewer(token: &str) -> Result<AniListViewer, String> {
         .map_err(|e| format!("AniList HTTP error: {e}"))?;
 
     let status = resp.status();
+    let headers = resp.headers().clone();
     let body = resp
         .text()
         .await
         .map_err(|e| format!("AniList response read failed: {e}"))?;
+    // Participate in the same rate-limit cooldown the in-module AL
+    // callers use. Without this, a 429 / 5xx during link doesn't flip
+    // the process-wide cooldown, so a metadata sync or library-page
+    // render firing right after the link attempt charges in unaware
+    // and earns its own 429.
+    anilist::note_external_anilist_response(status, &headers);
     if !status.is_success() {
-        return Err(format!("AniList returned {status}: {body}"));
+        return Err(format!("AniList returned {status}: {}", excerpt(&body)));
     }
 
     // The GraphQL shape is `{"data": {"Viewer": { id, name, mediaListOptions: { scoreFormat } }}}`.
@@ -606,11 +613,18 @@ async fn exchange_mal_code(code: &str, verifier: &str) -> Result<MalTokenRespons
         .await
         .map_err(|e| format!("MAL token response read failed: {e}"))?;
     if !status.is_success() {
-        return Err(format!("MAL token endpoint returned {status}: {body}"));
+        return Err(format!(
+            "MAL token endpoint returned {status}: {}",
+            excerpt(&body)
+        ));
     }
 
-    serde_json::from_str::<MalTokenResponse>(&body)
-        .map_err(|e| format!("MAL token response parse failed: {e} (body: {body})"))
+    serde_json::from_str::<MalTokenResponse>(&body).map_err(|e| {
+        format!(
+            "MAL token response parse failed: {e} (body: {})",
+            excerpt(&body)
+        )
+    })
 }
 
 #[derive(Deserialize)]
@@ -640,11 +654,11 @@ async fn fetch_mal_me(token: &str) -> Result<MalUserInfo, String> {
         .await
         .map_err(|e| format!("MAL @me response read failed: {e}"))?;
     if !status.is_success() {
-        return Err(format!("MAL @me returned {status}: {body}"));
+        return Err(format!("MAL @me returned {status}: {}", excerpt(&body)));
     }
 
     serde_json::from_str::<MalUserInfo>(&body)
-        .map_err(|e| format!("MAL @me parse failed: {e} (body: {body})"))
+        .map_err(|e| format!("MAL @me parse failed: {e} (body: {})", excerpt(&body)))
 }
 
 // ── Small helpers ────────────────────────────────────────────────────
@@ -708,6 +722,25 @@ fn current_unix_ts() -> i64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs() as i64)
         .unwrap_or(0)
+}
+
+/// Truncate a provider response body for an error string. Both AL and
+/// MAL can return large bodies on edge failure modes (Cloudflare HTML
+/// when AL is melting, MAL's own error pages); without this cap, a
+/// `Sync now` toast or the link-flow error renders multi-KB inline.
+/// **Char-aware** rather than byte-aware: a multi-byte UTF-8 sequence
+/// crossing the 240-byte boundary would panic a byte-slice. Mirrors
+/// the same-named helpers in `services::mal` and
+/// `services::anilist::rate_limit`.
+fn excerpt(s: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    let mut iter = s.chars();
+    let prefix: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{prefix}…")
+    } else {
+        prefix
+    }
 }
 
 #[cfg(test)]

--- a/src/handlers/radarr_compat/helpers.rs
+++ b/src/handlers/radarr_compat/helpers.rs
@@ -3,12 +3,51 @@
 use axum::{Json, http::StatusCode};
 
 use crate::AppState;
-use crate::models::{config, monitoring, series};
+use crate::models::{config, metadata_cache, monitoring, series};
 use crate::services::{anibridge, anilist, media};
 
 use super::types::{RadarrImage, RadarrMovie, RadarrRatingValue, RadarrRatings};
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/// AL 0-100 / Jikan-x10 → Radarr's nested `RadarrRatings`. Radarr's
+/// shape carries an `imdb` and a `tmdb` slot, both with the same
+/// 0-10 scale Sonarr's flat shape uses; we populate both with the
+/// same value so Seerr renders a rating regardless of which slot it
+/// reads. `None` → zeroed; matches Sonarr's `ratings_from_score`.
+pub(super) fn ratings_from_score(score: Option<i32>) -> RadarrRatings {
+    let value = match score {
+        Some(s) if s > 0 => f64::from(s) / 10.0,
+        _ => 0.0,
+    };
+    RadarrRatings {
+        imdb: RadarrRatingValue {
+            votes: 0,
+            value,
+            rating_type: "user".to_string(),
+        },
+        tmdb: RadarrRatingValue {
+            votes: 0,
+            value,
+            rating_type: "user".to_string(),
+        },
+    }
+}
+
+/// Mirror of `sonarr_compat::cached_detail_for`. Pulls the cached
+/// `AnimeDetail` for a tracked series so callers that need the
+/// average_score (or other metadata) can recover it without
+/// duplicating the cache-miss handling at every call site.
+pub(super) async fn cached_detail_for(
+    db: &sqlx::SqlitePool,
+    series_id: i64,
+) -> Option<anilist::AnimeDetail> {
+    metadata_cache::get_by_series_id(db, series_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|c| c.detail)
+}
 
 pub(super) async fn lookup_by_tmdb_id(
     state: &AppState,
@@ -95,6 +134,7 @@ pub(super) async fn lookup_by_tmdb_id(
             episodes: detail.episodes,
             season_year: detail.season_year,
             source: if detail.id > 0 { "anilist" } else { "mal" }.to_string(),
+            average_score: detail.average_score,
         };
 
         results.push(
@@ -167,7 +207,7 @@ pub(super) async fn build_radarr_movie_from_search(
         } else {
             String::new()
         },
-        ratings: default_ratings(),
+        ratings: ratings_from_score(r.average_score),
         has_file,
         is_available: true,
         folder_name: folder_name.clone(),
@@ -181,6 +221,7 @@ pub(super) async fn build_radarr_movie_from_search(
 
 pub(super) async fn build_radarr_movie_from_tracked(
     s: &series::Series,
+    detail: Option<&anilist::AnimeDetail>,
     tmdb_id: i64,
     cfg: &config::Config,
 ) -> RadarrMovie {
@@ -225,7 +266,7 @@ pub(super) async fn build_radarr_movie_from_tracked(
         genres: vec!["Anime".to_string()],
         tags: vec![],
         added: "2024-01-01T00:00:00Z".to_string(),
-        ratings: default_ratings(),
+        ratings: ratings_from_score(detail.and_then(|d| d.average_score)),
         has_file,
         is_available: true,
         folder_name: s.folder_name.clone(),
@@ -242,21 +283,6 @@ pub(super) fn map_status(anilist_status: &str) -> String {
         "RELEASING" | "NOT_YET_RELEASED" => "announced".to_string(),
         "FINISHED" | "FINISHED_AIRING" | "CANCELLED" => "released".to_string(),
         _ => "released".to_string(),
-    }
-}
-
-pub(super) fn default_ratings() -> RadarrRatings {
-    RadarrRatings {
-        imdb: RadarrRatingValue {
-            votes: 0,
-            value: 0.0,
-            rating_type: "user".to_string(),
-        },
-        tmdb: RadarrRatingValue {
-            votes: 0,
-            value: 0.0,
-            rating_type: "user".to_string(),
-        },
     }
 }
 
@@ -288,7 +314,7 @@ pub(super) fn build_stub_movie(tmdb_id: i64, cfg: &config::Config) -> RadarrMovi
         genres: vec!["Anime".to_string()],
         tags: vec![],
         added: String::new(),
-        ratings: default_ratings(),
+        ratings: ratings_from_score(None),
         has_file: false,
         is_available: true,
         folder_name: String::new(),

--- a/src/handlers/radarr_compat/helpers.rs
+++ b/src/handlers/radarr_compat/helpers.rs
@@ -40,6 +40,13 @@ pub(super) async fn lookup_by_tmdb_id(
         tracing::debug!("Radarr fan-out: AL batch prefetch failed (per-id loop will retry): {e}");
     }
 
+    // Same shape as the AL prefetch: one batched DB read keyed on every
+    // AL id we'll look up below. Without this the per-id loop hits SQLite
+    // N times for what is structurally a single `IN (…)` query.
+    let db_by_id = series::get_by_anilist_ids(&state.db, &prefetch_ids)
+        .await
+        .unwrap_or_default();
+
     let mut results = Vec::new();
     for ids in &anime_ids {
         let detail = if let Some(al_id) = ids.anilist_id {
@@ -64,10 +71,7 @@ pub(super) async fn lookup_by_tmdb_id(
         };
 
         let db_series = if detail.id > 0 {
-            series::get_by_anilist_id(&state.db, detail.id)
-                .await
-                .ok()
-                .flatten()
+            db_by_id.get(&detail.id).cloned()
         } else {
             None
         };
@@ -93,19 +97,16 @@ pub(super) async fn lookup_by_tmdb_id(
             source: if detail.id > 0 { "anilist" } else { "mal" }.to_string(),
         };
 
-        results.push(build_radarr_movie_from_search(
-            &search_result,
-            title,
-            tmdb_id,
-            db_series.as_ref(),
-            cfg,
-        ));
+        results.push(
+            build_radarr_movie_from_search(&search_result, title, tmdb_id, db_series.as_ref(), cfg)
+                .await,
+        );
     }
 
     Ok(Json(results))
 }
 
-pub(super) fn build_radarr_movie_from_search(
+pub(super) async fn build_radarr_movie_from_search(
     r: &anilist::AnimeEntry,
     title: &str,
     tmdb_id: i64,
@@ -120,7 +121,9 @@ pub(super) fn build_radarr_movie_from_search(
         .unwrap_or_else(|| media::sanitize_folder_name(title));
 
     let has_file = if is_in_library {
-        !media::scan_series_folder(&cfg.media_root, &folder_name).is_empty()
+        !media::scan_series_folder(&cfg.media_root, &folder_name)
+            .await
+            .is_empty()
     } else {
         false
     };
@@ -176,12 +179,12 @@ pub(super) fn build_radarr_movie_from_search(
     }
 }
 
-pub(super) fn build_radarr_movie_from_tracked(
+pub(super) async fn build_radarr_movie_from_tracked(
     s: &series::Series,
     tmdb_id: i64,
     cfg: &config::Config,
 ) -> RadarrMovie {
-    let disk_files = media::scan_series_folder(&cfg.media_root, &s.folder_name);
+    let disk_files = media::scan_series_folder(&cfg.media_root, &s.folder_name).await;
     let has_file = !disk_files.is_empty();
     let monitored = s.monitor_mode_enum() != monitoring::MonitorMode::None;
 

--- a/src/handlers/radarr_compat/movie.rs
+++ b/src/handlers/radarr_compat/movie.rs
@@ -56,13 +56,9 @@ pub async fn movie_lookup(
             &r.title_romaji
         };
 
-        movies.push(build_radarr_movie_from_search(
-            &r,
-            title,
-            tmdb_id,
-            db_series.as_ref(),
-            &cfg,
-        ));
+        movies.push(
+            build_radarr_movie_from_search(&r, title, tmdb_id, db_series.as_ref(), &cfg).await,
+        );
     }
 
     Ok(Json(movies))
@@ -85,7 +81,7 @@ pub async fn list_movies(
     let mut results = Vec::new();
     for s in &tracked {
         let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-        results.push(build_radarr_movie_from_tracked(s, tmdb_id, &cfg));
+        results.push(build_radarr_movie_from_tracked(s, tmdb_id, &cfg).await);
     }
 
     Ok(Json(results))
@@ -108,7 +104,9 @@ pub async fn get_movie(
         .ok_or((StatusCode::NOT_FOUND, "Movie not found".to_string()))?;
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-    Ok(Json(build_radarr_movie_from_tracked(&s, tmdb_id, &cfg)))
+    Ok(Json(
+        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+    ))
 }
 
 /// POST /radarr/api/v3/movie — add a new movie (anime).
@@ -248,7 +246,9 @@ pub async fn add_movie(
             "Movie not found after insert".to_string(),
         ))?;
 
-    Ok(Json(build_radarr_movie_from_tracked(&s, tmdb_id, &cfg)))
+    Ok(Json(
+        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+    ))
 }
 
 /// PUT /radarr/api/v3/movie — update an existing movie.
@@ -286,7 +286,9 @@ pub async fn update_movie(
         .unwrap_or_default();
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-    Ok(Json(build_radarr_movie_from_tracked(&s, tmdb_id, &cfg)))
+    Ok(Json(
+        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+    ))
 }
 
 /// POST /radarr/api/v3/command — execute a command. Seerr sends MoviesSearch.

--- a/src/handlers/radarr_compat/movie.rs
+++ b/src/handlers/radarr_compat/movie.rs
@@ -14,7 +14,8 @@ use crate::models::{config, monitoring, series};
 use crate::services::{anibridge, anilist, logger, monitoring as monitoring_service};
 
 use super::helpers::{
-    build_radarr_movie_from_search, build_radarr_movie_from_tracked, lookup_by_tmdb_id,
+    build_radarr_movie_from_search, build_radarr_movie_from_tracked, cached_detail_for,
+    lookup_by_tmdb_id,
 };
 use super::types::{AddMovieBody, RadarrCommandBody, RadarrMovie, UpdateMovieBody};
 
@@ -81,7 +82,8 @@ pub async fn list_movies(
     let mut results = Vec::new();
     for s in &tracked {
         let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-        results.push(build_radarr_movie_from_tracked(s, tmdb_id, &cfg).await);
+        let detail = cached_detail_for(&state.db, s.id).await;
+        results.push(build_radarr_movie_from_tracked(s, detail.as_ref(), tmdb_id, &cfg).await);
     }
 
     Ok(Json(results))
@@ -104,8 +106,9 @@ pub async fn get_movie(
         .ok_or((StatusCode::NOT_FOUND, "Movie not found".to_string()))?;
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let detail = cached_detail_for(&state.db, s.id).await;
     Ok(Json(
-        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+        build_radarr_movie_from_tracked(&s, detail.as_ref(), tmdb_id, &cfg).await,
     ))
 }
 
@@ -246,8 +249,9 @@ pub async fn add_movie(
             "Movie not found after insert".to_string(),
         ))?;
 
+    let detail = cached_detail_for(&state.db, s.id).await;
     Ok(Json(
-        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+        build_radarr_movie_from_tracked(&s, detail.as_ref(), tmdb_id, &cfg).await,
     ))
 }
 
@@ -286,8 +290,9 @@ pub async fn update_movie(
         .unwrap_or_default();
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let detail = cached_detail_for(&state.db, s.id).await;
     Ok(Json(
-        build_radarr_movie_from_tracked(&s, tmdb_id, &cfg).await,
+        build_radarr_movie_from_tracked(&s, detail.as_ref(), tmdb_id, &cfg).await,
     ))
 }
 

--- a/src/handlers/radarr_compat/system.rs
+++ b/src/handlers/radarr_compat/system.rs
@@ -18,7 +18,7 @@ pub async fn system_status() -> Json<SystemStatus> {
     // is the `/radarr/` prefix this shim is mounted under; everything else
     // matches the shared default.
     let mut s = SystemStatus::default_with_name("Ryokan");
-    s.version = "5.2.6.8376".to_string();
+    s.version = "6.1.1.10360".to_string();
     s.url_base = "/radarr".to_string();
     Json(s)
 }

--- a/src/handlers/radarr_compat/system.rs
+++ b/src/handlers/radarr_compat/system.rs
@@ -13,11 +13,11 @@ use super::types::RadarrRootFolder;
 // ── Handlers ───────────────────────────────────────────────────────────────
 
 /// GET /radarr/api/v3/system/status
-pub async fn system_status() -> Json<SystemStatus> {
-    // Radarr reports a different version string (5.x line) and the url_base
+pub async fn system_status(State(state): State<AppState>) -> Json<SystemStatus> {
+    // Radarr reports a different version string (6.x line) and the url_base
     // is the `/radarr/` prefix this shim is mounted under; everything else
     // matches the shared default.
-    let mut s = SystemStatus::default_with_name("Ryokan");
+    let mut s = SystemStatus::default_with_name("Ryokan", state.start_time);
     s.version = "6.1.1.10360".to_string();
     s.url_base = "/radarr".to_string();
     Json(s)

--- a/src/handlers/radarr_compat/tests/helpers.rs
+++ b/src/handlers/radarr_compat/tests/helpers.rs
@@ -1,0 +1,82 @@
+//! Pure-helper coverage for the Radarr shim. Radarr's nested
+//! `RadarrRatings` shape duplicates the score across both `imdb`
+//! and `tmdb` slots — Seerr reads whichever slot fits its render
+//! path, so populating only one would render a missing-rating
+//! state in some Seerr versions. Pin both slots.
+
+use crate::handlers::radarr_compat::helpers::{map_status, ratings_from_score};
+
+// ── ratings_from_score ───────────────────────────────────────────────
+
+#[test]
+fn ratings_from_score_none_zeros_both_slots() {
+    let r = ratings_from_score(None);
+    assert_eq!(r.imdb.value, 0.0);
+    assert_eq!(r.imdb.votes, 0);
+    assert_eq!(r.tmdb.value, 0.0);
+    assert_eq!(r.tmdb.votes, 0);
+}
+
+#[test]
+fn ratings_from_score_zero_or_negative_zeros_both_slots() {
+    for s in [Some(0), Some(-1)] {
+        let r = ratings_from_score(s);
+        assert_eq!(r.imdb.value, 0.0);
+        assert_eq!(r.tmdb.value, 0.0);
+    }
+}
+
+#[test]
+fn ratings_from_score_divides_by_ten_and_mirrors_to_both_slots() {
+    // The same value lands in both slots so Seerr renders a
+    // rating regardless of which slot it reads.
+    let r = ratings_from_score(Some(85));
+    assert_eq!(r.imdb.value, 8.5);
+    assert_eq!(r.tmdb.value, 8.5);
+}
+
+#[test]
+fn ratings_from_score_rating_type_user_in_both_slots() {
+    // The rating-type label is hardcoded "user" — Radarr uses this
+    // to distinguish IMDB's site rating from a per-user score; we
+    // only have the AL community average, which is closest to a
+    // user-rating shape.
+    let r = ratings_from_score(Some(75));
+    assert_eq!(r.imdb.rating_type, "user");
+    assert_eq!(r.tmdb.rating_type, "user");
+}
+
+// ── map_status ───────────────────────────────────────────────────────
+
+#[test]
+fn map_status_releasing_to_announced() {
+    // Radarr's vocabulary differs from Sonarr's — movies use
+    // "announced" / "released" rather than "continuing" / "ended".
+    assert_eq!(map_status("RELEASING"), "announced");
+    assert_eq!(map_status("NOT_YET_RELEASED"), "announced");
+}
+
+#[test]
+fn map_status_finished_to_released() {
+    assert_eq!(map_status("FINISHED"), "released");
+    assert_eq!(map_status("FINISHED_AIRING"), "released");
+    assert_eq!(map_status("CANCELLED"), "released");
+}
+
+#[test]
+fn map_status_is_case_insensitive() {
+    assert_eq!(map_status("releasing"), "announced");
+    assert_eq!(map_status("Finished"), "released");
+}
+
+#[test]
+fn map_status_unknown_defaults_to_released() {
+    // Movies default to "released" — for an unknown AL status,
+    // assume the movie is out (Radarr's "released" state). The
+    // Sonarr side defaults to "continuing" because TV is more
+    // forgiving of an "in progress" assumption; the Radarr side
+    // leans the other way because most anime "movies" tracked
+    // here are theatrical releases that have already premiered.
+    assert_eq!(map_status("HIATUS"), "released");
+    assert_eq!(map_status(""), "released");
+}

--- a/src/handlers/radarr_compat/tests/mod.rs
+++ b/src/handlers/radarr_compat/tests/mod.rs
@@ -3,4 +3,5 @@
 //! endpoints follow in a later PR.
 
 mod auth;
+mod helpers;
 mod system;

--- a/src/handlers/radarr_compat/tests/snapshots/ryokan__handlers__radarr_compat__tests__system__radarr_system_status.snap
+++ b/src/handlers/radarr_compat/tests/snapshots/ryokan__handlers__radarr_compat__tests__system__radarr_system_status.snap
@@ -29,5 +29,5 @@ expression: body
   "startTime": "2024-01-01T00:00:00Z",
   "startupPath": "",
   "urlBase": "/radarr",
-  "version": "5.2.6.8376"
+  "version": "6.1.1.10360"
 }

--- a/src/handlers/settings/custom_formats.rs
+++ b/src/handlers/settings/custom_formats.rs
@@ -1555,4 +1555,80 @@ mod tests {
             "Imported 2, failed 1. First error: oops"
         );
     }
+
+    // ── cf_redirect ──────────────────────────────────────────────────
+
+    #[test]
+    fn cf_redirect_minimal_just_returns_tab_url() {
+        // The base shape — no params at all means a clean redirect
+        // to the CF tab. Used after a delete-no-confirm that
+        // shouldn't surface a flash.
+        assert_eq!(
+            cf_redirect(None, None, None),
+            "/settings?tab=custom_formats"
+        );
+    }
+
+    #[test]
+    fn cf_redirect_with_edit_id_appends_query_param() {
+        // The edit drawer's redirect on save: send the user back to
+        // the same row they were editing.
+        assert_eq!(
+            cf_redirect(Some(42), None, None),
+            "/settings?tab=custom_formats&edit_id=42"
+        );
+    }
+
+    #[test]
+    fn cf_redirect_url_encodes_msg_and_err() {
+        // A message like "Imported 2, skipped 1." has commas + a
+        // space that must be percent-encoded so the resulting URL
+        // parses correctly. A naive concat would produce a broken
+        // querystring on the receiving page.
+        let url = cf_redirect(None, Some("imported 2 of 3"), None);
+        assert!(url.contains("&msg="));
+        // Spaces are percent-encoded — `urlencoding` uses %20 (not '+').
+        assert!(url.contains("%20") || url.contains("imported%202%20of%203"));
+
+        // Err side encodes identically.
+        let url_err = cf_redirect(None, None, Some("regex compile failed: oops"));
+        assert!(url_err.contains("&err="));
+        assert!(url_err.contains("%20"));
+    }
+
+    #[test]
+    fn cf_redirect_includes_edit_id_msg_and_err_simultaneously() {
+        // Edit-drawer save + flash + warning: all three params land
+        // on the same redirect when present.
+        let url = cf_redirect(Some(7), Some("saved"), Some("warning"));
+        assert!(url.contains("edit_id=7"));
+        assert!(url.contains("&msg=saved"));
+        assert!(url.contains("&err=warning"));
+    }
+
+    // ── parse_default_cf_entries ─────────────────────────────────────
+
+    #[test]
+    fn parse_default_cf_entries_returns_nonempty_array() {
+        // The bundled `static/default_custom_formats.json` is wired
+        // in via `include_str!` and must always parse — a syntax
+        // error there breaks the "Install defaults" / "Reset
+        // defaults" buttons silently. Pin both that it parses and
+        // that it has entries.
+        let entries = parse_default_cf_entries().expect("default CFs must parse");
+        assert!(
+            !entries.is_empty(),
+            "bundled default CFs must contain at least one entry"
+        );
+        // Every entry should be an object with at least a `name`
+        // field — defends against a future commit replacing the
+        // content with an array of strings or similar.
+        for entry in &entries {
+            assert!(entry.is_object(), "default CF entry must be an object");
+            assert!(
+                entry.get("name").and_then(|v| v.as_str()).is_some(),
+                "default CF entry missing 'name' field: {entry}"
+            );
+        }
+    }
 }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -1840,4 +1840,167 @@ mod tests {
         assert_eq!(validate_resolution("360p", "1080"), "1080");
         assert_eq!(validate_resolution("540p", "1080"), "1080");
     }
+
+    // ── normalize_settings_tab ───────────────────────────────────────
+
+    #[test]
+    fn normalize_settings_tab_known_tabs_pass_through() {
+        for tab in ["quality", "custom_formats", "groups", "general"] {
+            assert_eq!(normalize_settings_tab(Some(tab.into())), tab);
+        }
+    }
+
+    #[test]
+    fn normalize_settings_tab_unknown_or_missing_defaults_to_integrations() {
+        // Integrations is the default landing — first-run users
+        // most often need to wire a download client + Jellyfin
+        // before doing anything else, so that's the natural first
+        // tab.
+        assert_eq!(normalize_settings_tab(None), "integrations");
+        assert_eq!(
+            normalize_settings_tab(Some("garbage".into())),
+            "integrations"
+        );
+        assert_eq!(normalize_settings_tab(Some("".into())), "integrations");
+    }
+
+    // ── min_score_display ────────────────────────────────────────────
+
+    #[test]
+    fn min_score_display_renders_blank_for_no_floor_sentinel() {
+        // i32::MIN is the "no minimum score floor" sentinel — must
+        // render as an empty string so the input shows blank, not
+        // "-2147483648".
+        assert_eq!(min_score_display(i32::MIN), "");
+    }
+
+    #[test]
+    fn min_score_display_renders_normal_values_as_string() {
+        assert_eq!(min_score_display(0), "0");
+        assert_eq!(min_score_display(50), "50");
+        assert_eq!(min_score_display(-5), "-5");
+        // Just-above-the-sentinel renders normally — only the exact
+        // i32::MIN value is special.
+        assert_eq!(min_score_display(i32::MIN + 1), (i32::MIN + 1).to_string());
+    }
+
+    // ── humanize_relative_time ───────────────────────────────────────
+
+    #[test]
+    fn humanize_relative_time_none_renders_never() {
+        // No row in scheduled_task_runs yet → "Never", which is
+        // what the Settings dashboard shows for unrun tasks.
+        assert_eq!(humanize_relative_time(None), "Never");
+    }
+
+    fn now_ts() -> i64 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0)
+    }
+
+    #[test]
+    fn humanize_relative_time_under_one_minute_says_just_now() {
+        assert_eq!(humanize_relative_time(Some(now_ts())), "Just now");
+        assert_eq!(humanize_relative_time(Some(now_ts() - 30)), "Just now");
+    }
+
+    #[test]
+    fn humanize_relative_time_under_one_hour_uses_minutes() {
+        // The pluralization arm: 1 minute is singular, 2+ is plural.
+        assert_eq!(humanize_relative_time(Some(now_ts() - 60)), "1 minute ago");
+        assert_eq!(
+            humanize_relative_time(Some(now_ts() - 120)),
+            "2 minutes ago"
+        );
+        assert_eq!(
+            humanize_relative_time(Some(now_ts() - 30 * 60)),
+            "30 minutes ago"
+        );
+    }
+
+    #[test]
+    fn humanize_relative_time_under_one_day_uses_hours() {
+        assert_eq!(humanize_relative_time(Some(now_ts() - 3600)), "1 hour ago");
+        assert_eq!(humanize_relative_time(Some(now_ts() - 7200)), "2 hours ago");
+        // 23h59m is still in hours.
+        assert_eq!(
+            humanize_relative_time(Some(now_ts() - (23 * 3600 + 59 * 60))),
+            "23 hours ago"
+        );
+    }
+
+    #[test]
+    fn humanize_relative_time_one_day_or_more_uses_days() {
+        assert_eq!(humanize_relative_time(Some(now_ts() - 86400)), "1 day ago");
+        assert_eq!(
+            humanize_relative_time(Some(now_ts() - 86400 * 7)),
+            "7 days ago"
+        );
+    }
+
+    #[test]
+    fn humanize_relative_time_future_timestamp_renders_just_now() {
+        // Defensive: a clock skew or pre-clock-init timestamp could
+        // produce ts > now. The `.max(0)` keeps the delta non-negative
+        // so we render "Just now" rather than "-N days ago".
+        assert_eq!(humanize_relative_time(Some(now_ts() + 10000)), "Just now");
+    }
+
+    // ── extract_spec_labels ──────────────────────────────────────────
+
+    #[test]
+    fn extract_spec_labels_parses_spec_array_into_views() {
+        let json = r#"{
+            "name": "BD",
+            "specifications": [
+                {"name": "BluRay", "implementation": "ReleaseTitleSpecification", "negate": false, "required": true},
+                {"name": "WEB", "implementation": "ReleaseTitleSpecification", "negate": true, "required": false}
+            ]
+        }"#;
+        let labels = extract_spec_labels(json);
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[0].name, "BluRay");
+        assert_eq!(labels[0].implementation, "ReleaseTitleSpecification");
+        assert!(!labels[0].negate);
+        assert!(labels[0].required);
+        assert_eq!(labels[1].name, "WEB");
+        assert!(labels[1].negate);
+        assert!(!labels[1].required);
+    }
+
+    #[test]
+    fn extract_spec_labels_returns_empty_on_invalid_json() {
+        // Defensive: a parse failure mustn't bubble up — the caller
+        // already surfaces the raw parse error via `parse_error`,
+        // and the spec-pill row just renders empty.
+        assert!(extract_spec_labels("{not json").is_empty());
+        assert!(extract_spec_labels("").is_empty());
+    }
+
+    #[test]
+    fn extract_spec_labels_returns_empty_when_specifications_missing() {
+        // CF JSON without a "specifications" array (e.g. malformed
+        // import or partial CF in flight) yields zero labels rather
+        // than a panic.
+        assert!(extract_spec_labels(r#"{"name": "BD"}"#).is_empty());
+        // Wrong type for "specifications" → also empty.
+        assert!(extract_spec_labels(r#"{"specifications": "oops"}"#).is_empty());
+    }
+
+    #[test]
+    fn extract_spec_labels_uses_defaults_for_missing_fields() {
+        // Each spec entry that omits a field falls back to the
+        // typed default — empty strings for `name`/`implementation`,
+        // false for both bools. This is what unblocks rendering
+        // half-imported CFs in the edit drawer.
+        let json = r#"{"specifications": [{}]}"#;
+        let labels = extract_spec_labels(json);
+        assert_eq!(labels.len(), 1);
+        assert_eq!(labels[0].name, "");
+        assert_eq!(labels[0].implementation, "");
+        assert!(!labels[0].negate);
+        assert!(!labels[0].required);
+    }
 }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -1721,4 +1721,123 @@ mod tests {
             EXTERNAL_SYNC_INTERVAL_DEFAULT_MIN
         );
     }
+
+    // ── validate_source ───────────────────────────────────────────────
+    //
+    // Settings save uses these to coerce form values into
+    // canonical-lowercase strings the rest of the codebase reads
+    // back via `Source::from_str`. A regression that forgot to
+    // canonicalize would persist mixed-case values and break the
+    // CF / scoring matchers that case-sensitive-compare the column.
+
+    #[test]
+    fn validate_source_canonicalizes_known_values_to_lowercase() {
+        // The user-facing dropdown emits canonical strings, but
+        // hand-crafted POSTs / older DB rows can carry mixed case.
+        // Every recognized variant lands in lowercase.
+        assert_eq!(validate_source("BluRay", "web"), "bluray");
+        assert_eq!(validate_source("BD", "web"), "bluray");
+        assert_eq!(validate_source("BDRIP", "web"), "bluray");
+        assert_eq!(validate_source("Web-DL", "bluray"), "web");
+        assert_eq!(validate_source("WEBRIP", "bluray"), "web");
+        assert_eq!(validate_source("HDTV", "web"), "hdtv");
+        assert_eq!(validate_source("DVD", "web"), "dvd");
+    }
+
+    #[test]
+    fn validate_source_falls_back_to_default_on_unknown() {
+        // A garbage form value resolves to the supplied default
+        // rather than persisting `Unknown` — every read path
+        // assumes a known variant.
+        assert_eq!(validate_source("garbage", "web"), "web");
+        assert_eq!(validate_source("", "bluray"), "bluray");
+        // The default itself isn't canonicalized — it's a static
+        // string the caller already chose.
+        assert_eq!(validate_source("unknown-source", "WEB"), "WEB");
+    }
+
+    #[test]
+    fn validate_source_trims_whitespace() {
+        // `Source::from_str` trims, so the validator inherits that.
+        assert_eq!(validate_source("  bluray  ", "web"), "bluray");
+    }
+
+    // ── validate_cutoff_source ────────────────────────────────────────
+
+    #[test]
+    fn validate_cutoff_source_passes_through_bluray_subtiers() {
+        // The cutoff dropdown surfaces three BluRay tiers: plain
+        // bluray, bluray_remux, bluray_bdmv. The latter two are stored
+        // as-is so `parse_cutoff_source` can branch on the exact string.
+        assert_eq!(
+            validate_cutoff_source("bluray_remux", "bluray"),
+            "bluray_remux"
+        );
+        assert_eq!(
+            validate_cutoff_source("bluray_bdmv", "bluray"),
+            "bluray_bdmv"
+        );
+    }
+
+    #[test]
+    fn validate_cutoff_source_falls_through_to_validate_source_for_other_values() {
+        // Plain BluRay / WEB / etc. take the regular validate_source
+        // path, including canonicalization.
+        assert_eq!(validate_cutoff_source("BluRay", "web"), "bluray");
+        assert_eq!(validate_cutoff_source("garbage", "bluray"), "bluray");
+    }
+
+    #[test]
+    fn validate_cutoff_source_is_case_sensitive_on_subtier_markers() {
+        // `bluray_remux` / `bluray_bdmv` are exact-match in the
+        // passthrough — `BLURAY_REMUX` doesn't get the special
+        // treatment. It then falls through to validate_source where
+        // `Source::from_str` (which underscore-matches "bdremux" /
+        // "bluray" / etc., but NOT "bluray_remux") returns Unknown
+        // → the default fires. Net result: a hand-crafted POST with
+        // an uppercase sub-tier marker silently loses both the
+        // sub-tier intent AND the BluRay source classification —
+        // ends up with the supplied default. Worth pinning so a
+        // refactor that adds case-folding to either path has to
+        // confront this asymmetry.
+        assert_eq!(validate_cutoff_source("BLURAY_REMUX", "web"), "web");
+    }
+
+    // ── validate_resolution ───────────────────────────────────────────
+
+    #[test]
+    fn validate_resolution_strips_p_suffix_for_db_storage() {
+        // The DB column convention is bare-digit strings ("1080") so
+        // `Resolution::from_str` reads them back uniformly. The
+        // validator strips the trailing `p` Settings emits with the
+        // dropdown.
+        assert_eq!(validate_resolution("1080p", "1080"), "1080");
+        assert_eq!(validate_resolution("720p", "1080"), "720");
+        assert_eq!(validate_resolution("2160p", "1080"), "2160");
+        assert_eq!(validate_resolution("480p", "1080"), "480");
+    }
+
+    #[test]
+    fn validate_resolution_accepts_bare_digit() {
+        // Both shapes in the wild — bare digit and suffixed.
+        assert_eq!(validate_resolution("1080", "720"), "1080");
+        assert_eq!(validate_resolution("720", "1080"), "720");
+    }
+
+    #[test]
+    fn validate_resolution_accepts_4k_aliases() {
+        // 4k / UHD aliases canonicalize to "2160" via Resolution::from_str.
+        assert_eq!(validate_resolution("4k", "1080"), "2160");
+        assert_eq!(validate_resolution("UHD", "1080"), "2160");
+    }
+
+    #[test]
+    fn validate_resolution_falls_back_to_default_on_garbage() {
+        assert_eq!(validate_resolution("garbage", "1080"), "1080");
+        assert_eq!(validate_resolution("", "720"), "720");
+        // Sonarr's 360p / 540p don't have Ryokan tiers and fold to
+        // the default rather than persisting an unrecognized value.
+        assert_eq!(validate_resolution("360p", "1080"), "1080");
+        assert_eq!(validate_resolution("540p", "1080"), "1080");
+    }
 }

--- a/src/handlers/sonarr_compat/helpers.rs
+++ b/src/handlers/sonarr_compat/helpers.rs
@@ -6,7 +6,7 @@
 use axum::{Json, http::StatusCode};
 
 use crate::AppState;
-use crate::models::{config, monitoring, series};
+use crate::models::{config, metadata_cache, monitoring, series};
 use crate::services::{anibridge, anilist, media};
 
 use super::types::{
@@ -14,6 +14,44 @@ use super::types::{
 };
 
 // ── Helpers ────────────────────────────────────────────────────────────────
+
+/// Map AL's 0-100 `averageScore` (also Jikan's 0-10 score multiplied
+/// by 10 inside `services::jikan`) onto Sonarr's `ratings.value`,
+/// which is a float on the 0-10 scale. `None` flattens to a zeroed
+/// `SonarrRatings` so the JSON payload keeps the same shape Seerr's
+/// `radarr-models` expects. `votes` stays at 0 — neither AL nor MAL
+/// gives us a vote count we can map cleanly onto Sonarr's notion of
+/// "vote count," and 0-with-a-non-zero-value is a shape Sonarr itself
+/// emits for unrated newer entries.
+pub(super) fn ratings_from_score(score: Option<i32>) -> SonarrRatings {
+    match score {
+        Some(s) if s > 0 => SonarrRatings {
+            votes: 0,
+            value: f64::from(s) / 10.0,
+        },
+        _ => SonarrRatings {
+            votes: 0,
+            value: 0.0,
+        },
+    }
+}
+
+/// Pull the cached `AnimeDetail` for `series_id`, or `None` on a cache
+/// miss / decode error. Used by `build_sonarr_series_from_tracked` to
+/// recover the average_score that the `series` row doesn't carry —
+/// metadata_cache is the canonical store. A miss falls through to a
+/// zeroed rating, which is the same shape Sonarr emits for entries
+/// whose metadata hasn't been refreshed yet.
+pub(super) async fn cached_detail_for(
+    db: &sqlx::SqlitePool,
+    series_id: i64,
+) -> Option<anilist::AnimeDetail> {
+    metadata_cache::get_by_series_id(db, series_id)
+        .await
+        .ok()
+        .flatten()
+        .map(|c| c.detail)
+}
 
 /// Look up anime by external ID (TVDB or TMDB). Tries TVDB index first since
 /// Sonarr/Seerr sends real TVDB IDs, then falls back to TMDB index.
@@ -137,10 +175,7 @@ pub(super) async fn lookup_by_external_id(
         genres: vec!["Anime".to_string()],
         tags: vec![],
         added: String::new(),
-        ratings: SonarrRatings {
-            votes: 0,
-            value: 0.0,
-        },
+        ratings: ratings_from_score(show_detail.as_ref().and_then(|d| d.average_score)),
         quality_profile_id: 1,
         root_folder_path: cfg.media_root.clone(),
         statistics: SonarrStatistics {
@@ -259,10 +294,7 @@ pub(super) async fn build_sonarr_series_from_search(
         genres: vec!["Anime".to_string()],
         tags: vec![],
         added: String::new(),
-        ratings: SonarrRatings {
-            votes: 0,
-            value: 0.0,
-        },
+        ratings: ratings_from_score(r.average_score),
         quality_profile_id: 1,
         root_folder_path: cfg.media_root.clone(),
         statistics: SonarrStatistics {
@@ -282,6 +314,7 @@ pub(super) async fn build_sonarr_series_from_search(
 
 pub(super) async fn build_sonarr_series_from_tracked(
     s: &series::Series,
+    detail: Option<&anilist::AnimeDetail>,
     tmdb_id: i64,
     cfg: &config::Config,
 ) -> SonarrSeries {
@@ -352,10 +385,7 @@ pub(super) async fn build_sonarr_series_from_tracked(
         genres: vec!["Anime".to_string()],
         tags: vec![],
         added: String::new(),
-        ratings: SonarrRatings {
-            votes: 0,
-            value: 0.0,
-        },
+        ratings: ratings_from_score(detail.and_then(|d| d.average_score)),
         quality_profile_id: 1,
         root_folder_path: cfg.media_root.clone(),
         statistics: SonarrStatistics {

--- a/src/handlers/sonarr_compat/helpers.rs
+++ b/src/handlers/sonarr_compat/helpers.rs
@@ -177,7 +177,7 @@ pub(super) async fn fetch_anime_detail(ids: &anibridge::AnimeIds) -> Option<anil
     None
 }
 
-pub(super) fn build_sonarr_series_from_search(
+pub(super) async fn build_sonarr_series_from_search(
     r: &anilist::AnimeEntry,
     title: &str,
     tmdb_id: i64,
@@ -193,7 +193,7 @@ pub(super) fn build_sonarr_series_from_search(
         .unwrap_or_else(|| media::sanitize_folder_name(title));
 
     let disk_files = if is_in_library {
-        media::scan_series_folder(&cfg.media_root, &folder_name)
+        media::scan_series_folder(&cfg.media_root, &folder_name).await
     } else {
         Vec::new()
     };
@@ -280,13 +280,13 @@ pub(super) fn build_sonarr_series_from_search(
     }
 }
 
-pub(super) fn build_sonarr_series_from_tracked(
+pub(super) async fn build_sonarr_series_from_tracked(
     s: &series::Series,
     tmdb_id: i64,
     cfg: &config::Config,
 ) -> SonarrSeries {
     let total_eps = s.episodes.unwrap_or(0).max(0);
-    let disk_files = media::scan_series_folder(&cfg.media_root, &s.folder_name);
+    let disk_files = media::scan_series_folder(&cfg.media_root, &s.folder_name).await;
     let on_disk = disk_files.len() as i32;
     let monitored = s.monitor_mode_enum() != monitoring::MonitorMode::None;
 

--- a/src/handlers/sonarr_compat/series.rs
+++ b/src/handlers/sonarr_compat/series.rs
@@ -44,12 +44,17 @@ pub async fn series_lookup(
         .await
         .map_err(|e| (StatusCode::BAD_GATEWAY, e))?;
 
+    // One batched DB read keyed on every AL id we got back, instead of
+    // N sequential round-trips per result. Seerr polls this endpoint
+    // every connection-test and every search submission.
+    let result_ids: Vec<i64> = results.iter().map(|r| r.id).collect();
+    let db_by_id = series::get_by_anilist_ids(&state.db, &result_ids)
+        .await
+        .unwrap_or_default();
+
     let mut sonarr_results = Vec::new();
     for r in results {
-        let db_series = series::get_by_anilist_id(&state.db, r.id)
-            .await
-            .ok()
-            .flatten();
+        let db_series = db_by_id.get(&r.id);
 
         let tmdb_id = anibridge::resolve_tmdb_id(r.id, r.id_mal).await;
         let title = if !r.title_english.is_empty() {
@@ -58,13 +63,8 @@ pub async fn series_lookup(
             &r.title_romaji
         };
 
-        sonarr_results.push(build_sonarr_series_from_search(
-            &r,
-            title,
-            tmdb_id,
-            db_series.as_ref(),
-            &cfg,
-        ));
+        sonarr_results
+            .push(build_sonarr_series_from_search(&r, title, tmdb_id, db_series, &cfg).await);
     }
 
     Ok(Json(sonarr_results))
@@ -87,7 +87,7 @@ pub async fn list_series(
     let mut results = Vec::new();
     for s in &tracked {
         let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-        results.push(build_sonarr_series_from_tracked(s, tmdb_id, &cfg));
+        results.push(build_sonarr_series_from_tracked(s, tmdb_id, &cfg).await);
     }
 
     Ok(Json(results))
@@ -110,7 +110,9 @@ pub async fn get_series(
         .ok_or((StatusCode::NOT_FOUND, "Series not found".to_string()))?;
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-    Ok(Json(build_sonarr_series_from_tracked(&s, tmdb_id, &cfg)))
+    Ok(Json(
+        build_sonarr_series_from_tracked(&s, tmdb_id, &cfg).await,
+    ))
 }
 
 /// POST /api/v3/series — add a new series.
@@ -507,9 +509,9 @@ pub async fn add_series(
     // cours exist in Ryokan's DB but don't need to be reflected in the
     // Sonarr response shape.
     let primary = &processed[0];
-    Ok(Json(build_sonarr_series_from_tracked(
-        primary, tvdb_id, &cfg,
-    )))
+    Ok(Json(
+        build_sonarr_series_from_tracked(primary, tvdb_id, &cfg).await,
+    ))
 }
 
 /// PUT /api/v3/series — update an existing series.
@@ -548,7 +550,9 @@ pub async fn update_series(
         .unwrap_or_default();
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-    Ok(Json(build_sonarr_series_from_tracked(&s, tmdb_id, &cfg)))
+    Ok(Json(
+        build_sonarr_series_from_tracked(&s, tmdb_id, &cfg).await,
+    ))
 }
 
 /// POST /api/v3/command — execute a command. Seerr sends SeriesSearch.

--- a/src/handlers/sonarr_compat/series.rs
+++ b/src/handlers/sonarr_compat/series.rs
@@ -15,7 +15,8 @@ use crate::models::{config, monitoring, series};
 use crate::services::{anibridge, anilist, logger, monitoring as monitoring_service};
 
 use super::helpers::{
-    build_sonarr_series_from_search, build_sonarr_series_from_tracked, lookup_by_external_id,
+    build_sonarr_series_from_search, build_sonarr_series_from_tracked, cached_detail_for,
+    lookup_by_external_id,
 };
 use super::types::{AddSeriesBody, CommandBody, SonarrSeries, UpdateSeriesBody};
 
@@ -87,7 +88,8 @@ pub async fn list_series(
     let mut results = Vec::new();
     for s in &tracked {
         let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
-        results.push(build_sonarr_series_from_tracked(s, tmdb_id, &cfg).await);
+        let detail = cached_detail_for(&state.db, s.id).await;
+        results.push(build_sonarr_series_from_tracked(s, detail.as_ref(), tmdb_id, &cfg).await);
     }
 
     Ok(Json(results))
@@ -110,8 +112,9 @@ pub async fn get_series(
         .ok_or((StatusCode::NOT_FOUND, "Series not found".to_string()))?;
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let detail = cached_detail_for(&state.db, s.id).await;
     Ok(Json(
-        build_sonarr_series_from_tracked(&s, tmdb_id, &cfg).await,
+        build_sonarr_series_from_tracked(&s, detail.as_ref(), tmdb_id, &cfg).await,
     ))
 }
 
@@ -509,8 +512,9 @@ pub async fn add_series(
     // cours exist in Ryokan's DB but don't need to be reflected in the
     // Sonarr response shape.
     let primary = &processed[0];
+    let detail = cached_detail_for(&state.db, primary.id).await;
     Ok(Json(
-        build_sonarr_series_from_tracked(primary, tvdb_id, &cfg).await,
+        build_sonarr_series_from_tracked(primary, detail.as_ref(), tvdb_id, &cfg).await,
     ))
 }
 
@@ -550,8 +554,9 @@ pub async fn update_series(
         .unwrap_or_default();
 
     let tmdb_id = anibridge::resolve_tmdb_id(s.anilist_id, s.mal_id).await;
+    let detail = cached_detail_for(&state.db, s.id).await;
     Ok(Json(
-        build_sonarr_series_from_tracked(&s, tmdb_id, &cfg).await,
+        build_sonarr_series_from_tracked(&s, detail.as_ref(), tmdb_id, &cfg).await,
     ))
 }
 

--- a/src/handlers/sonarr_compat/system.rs
+++ b/src/handlers/sonarr_compat/system.rs
@@ -13,8 +13,8 @@ use super::types::{LanguageProfile, RootFolder};
 // ── Handlers ───────────────────────────────────────────────────────────────
 
 /// GET /api/v3/system/status
-pub async fn system_status() -> Json<SystemStatus> {
-    Json(SystemStatus::default_with_name("Ryokan"))
+pub async fn system_status(State(state): State<AppState>) -> Json<SystemStatus> {
+    Json(SystemStatus::default_with_name("Ryokan", state.start_time))
 }
 
 /// GET /api/v3/qualityprofile

--- a/src/handlers/sonarr_compat/tests/helpers.rs
+++ b/src/handlers/sonarr_compat/tests/helpers.rs
@@ -1,0 +1,92 @@
+//! Pure-helper coverage for the Sonarr shim — `ratings_from_score`
+//! and `map_status` are tiny but load-bearing. Both feed every series
+//! payload Seerr sees. A wrong rating denominator (Sonarr expects
+//! 0-10, AL is 0-100) flashes an obviously-broken score in the
+//! Seerr UI; a wrong `map_status` value silently corrupts Seerr's
+//! "show ended" detection so finished anime never get marked as
+//! such on its dashboard.
+
+use crate::handlers::sonarr_compat::helpers::{map_status, ratings_from_score};
+
+// ── ratings_from_score ───────────────────────────────────────────────
+
+#[test]
+fn ratings_from_score_none_renders_zeroed() {
+    // The "metadata never refreshed" shape — Sonarr itself emits
+    // this for new entries, so Seerr handles it cleanly.
+    let r = ratings_from_score(None);
+    assert_eq!(r.votes, 0);
+    assert_eq!(r.value, 0.0);
+}
+
+#[test]
+fn ratings_from_score_zero_or_negative_renders_zeroed() {
+    // AL emits `averageScore: null` as Some(0) after our parser's
+    // `unwrap_or(0)` fallback. Treat both 0 and the (theoretically
+    // impossible) negative case as "no rating" rather than letting
+    // a 0.0 value rendered in Seerr suggest a real bottom-of-scale
+    // score.
+    assert_eq!(ratings_from_score(Some(0)).value, 0.0);
+    assert_eq!(ratings_from_score(Some(-5)).value, 0.0);
+}
+
+#[test]
+fn ratings_from_score_divides_by_ten_for_zero_to_ten_scale() {
+    // AL: 0-100 integer. Sonarr/Seerr: 0-10 float. Pin the
+    // denominator at 10 — a regression that drops the divisor would
+    // produce visibly broken 8500-style ratings in Seerr.
+    assert_eq!(ratings_from_score(Some(85)).value, 8.5);
+    assert_eq!(ratings_from_score(Some(100)).value, 10.0);
+    assert_eq!(ratings_from_score(Some(1)).value, 0.1);
+}
+
+#[test]
+fn ratings_from_score_votes_always_zero() {
+    // We don't have a vote count from AL/MAL that maps cleanly to
+    // Sonarr's notion. 0-with-a-non-zero-value is the shape Sonarr
+    // itself emits for unrated newer entries, so Seerr handles it.
+    for s in [None, Some(0), Some(50), Some(100)] {
+        assert_eq!(ratings_from_score(s).votes, 0, "score {:?}", s);
+    }
+}
+
+// ── map_status ───────────────────────────────────────────────────────
+
+#[test]
+fn map_status_releasing_to_continuing() {
+    // AL's "RELEASING" + "NOT_YET_RELEASED" both map to Sonarr's
+    // "continuing" — the show is still emitting episodes from
+    // Sonarr's POV.
+    assert_eq!(map_status("RELEASING"), "continuing");
+    assert_eq!(map_status("NOT_YET_RELEASED"), "continuing");
+}
+
+#[test]
+fn map_status_finished_to_ended() {
+    // AL's "FINISHED" / "FINISHED_AIRING" / "CANCELLED" all map to
+    // Sonarr's "ended". Cancelled is bundled with finished because
+    // Sonarr has no separate concept for canceled-mid-air; both
+    // mean "no more episodes coming."
+    assert_eq!(map_status("FINISHED"), "ended");
+    assert_eq!(map_status("FINISHED_AIRING"), "ended");
+    assert_eq!(map_status("CANCELLED"), "ended");
+}
+
+#[test]
+fn map_status_is_case_insensitive() {
+    // The AL parser sometimes lower-cases the status field on
+    // negative-id (Jikan-fallback) rows. Pin the case-insensitivity
+    // so a parser tweak doesn't silently break the mapping.
+    assert_eq!(map_status("releasing"), "continuing");
+    assert_eq!(map_status("Finished"), "ended");
+}
+
+#[test]
+fn map_status_unknown_defaults_to_continuing() {
+    // Defensive default — better to mark an unknown status as
+    // "continuing" (Sonarr keeps watching) than as "ended" (Sonarr
+    // stops monitoring entirely). New AL status variants get a
+    // safe landing without a code change.
+    assert_eq!(map_status("HIATUS"), "continuing");
+    assert_eq!(map_status(""), "continuing");
+}

--- a/src/handlers/sonarr_compat/tests/mod.rs
+++ b/src/handlers/sonarr_compat/tests/mod.rs
@@ -13,4 +13,5 @@
 //!     break Seerr without a test failure.
 
 mod auth;
+mod helpers;
 mod system;

--- a/src/handlers/sonarr_compat/tests/snapshots/ryokan__handlers__sonarr_compat__tests__system__sonarr_system_status.snap
+++ b/src/handlers/sonarr_compat/tests/snapshots/ryokan__handlers__sonarr_compat__tests__system__sonarr_system_status.snap
@@ -29,5 +29,5 @@ expression: body
   "startTime": "2024-01-01T00:00:00Z",
   "startupPath": "",
   "urlBase": "",
-  "version": "3.0.9.1549"
+  "version": "4.0.17.2952"
 }

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -638,16 +638,34 @@ static CLIENT_LOG_HITS: LazyLock<Mutex<VecDeque<Instant>>> =
     LazyLock::new(|| Mutex::new(VecDeque::with_capacity(CLIENT_LOG_RATE_MAX)));
 
 fn check_client_log_rate() -> bool {
-    let now = Instant::now();
     let mut hits = CLIENT_LOG_HITS.lock().unwrap();
+    admit_log_event(
+        &mut hits,
+        Instant::now(),
+        CLIENT_LOG_RATE_WINDOW,
+        CLIENT_LOG_RATE_MAX,
+    )
+}
+
+/// Pure sliding-window rate-limit check, factored out of
+/// `check_client_log_rate` so the policy is testable without poking
+/// the process-wide `CLIENT_LOG_HITS` static. Drops timestamps older
+/// than `window` from the front of `hits`, then admits the event if
+/// the remaining count is under `max`. On admission, records `now`.
+fn admit_log_event(
+    hits: &mut VecDeque<Instant>,
+    now: Instant,
+    window: Duration,
+    max: usize,
+) -> bool {
     while let Some(front) = hits.front() {
-        if now.duration_since(*front) > CLIENT_LOG_RATE_WINDOW {
+        if now.duration_since(*front) > window {
             hits.pop_front();
         } else {
             break;
         }
     }
-    if hits.len() >= CLIENT_LOG_RATE_MAX {
+    if hits.len() >= max {
         return false;
     }
     hits.push_back(now);
@@ -920,5 +938,99 @@ pub async fn api_force_upgrade_search(
                 scheduled_tasks::mark_finished(&state.db, "upgrade_search", "error", &err).await;
             Err((axum::http::StatusCode::BAD_GATEWAY, err))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── admit_log_event ──────────────────────────────────────────────
+    //
+    // The pure helper behind `check_client_log_rate`. Tested with an
+    // explicit clock + state so we can drive the sliding window
+    // without poking the process-wide `CLIENT_LOG_HITS` static.
+
+    fn t0() -> Instant {
+        Instant::now()
+    }
+
+    #[test]
+    fn admit_log_event_admits_under_cap() {
+        let mut hits = VecDeque::new();
+        let now = t0();
+        let window = Duration::from_secs(60);
+        let max = 3;
+        assert!(admit_log_event(&mut hits, now, window, max));
+        assert!(admit_log_event(&mut hits, now, window, max));
+        assert!(admit_log_event(&mut hits, now, window, max));
+        // Three admitted, queue is full.
+        assert_eq!(hits.len(), 3);
+    }
+
+    #[test]
+    fn admit_log_event_rejects_at_cap() {
+        let mut hits = VecDeque::new();
+        let now = t0();
+        let window = Duration::from_secs(60);
+        let max = 2;
+        assert!(admit_log_event(&mut hits, now, window, max));
+        assert!(admit_log_event(&mut hits, now, window, max));
+        // Cap reached — third call must reject.
+        assert!(!admit_log_event(&mut hits, now, window, max));
+        // Queue stays at the cap; the rejected event is NOT recorded
+        // (otherwise a sustained burst would push the window forward
+        // forever and never let traffic in again).
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn admit_log_event_drops_expired_timestamps_before_check() {
+        let mut hits = VecDeque::new();
+        let window = Duration::from_secs(60);
+        let max = 2;
+
+        let earlier = t0();
+        // Seed two old hits manually.
+        hits.push_back(earlier);
+        hits.push_back(earlier);
+
+        // Advance past the window — both should age out and the next
+        // event admits cleanly.
+        let now = earlier + Duration::from_secs(61);
+        assert!(admit_log_event(&mut hits, now, window, max));
+        // Only the just-admitted event remains.
+        assert_eq!(hits.len(), 1);
+    }
+
+    #[test]
+    fn admit_log_event_keeps_in_window_timestamps() {
+        let mut hits = VecDeque::new();
+        let window = Duration::from_secs(60);
+        let max = 2;
+        let earlier = t0();
+        hits.push_back(earlier);
+
+        // Half a window later — the seeded hit is still in window so
+        // the second event tips us up to cap; the third must reject.
+        let now = earlier + Duration::from_secs(30);
+        assert!(admit_log_event(&mut hits, now, window, max));
+        assert!(!admit_log_event(&mut hits, now, window, max));
+    }
+
+    #[test]
+    fn admit_log_event_zero_max_rejects_everything() {
+        // Defensive: a misconfigured cap of 0 must not admit any
+        // events (rather than treating "0" as "no limit"). Pin the
+        // ordering so a future "shortcut" optimization can't flip
+        // the policy.
+        let mut hits = VecDeque::new();
+        assert!(!admit_log_event(
+            &mut hits,
+            t0(),
+            Duration::from_secs(60),
+            0
+        ));
+        assert!(hits.is_empty());
     }
 }

--- a/src/handlers/system.rs
+++ b/src/handlers/system.rs
@@ -79,6 +79,11 @@ fn normalize_system_tab(tab: Option<String>) -> String {
     }
 }
 
+#[cfg(test)]
+pub(crate) fn normalize_system_tab_for_test(tab: Option<String>) -> String {
+    normalize_system_tab(tab)
+}
+
 pub async fn system_page(
     State(state): State<AppState>,
     Query(params): Query<SystemQuery>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,6 +97,14 @@ pub struct AppState {
     /// 10-minute TTL sweeps forgotten flows. See
     /// [`services::oauth_state`] for scope + lifecycle.
     pub oauth_state: OAuthStateStore,
+    /// Wall-clock timestamp captured at process boot. Used by the
+    /// Sonarr/Radarr shims' `system_status` endpoint so Seerr's UI
+    /// pill reports the actual time the connected app came online —
+    /// the prior hardcoded "2024-01-01T00:00:00Z" effectively claimed
+    /// the indexer had been up for over a year regardless of when
+    /// Ryokan was last restarted, which made the pill useless as a
+    /// liveness signal.
+    pub start_time: chrono::DateTime<chrono::Utc>,
 }
 
 impl FromRef<AppState> for SqlitePool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -439,6 +439,7 @@ async fn main() {
         users_exist,
         interactive_search_cache: services::interactive_search_cache::new(),
         oauth_state: services::oauth_state::new(),
+        start_time: chrono::Utc::now(),
     };
 
     // Initialize download client from saved config. Branches on

--- a/src/models/external_accounts.rs
+++ b/src/models/external_accounts.rs
@@ -227,15 +227,26 @@ pub async fn link(db: &SqlitePool, req: LinkRequest) -> Result<i64, String> {
         return Ok(id);
     }
 
+    // The NOT EXISTS guard rejects ANY existing row, not just
+    // different-provider ones. The earlier UPDATE step already handled
+    // the "re-link the same account" case (same provider AND same
+    // user_id) idempotently — anything reaching this INSERT either has
+    // no row yet (fresh link) or has a row that *isn't* a re-link
+    // candidate. The pre-fix narrow guard (`WHERE provider != ?`) let
+    // a same-provider-different-user link slip through to a UNIQUE(provider)
+    // constraint hit, surfacing the cryptic SQL error
+    // "external_accounts INSERT failed: UNIQUE constraint failed:
+    // external_accounts.provider" instead of the friendly
+    // "another account is already linked, unlink first" string. Widening
+    // to "any row" routes both same-provider-different-user and
+    // different-provider switches through the same friendly error.
     let inserted: Option<i64> = sqlx::query_scalar(
         "INSERT INTO external_accounts
             (provider, provider_user_id, username,
              access_token_encrypted, refresh_token_encrypted,
              access_token_expires_at, score_format, linked_at)
          SELECT ?, ?, ?, ?, ?, ?, ?, ?
-          WHERE NOT EXISTS (
-             SELECT 1 FROM external_accounts WHERE provider != ?
-          )
+          WHERE NOT EXISTS (SELECT 1 FROM external_accounts)
          RETURNING id",
     )
     .bind(&req.provider)
@@ -246,13 +257,12 @@ pub async fn link(db: &SqlitePool, req: LinkRequest) -> Result<i64, String> {
     .bind(req.access_token_expires_at)
     .bind(&req.score_format)
     .bind(now)
-    .bind(&req.provider)
     .fetch_optional(db)
     .await
     .map_err(|e| format!("external_accounts INSERT failed: {e}"))?;
 
     inserted.ok_or_else(|| {
-        "Another external account is already linked; unlink it first before switching providers."
+        "Another external account is already linked; unlink it first before switching accounts."
             .into()
     })
 }
@@ -666,18 +676,28 @@ mod tests {
 
     #[tokio::test]
     async fn link_same_provider_different_user_id_is_rejected() {
-        // UNIQUE(provider) at the schema level fires here — a user
-        // switching MAL accounts can't double-link; they must
-        // unlink first. The update path in `link` only triggers
-        // when both provider AND user_id match.
+        // Same-provider-different-user must reach the friendly
+        // "unlink first" error, NOT the cryptic UNIQUE(provider)
+        // constraint string. The narrow `WHERE provider != ?` guard
+        // used to let this case slip past the NOT EXISTS check and
+        // hit the schema constraint at INSERT time, surfacing
+        // "external_accounts INSERT failed: UNIQUE constraint failed"
+        // to the OAuth submit toast — a confusing error for what's
+        // actually "you already linked a different account; unlink
+        // first." The widened guard now catches both same-provider
+        // and cross-provider switches with the same message.
         let db = in_memory_pool().await;
         link(&db, sample_mal_request()).await.unwrap();
         let mut other_user = sample_mal_request();
         other_user.provider_user_id = "different_mal_user".to_string();
         let err = link(&db, other_user).await.unwrap_err();
         assert!(
-            err.to_lowercase().contains("unique") || err.to_lowercase().contains("constraint"),
-            "schema UNIQUE(provider) must surface: {err}"
+            err.contains("Another external account is already linked"),
+            "expected friendly unlink-first message, got: {err}"
+        );
+        assert!(
+            !err.to_lowercase().contains("unique"),
+            "raw SQL constraint error must not leak through to the user: {err}"
         );
     }
 

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -1580,42 +1580,32 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // doesn't re-run on every boot. Nyaa magnets are overwhelmingly
     // hex so the affected row count should be near zero in practice,
     // but the backfill unifies the partial UNIQUE index on (hash)
-    // once and forever.
-    sqlx::query("ALTER TABLE config ADD COLUMN base32_backfill_done INTEGER NOT NULL DEFAULT 0")
-        .execute(db)
-        .await
-        .ok();
-
-    let backfill_done: i64 =
-        sqlx::query_scalar("SELECT COALESCE((SELECT base32_backfill_done FROM config LIMIT 1), 0)")
-            .fetch_one(db)
+    // once and forever. The `base32_backfill_done` config column the
+    // first version of this migration added is intentionally left in
+    // place on existing DBs (DROP COLUMN is risky and the column is
+    // harmless): the SELECT below already self-gates by length, so
+    // the bespoke flag was redundant from the start. Per CLAUDE.md
+    // ("Do NOT invent a per-migration config flag — that's what
+    // `schema_migrations` is for"), one-shot data rewrites that need
+    // a guard go through `schema_migrations`; this one doesn't need
+    // any guard at all because base32 hashes are 32 chars and hex
+    // hashes are 40, so once a row is converted it never matches the
+    // SELECT again. Re-running on a fully-migrated DB is a no-op.
+    let rows: Vec<(i64, String)> =
+        sqlx::query_as("SELECT id, hash FROM grabbed_torrents WHERE LENGTH(hash) = 32")
+            .fetch_all(db)
             .await
-            .unwrap_or(0);
+            .unwrap_or_default();
 
-    if backfill_done == 0 {
-        let rows: Vec<(i64, String)> =
-            sqlx::query_as("SELECT id, hash FROM grabbed_torrents WHERE LENGTH(hash) = 32")
-                .fetch_all(db)
-                .await
-                .unwrap_or_default();
-
-        for (id, b32_hash) in rows {
-            if let Some(bytes) = crate::services::nyaa::base32_decode_infohash(&b32_hash) {
-                let hex_hash = hex::encode(bytes);
-                let _ = sqlx::query("UPDATE grabbed_torrents SET hash = ? WHERE id = ?")
-                    .bind(&hex_hash)
-                    .bind(id)
-                    .execute(db)
-                    .await;
-            }
+    for (id, b32_hash) in rows {
+        if let Some(bytes) = crate::services::nyaa::base32_decode_infohash(&b32_hash) {
+            let hex_hash = hex::encode(bytes);
+            let _ = sqlx::query("UPDATE grabbed_torrents SET hash = ? WHERE id = ?")
+                .bind(&hex_hash)
+                .bind(id)
+                .execute(db)
+                .await;
         }
-
-        // Mark done whether or not any rows were found — fresh installs
-        // with no legacy base32 rows also get the flag set so we don't
-        // rescan on every boot.
-        let _ = sqlx::query("UPDATE config SET base32_backfill_done = 1")
-            .execute(db)
-            .await;
     }
 
     sqlx::query("ALTER TABLE episode_quality_tags ADD COLUMN web_kind TEXT NOT NULL DEFAULT ''")

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -567,6 +567,14 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     // reconciler dispatches on the (legacy, new) presence matrix so
     // each starting state moves to the correct end state without
     // creating ghost columns.
+    //
+    // Cleanup of pre-existing vestiges: DBs that already passed
+    // through the v1 ADD-then-RENAME-with-.ok() pattern carry the
+    // stray `force_tmdb_fallback` INTEGER alongside the live
+    // `force_kitsu_fallback` column. The (true, true) arm of the
+    // reconciler DROPs the legacy column on next boot, so a long-
+    // running install picks up the cleanup automatically — no
+    // operator action required.
     reconcile_column_rename_typed(
         db,
         "config",

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -39,32 +39,49 @@ async fn column_exists(db: &SqlitePool, table: &str, column: &str) -> bool {
 ///
 /// | legacy | new | action                                             |
 /// |--------|-----|----------------------------------------------------|
-/// |   ✓    | ✓   | copy legacy→new (only when new is empty), drop legacy |
+/// |   ✓    | ✓   | copy legacy→new (only when new still the default), drop legacy |
 /// |   ✓    | ✗   | rename legacy→new                                  |
 /// |   ✗    | ✓   | no-op                                              |
-/// |   ✗    | ✗   | add new (empty default)                            |
+/// |   ✗    | ✗   | add new (caller-supplied declaration)              |
 ///
 /// The "both columns exist" row is the one PR #37's first migration
 /// attempt produced: it ran ADD-then-RENAME, so ADD succeeded, RENAME
 /// hit "duplicate column" → `.ok()` → data stranded in the legacy
 /// column alongside an empty new column.
 ///
-/// `legacy` / `new` are hardcoded column-name string literals from
-/// the callers in `migrate()`, so inline interpolation into the SQL
-/// is safe (no user input reaches PRAGMA or ALTER TABLE here).
-async fn reconcile_column_rename(db: &SqlitePool, table: &str, legacy: &str, new: &str) {
+/// `legacy` / `new` / `add_decl` / `default_predicate` are all
+/// hardcoded literals from the callers in `migrate()`, so inline
+/// interpolation into the SQL is safe (no user input reaches PRAGMA
+/// or ALTER TABLE here).
+///
+/// `add_decl` is the column declaration used when neither column
+/// exists (fresh install) — e.g. `"TEXT NOT NULL DEFAULT ''"` for
+/// string renames, `"INTEGER NOT NULL DEFAULT 0"` for boolean flag
+/// renames. `default_predicate` is the WHERE-clause fragment that
+/// identifies "new column still has its default value" so the
+/// recovery copy doesn't clobber a value the user / a later
+/// migration pass legitimately wrote — `"= ''"` for strings,
+/// `"= 0"` for integer flags.
+async fn reconcile_column_rename_typed(
+    db: &SqlitePool,
+    table: &str,
+    legacy: &str,
+    new: &str,
+    add_decl: &str,
+    default_predicate: &str,
+) {
     let legacy_exists = column_exists(db, table, legacy).await;
     let new_exists = column_exists(db, table, new).await;
 
     match (legacy_exists, new_exists) {
         (true, true) => {
             // Recovery path for the PR #37 half-migrated state.
-            // Copy legacy→new where new is still the default
-            // (empty string). Guard with `new = ''` so a later pass
-            // that legitimately set new via UPDATE isn't overwritten
+            // Copy legacy→new where new is still the default. Guard
+            // on the type-appropriate predicate so a later pass that
+            // legitimately set `new` via UPDATE isn't overwritten
             // from the stale legacy value.
             let copy = format!(
-                "UPDATE {table} SET {new} = {legacy} WHERE {new} = '' AND {legacy} IS NOT NULL"
+                "UPDATE {table} SET {new} = {legacy} WHERE {new} {default_predicate} AND {legacy} IS NOT NULL"
             );
             let _ = sqlx::query(&copy).execute(db).await;
 
@@ -84,11 +101,18 @@ async fn reconcile_column_rename(db: &SqlitePool, table: &str, legacy: &str, new
             // Already migrated, nothing to do.
         }
         (false, false) => {
-            // Fresh install — ADD with empty default.
-            let add = format!("ALTER TABLE {table} ADD COLUMN {new} TEXT NOT NULL DEFAULT ''");
+            // Fresh install — ADD with caller-supplied declaration.
+            let add = format!("ALTER TABLE {table} ADD COLUMN {new} {add_decl}");
             let _ = sqlx::query(&add).execute(db).await;
         }
     }
+}
+
+/// String-column rename — backwards-compatible wrapper for the
+/// pre-existing call sites that all carried the `TEXT NOT NULL DEFAULT
+/// ''` shape.
+async fn reconcile_column_rename(db: &SqlitePool, table: &str, legacy: &str, new: &str) {
+    reconcile_column_rename_typed(db, table, legacy, new, "TEXT NOT NULL DEFAULT ''", "= ''").await
 }
 
 /// Run all database migrations.
@@ -533,31 +557,25 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
-    // Three-DB-states rename for `force_tmdb_fallback` → `force_kitsu_fallback`:
-    //
-    //   1. Fresh install — neither column exists. The ADD succeeds and creates
-    //      `force_tmdb_fallback`; the subsequent RENAME moves it to the new name.
-    //      End state: `force_kitsu_fallback` exists.
-    //   2. Legacy install — only `force_tmdb_fallback` exists. The ADD is a no-op
-    //      (`.ok()` swallows "duplicate column name"); the RENAME moves it to the
-    //      new name. End state: `force_kitsu_fallback` exists.
-    //   3. Post-migration install — only `force_kitsu_fallback` exists. The ADD
-    //      *creates* `force_tmdb_fallback` as a vestigial column because SQLite has
-    //      no IF NOT EXISTS check on column name alone; the RENAME then fails
-    //      because the target name is already taken (swallowed by `.ok()`). End
-    //      state: `force_kitsu_fallback` still exists, but so does a stray
-    //      `force_tmdb_fallback` column. This is harmless — nothing reads it — but
-    //      it's a cosmetic wart. If you're cleaning up, an `IF NOT EXISTS` guarded
-    //      by a `PRAGMA table_info` check would fix it.
-    sqlx::query("ALTER TABLE config ADD COLUMN force_tmdb_fallback INTEGER NOT NULL DEFAULT 0")
-        .execute(db)
-        .await
-        .ok();
-
-    sqlx::query("ALTER TABLE config RENAME COLUMN force_tmdb_fallback TO force_kitsu_fallback")
-        .execute(db)
-        .await
-        .ok();
+    // Rename `force_tmdb_fallback` → `force_kitsu_fallback` via the
+    // four-state reconciler. The pre-fix path was the same ADD-then-
+    // RENAME-with-.ok() pattern that the file_name + restrict_to_*
+    // renames moved away from: on a post-migrated install the ADD
+    // re-created the legacy column as a vestigial INTEGER alongside
+    // the new one (RENAME silently failed against the existing
+    // target), leaving a stray column nothing read. The typed
+    // reconciler dispatches on the (legacy, new) presence matrix so
+    // each starting state moves to the correct end state without
+    // creating ghost columns.
+    reconcile_column_rename_typed(
+        db,
+        "config",
+        "force_tmdb_fallback",
+        "force_kitsu_fallback",
+        "INTEGER NOT NULL DEFAULT 0",
+        "= 0",
+    )
+    .await;
 
     sqlx::query("ALTER TABLE config ADD COLUMN plex_mappings_enabled INTEGER NOT NULL DEFAULT 0")
         .execute(db)

--- a/src/models/migrations/tests.rs
+++ b/src/models/migrations/tests.rs
@@ -537,3 +537,145 @@ async fn migrate_creates_schema_migrations_table() {
         "schema_migrations table should exist after seed pass"
     );
 }
+
+/// Stronger companion to `migrate_is_idempotent_on_second_invocation`
+/// — that test only proves the second call doesn't *error*. This one
+/// proves it doesn't silently *mutate* user-set values that the
+/// initial migration backfilled.
+///
+/// The Jellyfin URL backfill is the load-bearing case: it derives
+/// `jellyfin_url` from the legacy `jellyfin_host`/`jellyfin_port`/
+/// `jellyfin_use_ssl` columns when `jellyfin_url` is empty. Without
+/// the `WHERE jellyfin_url = ''` gate, a second migration call after
+/// the user customized the derived URL would clobber it back to the
+/// host-derived form. The gate is the actual idempotency guarantee
+/// for every other UPDATE-style backfill in `migrate()`; this test
+/// pins it for the most user-impactful one.
+#[tokio::test]
+async fn migrate_does_not_overwrite_user_values_on_second_invocation() {
+    let db = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite");
+    migrate(&db).await.expect("first migrate");
+
+    // migrate() doesn't seed the config row (`save_config` does that
+    // on first settings-page write). Seed a minimal row directly so
+    // the test exercises the user-customized-URL → second-migrate
+    // path. Only the four jellyfin_* columns the backfill cares
+    // about need real values.
+    sqlx::query(
+        "INSERT INTO config (id, jellyfin_url, jellyfin_host, jellyfin_port, jellyfin_use_ssl) \
+         VALUES (1, 'https://my.real.jellyfin.example/jf', 'derived.example', '8096', 0)",
+    )
+    .execute(&db)
+    .await
+    .expect("seed config row with user-customized jellyfin_url");
+
+    migrate(&db).await.expect("second migrate must succeed");
+
+    let url: String = sqlx::query_scalar("SELECT jellyfin_url FROM config WHERE id = 1")
+        .fetch_one(&db)
+        .await
+        .expect("read jellyfin_url back");
+    assert_eq!(
+        url, "https://my.real.jellyfin.example/jf",
+        "second migrate must not overwrite the user's custom jellyfin_url"
+    );
+}
+
+/// Pin behavior of the typed-rename helper for the
+/// `force_tmdb_fallback` → `force_kitsu_fallback` recovery path.
+/// PR #37's regression shape (ADD-then-RENAME with `.ok()`) used to
+/// leave a stray INTEGER column alongside the new one on a post-
+/// migrated install, with the user's enable/disable bit stranded in
+/// either column depending on which migrate() build ran first.
+/// `reconcile_column_rename_typed` collapses every starting state to
+/// "new column exists, value preserved, legacy column dropped".
+#[tokio::test]
+async fn reconcile_typed_rename_recovers_half_migrated_integer_column() {
+    let db = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite");
+
+    // Simulate the half-migrated state: BOTH columns present, user's
+    // bit in the legacy one, new one still at the default 0.
+    sqlx::query(
+        r#"CREATE TABLE config (
+            id INTEGER PRIMARY KEY CHECK (id = 1),
+            force_tmdb_fallback   INTEGER NOT NULL DEFAULT 0,
+            force_kitsu_fallback  INTEGER NOT NULL DEFAULT 0
+        )"#,
+    )
+    .execute(&db)
+    .await
+    .expect("create legacy config");
+    sqlx::query(
+        "INSERT INTO config (id, force_tmdb_fallback, force_kitsu_fallback) VALUES (1, 1, 0)",
+    )
+    .execute(&db)
+    .await
+    .expect("seed legacy bit");
+
+    reconcile_column_rename_typed(
+        &db,
+        "config",
+        "force_tmdb_fallback",
+        "force_kitsu_fallback",
+        "INTEGER NOT NULL DEFAULT 0",
+        "= 0",
+    )
+    .await;
+
+    let kitsu: i64 = sqlx::query_scalar("SELECT force_kitsu_fallback FROM config WHERE id = 1")
+        .fetch_one(&db)
+        .await
+        .expect("read new column");
+    assert_eq!(
+        kitsu, 1,
+        "user's enable bit must move from legacy → new column"
+    );
+    assert!(
+        !column_exists(&db, "config", "force_tmdb_fallback").await,
+        "legacy column must be dropped, not duplicated"
+    );
+}
+
+/// The fresh-install path: neither column exists yet, the typed
+/// helper must add the new one with the caller-supplied INTEGER
+/// declaration (not the TEXT default the string-flavored helper
+/// uses).
+#[tokio::test]
+async fn reconcile_typed_rename_adds_integer_column_on_fresh_install() {
+    let db = SqlitePool::connect("sqlite::memory:")
+        .await
+        .expect("in-memory sqlite");
+    sqlx::query("CREATE TABLE config (id INTEGER PRIMARY KEY CHECK (id = 1))")
+        .execute(&db)
+        .await
+        .expect("create empty config");
+    sqlx::query("INSERT INTO config (id) VALUES (1)")
+        .execute(&db)
+        .await
+        .expect("seed config row");
+
+    reconcile_column_rename_typed(
+        &db,
+        "config",
+        "force_tmdb_fallback",
+        "force_kitsu_fallback",
+        "INTEGER NOT NULL DEFAULT 0",
+        "= 0",
+    )
+    .await;
+
+    assert!(column_exists(&db, "config", "force_kitsu_fallback").await);
+    let kitsu: i64 = sqlx::query_scalar("SELECT force_kitsu_fallback FROM config WHERE id = 1")
+        .fetch_one(&db)
+        .await
+        .expect("read new column");
+    assert_eq!(kitsu, 0, "fresh-install default must be the integer 0");
+    assert!(
+        !column_exists(&db, "config", "force_tmdb_fallback").await,
+        "fresh-install path must not create the legacy column",
+    );
+}

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -167,6 +167,34 @@ pub async fn get_by_anilist_id(
     Ok(row.map(map_series_row))
 }
 
+/// Batch lookup keyed by AniList id. Returns a map of `anilist_id ->
+/// Series` for the rows that exist; ids with no row are absent. Used
+/// by the Sonarr/Radarr search-result fan-outs so a 10-result AL page
+/// turns into one DB round-trip instead of N. Empty input returns an
+/// empty map without hitting the DB.
+pub async fn get_by_anilist_ids(
+    db: &SqlitePool,
+    anilist_ids: &[i64],
+) -> Result<std::collections::HashMap<i64, Series>, sqlx::Error> {
+    if anilist_ids.is_empty() {
+        return Ok(std::collections::HashMap::new());
+    }
+    let placeholders = vec!["?"; anilist_ids.len()].join(",");
+    let sql = format!(
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id IN ({placeholders})"
+    );
+    let mut q = sqlx::query(&sql);
+    for id in anilist_ids {
+        q = q.bind(id);
+    }
+    let rows = q.fetch_all(db).await?;
+    Ok(rows
+        .into_iter()
+        .map(map_series_row)
+        .map(|s| (s.anilist_id, s))
+        .collect())
+}
+
 pub async fn get_by_mal_id(db: &SqlitePool, mal_id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
         "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id = ?",

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -654,19 +654,27 @@ pub async fn search_anime_with_options(
 
     let entries: Vec<AnimeEntry> = media
         .iter()
-        .map(|m| AnimeEntry {
-            id: m["id"].as_i64().unwrap_or(0),
-            id_mal: m["idMal"].as_i64(),
-            title_romaji: m["title"]["romaji"].as_str().unwrap_or("").to_string(),
-            title_english: m["title"]["english"].as_str().unwrap_or("").to_string(),
-            title_native: m["title"]["native"].as_str().unwrap_or("").to_string(),
-            cover_url: m["coverImage"]["large"].as_str().unwrap_or("").to_string(),
-            format: m["format"].as_str().unwrap_or("").to_string(),
-            status: m["status"].as_str().unwrap_or("").to_string(),
-            status_display: prettify_status(m["status"].as_str().unwrap_or("")),
-            episodes: m["episodes"].as_i64().filter(|&n| n > 0).map(|e| e as i32),
-            season_year: m["seasonYear"].as_i64().map(|y| y as i32),
-            source: "anilist".to_string(),
+        .filter_map(|m| {
+            // Drop entries with a missing/non-numeric id rather than
+            // collapsing them to 0. A 0-id record would slip past the
+            // `id > 0` filters elsewhere only by virtue of being equal
+            // to 0 (which is filtered out), but it can still leak into
+            // SEARCH_CACHE for SEARCH_CACHE_TTL and confuse the UI.
+            let id = m["id"].as_i64().filter(|&n| n > 0)?;
+            Some(AnimeEntry {
+                id,
+                id_mal: m["idMal"].as_i64(),
+                title_romaji: m["title"]["romaji"].as_str().unwrap_or("").to_string(),
+                title_english: m["title"]["english"].as_str().unwrap_or("").to_string(),
+                title_native: m["title"]["native"].as_str().unwrap_or("").to_string(),
+                cover_url: m["coverImage"]["large"].as_str().unwrap_or("").to_string(),
+                format: m["format"].as_str().unwrap_or("").to_string(),
+                status: m["status"].as_str().unwrap_or("").to_string(),
+                status_display: prettify_status(m["status"].as_str().unwrap_or("")),
+                episodes: m["episodes"].as_i64().filter(|&n| n > 0).map(|e| e as i32),
+                season_year: m["seasonYear"].as_i64().map(|y| y as i32),
+                source: "anilist".to_string(),
+            })
         })
         .collect();
 
@@ -1121,14 +1129,17 @@ async fn fetch_media_detail(selector: MediaSelector) -> Result<Option<AnimeDetai
         return Ok(None);
     }
 
-    Ok(Some(parse_media_node(m)))
+    Ok(parse_media_node(m))
 }
 
 /// Convert a single Media node from the AniList GraphQL response into
 /// `AnimeDetail`. Used by both the single-id `fetch_media_detail` path
 /// and the batched `get_anime_details_batch` path so the field plucking
-/// logic only lives in one place.
-fn parse_media_node(m: &serde_json::Value) -> AnimeDetail {
+/// logic only lives in one place. Returns `None` when the `id` field is
+/// missing or non-numeric — every downstream consumer requires `id > 0`,
+/// so a 0-id placeholder would just leak into caches and confuse later
+/// `id > 0` filters into thinking the entry is a Jikan-fallback row.
+fn parse_media_node(m: &serde_json::Value) -> Option<AnimeDetail> {
     let streaming_episodes = m["streamingEpisodes"]
         .as_array()
         .map(|arr| {
@@ -1175,8 +1186,9 @@ fn parse_media_node(m: &serde_json::Value) -> AnimeDetail {
         })
         .unwrap_or_default();
 
-    AnimeDetail {
-        id: m["id"].as_i64().unwrap_or(0),
+    let id = m["id"].as_i64().filter(|&n| n > 0)?;
+    Some(AnimeDetail {
+        id,
         id_mal: m["idMal"].as_i64(),
         title_romaji: m["title"]["romaji"].as_str().unwrap_or("").to_string(),
         title_english: m["title"]["english"].as_str().unwrap_or("").to_string(),
@@ -1220,7 +1232,7 @@ fn parse_media_node(m: &serde_json::Value) -> AnimeDetail {
             .unwrap_or_default(),
         streaming_episodes,
         relations,
-    }
+    })
 }
 
 /// Look up an anime by MAL id and return the full `AnimeDetail` payload
@@ -1417,17 +1429,17 @@ pub async fn get_anime_details_batch(ids: &[i64]) -> Result<HashMap<i64, AnimeDe
             // `get_anime_detail` calls for these ids hit the cache.
             let mut cache = DETAIL_CACHE.write().await;
             for node in media {
-                let detail = parse_media_node(node);
-                if detail.id > 0 {
-                    cache.insert(
-                        detail.id,
-                        CacheEntry {
-                            detail: detail.clone(),
-                            fetched_at: Instant::now(),
-                        },
-                    );
-                    out.insert(detail.id, detail);
-                }
+                let Some(detail) = parse_media_node(node) else {
+                    continue;
+                };
+                cache.insert(
+                    detail.id,
+                    CacheEntry {
+                        detail: detail.clone(),
+                        fetched_at: Instant::now(),
+                    },
+                );
+                out.insert(detail.id, detail);
             }
             // Light eviction — same shape as the single-id path so a
             // big batch can't unbounded-grow the cache. Drop expired

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -15,7 +15,9 @@ use rate_limit::{
     excerpt, extract_graphql_error, record_rate_limit_headers, set_anilist_cooldown,
     set_cooldown_until_now_plus, throttle_before_anilist_request,
 };
-pub use rate_limit::{anilist_cooldown_active, is_rate_limit_error};
+pub use rate_limit::{
+    anilist_cooldown_active, is_rate_limit_error, note_external_anilist_response,
+};
 
 const ANILIST_API_DEFAULT: &str = "https://graphql.anilist.co";
 

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -137,6 +137,14 @@ pub struct AnimeEntry {
     pub episodes: Option<i32>,
     pub season_year: Option<i32>,
     pub source: String,
+    /// Average viewer score on the provider's native scale: AL is
+    /// 0-100, Jikan ingest multiplies by 10 to match. `None` for
+    /// entries with no community score yet (unaired / recently
+    /// added). Used by the Sonarr/Radarr shims to populate the
+    /// `ratings` field — Sonarr expects a 0-10 float, so the
+    /// downstream conversion divides by 10.
+    #[serde(default)]
+    pub average_score: Option<i32>,
 }
 
 /// One entry from a user's AniList watch list, projected to the
@@ -519,6 +527,8 @@ pub async fn search_anime_with_options(
                         format
                         status
                         episodes
+                        seasonYear
+                        averageScore
                     }
                 }
             }
@@ -676,6 +686,10 @@ pub async fn search_anime_with_options(
                 episodes: m["episodes"].as_i64().filter(|&n| n > 0).map(|e| e as i32),
                 season_year: m["seasonYear"].as_i64().map(|y| y as i32),
                 source: "anilist".to_string(),
+                average_score: m["averageScore"]
+                    .as_i64()
+                    .filter(|&n| n > 0)
+                    .map(|s| s as i32),
             })
         })
         .collect();
@@ -1574,6 +1588,7 @@ mod tests {
             episodes: Some(12),
             season_year: Some(2020),
             source: "anilist".into(),
+            average_score: Some(85),
         }];
         search_cache_put(key.clone(), entries.clone());
         let got = search_cache_get(&key).expect("cached value should be present");

--- a/src/services/anilist/rate_limit.rs
+++ b/src/services/anilist/rate_limit.rs
@@ -369,6 +369,25 @@ pub(super) fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: D
     set_cooldown_until_now_plus(dur);
 }
 
+/// Apply the AL rate-limit policy to a response from any AL endpoint
+/// reachable outside the `services::anilist` module. 429 / 5xx flips
+/// the process-wide cooldown so subsequent AL calls (metadata sync,
+/// library page render, scoring path) back off; 2xx is a no-op.
+///
+/// Exists so the link-flow viewer fetch in `handlers::oauth` can
+/// participate in the same throttle state as the in-module callers
+/// without exposing the internal `(super)` primitives. Mirrors the
+/// 429/5xx branch in `fetch_media_list_collection`.
+pub fn note_external_anilist_response(
+    status: reqwest::StatusCode,
+    headers: &reqwest::header::HeaderMap,
+) {
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        let dur = cooldown_from_headers(headers, ANILIST_COOLDOWN_DEFAULT);
+        set_cooldown_until_now_plus(dur);
+    }
+}
+
 /// Set the cooldown-until marker to `now + dur`. Used by `mod.rs` call sites
 /// that have already computed a duration via `cooldown_from_headers` — they
 /// don't need the `compute_cooldown_duration` step.

--- a/src/services/anilist/rate_limit.rs
+++ b/src/services/anilist/rate_limit.rs
@@ -370,18 +370,23 @@ pub(super) fn set_anilist_cooldown(retry_after_secs: Option<u64>, default_dur: D
 }
 
 /// Apply the AL rate-limit policy to a response from any AL endpoint
-/// reachable outside the `services::anilist` module. 429 / 5xx flips
-/// the process-wide cooldown so subsequent AL calls (metadata sync,
-/// library page render, scoring path) back off; 2xx is a no-op.
+/// reachable outside the `services::anilist` module. Records the
+/// `X-RateLimit-*` headroom counters on every response (so the next
+/// in-module AL call sees a fresh-from-AL view of the window), and
+/// flips the process-wide cooldown on 429 / 5xx so subsequent AL
+/// calls (metadata sync, library page render, scoring path) back
+/// off.
 ///
 /// Exists so the link-flow viewer fetch in `handlers::oauth` can
-/// participate in the same throttle state as the in-module callers
-/// without exposing the internal `(super)` primitives. Mirrors the
-/// 429/5xx branch in `fetch_media_list_collection`.
+/// fully participate in the same throttle state as the in-module
+/// callers without exposing the internal `(super)` primitives.
+/// Mirrors the per-response `record_rate_limit_headers` call plus
+/// the 429/5xx branch in `fetch_media_list_collection`.
 pub fn note_external_anilist_response(
     status: reqwest::StatusCode,
     headers: &reqwest::header::HeaderMap,
 ) {
+    record_rate_limit_headers(headers);
     if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
         let dur = cooldown_from_headers(headers, ANILIST_COOLDOWN_DEFAULT);
         set_cooldown_until_now_plus(dur);

--- a/src/services/auto_search/release_parse.rs
+++ b/src/services/auto_search/release_parse.rs
@@ -70,7 +70,18 @@ static RE_RELEASE_ROMAN: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\b(ii{1,2}|iv|vi{1,3}|ix)\b(?:\s*[:\-\s\.\]\)\,]|$)").unwrap());
 
 fn is_noise_number(n: i32) -> bool {
-    matches!(n, 480 | 576 | 720 | 1080 | 2160 | 264 | 265) || (1900..=2100).contains(&n)
+    // Year range only. Resolution values (480/576/720/1080/2160) and
+    // codec markers (264/265) used to live here as belt-and-suspenders
+    // protection, but `parse_release_numbers` already strips bracketed
+    // and parenthesized content (where every well-formed release puts
+    // its resolution / codec tags) before running these regexes — so
+    // an unbracketed `1080` *can* only be a real episode number, e.g.
+    // One Piece 1080. Filtering it out as "noise" was silently making
+    // those specific episodes ungrabbable for long-running shows. The
+    // 1900..=2100 year range stays because release titles legitimately
+    // carry an unbracketed year token (`Show 2024 BD`) that the dash-
+    // number regex would otherwise capture as an episode.
+    (1900..=2100).contains(&n)
 }
 
 pub fn parse_release_numbers(title: &str) -> HashSet<i32> {
@@ -1118,5 +1129,48 @@ mod tests {
         ));
         // Part N match.
         assert!(!season_mismatch("[Group] Show Part 3 - 01.mkv", 3));
+    }
+
+    #[test]
+    fn parse_release_numbers_picks_up_long_running_episode_1080() {
+        // Bracket-stripping removes [1080p]; the dash-number regex then
+        // captures the unbracketed `1080` as a real episode (One Piece
+        // E1080). Previously the noise-number filter rejected this
+        // value as "must be a resolution," silently making the One
+        // Piece 1080 episode (and 480/576/720/2160) ungrabbable.
+        let parsed = parse_release_numbers("[SubsPlease] One Piece - 1080 (1080p) [ABCD1234].mkv");
+        assert!(
+            parsed.contains(&1080),
+            "expected episode 1080 in {:?}",
+            parsed
+        );
+    }
+
+    #[test]
+    fn parse_release_numbers_picks_up_long_running_episode_720() {
+        let parsed = parse_release_numbers("[SubsPlease] One Piece - 720 (720p) [ABCD1234].mkv");
+        assert!(
+            parsed.contains(&720),
+            "expected episode 720 in {:?}",
+            parsed
+        );
+    }
+
+    #[test]
+    fn parse_release_numbers_still_rejects_year_token() {
+        // The 1900..=2100 year guard stays — without it, a release
+        // titled `Show 2024 BD 1080p` would slip the unbracketed `2024`
+        // through as an absolute episode number.
+        let parsed = parse_release_numbers("[Group] Show 2024 BD - 12 (1080p).mkv");
+        assert!(
+            !parsed.contains(&2024),
+            "year token must not be parsed as episode in {:?}",
+            parsed
+        );
+        assert!(
+            parsed.contains(&12),
+            "real episode 12 should still parse in {:?}",
+            parsed
+        );
     }
 }

--- a/src/services/auto_search/scoring.rs
+++ b/src/services/auto_search/scoring.rs
@@ -311,12 +311,21 @@ pub(super) fn rescore_for_auto_search_with_breakdown(
         }
         SearchTarget::Episode(ep) => {
             if result.is_batch {
-                add(
-                    &mut parts,
-                    "Batch Penalty (episode target)",
-                    -20,
-                    Some("single-episode grab preferred".to_string()),
-                );
+                if !batch_search_mode {
+                    // Same gate the SearchTarget::Single arm uses: the
+                    // user explicitly asked for batches when batch_search_mode
+                    // is on, so penalizing every candidate -20 for being a
+                    // batch is uniform across the slate (doesn't change
+                    // ranking) but produces a confusing "Batch Penalty
+                    // (episode target): single-episode grab preferred"
+                    // line on every row in the breakdown. Suppress.
+                    add(
+                        &mut parts,
+                        "Batch Penalty (episode target)",
+                        -20,
+                        Some("single-episode grab preferred".to_string()),
+                    );
+                }
             } else {
                 add(&mut parts, "Single-Episode Target", 10, None);
             }

--- a/src/services/custom_formats/evaluator.rs
+++ b/src/services/custom_formats/evaluator.rs
@@ -139,6 +139,58 @@ pub(super) fn total_cf_score(cfs: &[CompiledCustomFormat], ctx: &EvalContext) ->
         .fold(0i32, i32::saturating_add)
 }
 
+/// Variant of [`total_cf_score`] for callers that have the candidate's
+/// fields directly rather than a full [`SearchResult`]. Internally
+/// builds a minimal `SearchResult` shim — only `title`, `group`,
+/// `size_bytes`, and `info_hash` are read by any spec kernel (see
+/// [`evaluate_spec_kernel`]); the rest are filled with defaults.
+///
+/// Currently used by the RSS sync path, which carries `RssItem` (a
+/// strict subset of `SearchResult`'s fields) and would otherwise
+/// have no way into the CF evaluator. Without this helper RSS
+/// auto-grab silently bypasses every CF the user has configured —
+/// only the auto-search and upgrade-search paths would respect them.
+pub fn total_cf_score_for_release(
+    cfs: &[CompiledCustomFormat],
+    classification: &super::ClassificationResult,
+    title: &str,
+    group: &str,
+    size_bytes: i64,
+    info_hash: &str,
+    seadex_hashes: &std::collections::HashSet<String>,
+) -> i32 {
+    let result = super::SearchResult {
+        title: title.to_string(),
+        group: group.to_string(),
+        size_bytes,
+        info_hash: info_hash.to_string(),
+        link: String::new(),
+        magnet: String::new(),
+        torrent: String::new(),
+        size: String::new(),
+        seeders: 0,
+        leechers: 0,
+        downloads: 0,
+        resolution: String::new(),
+        quality_label: String::new(),
+        source: String::new(),
+        web_kind: String::new(),
+        is_remux: false,
+        is_bdmv: false,
+        is_batch: false,
+        is_trusted: false,
+        score: 0,
+        score_breakdown: Vec::new(),
+        upload_date: String::new(),
+    };
+    let ctx = EvalContext {
+        result: &result,
+        classification,
+        seadex_hashes,
+    };
+    total_cf_score(cfs, &ctx)
+}
+
 /// Same total as [`total_cf_score`], but also returns the per-CF
 /// breakdown of every matching CF with a non-zero score contribution,
 /// in `custom_formats.id` order (the natural iteration order of the

--- a/src/services/custom_formats/mod.rs
+++ b/src/services/custom_formats/mod.rs
@@ -37,7 +37,7 @@ use super::source::{ClassificationResult, Resolution, Source, WebKind};
 mod evaluator;
 mod parser;
 
-pub use evaluator::{evaluate, total_cf_score_with_breakdown};
+pub use evaluator::{evaluate, total_cf_score_for_release, total_cf_score_with_breakdown};
 pub use parser::compile_from_json;
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/services/download_client/rtorrent/xmlrpc.rs
+++ b/src/services/download_client/rtorrent/xmlrpc.rs
@@ -196,7 +196,26 @@ pub(super) fn xml_text_unescape(s: &str) -> String {
         .replace("&amp;", "&")
 }
 
+/// Maximum nesting depth `decode_value` will recurse into before
+/// erroring out. rtorrent's real responses nest at most 2-3 levels
+/// (`d.multicall2` returns an array of arrays of primitives); 256
+/// is hundreds of times more than any legitimate response shape and
+/// well below the default cargo-test thread stack budget. Without
+/// this gate, a malicious proxy or buggy plugin sitting between
+/// Ryokan and rtorrent could send a deeply nested `<array>` tower
+/// and panic-abort the post-processing task on stack overflow.
+pub(super) const MAX_NESTING_DEPTH: usize = 256;
+
 pub(super) fn decode_value(p: &mut Parser) -> Result<XmlValue, String> {
+    decode_value_with_depth(p, 0)
+}
+
+fn decode_value_with_depth(p: &mut Parser, depth: usize) -> Result<XmlValue, String> {
+    if depth > MAX_NESTING_DEPTH {
+        return Err(format!(
+            "XML-RPC value nesting exceeds limit of {MAX_NESTING_DEPTH}"
+        ));
+    }
     p.expect_open("value")?;
     // Implicit string: `<value>bare text</value>` is legal per XML-RPC
     // spec. rtorrent sometimes emits this for empty strings.
@@ -236,7 +255,7 @@ pub(super) fn decode_value(p: &mut Parser) -> Result<XmlValue, String> {
             p.expect_open("data")?;
             let mut items = Vec::new();
             while p.peek_open() == Some("value") {
-                items.push(decode_value(p)?);
+                items.push(decode_value_with_depth(p, depth + 1)?);
             }
             p.expect_close("data")?;
             p.expect_close("array")?;
@@ -364,5 +383,392 @@ impl<'a> Parser<'a> {
             .ok_or_else(|| format!("XML parse: no {close} found"))?;
         self.pos += idx + close.len();
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! XML-RPC codec coverage. The decoder runs against rtorrent's
+    //! real responses (with the wiremock harness in
+    //! `wiremock_tests/`), but those are fixture-based and don't pin
+    //! the codec's individual parse branches. These tests do.
+    //!
+    //! The malformed-input battery at the bottom is fuzz-lite: a
+    //! curated corpus of inputs the parser must reject as `Err`
+    //! rather than panic. A future cargo-fuzz target for
+    //! `decode_response` would seed from this corpus.
+    use super::*;
+    use rstest::rstest;
+    // ── XML escape / unescape ─────────────────────────────────────────
+    //
+    // The escape and unescape paths must round-trip every legal XML
+    // entity in both text and attribute contexts. A regression here
+    // silently corrupts torrent paths containing `&` (every magnet
+    // URI carries one in `dn=…&tr=…`).
+
+    #[test]
+    fn xml_text_escape_handles_three_xml_text_entities() {
+        // `xml_text_escape` only escapes the three characters that
+        // are unsafe in an XML text node (`&`, `<`, `>`); single and
+        // double quotes are LEGAL in text nodes and pass through.
+        // The unescape path still strips `&apos;`/`&quot;` for
+        // round-trip safety with sources that emit them.
+        assert_eq!(xml_text_escape("a&b<c>d"), "a&amp;b&lt;c&gt;d");
+        // Quotes pass through.
+        assert_eq!(xml_text_escape(r#"'"#), "'");
+        assert_eq!(xml_text_escape(r#"""#), "\"");
+    }
+
+    #[test]
+    fn xml_text_escape_leaves_safe_chars_alone() {
+        // ASCII printables, whitespace, and a high-codepoint character
+        // — none of these need escaping for an XML text node.
+        let s = "Show: 12 — résumé 漢字";
+        assert_eq!(xml_text_escape(s), s);
+    }
+
+    #[test]
+    fn xml_attr_escape_is_backslash_quote_escape() {
+        // Despite the name, this isn't an XML attribute escape —
+        // rtorrent's cmd parser re-parses the value out of a
+        // double-quoted command-string param, so we backslash-escape
+        // `"` and `\` per rtorrent's own convention. Pin the actual
+        // contract so a future "let's make this an XML escape"
+        // refactor has to update the test (and the rtorrent-side
+        // command parser, which would then break).
+        assert_eq!(xml_attr_escape(r#"a"b\c"#), r#"a\"b\\c"#);
+        // Other characters pass through, including `<` / `>` / `&`
+        // (the param string isn't an XML attr — those are fine here).
+        assert_eq!(xml_attr_escape("a<b>c&d"), "a<b>c&d");
+    }
+
+    #[test]
+    fn unescape_inverts_escape_on_text() {
+        // Round-trip the three xml_text_escape entities. The unescape
+        // also handles `&apos;` and `&quot;` (incoming wire form), but
+        // the escape path doesn't emit them — so the round-trip target
+        // is whatever survives `text_escape → text_unescape`.
+        let original = "a&b<c>d";
+        let escaped = xml_text_escape(original);
+        assert_eq!(xml_text_unescape(&escaped), original);
+    }
+
+    // ── Decode primitives ─────────────────────────────────────────────
+
+    fn wrap_methodresponse(value_xml: &str) -> String {
+        format!(
+            "<?xml version=\"1.0\"?><methodResponse><params><param>{value_xml}</param></params></methodResponse>"
+        )
+    }
+
+    #[test]
+    fn decode_string_value() {
+        let xml = wrap_methodresponse("<value><string>hello</string></value>");
+        match decode_response(&xml).unwrap() {
+            XmlValue::String(s) => assert_eq!(s, "hello"),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_string_unescapes_entities() {
+        // The on-the-wire form of `Show & Tell <2024>` carries entities;
+        // the decoded value must be the original.
+        let xml =
+            wrap_methodresponse("<value><string>Show &amp; Tell &lt;2024&gt;</string></value>");
+        match decode_response(&xml).unwrap() {
+            XmlValue::String(s) => assert_eq!(s, "Show & Tell <2024>"),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_implicit_string_without_explicit_type_tag() {
+        // `<value>bare text</value>` is legal per the XML-RPC spec and
+        // rtorrent emits it for empty / short strings. The decoder
+        // promotes the raw text into an `XmlValue::String`.
+        let xml = wrap_methodresponse("<value>bare</value>");
+        match decode_response(&xml).unwrap() {
+            XmlValue::String(s) => assert_eq!(s, "bare"),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case("<i4>42</i4>", 42)]
+    #[case("<int>42</int>", 42)]
+    #[case("<i8>9223372036854775807</i8>", i64::MAX)]
+    #[case("<i4>-1</i4>", -1)]
+    #[case("<i4>  17  </i4>", 17)] // trim whitespace per spec
+    fn decode_integer_variants(#[case] inner: &str, #[case] expected: i64) {
+        // i4 / int / i8 should all decode to XmlValue::Int. rtorrent's
+        // responses mix all three (i8 for sizes/rates, i4 for state
+        // codes) so dropping any of these would break list_scoped.
+        let xml = wrap_methodresponse(&format!("<value>{inner}</value>"));
+        match decode_response(&xml).unwrap() {
+            XmlValue::Int(i) => assert_eq!(i, expected),
+            other => panic!("expected Int, got {other:?}"),
+        }
+    }
+
+    #[rstest]
+    #[case("0", false)]
+    #[case("1", true)]
+    fn decode_boolean_canonical(#[case] inner: &str, #[case] expected: bool) {
+        let xml = wrap_methodresponse(&format!("<value><boolean>{inner}</boolean></value>"));
+        match decode_response(&xml).unwrap() {
+            XmlValue::Bool(b) => assert_eq!(b, expected),
+            other => panic!("expected Bool, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_boolean_treats_anything_nonzero_as_true() {
+        // Defensive parser: any non-`0` character flips the bool. This
+        // is more lenient than the spec but matches rtorrent's actual
+        // emissions which sometimes leak literal `true`/`false`.
+        let xml = wrap_methodresponse("<value><boolean>true</boolean></value>");
+        match decode_response(&xml).unwrap() {
+            XmlValue::Bool(true) => {}
+            other => panic!("expected Bool(true), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_empty_array() {
+        let xml = wrap_methodresponse("<value><array><data></data></array></value>");
+        match decode_response(&xml).unwrap() {
+            XmlValue::Array(items) => assert!(items.is_empty()),
+            other => panic!("expected empty Array, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_array_of_mixed_values() {
+        // rtorrent's d.multicall2 returns arrays-of-arrays-of-mixed.
+        // Mixed primitives is the cheapest pinnable shape.
+        let xml = wrap_methodresponse(
+            "<value><array><data>\
+             <value><string>abc</string></value>\
+             <value><i8>42</i8></value>\
+             <value><boolean>1</boolean></value>\
+             </data></array></value>",
+        );
+        let v = decode_response(&xml).unwrap();
+        let items = v.into_array().expect("Array");
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].as_string(), Some("abc"));
+        assert_eq!(items[1].as_int(), Some(42));
+        // Bool's accessor isn't exposed; pattern-match.
+        match &items[2] {
+            XmlValue::Bool(true) => {}
+            other => panic!("expected Bool(true), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn decode_nested_arrays() {
+        // d.multicall2 nests one level deep. Keep the test shallow on
+        // purpose — the recursive parser handles unbounded depth via
+        // the regular Rust call stack, so deep nesting is a separate
+        // concern (covered by the malformed-input battery below).
+        let xml = wrap_methodresponse(
+            "<value><array><data>\
+             <value><array><data>\
+             <value><i4>1</i4></value>\
+             <value><i4>2</i4></value>\
+             </data></array></value>\
+             </data></array></value>",
+        );
+        let outer = decode_response(&xml).unwrap().into_array().unwrap();
+        assert_eq!(outer.len(), 1);
+        let inner = outer.into_iter().next().unwrap().into_array().unwrap();
+        assert_eq!(inner.len(), 2);
+        assert_eq!(inner[0].as_int(), Some(1));
+        assert_eq!(inner[1].as_int(), Some(2));
+    }
+
+    #[test]
+    fn decode_struct_collapses_to_empty_string() {
+        // The decoder doesn't care about struct shapes anywhere except
+        // inside fault responses, which take the fault_message
+        // shortcut. Plain struct values flatten to empty string —
+        // documented contract; pin it so a future "let's actually
+        // parse structs" change has to update this test.
+        let xml = wrap_methodresponse(
+            "<value><struct>\
+             <member><name>a</name><value><string>x</string></value></member>\
+             </struct></value>",
+        );
+        match decode_response(&xml).unwrap() {
+            XmlValue::String(s) => assert_eq!(s, ""),
+            other => panic!("expected empty String for struct, got {other:?}"),
+        }
+    }
+
+    // ── Fault handling ────────────────────────────────────────────────
+
+    #[test]
+    fn decode_fault_returns_err_with_message() {
+        // rtorrent's fault responses are the canonical path for "this
+        // method doesn't exist" / "session not connected" / etc. The
+        // caller matches on the Err string to discriminate — a regression
+        // that flipped Err → Ok would be silent until something downstream
+        // tried to use the bogus value.
+        let xml = r#"<?xml version="1.0"?><methodResponse><fault><value><struct>
+            <member><name>faultCode</name><value><i4>-503</i4></value></member>
+            <member><name>faultString</name><value><string>method not found</string></value></member>
+        </struct></value></fault></methodResponse>"#;
+        let err = decode_response(xml).unwrap_err();
+        assert!(err.contains("rtorrent fault"), "got {err}");
+        assert!(err.contains("method not found"), "got {err}");
+    }
+
+    #[test]
+    fn fault_message_unescapes_entities_in_message() {
+        // Real rtorrent fault strings sometimes carry the offending
+        // method name with embedded `<` / `>` (debug rendering of
+        // un-resolved typed targets). The unescape must run.
+        let xml = r#"<?xml version="1.0"?><methodResponse><fault><value><struct>
+            <member><name>faultCode</name><value><i4>-503</i4></value></member>
+            <member><name>faultString</name><value><string>bad &lt;target&gt;</string></value></member>
+        </struct></value></fault></methodResponse>"#;
+        assert_eq!(fault_message(xml), Some("bad <target>".to_string()));
+    }
+
+    #[test]
+    fn fault_message_returns_none_when_absent() {
+        // Defensive — if the fault struct doesn't carry a faultString
+        // member at all, the function returns None and the caller
+        // falls back to "(no fault message)".
+        let xml = "<?xml version=\"1.0\"?><methodResponse><params><param><value><i4>0</i4></value></param></params></methodResponse>";
+        assert!(fault_message(xml).is_none());
+    }
+
+    // ── Encode round-trips ────────────────────────────────────────────
+    //
+    // The encoder is one-way from Ryokan's side, but the round-trip
+    // through (encode → wrap as response → decode) catches "encoder
+    // emits something the decoder rejects" regressions in one shot.
+
+    #[test]
+    fn encode_request_shape_is_well_formed() {
+        let req = encode_request("d.multicall2", &[XmlValue::String("main".into())]);
+        assert!(req.starts_with("<?xml version=\"1.0\"?><methodCall>"));
+        assert!(req.contains("<methodName>d.multicall2</methodName>"));
+        assert!(req.contains("<value><string>main</string></value>"));
+        assert!(req.ends_with("</methodCall>"));
+    }
+
+    #[test]
+    fn encode_request_escapes_unsafe_chars_in_method_name() {
+        // Method name shouldn't ever contain unsafe chars (rtorrent's
+        // are dotted ASCII), but the escape is the right defensive
+        // shape — pin it.
+        let req = encode_request("a&b", &[]);
+        assert!(req.contains("<methodName>a&amp;b</methodName>"));
+    }
+
+    #[test]
+    fn round_trip_string_via_methodresponse() {
+        // Encoder emits an inner <value>; wrap as a methodResponse
+        // and decode it back. End-to-end: a torrent name with every
+        // entity must survive the round-trip exactly.
+        let original = "Show & Tell <Vol. \"1\">";
+        let mut inner = String::new();
+        encode_value(&XmlValue::String(original.into()), &mut inner);
+        let xml = format!(
+            "<?xml version=\"1.0\"?><methodResponse><params><param>{inner}</param></params></methodResponse>"
+        );
+        match decode_response(&xml).unwrap() {
+            XmlValue::String(s) => assert_eq!(s, original),
+            other => panic!("expected String, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn round_trip_int_array_via_methodresponse() {
+        let mut inner = String::new();
+        encode_value(
+            &XmlValue::Array(vec![XmlValue::Int(1), XmlValue::Int(2), XmlValue::Int(-3)]),
+            &mut inner,
+        );
+        let xml = format!(
+            "<?xml version=\"1.0\"?><methodResponse><params><param>{inner}</param></params></methodResponse>"
+        );
+        let items = decode_response(&xml).unwrap().into_array().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0].as_int(), Some(1));
+        assert_eq!(items[1].as_int(), Some(2));
+        assert_eq!(items[2].as_int(), Some(-3));
+    }
+
+    // ── Malformed input battery (fuzz-lite) ───────────────────────────
+    //
+    // Every entry in this list is a string the decoder must reject as
+    // `Err`, never panic. A future `cargo-fuzz` target for
+    // `decode_response` would seed its corpus from these — they
+    // cover the known-rough edges (truncations, wrong-tag swaps,
+    // empty inputs) without random mutation. Add new lines here when
+    // a fuzzing run finds a panic; promoting the panicking input to a
+    // pinning test is the cheapest way to lock in the fix.
+
+    #[rstest]
+    #[case("")] // empty
+    #[case("<?xml version=\"1.0\"?>")] // only prolog
+    #[case("<methodResponse>")] // truncated open
+    #[case("<methodResponse></methodResponse>")] // empty body
+    #[case("<methodResponse><params></params></methodResponse>")] // no <param>
+    #[case("<methodResponse><params><param></param></params></methodResponse>")] // empty <param>
+    #[case("<methodResponse><params><param><value>")] // truncated mid-value
+    #[case(
+        "<methodResponse><params><param><value><i4>not-a-number</i4></value></param></params></methodResponse>"
+    )]
+    #[case(
+        "<methodResponse><params><param><value><i8>9999999999999999999999</i8></value></param></params></methodResponse>"
+    )] // i64 overflow
+    #[case(
+        "<methodResponse><params><param><value><array></array></value></param></params></methodResponse>"
+    )] // array missing <data>
+    #[case(
+        "<methodResponse><params><param><value><array><data><value><i4>1</i4></value></data></value></param></params></methodResponse>"
+    )] // unclosed array
+    #[case("<methodResponse><randomtag/></methodResponse>")] // unexpected top-level
+    fn malformed_input_returns_err_not_panic(#[case] xml: &str) {
+        // We don't care about the specific error message — the
+        // contract is "no panic, returns Err." A regression that
+        // collapses any of these into Ok / panic is what this test
+        // catches.
+        let result = decode_response(xml);
+        assert!(result.is_err(), "expected Err for {xml:?}, got {result:?}");
+    }
+
+    #[test]
+    fn deeply_nested_array_returns_err_without_stack_overflow() {
+        // Pin the depth-limit defense. Without `MAX_NESTING_DEPTH`,
+        // recursive `decode_value` calls grow the stack ~one frame
+        // per `<array>` level; the default cargo-test thread stack
+        // (2 MiB on Linux) overflows around the 4-5k mark and
+        // panic-aborts the test process. The depth limit makes the
+        // parser refuse pathological inputs gracefully — feeds well
+        // above the cap to confirm we hit `Err`, not abort.
+        let mut xml = String::from("<?xml version=\"1.0\"?><methodResponse><params><param>");
+        let depth = MAX_NESTING_DEPTH * 4;
+        for _ in 0..depth {
+            xml.push_str("<value><array><data>");
+        }
+        xml.push_str("<value><i4>1</i4></value>");
+        for _ in 0..depth {
+            xml.push_str("</data></array></value>");
+        }
+        xml.push_str("</param></params></methodResponse>");
+
+        let result = decode_response(&xml);
+        assert!(result.is_err(), "expected depth-limit Err, got {result:?}");
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("nesting exceeds"),
+            "expected depth-limit message, got {err}"
+        );
     }
 }

--- a/src/services/jellyfin.rs
+++ b/src/services/jellyfin.rs
@@ -177,21 +177,188 @@ fn normalize_base_url(base_url: &str) -> String {
     }
 
     let lower = trimmed.to_ascii_lowercase();
-    let is_local = lower.starts_with("localhost")
-        || lower.starts_with("127.")
-        || lower.starts_with("10.")
-        || lower.starts_with("192.168.")
-        || lower.starts_with("172.16.")
-        || lower.starts_with("172.17.")
-        || lower.starts_with("172.18.")
-        || lower.starts_with("172.19.")
-        || lower.starts_with("172.2")
-        || lower.starts_with("172.30.")
-        || lower.starts_with("172.31.");
+    let is_local = is_local_address(&lower);
 
     if is_local {
         format!("http://{}", trimmed)
     } else {
         format!("https://{}", trimmed)
+    }
+}
+
+/// True when `s` (lowercased, scheme-stripped) refers to an address
+/// that warrants plain HTTP instead of HTTPS by default — loopback
+/// names + the three RFC 1918 ranges + the IPv6 loopback.
+///
+/// The 172.16.0.0/12 range needs each second-octet enumerated rather
+/// than a `starts_with("172.2")` check: that prefix catches 172.20
+/// through 172.29 (which IS private) but ALSO 172.200 through 172.255
+/// (which is PUBLIC). The pre-fix path mis-classified those public
+/// IPs as local and emitted an `http://172.200.x.x:…` URL — the
+/// Jellyfin API key would then ride a plain-text request to a public
+/// host.
+fn is_local_address(lower: &str) -> bool {
+    if lower.starts_with("localhost") || lower.starts_with("127.") {
+        return true;
+    }
+    // IPv6 loopback. `[::1]` literal form is what users actually
+    // type in URL bars; the bare `::1` form is also accepted.
+    if lower.starts_with("[::1]") || lower == "::1" || lower.starts_with("::1:") {
+        return true;
+    }
+    if lower.starts_with("10.") || lower.starts_with("192.168.") {
+        return true;
+    }
+    // 172.16.0.0/12 — second octet must be 16-31 inclusive.
+    if let Some(rest) = lower.strip_prefix("172.")
+        && let Some((second_octet_str, _tail)) = rest.split_once('.').or(Some((rest, "")))
+        && let Ok(second_octet) = second_octet_str.parse::<u8>()
+    {
+        return (16..=31).contains(&second_octet);
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── truncate ─────────────────────────────────────────────────────
+
+    #[test]
+    fn truncate_handles_empty_input() {
+        // Empty trimmed input gets the "empty response" placeholder so
+        // log lines reading the truncated body have something useful to
+        // surface.
+        assert_eq!(truncate(""), "empty response");
+        assert_eq!(truncate("   \n\t"), "empty response");
+    }
+
+    #[test]
+    fn truncate_passes_through_short_input() {
+        assert_eq!(truncate("hello"), "hello");
+        assert_eq!(truncate("  hello  "), "hello"); // trims
+    }
+
+    #[test]
+    fn truncate_caps_long_input_with_ellipsis() {
+        let long = "X".repeat(500);
+        let got = truncate(&long);
+        // Cap is 180 chars + "..." suffix.
+        assert!(got.starts_with(&"X".repeat(180)), "got {got:?}");
+        assert!(got.ends_with("..."));
+        assert_eq!(got.len(), 183);
+    }
+
+    // ── normalize_base_url: the load-bearing private-IP check ────────
+
+    #[test]
+    fn normalize_keeps_explicit_scheme_intact() {
+        // If the user types a scheme, honor it — never override.
+        assert_eq!(
+            normalize_base_url("http://my-public.example.com:8096"),
+            "http://my-public.example.com:8096"
+        );
+        assert_eq!(
+            normalize_base_url("https://my.example.com:8096"),
+            "https://my.example.com:8096"
+        );
+        // Trailing slash gets trimmed even with a scheme.
+        assert_eq!(
+            normalize_base_url("https://my.example.com/"),
+            "https://my.example.com"
+        );
+    }
+
+    #[test]
+    fn normalize_empty_input_returns_empty() {
+        assert!(normalize_base_url("").is_empty());
+        assert!(normalize_base_url("   ").is_empty());
+    }
+
+    #[test]
+    fn normalize_local_addresses_get_http() {
+        // The four canonical local shapes — must default to plain HTTP
+        // since the user is almost certainly running Jellyfin on the
+        // same LAN with no certificate.
+        for addr in [
+            "localhost:8096",
+            "127.0.0.1:8096",
+            "10.0.5.42:8096",
+            "192.168.1.10:8096",
+        ] {
+            assert!(
+                normalize_base_url(addr).starts_with("http://"),
+                "{addr} should default to http://, got {:?}",
+                normalize_base_url(addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_172_16_range_correctly_classified_as_private() {
+        // RFC 1918 specifies 172.16.0.0/12 — second octet 16..=31
+        // inclusive. Each boundary deserves a pin; the loop checks
+        // every value in the range.
+        for second in 16..=31 {
+            let addr = format!("172.{}.0.5:8096", second);
+            assert!(
+                normalize_base_url(&addr).starts_with("http://"),
+                "172.{second}.0.5 is RFC 1918 private; expected http://, got {:?}",
+                normalize_base_url(&addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_172_outside_private_range_classified_as_public() {
+        // The pre-fix bug: `starts_with("172.2")` matched 172.200 through
+        // 172.255 even though those are public. A user with that as
+        // their Jellyfin host would get http://, leaking the API key.
+        for second in [0, 15, 32, 100, 200, 255] {
+            let addr = format!("172.{}.0.5:8096", second);
+            assert!(
+                normalize_base_url(&addr).starts_with("https://"),
+                "172.{second}.0.5 is public; expected https://, got {:?}",
+                normalize_base_url(&addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_public_addresses_default_to_https() {
+        // Conservative: anything we can't prove is local gets HTTPS.
+        for addr in [
+            "jellyfin.example.com:8096",
+            "8.8.8.8:8096",
+            "203.0.113.5:8096",
+            "my.public.server",
+        ] {
+            assert!(
+                normalize_base_url(addr).starts_with("https://"),
+                "{addr} should default to https://, got {:?}",
+                normalize_base_url(addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_ipv6_loopback_classified_as_private() {
+        // `[::1]` literal form is what `url::Url` round-trips. Some
+        // users type bare `::1` in settings and the input still
+        // resolves to localhost.
+        for addr in ["[::1]:8096", "[::1]"] {
+            assert!(
+                normalize_base_url(addr).starts_with("http://"),
+                "{addr} should be classified as IPv6 loopback (http://), got {:?}",
+                normalize_base_url(addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_strips_trailing_slash() {
+        assert!(normalize_base_url("localhost:8096/").ends_with(":8096"));
+        assert!(!normalize_base_url("localhost:8096/").ends_with("/"));
     }
 }

--- a/src/services/jellyfin.rs
+++ b/src/services/jellyfin.rs
@@ -197,13 +197,23 @@ fn normalize_base_url(base_url: &str) -> String {
 /// IPs as local and emitted an `http://172.200.x.x:…` URL — the
 /// Jellyfin API key would then ride a plain-text request to a public
 /// host.
+///
+/// IPv6 loopback handling: only the bracketed form (`[::1]` or
+/// `[::1]:port`) and the bare `::1` exact match count. An earlier
+/// fix tried to also accept `::1:port` (bracketless host:port), but
+/// that prefix mis-matches valid non-loopback addresses like
+/// `::1:abcd:1234` (which expands to `0:0:0:0:0:1:abcd:1234`) —
+/// the same shape as the original 172.x bug. RFC 3986 requires
+/// brackets around an IPv6 host in a URL anyway, so any input that
+/// would lose the bracketless prefix path was already malformed.
 fn is_local_address(lower: &str) -> bool {
     if lower.starts_with("localhost") || lower.starts_with("127.") {
         return true;
     }
-    // IPv6 loopback. `[::1]` literal form is what users actually
-    // type in URL bars; the bare `::1` form is also accepted.
-    if lower.starts_with("[::1]") || lower == "::1" || lower.starts_with("::1:") {
+    // IPv6 loopback — bracketed form (`[::1]` / `[::1]:port`) or the
+    // bare `::1` exact literal. See doc comment for why the bracketless
+    // `::1:port` prefix was deliberately dropped.
+    if lower.starts_with("[::1]") || lower == "::1" {
         return true;
     }
     if lower.starts_with("10.") || lower.starts_with("192.168.") {
@@ -351,6 +361,24 @@ mod tests {
             assert!(
                 normalize_base_url(addr).starts_with("http://"),
                 "{addr} should be classified as IPv6 loopback (http://), got {:?}",
+                normalize_base_url(addr)
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_ipv6_non_loopback_with_one_hextet_classified_as_public() {
+        // PR #101 review: the earlier fix accepted `::1:port` as a
+        // bracketless loopback shorthand, which over-matched valid
+        // non-loopback IPv6 addresses whose second hextet starts with
+        // `1`. `::1:abcd:1234` expands to `0:0:0:0:0:1:abcd:1234` —
+        // public, not loopback. Pin both that the bracketless input
+        // gets HTTPS now and that the bracketed loopback path still
+        // works.
+        for addr in ["::1:abcd:1234", "::1:9000:9000:9000"] {
+            assert!(
+                normalize_base_url(addr).starts_with("https://"),
+                "{addr} is non-loopback IPv6; expected https://, got {:?}",
                 normalize_base_url(addr)
             );
         }

--- a/src/services/jikan.rs
+++ b/src/services/jikan.rs
@@ -195,6 +195,11 @@ struct SearchAnime {
     anime_type: Option<String>,
     status: Option<String>,
     episodes: Option<i32>,
+    /// MAL's 1-10 community score, e.g. `7.85`. `None` for entries
+    /// with no rating yet. Multiplied by 10 on conversion to
+    /// `AnimeEntry::average_score` (Option<i32> on the AL 0-100
+    /// scale) so both providers feed the same downstream sink.
+    score: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -373,6 +378,14 @@ pub async fn search_anime(query: &str) -> Result<Vec<AnimeEntry>, String> {
                 episodes: anime.episodes.filter(|&n| n > 0),
                 season_year: None, // Jikan search results don't include year
                 source: "mal".to_string(),
+                // MAL ships a 0-10 float; AnimeEntry stores 0-100 to
+                // match AL's `averageScore` shape. `(s * 10.0).round()`
+                // keeps the typical "7.85" → 79 mapping (AL would
+                // call this 79).
+                average_score: anime
+                    .score
+                    .filter(|s| *s > 0.0)
+                    .map(|s| (s * 10.0).round() as i32),
             }
         })
         .collect())

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -115,12 +115,25 @@ pub struct EpisodeFile {
     pub size_display: String,
 }
 
-/// Scan a series folder for video files and parse episode info from filenames.
-pub fn scan_series_folder(media_root: &str, folder_name: &str) -> Vec<EpisodeFile> {
+/// Scan a series folder for video files and parse episode info from
+/// filenames. The recursive `std::fs::read_dir` walk runs inside
+/// `spawn_blocking` so a deep multi-season tree on a slow / network-
+/// mounted media root can't stall a Tokio worker — Sonarr/Radarr poll
+/// the compat handlers aggressively and the RSS/upgrade/post-processing
+/// background tasks share the same runtime.
+pub async fn scan_series_folder(media_root: &str, folder_name: &str) -> Vec<EpisodeFile> {
     if media_root.is_empty() || folder_name.is_empty() {
         return Vec::new();
     }
 
+    let media_root = media_root.to_string();
+    let folder_name = folder_name.to_string();
+    tokio::task::spawn_blocking(move || scan_series_folder_blocking(&media_root, &folder_name))
+        .await
+        .unwrap_or_default()
+}
+
+fn scan_series_folder_blocking(media_root: &str, folder_name: &str) -> Vec<EpisodeFile> {
     let series_path = Path::new(media_root).join(folder_name);
     if !series_path.is_dir() {
         return Vec::new();

--- a/src/services/monitoring.rs
+++ b/src/services/monitoring.rs
@@ -216,6 +216,22 @@ fn resolve_monitored_episodes(
                 if existing_eps.contains(ep) {
                     return false;
                 }
+                // A finished series has, by definition, nothing in the
+                // future — every episode has already aired. Without
+                // this short-circuit, a finished series with no aired-
+                // date metadata cached (a freshly-added show before
+                // its first metadata refresh) hits the
+                // `*ep > max_existing` fallback below: with no on-disk
+                // files, that's `ep > 0` for every episode →
+                // monitor everything, exactly the wrong answer. The
+                // aired-date branch above catches the case where
+                // metadata IS present (every aired date is in the
+                // past, so `aired > today` is false everywhere); the
+                // explicit `is_finished` gate covers the no-metadata
+                // case symmetrically.
+                if is_finished {
+                    return false;
+                }
                 if let Some(info) = episode_info.get(ep)
                     && let Some(aired) = parse_aired_date(&info.aired)
                 {
@@ -238,4 +254,381 @@ fn parse_aired_date(value: &str) -> Option<NaiveDate> {
     }
     let date_part = trimmed.split('T').next().unwrap_or(trimmed);
     NaiveDate::parse_from_str(date_part, "%Y-%m-%d").ok()
+}
+
+#[cfg(test)]
+mod tests {
+    //! `resolve_monitored_episodes` drives every "what should I grab?"
+    //! decision in Ryokan — five modes (`All`/`None`/`Existing`/
+    //! `Missing`/`Future`) crossed with finished/airing status and
+    //! whether per-episode aired-date metadata is present. The
+    //! function is pure (no async, no DB, no I/O), which makes
+    //! comprehensive coverage cheap and makes regressions in the
+    //! date-based fallbacks immediately visible.
+    //!
+    //! The "no episode info" tests are the load-bearing ones — most
+    //! tracked series eventually have aired-date metadata cached, but
+    //! a freshly-added series before its first metadata refresh has
+    //! none, and the fallback math in `Future` mode used to monitor
+    //! every episode of a finished series in that state. The fix
+    //! lives in the `is_finished` short-circuit at the top of the
+    //! Future arm.
+    use super::*;
+    use chrono::TimeZone;
+    use rstest::rstest;
+
+    /// Build a minimal `Series` with the fields `resolve_monitored_episodes`
+    /// reads (just `status`). Everything else gets cheap defaults so the
+    /// test bodies stay focused on the inputs that matter.
+    fn series_with_status(status: &str) -> series::Series {
+        series::Series {
+            id: 1,
+            anilist_id: 1,
+            mal_id: None,
+            title: String::new(),
+            title_romaji: String::new(),
+            title_english: String::new(),
+            title_native: String::new(),
+            cover_url: String::new(),
+            format: String::new(),
+            status: status.to_string(),
+            episodes: Some(12),
+            season_year: None,
+            end_year: None,
+            folder_name: String::new(),
+            monitor_mode: "all".to_string(),
+            allow_upgrades: true,
+            custom_query_tokens: String::new(),
+            restrict_to_uploader: String::new(),
+            cumulative_prior_episodes: 0,
+            monitor_mode_manual_override: false,
+            user_score: None,
+            added_at: String::new(),
+        }
+    }
+
+    /// Build episode-info entries with aired-dates relative to "today."
+    /// The function under test compares against `Utc::now().date_naive()`,
+    /// so we have to use real wall-clock time rather than fixturing —
+    /// `chrono::Utc.with_ymd_and_hms` doesn't cleanly stub out the
+    /// inner clock. We build offsets that are far enough from today
+    /// that timezone drift around a date boundary can't flip them.
+    fn aired(days_offset: i64) -> jikan::EpisodeInfo {
+        let today = chrono::Utc::now().date_naive();
+        let date = today
+            .checked_add_signed(chrono::Duration::days(days_offset))
+            .unwrap_or_else(|| {
+                chrono::Utc
+                    .with_ymd_and_hms(2000, 1, 1, 0, 0, 0)
+                    .unwrap()
+                    .date_naive()
+            });
+        jikan::EpisodeInfo {
+            title: String::new(),
+            aired: date.format("%Y-%m-%d").to_string(),
+        }
+    }
+
+    fn ep_set(eps: &[i32]) -> HashSet<i32> {
+        eps.iter().copied().collect()
+    }
+
+    // ── parse_aired_date ──────────────────────────────────────────────
+
+    #[rstest]
+    #[case("2024-04-25", true)]
+    #[case("2024-04-25T13:00:00+00:00", true)] // strips T-suffix
+    #[case("", false)]
+    #[case("not a date", false)]
+    #[case("2024-13-99", false)] // month 13 out of range
+    #[case("2024-04-25 13:00", false)] // space-separated datetime — only 'T' is stripped
+    fn parse_aired_date_handles_realistic_inputs(#[case] input: &str, #[case] should_parse: bool) {
+        let got = parse_aired_date(input);
+        assert_eq!(
+            got.is_some(),
+            should_parse,
+            "parse_aired_date({input:?}) → {got:?}"
+        );
+    }
+
+    // ── MonitorMode::All / None ───────────────────────────────────────
+
+    #[test]
+    fn all_mode_monitors_every_episode() {
+        let row = series_with_status("RELEASING");
+        let eps: Vec<i32> = (1..=5).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &HashSet::new(),
+            &HashMap::new(),
+            MonitorMode::All,
+        );
+        assert_eq!(got, ep_set(&[1, 2, 3, 4, 5]));
+    }
+
+    #[test]
+    fn none_mode_monitors_nothing() {
+        let row = series_with_status("RELEASING");
+        let eps: Vec<i32> = (1..=5).collect();
+        // Even with on-disk files, None means none.
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &ep_set(&[1, 2]),
+            &HashMap::new(),
+            MonitorMode::None,
+        );
+        assert!(got.is_empty());
+    }
+
+    // ── MonitorMode::Existing ─────────────────────────────────────────
+
+    #[test]
+    fn existing_mode_monitors_only_on_disk() {
+        let row = series_with_status("FINISHED");
+        let eps: Vec<i32> = (1..=10).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &ep_set(&[2, 5, 9]),
+            &HashMap::new(),
+            MonitorMode::Existing,
+        );
+        assert_eq!(got, ep_set(&[2, 5, 9]));
+    }
+
+    #[test]
+    fn existing_mode_with_empty_disk_set_returns_empty() {
+        let row = series_with_status("RELEASING");
+        let eps: Vec<i32> = (1..=5).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &HashSet::new(),
+            &HashMap::new(),
+            MonitorMode::Existing,
+        );
+        assert!(got.is_empty());
+    }
+
+    // ── MonitorMode::Missing ──────────────────────────────────────────
+
+    #[test]
+    fn missing_mode_finished_monitors_everything_not_on_disk() {
+        let row = series_with_status("FINISHED");
+        let eps: Vec<i32> = (1..=10).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &ep_set(&[1, 2, 3]),
+            &HashMap::new(),
+            MonitorMode::Missing,
+        );
+        assert_eq!(got, ep_set(&[4, 5, 6, 7, 8, 9, 10]));
+    }
+
+    #[test]
+    fn missing_mode_finished_aliases_count() {
+        // FINISHED / FINISHED_AIRING / CANCELLED all hit the same branch.
+        for status in ["FINISHED", "finished_airing", "Cancelled"] {
+            let row = series_with_status(status);
+            let eps = vec![1, 2, 3];
+            let got = resolve_monitored_episodes(
+                &row,
+                &eps,
+                &ep_set(&[]),
+                &HashMap::new(),
+                MonitorMode::Missing,
+            );
+            assert_eq!(
+                got,
+                ep_set(&[1, 2, 3]),
+                "status {status:?} should be treated as finished",
+            );
+        }
+    }
+
+    #[test]
+    fn missing_mode_airing_uses_aired_dates_when_present() {
+        // E1-E3 already aired, E4 airs tomorrow, E5 in a week.
+        // None on disk. Expect: monitor only the past-aired ones.
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(1, aired(-21));
+        info.insert(2, aired(-14));
+        info.insert(3, aired(-7));
+        info.insert(4, aired(1));
+        info.insert(5, aired(7));
+        let eps: Vec<i32> = (1..=5).collect();
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Missing);
+        assert_eq!(got, ep_set(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn missing_mode_airing_falls_back_to_latest_aired_known() {
+        // E1-E3 have aired-date metadata (in the past), E4-E5 don't.
+        // The fallback should monitor up to `latest_aired_known = 3`.
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(1, aired(-30));
+        info.insert(2, aired(-23));
+        info.insert(3, aired(-16));
+        // E4, E5 missing from info — date unknown.
+        let eps: Vec<i32> = (1..=5).collect();
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Missing);
+        // E1-3 monitored via aired check; E4-5 NOT monitored because
+        // `*ep <= latest_aired_known(3)` is false for both.
+        assert_eq!(got, ep_set(&[1, 2, 3]));
+    }
+
+    #[test]
+    fn missing_mode_airing_with_no_info_at_all_returns_empty() {
+        // No episode_info, latest_aired_known = 0, no fallback signal
+        // for "aired or not." Conservative behavior: monitor nothing
+        // until the metadata sync populates aired dates.
+        let row = series_with_status("RELEASING");
+        let eps: Vec<i32> = (1..=5).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &HashSet::new(),
+            &HashMap::new(),
+            MonitorMode::Missing,
+        );
+        assert!(got.is_empty());
+    }
+
+    // ── MonitorMode::Future ───────────────────────────────────────────
+
+    #[test]
+    fn future_mode_airing_monitors_unaired_episodes() {
+        // E1-E2 already aired, E3-E5 in the future. None on disk.
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(1, aired(-14));
+        info.insert(2, aired(-7));
+        info.insert(3, aired(1));
+        info.insert(4, aired(8));
+        info.insert(5, aired(15));
+        let eps: Vec<i32> = (1..=5).collect();
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Future);
+        assert_eq!(got, ep_set(&[3, 4, 5]));
+    }
+
+    #[test]
+    fn future_mode_airing_falls_back_to_latest_aired_known() {
+        // E1-3 aired-known (past), E4-E5 unknown. Fallback says
+        // "future = anything past the latest known aired episode."
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(1, aired(-30));
+        info.insert(2, aired(-23));
+        info.insert(3, aired(-16));
+        let eps: Vec<i32> = (1..=5).collect();
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Future);
+        assert_eq!(got, ep_set(&[4, 5]));
+    }
+
+    #[test]
+    fn future_mode_finished_with_episode_info_monitors_nothing() {
+        // Every episode of a finished series has, by definition,
+        // already aired. With aired-date metadata this collapses
+        // correctly via the `aired > today` check.
+        let row = series_with_status("FINISHED");
+        let mut info = HashMap::new();
+        for ep in 1..=5 {
+            info.insert(ep, aired(-365));
+        }
+        let eps: Vec<i32> = (1..=5).collect();
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Future);
+        assert!(got.is_empty());
+    }
+
+    #[test]
+    fn future_mode_finished_without_episode_info_monitors_nothing() {
+        // The bug-pinning case. A finished series with no aired-date
+        // metadata used to fall through to `*ep > max_existing` (0)
+        // — which is `ep > 0` for every episode → monitor everything,
+        // exactly the wrong answer for Future mode on a show where
+        // nothing is in the future. The `is_finished` short-circuit
+        // at the top of the Future arm catches this.
+        let row = series_with_status("FINISHED");
+        let eps: Vec<i32> = (1..=5).collect();
+        let got = resolve_monitored_episodes(
+            &row,
+            &eps,
+            &HashSet::new(),
+            &HashMap::new(),
+            MonitorMode::Future,
+        );
+        assert!(
+            got.is_empty(),
+            "finished series + no episode info + no on-disk files \
+             must NOT monitor every episode in Future mode; got {got:?}"
+        );
+    }
+
+    #[test]
+    fn future_mode_existing_episodes_never_monitored() {
+        // Even a future-aired episode that's somehow on disk (manual
+        // import? grab landed early?) should NOT be monitored — it's
+        // already there, no point in re-grabbing.
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(1, aired(7)); // future-aired
+        let eps = vec![1];
+        let got = resolve_monitored_episodes(&row, &eps, &ep_set(&[1]), &info, MonitorMode::Future);
+        assert!(got.is_empty());
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────
+
+    #[test]
+    fn empty_episode_numbers_returns_empty_for_every_mode() {
+        let row = series_with_status("RELEASING");
+        for mode in [
+            MonitorMode::All,
+            MonitorMode::None,
+            MonitorMode::Existing,
+            MonitorMode::Missing,
+            MonitorMode::Future,
+        ] {
+            let got = resolve_monitored_episodes(&row, &[], &HashSet::new(), &HashMap::new(), mode);
+            assert!(got.is_empty(), "mode {mode:?} should return empty set");
+        }
+    }
+
+    #[test]
+    fn malformed_aired_date_treated_as_unknown() {
+        // A junk aired string (Jikan occasionally returns "Not yet
+        // aired" or similar non-date values) must NOT crash and must
+        // NOT count toward latest_aired_known.
+        let row = series_with_status("RELEASING");
+        let mut info = HashMap::new();
+        info.insert(
+            1,
+            jikan::EpisodeInfo {
+                title: String::new(),
+                aired: "Not yet aired".into(),
+            },
+        );
+        info.insert(2, aired(-7));
+        let eps = vec![1, 2, 3];
+        // Missing mode should treat E1 as unknown-aired, E2 as
+        // past-aired, E3 as unknown. latest_aired_known = 2, so
+        // E3 (unknown) doesn't pass `*ep <= latest_aired_known` since
+        // it would (3 ≤ 2 is false).
+        let got =
+            resolve_monitored_episodes(&row, &eps, &HashSet::new(), &info, MonitorMode::Missing);
+        // E1: no parseable date, falls through to fallback. 1 ≤ 2 → monitored.
+        // E2: aired ≤ today → monitored.
+        // E3: no info, fallback `3 ≤ 2` → not monitored.
+        assert_eq!(got, ep_set(&[1, 2]));
+    }
 }

--- a/src/services/monitoring.rs
+++ b/src/services/monitoring.rs
@@ -62,7 +62,7 @@ pub async fn recompute_series_monitoring(
         .flatten()
         .unwrap_or_default();
 
-    let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name);
+    let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name).await;
     let existing_eps: HashSet<i32> = disk_files.iter().map(|f| f.episode_number).collect();
     let episode_info = load_episode_info(db, &row).await;
     let monitored_eps =

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -218,6 +218,33 @@ async fn load_series_import_ctx(
 /// Process a single completed torrent. Returns `true` if at least one file was
 /// imported, `false` if there was nothing to do yet.
 ///
+/// Outcome of an [`import_torrent`] call. Replaces the older
+/// `Result<bool, String>` shape so the caller can distinguish four
+/// states the prior bool flattened together:
+///
+/// - `NotReady` — torrent complete but no video files visible yet
+///   (qBit still finalizing, or the pack is all samples/.nfo). Leave
+///   the grab pending so the next tick retries.
+/// - `Imported` — every video file landed.
+/// - `PartiallyImported { failed_episodes }` — some files imported,
+///   some failed (typically transient: disk full mid-copy, source
+///   vanished, permission flake on one file). Mark the grab imported
+///   so the user sees the partial success in the Downloads page, but
+///   surface a single SUMMARY error log naming the missing episodes
+///   so the failure is greppable in System → Logs rather than buried
+///   among per-file errors.
+/// - `AllFailed { failed_episodes }` — files were attempted but every
+///   `do_file_op` failed. Mark the grab failed rather than leaving it
+///   pending forever — the previous Ok(false) collapse meant a disk-
+///   full pack would re-attempt every tick, generating duplicate
+///   error logs without ever escalating to a user-visible failure.
+pub(crate) enum ImportOutcome {
+    NotReady,
+    Imported,
+    PartiallyImported { failed_episodes: Vec<i32> },
+    AllFailed { failed_episodes: Vec<i32> },
+}
+
 /// Phase 2: if the grab has routing rows in `grabbed_torrent_series`
 /// (written by the auto-expand path when a megapack contained sibling
 /// entries), each file is routed to the sibling's own library folder
@@ -230,7 +257,7 @@ async fn import_torrent(
     grab: &grabbed_torrents::GrabbedTorrent,
     torrent_hash: &str,
     torrent_save_path: &str,
-) -> Result<bool, String> {
+) -> Result<ImportOutcome, String> {
     let client = state
         .download_client
         .read()
@@ -371,7 +398,7 @@ async fn import_torrent(
         // like a finished video file. Most of the time this is a race
         // where the post-proc tick beat qBit's per-file progress update;
         // the next tick will find the files. Rare pathological case is
-        // a samples/.nfo-only torrent that stays Ok(false) forever —
+        // a samples/.nfo-only torrent that stays NotReady forever —
         // those would need the stuck-pending timeout fix (future work,
         // tracked separately from this commit).
         logger::debug(
@@ -384,7 +411,7 @@ async fn import_torrent(
             "",
         )
         .await;
-        return Ok(false);
+        return Ok(ImportOutcome::NotReady);
     }
 
     // Determine the source base path. Pick the per-client download
@@ -444,6 +471,16 @@ async fn import_torrent(
     let mut imported_eps_by_series: std::collections::BTreeMap<i64, Vec<(i32, i64, String)>> =
         std::collections::BTreeMap::new();
     let mut imported_count = 0_usize;
+    // Episode numbers (post-offset, the same value the rest of the
+    // codebase uses) that reached `do_file_op` but failed. Drives the
+    // PartiallyImported / AllFailed branches below so partial failures
+    // surface as a single summary log rather than scattered per-file
+    // errors. Files that never reached the file op (couldn't parse an
+    // episode number, offset produced a non-positive result, series
+    // context failed to load) skip via `continue` and aren't counted —
+    // those paths already log their own warning and aren't retryable
+    // by re-running the file op.
+    let mut failed_episodes: Vec<i32> = Vec::new();
 
     // Old grab ids we've marked as replaced during this import pass,
     // paired with the new `grab.id` that superseded them. Deduped via
@@ -953,12 +990,19 @@ async fn import_torrent(
                     &e.to_string(),
                 )
                 .await;
+                failed_episodes.push(ep_num);
             }
         }
     }
 
     if imported_count == 0 {
-        return Ok(false);
+        // Distinguish "no video files visible yet" (handled earlier as
+        // NotReady) from "video files were attempted but every one
+        // failed." The latter shouldn't sit pending forever.
+        if failed_episodes.is_empty() {
+            return Ok(ImportOutcome::NotReady);
+        }
+        return Ok(ImportOutcome::AllFailed { failed_episodes });
     }
 
     // Flush the `grabbed_torrents.state = 'replaced'` updates collected
@@ -1095,7 +1139,11 @@ async fn import_torrent(
         }
     }
 
-    Ok(true)
+    if failed_episodes.is_empty() {
+        Ok(ImportOutcome::Imported)
+    } else {
+        Ok(ImportOutcome::PartiallyImported { failed_episodes })
+    }
 }
 
 /// Run one post-processing cycle. Called by the background task every minute.
@@ -1259,7 +1307,7 @@ pub async fn run_once(state: &AppState) {
         let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
 
         match import_torrent(state, &cfg, grab, &torrent.hash, &local_save_path).await {
-            Ok(true) => {
+            Ok(ImportOutcome::Imported) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
                 // #27 — log every successful import so there's a trail
@@ -1285,7 +1333,54 @@ pub async fn run_once(state: &AppState) {
                 // still get the same flip as before via the
                 // `routes.is_empty()` fallback there.
             }
-            Ok(false) => {
+            Ok(ImportOutcome::PartiallyImported { failed_episodes }) => {
+                // Some files imported, some failed. Mark the grab
+                // imported because the user does have partial data on
+                // disk and the Downloads page should reflect that — but
+                // also emit a single SUMMARY error log so the failure
+                // is greppable in System → Logs rather than scattered
+                // across N per-file errors. Without this, a 24-episode
+                // pack that lost one file to a transient disk-full
+                // would silently report as fully imported and the user
+                // would only notice in Jellyfin.
+                any_imported = true;
+                let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;
+                logger::error(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!(
+                        "Partial import for '{}' — {} episode(s) failed",
+                        grab.torrent_name,
+                        failed_episodes.len()
+                    ),
+                    &format!(
+                        "series_id={} failed_episodes={:?}",
+                        grab.series_id, failed_episodes
+                    ),
+                )
+                .await;
+            }
+            Ok(ImportOutcome::AllFailed { failed_episodes }) => {
+                // Every video file we attempted failed. Mark the grab
+                // failed so the user can see and act — leaving it
+                // pending would re-run the same broken import every
+                // tick and just spam the log without ever escalating.
+                logger::error(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!(
+                        "Import failed for '{}' — every file errored",
+                        grab.torrent_name
+                    ),
+                    &format!(
+                        "series_id={} failed_episodes={:?}",
+                        grab.series_id, failed_episodes
+                    ),
+                )
+                .await;
+                let _ = grabbed_torrents::mark_failed(&state.db, grab.id).await;
+            }
+            Ok(ImportOutcome::NotReady) => {
                 // Torrent complete but no video files yet — leave as pending.
                 // The caller (qBit) might still be finalizing the files,
                 // or the torrent could be all samples/.nfo (pathological).

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -45,6 +45,37 @@ pub(crate) fn sanitize_filename(s: &str) -> String {
     media::sanitize_folder_name(s)
 }
 
+/// True when `a` and `b` resolve to the same inode (same device + same
+/// inode number). Used by [`do_file_op`] to detect "src and dst already
+/// point at the same bytes" cases — a re-import on top of a previously
+/// hardlinked dst, or a misconfiguration that resolves both paths to
+/// the same file. Without an early-out, the hardlink mode falls through
+/// to `fs::copy` on `EEXIST`, and `fs::copy` on a self-overlapping path
+/// truncates the shared inode to zero bytes (the read fd reads from the
+/// inode the write fd just truncated). That corrupts both the user's
+/// media file *and* the seeding source the torrent client still
+/// references.
+///
+/// On non-Unix targets we fall back to plain path equality, which still
+/// catches the misconfiguration case (caller passed identical paths)
+/// but misses the "hardlinked elsewhere" case. Windows hardlinks are
+/// rarer in this codebase's deployment shape (Docker / Linux is the
+/// primary target) and the path-identity check is sufficient for the
+/// catastrophic-data-loss scenario.
+#[cfg(unix)]
+fn files_share_inode(a: &Path, b: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    match (std::fs::metadata(a), std::fs::metadata(b)) {
+        (Ok(am), Ok(bm)) => am.dev() == bm.dev() && am.ino() == bm.ino(),
+        _ => false,
+    }
+}
+
+#[cfg(not(unix))]
+fn files_share_inode(a: &Path, b: &Path) -> bool {
+    a == b
+}
+
 /// Hardlink → copy fallback. For "move" mode: rename → copy+delete fallback.
 ///
 /// Runs the whole operation under `spawn_blocking` because a Blu-ray
@@ -58,6 +89,16 @@ pub(crate) async fn do_file_op(mode: &str, src: &Path, dst: &Path) -> std::io::R
     tokio::task::spawn_blocking(move || -> std::io::Result<()> {
         if let Some(p) = dst.parent() {
             std::fs::create_dir_all(p)?;
+        }
+        // No-op when src and dst already point at the same bytes — by
+        // a prior hardlink import landing the same file twice, or by a
+        // misconfiguration that resolves both to the same path. All
+        // three modes need this guard: a self-overlapping `fs::copy`
+        // truncates the shared inode (corrupting hardlink + copy modes)
+        // and the move-mode cross-fs fallback's `remove_file(src)`
+        // after the rename would delete the only surviving copy.
+        if files_share_inode(&src, &dst) {
+            return Ok(());
         }
         match mode.as_str() {
             "move" => {
@@ -97,7 +138,20 @@ pub(crate) async fn do_file_op(mode: &str, src: &Path, dst: &Path) -> std::io::R
                 Ok(())
             }
             _ => {
-                // "hardlink" (default): hardlink preferred, copy on failure (cross-fs).
+                // "hardlink" (default): hardlink preferred, copy on
+                // failure (cross-fs). `std::fs::hard_link` does NOT
+                // overwrite — it returns `EEXIST` if dst already exists.
+                // Clean any pre-existing dst first so a re-import
+                // doesn't fall through to the `fs::copy` fallback (which
+                // would silently degrade to a real copy, breaking the
+                // seed-safe-via-shared-inode property the user picked
+                // hardlink mode for). The same-inode short-circuit
+                // above already handled the "dst is the same file as
+                // src via prior hardlink" case; reaching here means
+                // dst is a different file we're free to replace.
+                if dst.exists() {
+                    let _ = std::fs::remove_file(&dst);
+                }
                 if std::fs::hard_link(&src, &dst).is_err() {
                     std::fs::copy(&src, &dst)?;
                 }

--- a/src/services/post_processing/state.rs
+++ b/src/services/post_processing/state.rs
@@ -159,7 +159,7 @@ async fn scan_for_unclassified(
             if row.folder_name.is_empty() {
                 continue;
             }
-            let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name);
+            let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name).await;
             if disk_files.is_empty() {
                 continue;
             }

--- a/src/services/post_processing/tests/file_ops.rs
+++ b/src/services/post_processing/tests/file_ops.rs
@@ -219,3 +219,106 @@ async fn missing_source_returns_error_not_panic() {
     assert_eq!(err.kind(), std::io::ErrorKind::NotFound);
     assert!(!dst.exists());
 }
+
+// ─── Re-import safety: src and dst already share an inode ──────────
+//
+// All three of these tests exercise the same scenario from a
+// different angle: the user re-runs an import where dst is already
+// a hardlink to src (the steady-state result of every prior
+// "hardlink" mode import). Without the same-inode guard, hardlink
+// mode falls through to `fs::copy` on EEXIST, and `fs::copy` on a
+// dst that points to the same inode as src truncates the shared
+// inode to zero — wiping both the user's media file and the seeding
+// source the torrent client still references.
+
+#[tokio::test]
+async fn hardlink_mode_is_noop_when_dst_already_hardlinked_to_src() {
+    let dir = TempDir::new().unwrap();
+    let src = write_src(&dir, "src.mkv", b"important-payload");
+    let dst = dir.path().join("dst.mkv");
+
+    // Pre-link to mirror the steady state after a prior import.
+    fs::hard_link(&src, &dst).expect("seed hardlink");
+    let pre_ino = fs::metadata(&src).unwrap().ino();
+    assert_eq!(fs::metadata(&dst).unwrap().ino(), pre_ino);
+
+    // Re-run the import. The bug: without the guard, `fs::copy`'s
+    // O_TRUNC on the shared inode would empty both files.
+    do_file_op("hardlink", &src, &dst)
+        .await
+        .expect("re-import must succeed");
+
+    assert_eq!(
+        fs::read(&src).unwrap(),
+        b"important-payload",
+        "src bytes must survive a re-import"
+    );
+    assert_eq!(
+        fs::read(&dst).unwrap(),
+        b"important-payload",
+        "dst bytes must survive a re-import (regression: would have been empty)"
+    );
+    assert_eq!(
+        fs::metadata(&src).unwrap().ino(),
+        fs::metadata(&dst).unwrap().ino(),
+        "src and dst should still share an inode"
+    );
+}
+
+#[tokio::test]
+async fn copy_mode_is_noop_when_paths_resolve_to_same_inode() {
+    // Misconfiguration variant: user's per-client download path and
+    // their media root resolve to the same file via hardlink. Copy
+    // mode would truncate the shared inode the same way.
+    let dir = TempDir::new().unwrap();
+    let src = write_src(&dir, "src.mkv", b"payload");
+    let dst = dir.path().join("dst.mkv");
+    fs::hard_link(&src, &dst).expect("seed hardlink");
+
+    do_file_op("copy", &src, &dst).await.expect("copy noop");
+
+    assert_eq!(fs::read(&src).unwrap(), b"payload");
+    assert_eq!(fs::read(&dst).unwrap(), b"payload");
+}
+
+#[tokio::test]
+async fn move_mode_is_noop_when_paths_resolve_to_same_inode() {
+    // Move mode's cross-fs fallback path is `copy → rename → remove(src)`.
+    // If src and dst share an inode, the `remove_file(src)` after the
+    // rename would delete the only surviving copy. The same-inode
+    // guard short-circuits to a no-op so neither path runs.
+    let dir = TempDir::new().unwrap();
+    let src = write_src(&dir, "src.mkv", b"payload");
+    let dst = dir.path().join("dst.mkv");
+    fs::hard_link(&src, &dst).expect("seed hardlink");
+
+    do_file_op("move", &src, &dst).await.expect("move noop");
+
+    // Both paths still resolve to the file with the original bytes.
+    assert!(src.exists(), "src must not be deleted when same-inode");
+    assert!(dst.exists(), "dst must still exist when same-inode");
+    assert_eq!(fs::read(&src).unwrap(), b"payload");
+}
+
+#[tokio::test]
+async fn hardlink_mode_replaces_unrelated_preexisting_dst() {
+    // Distinct from the same-inode case: dst exists but points at a
+    // different file (e.g. a stale leftover from a prior failed
+    // import). `fs::hard_link` returns EEXIST without overwriting,
+    // so the function must clean dst first to land a fresh hardlink
+    // rather than silently fall through to `fs::copy` and lose the
+    // shared-inode property.
+    let dir = TempDir::new().unwrap();
+    let src = write_src(&dir, "src.mkv", b"new-payload");
+    let dst = dir.path().join("dst.mkv");
+    fs::write(&dst, b"stale-unrelated-bytes").expect("seed unrelated dst");
+
+    do_file_op("hardlink", &src, &dst).await.expect("relink");
+
+    assert_eq!(fs::read(&dst).unwrap(), b"new-payload");
+    assert_eq!(
+        fs::metadata(&src).unwrap().ino(),
+        fs::metadata(&dst).unwrap().ino(),
+        "dst must share src's inode after the relink, not be a copy"
+    );
+}

--- a/src/services/quality.rs
+++ b/src/services/quality.rs
@@ -92,3 +92,237 @@ pub fn batch_probe_queries(aliases: &[String]) -> Vec<String> {
     }
     queries
 }
+
+#[cfg(test)]
+mod tests {
+    //! Coverage for the small pure helpers shared across RSS scoring
+    //! and auto-search. Each function lives on a hot path (every
+    //! candidate scored fires `preferred_group_bonus` once;
+    //! `parse_group_list` runs every Settings save), but none had
+    //! unit tests before this commit.
+    use super::*;
+
+    // ── FinishedSeriesMode::from_str ──────────────────────────────────
+
+    #[test]
+    fn finished_mode_from_str_canonical_values() {
+        assert_eq!(
+            FinishedSeriesMode::from_str("prefer_bd"),
+            FinishedSeriesMode::PreferBd
+        );
+        assert_eq!(
+            FinishedSeriesMode::from_str("bd_only"),
+            FinishedSeriesMode::BdOnly
+        );
+        assert_eq!(
+            FinishedSeriesMode::from_str("same_as_airing"),
+            FinishedSeriesMode::SameAsAiring
+        );
+    }
+
+    #[test]
+    fn finished_mode_from_str_unknown_falls_back_to_same_as_airing() {
+        // Defensive default: if a future settings key drifts, finished
+        // series get treated like airing rather than silently
+        // tightening to BD-only (which would unilaterally stop
+        // grabbing WEB releases).
+        assert_eq!(
+            FinishedSeriesMode::from_str(""),
+            FinishedSeriesMode::SameAsAiring
+        );
+        assert_eq!(
+            FinishedSeriesMode::from_str("garbage"),
+            FinishedSeriesMode::SameAsAiring
+        );
+    }
+
+    // ── preferred_group_bonus ─────────────────────────────────────────
+
+    #[test]
+    fn preferred_group_bonus_no_preference_returns_zero() {
+        // Empty preferred list = "user has no preference" — every
+        // group scores 0 from this dimension.
+        assert_eq!(preferred_group_bonus("SubsPlease", &[]), 0);
+        assert_eq!(preferred_group_bonus("", &[]), 0);
+    }
+
+    #[test]
+    fn preferred_group_bonus_orders_top_to_bottom() {
+        // The bonus formula is `180 - idx*30`. Pin every step so a
+        // refactor that touches the slope or starting point is caught.
+        let groups: Vec<String> = (0..7).map(|i| format!("Group{i}")).collect();
+        assert_eq!(preferred_group_bonus("Group0", &groups), 180);
+        assert_eq!(preferred_group_bonus("Group1", &groups), 150);
+        assert_eq!(preferred_group_bonus("Group2", &groups), 120);
+        assert_eq!(preferred_group_bonus("Group3", &groups), 90);
+        assert_eq!(preferred_group_bonus("Group4", &groups), 60);
+        assert_eq!(preferred_group_bonus("Group5", &groups), 30);
+        // The 7th preferred group hits exactly zero — still in the
+        // preferred list but contributes nothing. Past that, the
+        // formula gives negative values; users with overflowing lists
+        // see "preferred but with a discount."
+        assert_eq!(preferred_group_bonus("Group6", &groups), 0);
+    }
+
+    #[test]
+    fn preferred_group_bonus_unknown_group_in_non_empty_list_is_penalty() {
+        // The user picked preferences and this group isn't in them.
+        // A penalty pushes the candidate down vs. unstated-preference
+        // baseline.
+        let groups = vec!["MTBB".to_string(), "Erai-raws".to_string()];
+        assert_eq!(preferred_group_bonus("RandomGroup", &groups), -40);
+    }
+
+    #[test]
+    fn preferred_group_bonus_empty_group_with_non_empty_preferences_is_small_penalty() {
+        // Group field empty (Nyaa scraper couldn't parse a `[Group]`
+        // bracket) hits a softer penalty than "unknown group" — a
+        // missing tag is more often a parse miss than a "this is from
+        // a fly-by-night encoder" signal.
+        let groups = vec!["MTBB".to_string()];
+        assert_eq!(preferred_group_bonus("", &groups), -15);
+        assert_eq!(preferred_group_bonus("   ", &groups), -15);
+    }
+
+    #[test]
+    fn preferred_group_bonus_match_is_case_insensitive() {
+        // Real `[Group]` brackets are sometimes capitalized
+        // differently across releases — `[Subsplease]` vs
+        // `[SubsPlease]`. The match must collapse case so the
+        // user's preferences don't whiplash on capitalization drift.
+        let groups = vec!["MTBB".to_string()];
+        assert_eq!(preferred_group_bonus("mtbb", &groups), 180);
+        assert_eq!(preferred_group_bonus("MtBb", &groups), 180);
+        assert_eq!(preferred_group_bonus("MTBB", &groups), 180);
+    }
+
+    #[test]
+    fn preferred_group_bonus_trims_whitespace_on_group_input() {
+        // The Nyaa scraper occasionally emits trailing spaces inside
+        // bracket tokens. Don't let whitespace sabotage a match.
+        let groups = vec!["MTBB".to_string()];
+        assert_eq!(preferred_group_bonus("  MTBB  ", &groups), 180);
+    }
+
+    // ── parse_group_list ──────────────────────────────────────────────
+
+    #[test]
+    fn parse_group_list_splits_and_trims() {
+        assert_eq!(
+            parse_group_list("MTBB,Erai-raws,SubsPlease"),
+            vec!["MTBB", "Erai-raws", "SubsPlease"]
+        );
+        // Spaces around the commas are tolerated — Settings UI doesn't
+        // strip them and we don't want to bounce the user back for a
+        // formatting nit.
+        assert_eq!(
+            parse_group_list("MTBB, Erai-raws , SubsPlease"),
+            vec!["MTBB", "Erai-raws", "SubsPlease"]
+        );
+    }
+
+    #[test]
+    fn parse_group_list_drops_empty_segments() {
+        // Trailing comma, double comma, leading comma — all common
+        // copy-paste artifacts. Every shape collapses to the same
+        // empty-segments-removed list.
+        assert_eq!(
+            parse_group_list("MTBB,,Erai-raws,"),
+            vec!["MTBB", "Erai-raws"]
+        );
+        assert_eq!(parse_group_list(",MTBB"), vec!["MTBB"]);
+        assert!(parse_group_list("").is_empty());
+        assert!(parse_group_list(",,,").is_empty());
+        // Whitespace-only segments collapse too.
+        assert!(parse_group_list("   ,  , ").is_empty());
+    }
+
+    // ── nyaa_categories_for_format ────────────────────────────────────
+
+    #[test]
+    fn nyaa_categories_music_returns_amv_plus_audio() {
+        // MUSIC format covers AMV releases (1_1) and audio rips
+        // (2_0) — both can be relevant for music-format AL entries.
+        // `allow_non_english` is irrelevant for the MUSIC branch.
+        for allow in [false, true] {
+            assert_eq!(
+                nyaa_categories_for_format("MUSIC", allow),
+                vec!["1_1".to_string(), "2_0".to_string()]
+            );
+        }
+    }
+
+    #[test]
+    fn nyaa_categories_default_branches_on_allow_non_english() {
+        // Non-MUSIC formats funnel into a single category. The flag
+        // toggles between "English-translated only" (1_2) and
+        // "Anime All including raws" (1_0).
+        assert_eq!(
+            nyaa_categories_for_format("TV", false),
+            vec!["1_2".to_string()]
+        );
+        assert_eq!(
+            nyaa_categories_for_format("TV", true),
+            vec!["1_0".to_string()]
+        );
+        assert_eq!(
+            nyaa_categories_for_format("MOVIE", false),
+            vec!["1_2".to_string()]
+        );
+        assert_eq!(
+            nyaa_categories_for_format("OVA", true),
+            vec!["1_0".to_string()]
+        );
+    }
+
+    #[test]
+    fn nyaa_categories_unknown_format_treated_as_default() {
+        // Empty / unrecognized format strings land on the non-MUSIC
+        // branch. Better to overscan than to return an empty
+        // category list (which would silently disable RSS for that
+        // series).
+        assert_eq!(
+            nyaa_categories_for_format("", false),
+            vec!["1_2".to_string()]
+        );
+    }
+
+    // ── bd_probe_queries / batch_probe_queries ────────────────────────
+
+    #[test]
+    fn bd_probe_queries_emits_four_per_alias() {
+        // Each alias generates four queries (`bluray`, `BD`, `BDRip`,
+        // `remux`). Two aliases → 8 queries. The set is small enough
+        // to assert verbatim.
+        assert!(bd_probe_queries(&[]).is_empty());
+        let q = bd_probe_queries(&["Frieren".to_string()]);
+        assert_eq!(
+            q,
+            vec![
+                "Frieren bluray",
+                "Frieren BD",
+                "Frieren BDRip",
+                "Frieren remux",
+            ]
+        );
+    }
+
+    #[test]
+    fn batch_probe_queries_emits_three_per_alias() {
+        // `batch`, `complete`, `01-`. The "01-" tail matches the
+        // common batch naming `01-12`, `01~24` etc.
+        assert!(batch_probe_queries(&[]).is_empty());
+        let q = batch_probe_queries(&["Frieren".to_string()]);
+        assert_eq!(q, vec!["Frieren batch", "Frieren complete", "Frieren 01-"]);
+    }
+
+    #[test]
+    fn probe_queries_cross_product_with_multiple_aliases() {
+        // Both helpers run alias-major: every alias gets every probe.
+        // Two aliases × three probes = six queries from
+        // `batch_probe_queries`.
+        let aliases = vec!["A".to_string(), "B".to_string()];
+        assert_eq!(batch_probe_queries(&aliases).len(), 6);
+        assert_eq!(bd_probe_queries(&aliases).len(), 8);
+    }
+}

--- a/src/services/rss/feed.rs
+++ b/src/services/rss/feed.rs
@@ -544,3 +544,373 @@ mod detect_batch_tests {
         assert!(detect_batch("[Group] Kamen Rider 555 - 01-50 [BD]"));
     }
 }
+
+#[cfg(test)]
+mod parser_tests {
+    //! Coverage for the RSS feed parser primitives (`decode_xml`,
+    //! `extract_tag`, `strip_cdata`, `extract_group`,
+    //! `extract_resolution`, `build_item_key`) plus the entry-point
+    //! `parse_feed` and a fuzz-lite battery of malformed-XML inputs
+    //! it must reject without panicking. Same shape that surfaced
+    //! the stack-overflow bug in the rtorrent XML-RPC codec — the
+    //! RSS path also takes external Nyaa XML, so an unbounded
+    //! input range is real.
+    use super::*;
+
+    // ── decode_xml ────────────────────────────────────────────────────
+
+    #[test]
+    fn decode_xml_handles_predefined_entities() {
+        // The five XML 1.0 spec entities. A regression in any of these
+        // mangles every release title containing `&` (every magnet URI
+        // does), `<` / `>` (titles with episode ranges in angle
+        // brackets), or quotes (rare but real).
+        assert_eq!(decode_xml("&amp;&lt;&gt;&quot;&apos;"), "&<>\"'",);
+    }
+
+    #[test]
+    fn decode_xml_handles_decimal_numeric_references() {
+        // `&#39;` → `'`, `&#039;` → `'`, `&#65;` → `A`. The previous
+        // implementation only matched the literal `&#39;` for
+        // apostrophes, so feeds emitting any other padded form came
+        // through mangled.
+        assert_eq!(decode_xml("&#39;"), "'");
+        assert_eq!(decode_xml("&#039;"), "'");
+        assert_eq!(decode_xml("&#65;"), "A");
+    }
+
+    #[test]
+    fn decode_xml_handles_hex_numeric_references() {
+        // Lower / upper case `x` both legal per spec.
+        assert_eq!(decode_xml("&#x27;"), "'");
+        assert_eq!(decode_xml("&#X27;"), "'");
+        assert_eq!(decode_xml("&#x41;"), "A");
+        // Multi-byte: U+1F600 GRINNING FACE.
+        assert_eq!(decode_xml("&#x1F600;"), "😀");
+    }
+
+    #[test]
+    fn decode_xml_leaves_unknown_named_entity_intact() {
+        // `&copy;` etc. aren't in our table — pass through verbatim
+        // rather than dropping the text. Some Nyaa torrent titles
+        // carry literal `&` followed by random tokens.
+        assert_eq!(decode_xml("Show & &foo; rest"), "Show & &foo; rest");
+    }
+
+    #[test]
+    fn decode_xml_unterminated_ampersand_passes_through() {
+        // No `;` within a 16-byte window after `&` — emit `&` and keep
+        // scanning. A streaming-encoded Nyaa title that gets cut at
+        // the boundary shouldn't panic.
+        assert_eq!(decode_xml("Show & no entity"), "Show & no entity");
+    }
+
+    #[test]
+    fn decode_xml_invalid_codepoint_passes_through() {
+        // U+D800 is an unpaired surrogate, not a valid Unicode scalar.
+        // `char::from_u32` returns None; the entity is emitted
+        // literally rather than panicking.
+        assert_eq!(decode_xml("&#xD800;"), "&#xD800;");
+        // Numeric overflow: way past u32::MAX.
+        assert_eq!(
+            decode_xml("&#9999999999999999999;"),
+            "&#9999999999999999999;"
+        );
+    }
+
+    #[test]
+    fn decode_xml_does_not_double_decode() {
+        // The previous chain-of-replace approach decoded `&amp;` to
+        // `&` first, so `&amp;lt;` (escaped form of `&lt;`) became
+        // `<` instead of staying as `&lt;`. The single-pass scanner
+        // doesn't reprocess its own output.
+        assert_eq!(decode_xml("&amp;lt;"), "&lt;");
+    }
+
+    #[test]
+    fn decode_xml_empty_string_returns_empty() {
+        assert_eq!(decode_xml(""), "");
+    }
+
+    #[test]
+    fn decode_xml_no_entities_returns_input_verbatim() {
+        let s = "[Group] Show — épisode 12 (1080p) 漢字";
+        assert_eq!(decode_xml(s), s);
+    }
+
+    // ── strip_cdata ───────────────────────────────────────────────────
+
+    #[test]
+    fn strip_cdata_unwraps_when_wrapped() {
+        assert_eq!(strip_cdata("<![CDATA[hello]]>"), "hello");
+    }
+
+    #[test]
+    fn strip_cdata_passes_through_unwrapped() {
+        // Nyaa's RSS doesn't actually use CDATA but the helper has to
+        // round-trip arbitrary content for the case where someone
+        // proxies a different feed through it.
+        assert_eq!(strip_cdata("plain text"), "plain text");
+    }
+
+    #[test]
+    fn strip_cdata_requires_both_open_and_close() {
+        // Just an open marker isn't CDATA — leave intact.
+        assert_eq!(
+            strip_cdata("<![CDATA[never closed"),
+            "<![CDATA[never closed"
+        );
+    }
+
+    // ── extract_group ────────────────────────────────────────────────
+
+    #[test]
+    fn extract_group_finds_first_bracket_pair() {
+        assert_eq!(extract_group("[SubsPlease] Show - 01"), "SubsPlease");
+    }
+
+    #[test]
+    fn extract_group_returns_empty_when_no_brackets() {
+        assert_eq!(extract_group("Show - 01"), "");
+    }
+
+    #[test]
+    fn extract_group_returns_empty_when_unmatched_open() {
+        assert_eq!(extract_group("[unclosed group rest"), "");
+    }
+
+    #[test]
+    fn extract_group_handles_unicode_in_name() {
+        assert_eq!(extract_group("[漢字組] Show"), "漢字組");
+    }
+
+    #[test]
+    fn extract_group_handles_empty_brackets() {
+        assert_eq!(extract_group("[] Show"), "");
+    }
+
+    // ── extract_resolution ────────────────────────────────────────────
+
+    #[test]
+    fn extract_resolution_picks_highest_listed_first() {
+        // Loop order is 2160 → 1080 → 720 → 576 → 480; first hit
+        // wins. A title carrying both "1080p" and "720p" returns the
+        // bigger one.
+        assert_eq!(
+            extract_resolution("[Group] Show 1080p HEVC + 720p AVC dual-track"),
+            "1080"
+        );
+    }
+
+    #[test]
+    fn extract_resolution_handles_uppercase_p() {
+        assert_eq!(extract_resolution("[Group] Show 1080P"), "1080");
+    }
+
+    #[test]
+    fn extract_resolution_returns_empty_when_absent() {
+        assert_eq!(extract_resolution("[Group] Show - 01"), "");
+    }
+
+    #[test]
+    fn extract_resolution_matches_bare_token_with_spaces() {
+        // The fallback `" {res} "` pattern catches resolutions
+        // expressed without the `p` suffix when surrounded by
+        // whitespace. `10-bit 1080 BluRay` is a real shape.
+        assert_eq!(
+            extract_resolution("[Group] Show 10-bit 1080 BluRay"),
+            "1080"
+        );
+    }
+
+    // ── build_item_key ────────────────────────────────────────────────
+    //
+    // The dedup key feeds into `rss_seen.item_key`. A change in
+    // priority order (hash → guid → link → title) silently re-grabs
+    // every previously-seen item with a missing-from-the-prior-row
+    // identity column, so pin the precedence here.
+
+    fn make_item(info_hash: &str, guid: &str, link: &str, title: &str) -> RssItem {
+        RssItem {
+            title: title.into(),
+            link: link.into(),
+            guid: guid.into(),
+            torrent: String::new(),
+            magnet: String::new(),
+            info_hash: info_hash.into(),
+            group: String::new(),
+            resolution: String::new(),
+            is_batch: false,
+        }
+    }
+
+    #[test]
+    fn build_item_key_prefers_info_hash() {
+        let item = make_item("ABC123", "guid-1", "https://nyaa.si/view/1", "Title");
+        // Hash gets lowercased to canonical form so case drift
+        // between feed runs (some Nyaa endpoints uppercase the hex)
+        // doesn't produce two keys for the same release.
+        assert_eq!(build_item_key(&item), "hash:abc123");
+    }
+
+    #[test]
+    fn build_item_key_falls_back_to_guid() {
+        let item = make_item("", "guid-1", "https://nyaa.si/view/1", "Title");
+        assert_eq!(build_item_key(&item), "guid:guid-1");
+    }
+
+    #[test]
+    fn build_item_key_falls_back_to_link() {
+        let item = make_item("", "", "https://nyaa.si/view/1", "Title");
+        assert_eq!(build_item_key(&item), "link:https://nyaa.si/view/1");
+    }
+
+    #[test]
+    fn build_item_key_falls_back_to_title_lowercased() {
+        let item = make_item("", "", "", "Show TITLE");
+        // Title-only fallback fires for feeds that emit no identity
+        // columns at all — extremely rare, but real for the e2e
+        // wiremock fixtures. Lowercase so a feed run that capitalizes
+        // differently doesn't double-grab.
+        assert_eq!(build_item_key(&item), "title:show title");
+    }
+
+    // ── parse_feed: happy paths ───────────────────────────────────────
+
+    fn make_feed(items_xml: &str) -> String {
+        format!(
+            r#"<?xml version="1.0" encoding="UTF-8"?>
+            <rss xmlns:nyaa="https://nyaa.si/xmlns/nyaa">
+                <channel>{items_xml}</channel>
+            </rss>"#
+        )
+    }
+
+    #[test]
+    fn parse_feed_extracts_one_item() {
+        let xml = make_feed(
+            r#"<item>
+                <title>[SubsPlease] Frieren - 01 (1080p) [ABCD1234].mkv</title>
+                <link>https://nyaa.si/download/1.torrent</link>
+                <guid>https://nyaa.si/view/1</guid>
+                <nyaa:downloadurl>https://nyaa.si/download/1.torrent</nyaa:downloadurl>
+                <nyaa:magneturi>magnet:?xt=urn:btih:abc</nyaa:magneturi>
+                <nyaa:infohash>ABC</nyaa:infohash>
+            </item>"#,
+        );
+        let items = parse_feed(&xml);
+        assert_eq!(items.len(), 1);
+        let item = &items[0];
+        assert_eq!(
+            item.title,
+            "[SubsPlease] Frieren - 01 (1080p) [ABCD1234].mkv"
+        );
+        assert_eq!(item.link, "https://nyaa.si/download/1.torrent");
+        assert_eq!(item.guid, "https://nyaa.si/view/1");
+        assert_eq!(item.torrent, "https://nyaa.si/download/1.torrent");
+        assert_eq!(item.magnet, "magnet:?xt=urn:btih:abc");
+        // info_hash is lowercased even though the feed emitted uppercase.
+        assert_eq!(item.info_hash, "abc");
+        assert_eq!(item.group, "SubsPlease");
+        assert_eq!(item.resolution, "1080");
+        assert!(!item.is_batch);
+    }
+
+    #[test]
+    fn parse_feed_skips_items_with_empty_title() {
+        // Defensive: an `<item>` block with no title is unparseable
+        // upstream; better to drop than to seed a blank-title row that
+        // confuses every dedup downstream of it.
+        let xml = make_feed(
+            r#"<item>
+                <title></title>
+                <link>https://nyaa.si/x</link>
+            </item>
+            <item>
+                <title>Real Title</title>
+            </item>"#,
+        );
+        let items = parse_feed(&xml);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "Real Title");
+    }
+
+    #[test]
+    fn parse_feed_decodes_xml_entities_in_title() {
+        // Entity-encoded title is the standard case — Nyaa emits
+        // `&amp;` for any literal `&` in the original release name.
+        let xml = make_feed(
+            r#"<item>
+                <title>[Group] Show &amp; Tell &lt;Vol 1&gt;</title>
+            </item>"#,
+        );
+        let items = parse_feed(&xml);
+        assert_eq!(items[0].title, "[Group] Show & Tell <Vol 1>");
+    }
+
+    #[test]
+    fn parse_feed_handles_multiple_items() {
+        let xml = make_feed(
+            r#"<item><title>One</title></item>
+               <item><title>Two</title></item>
+               <item><title>Three</title></item>"#,
+        );
+        let items = parse_feed(&xml);
+        let titles: Vec<&str> = items.iter().map(|i| i.title.as_str()).collect();
+        assert_eq!(titles, vec!["One", "Two", "Three"]);
+    }
+
+    // ── parse_feed: malformed input battery (fuzz-lite) ───────────────
+    //
+    // Each input here must produce an empty `Vec<RssItem>` rather
+    // than panic. A future cargo-fuzz target seeded from this corpus
+    // would extend the same contract under random mutation.
+
+    #[test]
+    fn parse_feed_empty_returns_empty() {
+        assert!(parse_feed("").is_empty());
+    }
+
+    #[test]
+    fn parse_feed_no_items_returns_empty() {
+        assert!(parse_feed("<rss><channel></channel></rss>").is_empty());
+    }
+
+    #[test]
+    fn parse_feed_truncated_item_returns_empty() {
+        // `<item>` opened but never closed → the regex's `.*?` lazy
+        // match doesn't span back to the next `<item>`, so the block
+        // captures nothing. No panic on slicing.
+        let xml = "<rss><channel><item><title>Show";
+        let _ = parse_feed(xml); // contract: no panic; emptiness depends on regex match
+    }
+
+    #[test]
+    fn parse_feed_garbage_input_returns_empty() {
+        assert!(parse_feed("not xml at all").is_empty());
+        assert!(parse_feed("\u{0000}\u{0001}\u{0002}").is_empty());
+    }
+
+    #[test]
+    fn parse_feed_handles_huge_title_without_panic() {
+        // 100 KB title — well past anything Nyaa would emit, but no
+        // input-size cap exists in the regex. Test confirms there's
+        // no quadratic-blowup or slicing panic.
+        let huge = "X".repeat(100_000);
+        let xml = format!("<rss><channel><item><title>{huge}</title></item></channel></rss>");
+        let items = parse_feed(&xml);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title.len(), 100_000);
+    }
+
+    #[test]
+    fn parse_feed_handles_tag_with_attributes() {
+        // The extract_tag regex pattern is `<{tag}[^>]*>(.*?)</{tag}>` —
+        // accepts attributes on the open tag (some RSS variants emit
+        // `<title type="text">…</title>`).
+        let xml = make_feed(r#"<item><title type="text">With attrs</title></item>"#);
+        let items = parse_feed(&xml);
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].title, "With attrs");
+    }
+}

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -506,11 +506,14 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
             .filter(|ep| monitored_eps.contains(ep))
             .collect();
 
-        let disk_files = disk_cache
-            .entry(found.series.folder_name.clone())
-            .or_insert_with(|| {
-                media::scan_series_folder(&cfg.media_root, &found.series.folder_name)
-            });
+        let disk_files = if let Some(cached) = disk_cache.get(&found.series.folder_name) {
+            cached
+        } else {
+            let files = media::scan_series_folder(&cfg.media_root, &found.series.folder_name).await;
+            disk_cache
+                .entry(found.series.folder_name.clone())
+                .or_insert(files)
+        };
         let qtags = if let Some(cached) = quality_tags_cache.get(&found.series.id) {
             cached
         } else {

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -332,6 +332,19 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
     }
     let client = state.download_client.read().await.clone();
 
+    // One compiled-CF snapshot for the whole RSS pass so each item's
+    // score reflects the user's CF profile. Without this thread-through
+    // the auto-search path applied CFs but the RSS path silently
+    // bypassed them — a 10-bit/x265/FLAC release the user explicitly
+    // boosted via CF would tie or lose to a plain release on the
+    // every-60s auto-grab path while ranking correctly in the manual
+    // search UI. SeaDex hashes are passed empty for now: per-series
+    // SeaDex lookups would add N round-trips per cycle and the
+    // hardcoded `seadex_enabled` toggle bonus only matters when SeaDex
+    // is consulted, which only the auto/upgrade paths do today.
+    let cfs = state.custom_formats.read().await.clone();
+    let empty_seadex_hashes: HashSet<String> = HashSet::new();
+
     let whitelist = quality::parse_group_list(&cfg.preferred_groups);
     let blacklist = quality::parse_group_list(&cfg.blocked_groups);
     let all_meta: Vec<SeriesMeta> = tracked.iter().map(SeriesMeta::from_series).collect();
@@ -614,6 +627,8 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
             &found.resolved_eps,
             found.alias_score,
             found.parsed.parse_mode,
+            &cfs,
+            &empty_seadex_hashes,
         )
         .await;
         pending.push(PendingCandidate {
@@ -1024,6 +1039,7 @@ fn canonical_episode_key(found: &MatchResult, is_batch: bool) -> String {
     )
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn score_candidate(
     db: &sqlx::SqlitePool,
     cfg: &config::Config,
@@ -1032,6 +1048,8 @@ async fn score_candidate(
     parsed_eps: &HashSet<i32>,
     alias_score: f32,
     parse_mode: &str,
+    cfs: &[crate::services::custom_formats::CompiledCustomFormat],
+    seadex_hashes: &HashSet<String>,
 ) -> i32 {
     let preferred_source = Source::from_str(&cfg.preferred_source);
     let preferred_resolution = Resolution::from_str(&cfg.preferred_resolution);
@@ -1098,6 +1116,24 @@ async fn score_candidate(
         "range" => score += 10,
         _ => score -= 10,
     }
+
+    // CF overlay — the auto-search and upgrade paths fold the user's
+    // compiled Custom Formats into scoring at the equivalent layer; RSS
+    // used to skip this and silently rank candidates by the heuristic
+    // pieces above only. `total_cf_score_for_release` saturates the
+    // sum across CFs so a 10k-magnitude TRaSH boost can't wrap to a
+    // negative on overflow. RssItem doesn't carry size_bytes today, so
+    // CFs with a Size spec (rare in TRaSH-anime) won't match — known
+    // limitation, separable from this fix.
+    score = score.saturating_add(crate::services::custom_formats::total_cf_score_for_release(
+        cfs,
+        &classification,
+        &item.title,
+        &item.group,
+        0,
+        &item.info_hash,
+        seadex_hashes,
+    ));
 
     score
 }

--- a/src/services/source/types.rs
+++ b/src/services/source/types.rs
@@ -564,3 +564,320 @@ impl ClassificationResult {
         base
     }
 }
+
+#[cfg(test)]
+mod tests {
+    //! Coverage for the pure source-type primitives. None of these
+    //! touch the DB or the network — `from_str` / `as_str` /
+    //! `rank()` / `label()` are all pure functions, but they're
+    //! load-bearing: every classification result that ends up in
+    //! `episode_quality_tags`, every CF spec evaluation, and every
+    //! Sonarr-format quality string the user sees flows through these.
+    //! A regression in any of them silently mis-tags every episode.
+    //!
+    //! The from_str round-trips also lock in the case-insensitive +
+    //! variant-spelling acceptance that real-world tag strings use
+    //! (`"WEB-DL"` vs `"webdl"` vs `"web.dl"`).
+    use super::*;
+
+    // ── Source ────────────────────────────────────────────────────────
+
+    #[test]
+    fn source_rank_orders_correctly() {
+        // Strict total order; ties only between equal variants.
+        assert!(Source::BluRay.rank() > Source::Web.rank());
+        assert!(Source::Web.rank() > Source::Dvd.rank());
+        assert!(Source::Dvd.rank() > Source::Hdtv.rank());
+        assert!(Source::Hdtv.rank() > Source::Tv.rank());
+        assert!(Source::Tv.rank() > Source::Unknown.rank());
+    }
+
+    #[test]
+    fn source_from_str_accepts_canonical_and_variant_forms() {
+        // Trash-Guides CFs and historical Ryokan rows both feed strings
+        // through here, so the variant set has to cover what each emits.
+        assert_eq!(Source::from_str("BluRay"), Source::BluRay);
+        assert_eq!(Source::from_str("blu-ray"), Source::BluRay);
+        assert_eq!(Source::from_str("BD"), Source::BluRay);
+        assert_eq!(Source::from_str("bdrip"), Source::BluRay);
+        assert_eq!(Source::from_str("BDRemux"), Source::BluRay);
+        assert_eq!(Source::from_str("bdmv"), Source::BluRay);
+        assert_eq!(Source::from_str("WEB"), Source::Web);
+        assert_eq!(Source::from_str("Web-DL"), Source::Web);
+        assert_eq!(Source::from_str("WebDl"), Source::Web);
+        assert_eq!(Source::from_str("WEBRip"), Source::Web);
+        assert_eq!(Source::from_str("DVD"), Source::Dvd);
+        assert_eq!(Source::from_str("HDTV"), Source::Hdtv);
+        assert_eq!(Source::from_str("TV"), Source::Tv);
+    }
+
+    #[test]
+    fn source_from_str_unknown_for_garbage() {
+        // Defensive default — a rogue tag string can't bypass the
+        // classifier into a real source.
+        assert_eq!(Source::from_str(""), Source::Unknown);
+        assert_eq!(Source::from_str("not-a-source"), Source::Unknown);
+        assert_eq!(Source::from_str("4K"), Source::Unknown); // resolution, not source
+    }
+
+    #[test]
+    fn source_from_str_trims_whitespace() {
+        // Real persisted tags occasionally carry trailing whitespace
+        // from older write paths.
+        assert_eq!(Source::from_str("  bluray  "), Source::BluRay);
+        assert_eq!(Source::from_str("\tweb\n"), Source::Web);
+    }
+
+    // ── WebKind ───────────────────────────────────────────────────────
+
+    #[test]
+    fn web_kind_rank_webdl_beats_webrip_beats_unknown() {
+        assert!(WebKind::WebDl.rank() > WebKind::WebRip.rank());
+        assert!(WebKind::WebRip.rank() > WebKind::Unknown.rank());
+    }
+
+    #[test]
+    fn web_kind_from_str_accepts_canonical_and_punctuated() {
+        // Real tags carry every separator: `WEB-DL`, `WEBDL`, `WEB.DL`.
+        assert_eq!(WebKind::from_str("WEB-DL"), WebKind::WebDl);
+        assert_eq!(WebKind::from_str("webdl"), WebKind::WebDl);
+        assert_eq!(WebKind::from_str("web.dl"), WebKind::WebDl);
+        assert_eq!(WebKind::from_str("WEBRip"), WebKind::WebRip);
+        assert_eq!(WebKind::from_str("web-rip"), WebKind::WebRip);
+        assert_eq!(WebKind::from_str("web.rip"), WebKind::WebRip);
+    }
+
+    #[test]
+    fn web_kind_unknown_renders_as_empty_string() {
+        // The empty string is the contract — non-empty would pollute
+        // `BD-1080p` / `WEB-1080p` style labels with a stray suffix
+        // for the bare-WEB case the WebKind::Unknown variant exists for.
+        assert_eq!(WebKind::Unknown.as_str(), "");
+        assert_eq!(WebKind::WebDl.as_str(), "WEB-DL");
+        assert_eq!(WebKind::WebRip.as_str(), "WEBRip");
+    }
+
+    // ── Resolution ────────────────────────────────────────────────────
+
+    #[test]
+    fn resolution_from_str_accepts_bare_and_suffixed() {
+        // Settings-page emits `"1080"`; episode tags emit `"1080p"`.
+        // Both paths flow through here.
+        assert_eq!(Resolution::from_str("1080"), Resolution::R1080p);
+        assert_eq!(Resolution::from_str("1080p"), Resolution::R1080p);
+        assert_eq!(Resolution::from_str("1080P"), Resolution::R1080p);
+        assert_eq!(Resolution::from_str("1080i"), Resolution::R1080p);
+        assert_eq!(Resolution::from_str("720"), Resolution::R720p);
+        assert_eq!(Resolution::from_str("720p"), Resolution::R720p);
+        assert_eq!(Resolution::from_str("480"), Resolution::R480p);
+        assert_eq!(Resolution::from_str("576p"), Resolution::R576p);
+    }
+
+    #[test]
+    fn resolution_from_str_accepts_4k_aliases() {
+        // `4k` / `UHD` are user-facing aliases for 2160p.
+        for alias in ["2160", "2160p", "4k", "4K", "uhd", "UHD"] {
+            assert_eq!(
+                Resolution::from_str(alias),
+                Resolution::R2160p,
+                "alias {alias} should map to 2160p"
+            );
+        }
+    }
+
+    #[test]
+    fn resolution_from_str_unknown_for_garbage() {
+        assert_eq!(Resolution::from_str(""), Resolution::Unknown);
+        assert_eq!(Resolution::from_str("not-a-res"), Resolution::Unknown);
+        // Sonarr's 360 / 540 don't get tier'd by Ryokan.
+        assert_eq!(Resolution::from_str("360p"), Resolution::Unknown);
+        assert_eq!(Resolution::from_str("540p"), Resolution::Unknown);
+    }
+
+    #[test]
+    fn resolution_from_dimensions_loose_lower_bounds() {
+        // Lower-bound thresholds absorb anamorphic + cropped variants.
+        // Pin the exact bands documented on `from_dimensions`.
+        assert_eq!(Resolution::from_dimensions(3840, 2160), Resolution::R2160p);
+        assert_eq!(Resolution::from_dimensions(1920, 1080), Resolution::R1080p);
+        assert_eq!(Resolution::from_dimensions(1280, 720), Resolution::R720p);
+        // Anamorphic 720p (704×480 squished from 720×480) lands in the
+        // 480 band.
+        assert_eq!(Resolution::from_dimensions(704, 480), Resolution::R480p);
+        // PAL DVD (720×576).
+        assert_eq!(Resolution::from_dimensions(720, 576), Resolution::R576p);
+        // Below the floor → Unknown.
+        assert_eq!(Resolution::from_dimensions(640, 360), Resolution::Unknown);
+        // Boundary case: exactly the threshold.
+        assert_eq!(Resolution::from_dimensions(0, 460), Resolution::R480p);
+        assert_eq!(Resolution::from_dimensions(0, 459), Resolution::Unknown);
+    }
+
+    // ── ClassificationResult::label ──────────────────────────────────
+    //
+    // The label string is what `episode_quality_tags.quality_tag`
+    // stores AND what the UI renders. A regression here mis-tags
+    // every episode for the affected source class.
+
+    fn cr(source: Source, res: Resolution, is_remux: bool, is_bdmv: bool) -> ClassificationResult {
+        ClassificationResult {
+            source,
+            resolution: res,
+            is_remux,
+            web_kind: WebKind::Unknown,
+            is_bdmv,
+            confidence: 1.0,
+            needs_review: false,
+            evidence: Vec::new(),
+            decision_rule: DecisionRule::Empty,
+        }
+    }
+
+    #[test]
+    fn label_canonical_sonarr_shapes() {
+        // The four shapes the user sees most often. These strings are
+        // the contract Sonarr-compat code matches against.
+        assert_eq!(
+            cr(Source::BluRay, Resolution::R1080p, false, false).label(),
+            "BD-1080p"
+        );
+        assert_eq!(
+            cr(Source::BluRay, Resolution::R1080p, true, false).label(),
+            "BD-1080p Remux"
+        );
+        assert_eq!(
+            cr(Source::BluRay, Resolution::R1080p, false, true).label(),
+            "BD-1080p RAW"
+        );
+        assert_eq!(
+            cr(Source::Web, Resolution::R1080p, false, false).label(),
+            "WEB-1080p"
+        );
+        assert_eq!(
+            cr(Source::Hdtv, Resolution::R1080p, false, false).label(),
+            "HDTV-1080p"
+        );
+        assert_eq!(
+            cr(Source::Dvd, Resolution::R480p, false, false).label(),
+            "DVD-480p"
+        );
+    }
+
+    #[test]
+    fn label_collapses_webdl_to_bare_web() {
+        // Issue #48: WebDl renders as bare WEB so users don't see two
+        // labels for what's effectively the same tier. WebRip stays
+        // distinct because that's the lower-quality variant power
+        // users want to spot.
+        let mut webdl = cr(Source::Web, Resolution::R1080p, false, false);
+        webdl.web_kind = WebKind::WebDl;
+        assert_eq!(webdl.label(), "WEB-1080p");
+
+        let mut webrip = cr(Source::Web, Resolution::R1080p, false, false);
+        webrip.web_kind = WebKind::WebRip;
+        assert_eq!(webrip.label(), "WEBRip-1080p");
+    }
+
+    #[test]
+    fn label_bdmv_takes_precedence_over_remux_when_both_set() {
+        // Defensive: classifier shouldn't set both, but if it does,
+        // BDMV wins per `bluray_tier()` — `is_bdmv` checks first.
+        let cr = cr(Source::BluRay, Resolution::R1080p, true, true);
+        assert_eq!(cr.label(), "BD-1080p RAW");
+    }
+
+    #[test]
+    fn label_unknown_source_falls_back_to_resolution_only() {
+        // No source determined but resolution available — show the
+        // resolution alone rather than emit "Unknown-1080p" or similar.
+        assert_eq!(
+            cr(Source::Unknown, Resolution::R1080p, false, false).label(),
+            "1080p"
+        );
+    }
+
+    #[test]
+    fn label_all_unknown_is_unknown() {
+        assert_eq!(
+            cr(Source::Unknown, Resolution::Unknown, false, false).label(),
+            "Unknown"
+        );
+    }
+
+    #[test]
+    fn label_known_source_unknown_resolution_drops_resolution_suffix() {
+        // BD-Unknown isn't useful; just `BD` is what the UI wants.
+        assert_eq!(
+            cr(Source::BluRay, Resolution::Unknown, false, false).label(),
+            "BD"
+        );
+        // Sub-tier still lands.
+        assert_eq!(
+            cr(Source::BluRay, Resolution::Unknown, true, false).label(),
+            "BD Remux"
+        );
+    }
+
+    // ── ClassificationResult::rank ───────────────────────────────────
+
+    #[test]
+    fn rank_resolution_dominates_over_source() {
+        // Web-1080p > BluRay-720p (resolution dominates the tuple).
+        let web = cr(Source::Web, Resolution::R1080p, false, false);
+        let bd = cr(Source::BluRay, Resolution::R720p, false, false);
+        assert!(web.rank() > bd.rank());
+    }
+
+    #[test]
+    fn rank_bluray_tier_breaks_ties() {
+        // Same source + resolution, BDMV > Remux > plain.
+        let plain = cr(Source::BluRay, Resolution::R1080p, false, false);
+        let remux = cr(Source::BluRay, Resolution::R1080p, true, false);
+        let bdmv = cr(Source::BluRay, Resolution::R1080p, false, true);
+        assert!(remux.rank() > plain.rank());
+        assert!(bdmv.rank() > remux.rank());
+    }
+
+    #[test]
+    fn rank_web_kind_breaks_ties() {
+        // Pins the actual rank order: WebDl (2) > WebRip (1) >
+        // Unknown (0). The `WebKind` docstring claims bare-WEB "slots
+        // between WebRip and WebDl," but the code sits Unknown at the
+        // bottom — explicit WebRip outranks an untagged Web release.
+        // A consequence is that a `WEBRip` row on disk never gets
+        // upgraded by a same-resolution bare-WEB release (the upgrade
+        // gate compares `incoming.rank > existing.rank`); whether
+        // that's the intended semantics is a separate decision, but
+        // the test pins the current behavior so a refactor that
+        // touches the rank order has to confront the doc/code
+        // mismatch.
+        let mut webdl = cr(Source::Web, Resolution::R1080p, false, false);
+        webdl.web_kind = WebKind::WebDl;
+        let mut webrip = cr(Source::Web, Resolution::R1080p, false, false);
+        webrip.web_kind = WebKind::WebRip;
+        let webunknown = cr(Source::Web, Resolution::R1080p, false, false);
+        assert!(webdl.rank() > webrip.rank());
+        assert!(webrip.rank() > webunknown.rank());
+    }
+
+    // ── SourceEvidence::new clamps confidence to 0..=1 ───────────────
+
+    #[test]
+    fn source_evidence_new_clamps_confidence() {
+        // Layer authors emit confidences from heterogeneous sources;
+        // clamp at the boundary so a buggy 1.5 doesn't dominate
+        // aggregation, and a -0.1 doesn't subtract from the running sum.
+        assert_eq!(
+            SourceEvidence::new(Source::BluRay, 1.5, Origin::Filename, "").confidence,
+            1.0
+        );
+        assert_eq!(
+            SourceEvidence::new(Source::BluRay, -0.1, Origin::Filename, "").confidence,
+            0.0
+        );
+        assert_eq!(
+            SourceEvidence::new(Source::BluRay, 0.5, Origin::Filename, "").confidence,
+            0.5
+        );
+    }
+}

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::AppState;
 use crate::models::log::LogCategory;
@@ -168,7 +168,24 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
         )
         .await;
 
+        // Episode numbers already covered by a batch we grabbed earlier
+        // in this series's loop. Without this, a 12-episode BD pack
+        // covering eps 1..=12 would be re-found and re-grabbed once per
+        // remaining target — 12 redundant Nyaa sweeps, 12 episode_grab_history
+        // rows for the same release, and an inflated upgrade count in
+        // the summary log. `record_grab` deduplicates the parent
+        // grabbed_torrents row by hash, but episode_tags::record_grab
+        // is unconditional INSERT, so each iteration pollutes history.
+        let mut covered_by_batch: HashSet<i32> = HashSet::new();
+
         for target in targets {
+            // Skip targets a previously-grabbed batch already covers.
+            if let auto_search::SearchTarget::Episode(ep_num) = &target
+                && covered_by_batch.contains(ep_num)
+            {
+                continue;
+            }
+
             let label = auto_search::target_label(&target);
             // batch_episode_match=true so BD season packs can match episode targets.
             let best = auto_search::find_best_for_target(
@@ -261,6 +278,10 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                             ep_nums = parsed.into_iter().collect();
                             ep_nums.sort_unstable();
                         }
+                        // Mark every episode this batch will cover as
+                        // satisfied so the rest of this series's loop
+                        // doesn't re-find / re-grab the same pack.
+                        covered_by_batch.extend(&ep_nums);
                     }
                     let _ = crate::models::grabbed_torrents::record_grab(
                         &state.db,

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -99,7 +99,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             continue;
         }
 
-        let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name);
+        let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name).await;
         if disk_files.is_empty() {
             continue;
         }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -77,6 +77,11 @@ pub fn build_test_app_state(
         users_exist: Arc::new(AtomicBool::new(true)),
         interactive_search_cache: crate::services::interactive_search_cache::new(),
         oauth_state: crate::services::oauth_state::new(),
+        // A fixed start_time so snapshot tests of `system_status` get
+        // a stable serialization. Real production paths use
+        // `chrono::Utc::now()` at process boot.
+        start_time: chrono::DateTime::<chrono::Utc>::from_timestamp(1_704_067_200, 0)
+            .expect("epoch is valid"),
     }
 }
 

--- a/static/css/pages/series.css
+++ b/static/css/pages/series.css
@@ -815,6 +815,26 @@
     color: var(--red);
 }
 
+/* `is-manual-override` flags the quality-override button when the
+ * episode currently carries a pinned classification. Reuses the
+ * red palette from `is-error` (already in scope on this page) but
+ * keeps the hover lift + accent-border behavior so the button still
+ * reads as "click me to edit"; without the hover override it would
+ * look disabled. The persistent red signals "an override is active
+ * here" — replaces the prior 📌 emoji on the quality tag, which
+ * was easy to miss in dense episode lists. */
+.icon-btn.is-manual-override {
+    border-color: rgba(211, 125, 125, 0.55);
+    background: rgba(211, 125, 125, 0.16);
+    color: var(--red);
+}
+
+.icon-btn.is-manual-override:hover:not(:disabled) {
+    border-color: var(--red);
+    background: rgba(211, 125, 125, 0.22);
+    transform: translateY(-1px);
+}
+
 .btn.is-loading {
     opacity: 0.85;
 }

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -809,6 +809,21 @@ function syncWatchListNow() {
                     el.setAttribute('data-relative-time', String(nowSec));
                     el.textContent = 'Just now';
                 });
+                // A successful sync also clears `last_sync_auth_failed`
+                // server-side. The banner + legend badge are still
+                // server-rendered to whatever the page-load state was,
+                // so flip them in-place — without this, the user has
+                // to reload Settings to see "Re-link required" go
+                // away after a successful sync.
+                document
+                    .querySelectorAll('[data-ext-auth-banner]')
+                    .forEach((el) => el.setAttribute('hidden', ''));
+                document
+                    .querySelectorAll('[data-ext-auth-badge="error"]')
+                    .forEach((el) => el.setAttribute('hidden', ''));
+                document
+                    .querySelectorAll('[data-ext-auth-badge="ok"]')
+                    .forEach((el) => el.removeAttribute('hidden'));
             }
         },
     });

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -244,11 +244,10 @@
                 External Accounts
                 {% match external_account %}
                     {% when Some with (acct) %}
-                        {% if acct.last_sync_auth_failed %}
-                        <span class="form-hint"><span class="log-badge log-badge-error">Re-link required</span></span>
-                        {% else %}
-                        <span class="form-hint"><span class="log-badge log-badge-info">{{ acct.provider_label }} · {{ acct.username }}</span></span>
-                        {% endif %}
+                        <span class="form-hint">
+                            <span class="log-badge log-badge-error" data-ext-auth-badge="error" {% if !acct.last_sync_auth_failed %}hidden{% endif %}>Re-link required</span>
+                            <span class="log-badge log-badge-info" data-ext-auth-badge="ok" {% if acct.last_sync_auth_failed %}hidden{% endif %}>{{ acct.provider_label }} · {{ acct.username }}</span>
+                        </span>
                     {% when None %}
                         <span class="form-hint"><span class="log-badge">Not linked</span></span>
                 {% endmatch %}
@@ -259,12 +258,10 @@
                        successful sync. Sized + spaced like Seerr's
                        intro paragraph so they sit naturally inside
                        the fieldset. #}
-                    {% if acct.last_sync_auth_failed %}
-                    <div class="ext-alert ext-alert-error" role="alert">
+                    <div class="ext-alert ext-alert-error" role="alert" data-ext-auth-banner {% if !acct.last_sync_auth_failed %}hidden{% endif %}>
                         <strong>Re-link required.</strong>
                         Your {{ acct.provider_label }} authentication has expired or was revoked. Sync stopped working until you unlink and link again.
                     </div>
-                    {% endif %}
                     {% if acct.last_sync_deferred_count > 0 && acct.provider == "mal" %}
                     <div class="ext-alert ext-alert-warn">
                         <strong>{{ acct.last_sync_deferred_count }} series couldn't be mapped MyAnimeList → AniList</strong>

--- a/templates/series.html
+++ b/templates/series.html
@@ -378,12 +378,12 @@
                         {% if ep.quality_state == "grabbed" %}
                         <div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:0%"></div></div><span class="dl-progress-text">0.0%</span></div>
                         {% else if ep.quality_state == "completed" %}
-                        <span class="tag tag-quality{% if ep.manual_override %} tag-quality-manual{% endif %}">{{ ep.quality }}{% if ep.manual_override %} 📌{% endif %}</span>
+                        <span class="tag tag-quality">{{ ep.quality }}</span>
                         {% else if !ep.quality.is_empty() %}
                             {% if ep.quality_state == "failed" %}
                             <span class="tag tag-quality-failed">{{ ep.quality }} ✗</span>
                             {% else %}
-                            <span class="tag tag-quality{% if ep.manual_override %} tag-quality-manual{% endif %}">{{ ep.quality }}{% if ep.manual_override %} 📌{% endif %}</span>
+                            <span class="tag tag-quality">{{ ep.quality }}</span>
                             {% endif %}
                         {% else if ep.on_disk %}
                         <span class="tag tag-quality">UNKNOWN</span>
@@ -410,13 +410,21 @@
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="3" y1="6" x2="12" y2="6"/><line x1="3" y1="12" x2="10" y2="12"/><line x1="3" y1="18" x2="9" y2="18"/><circle cx="17" cy="15" r="3"/><line x1="19.2" y1="17.2" x2="21" y2="19"/></svg>
                             </span>
                         </button>
-                        <button class="icon-btn btn-episode-override" type="button" onclick="openManualOverride({{ ep.number }}, '{{ ep.class_source }}', '{{ ep.class_resolution }}', {{ ep.class_is_remux }}, {{ ep.class_is_bdmv }}, '{{ ep.class_web_kind }}')" title="Override source/resolution tag" aria-label="Override source/resolution tag for episode {{ ep.number }}">
+                        <button class="icon-btn btn-episode-override{% if ep.manual_override %} is-manual-override{% endif %}" type="button" onclick="openManualOverride({{ ep.number }}, '{{ ep.class_source }}', '{{ ep.class_resolution }}', {{ ep.class_is_remux }}, {{ ep.class_is_bdmv }}, '{{ ep.class_web_kind }}')" title="{% if ep.manual_override %}Edit pinned source/resolution tag{% else %}Override source/resolution tag{% endif %}" aria-label="{% if ep.manual_override %}Edit pinned source/resolution tag for episode {{ ep.number }}{% else %}Override source/resolution tag for episode {{ ep.number }}{% endif %}">
                             <span class="icon-btn-inner">
                                 {# Vertical sliders (Lucide sliders-vertical):
                                    reads as "adjust these values" — matches
                                    the act of overriding a source/resolution
                                    classification more directly than a
-                                   generic pencil/edit icon. #}
+                                   generic pencil/edit icon. The button
+                                   itself flips to a red highlight via the
+                                   `is-manual-override` class when an
+                                   override is active — the prior
+                                   📌 emoji on the quality tag was a
+                                   weaker signal: easy to miss in dense
+                                   episode lists, and pinned/unpinned
+                                   states drifted apart from where the
+                                   user clicks to change them. #}
                                 <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
                             </span>
                         </button>


### PR DESCRIPTION
## Summary

Investigation pass that surfaced four real bugs (one of them a stack overflow), wired in features the user asked for, and closed the handler-helper unit-test gap. 39 commits since 1.4.1.

### Bugs fixed
- **rtorrent XML-RPC stack overflow.** The decoder recursed without a depth gate; ~5000 nested `<array>` levels blew the default 2 MiB cargo-test stack. Capped at 256 levels, returns `Err` instead of crashing.
- **Jellyfin 172.x prefix over-match.** `starts_with(\"172.2\")` matched 172.200-172.255 (public) along with 172.20-172.29 (RFC 1918 private). A user with that as a Jellyfin host would have gotten plain HTTP and leaked the API key. Replaced with a real second-octet range parse.
- **Future-mode monitoring on no-episode-info finished series.** With AL not reporting an episode count, the Future-mode arm fell through to monitoring everything; now short-circuits to monitoring nothing for finished shows.
- **Post-processing same-inode hardlink fan-out.** `do_file_op` could attempt a hardlink against an already-linked destination; guarded against same-inode src/dst.

### Features
- **Sonarr/Radarr ratings + actual start time.** Shim payloads now carry `AnimeDetail.average_score` (was hardcoded 0) and the real process start time (was hardcoded epoch). Versions bumped to current stable (Sonarr 4.0.17.2952, Radarr 6.1.1.10360).
- **Override-button-red instead of pin-emoji.** Quality override now highlights the button red rather than rendering a separate pin emoji — one less UI element to scan.

### OAuth + sync polish
- Friendly error when a re-link picks a different user on the same provider.
- Cooldown + body truncation on the link-flow handler so AL/MAL transient meltdowns don't pin the spinner.
- Clear the re-link banner in-place after a successful sync.

### Auto-search + RSS + upgrade
- Apply Custom Formats to RSS auto-grab scoring (previously RSS scored without CF context).
- Stop dropping legit episode numbers as resolution noise (a release titled \"... 480 ...\" was getting the 480 stripped because it overlapped the 480p resolution token).
- Suppress episode-target batch penalty in batch search.
- Skip upgrade-search targets already covered by an earlier batch grab.

### Migrations
- Drop the bespoke `base32_backfill_done` flag and replace with a self-gating SELECT.
- Generalize the column-rename reconciler to typed columns.

### Test coverage (this PR's biggest delta)
- +104 tests across six handler modules (1397 → 1501). Targets: pages.rs, downloads.rs, oauth.rs, auth/sanitize, system rate-limit, sonarr_compat/radarr_compat helpers, library/search pure helpers, settings/mod (humanize_relative_time, normalize_settings_tab, etc.), settings/custom_formats (cf_redirect, parse_default_cf_entries).
- Three small refactors so helpers became cleanly testable: `should_persist_detail_cache` takes `i64` instead of `&Series`; `check_client_log_rate` factored into a pure `admit_log_event(deque, now, window, max)`; the relation builder in pages.rs replaced with a default-relation + per-test mutation.
- New fuzz-lite batteries for the rss feed parser, source/types primitives, the rtorrent XML-RPC codec.

### Refactors (large file split-ups)
- `external_sync` (2932 LoC) → mod/types/normalize/merge/cursor/removals/tests.
- `library/search` (2596 LoC) → mod/auto_search/interactive/grab/tests.
- rtorrent → extracted XML-RPC codec into `xmlrpc.rs`.
- auto_search → extracted SeaDex lookup + cache into `seadex_lookup.rs`.
- rss/migrations → tests blocks moved into sibling files.

## Test plan
- [x] cargo build --workspace --locked
- [x] cargo test --workspace --locked --features test-support (1501 passed; 22 ignored)
- [x] cargo clippy --workspace --all-targets --features test-support -- -D warnings
- [x] cargo fmt --all -- --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)