### PR TITLE
1.4.6: stress-test fixes — auto-search cascade-stop + short-alias gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2520,7 +2520,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "1.4.5"
+version = "1.4.6"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "1.4.5"
+version = "1.4.6"
 edition = "2024"
 rust-version = "1.95"
 

--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -180,6 +180,15 @@ async fn emit_auto_search_terminal(
 ) {
     match result {
         Ok(report) => {
+            // PR #104 review: the cascade-stop path (issue #102 fix)
+            // emits its own terminal "Auto-search cancelled" toast
+            // before returning the partial report. Without this
+            // short-circuit, the wrapper would emit ANOTHER terminal
+            // event (`Nothing to search` / `Grabbed N`) that
+            // immediately overwrites the cancel message in the UI.
+            if report.cancelled {
+                return;
+            }
             let grabbed = report.grabbed.len();
             if grabbed > 0 {
                 // Show titles for ≤3 grabs, otherwise just the count —
@@ -340,6 +349,7 @@ async fn run_auto_search_targets_with_upgrades(
                 grabbed,
                 skipped,
                 quality_profile: cfg.quality_profile,
+                cancelled: true,
             });
         }
         let label = auto_search::target_label(&target);
@@ -694,6 +704,7 @@ async fn run_auto_search_targets_with_upgrades(
         grabbed,
         skipped,
         quality_profile: cfg.quality_profile,
+        cancelled: false,
     })
 }
 

--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -30,6 +30,23 @@ use crate::services::{anilist, auto_search, logger, media, progress};
 
 use super::super::reconcile::{maybe_hydrate_cumulative_offset, resolve_series_context};
 
+/// Issue #102 — gate the per-target loop in
+/// `run_auto_search_targets_with_upgrades` (and the parallel
+/// per-series loop in `services::upgrade::run_once`) on whether the
+/// caller's `series_id` still refers to a row in the `series` table.
+/// Returns `true` when the loop should continue; `false` when the
+/// caller should break and terminate the cascade.
+///
+/// `None` means the caller didn't bind the search to a tracked
+/// series (typical for the search-before-add flow), so there's
+/// nothing to cancel — return `true` and let the loop run.
+pub(crate) async fn series_still_in_library(db: &SqlitePool, series_id: Option<i64>) -> bool {
+    let Some(sid) = series_id else {
+        return true;
+    };
+    series::get_by_id(db, sid).await.ok().flatten().is_some()
+}
+
 pub(super) fn batch_episode_numbers(title: &str, detail: &anilist::AnimeDetail) -> Vec<i32> {
     let mut ep_nums: Vec<i32> = auto_search::parse_release_numbers(title)
         .into_iter()
@@ -288,6 +305,43 @@ async fn run_auto_search_targets_with_upgrades(
     let mut skipped = Vec::new();
     let total_targets = targets.len();
     for (idx, target) in targets.into_iter().enumerate() {
+        // Issue #102 — auto-search of a "monitor all" series queues a
+        // per-episode loop. If the user removes the series mid-loop
+        // (typical stress-test discovery: notice the wrong show was
+        // added, delete it from the library), the loop used to keep
+        // grabbing episodes anyway because the targets vec was already
+        // materialized. Re-check existence at the top of each iteration
+        // so a removal stops the cascade promptly. Only applies when
+        // the caller bound a series_id; the search-before-add flow
+        // (series_id == None) is unaffected.
+        if !series_still_in_library(&state.db, series_id).await {
+            logger::info(
+                &state.db,
+                LogCategory::AutoSearch,
+                &format!(
+                    "Auto search cancelled for {}: series removed from library",
+                    title
+                ),
+                &format!(
+                    "{} of {} target(s) processed before cancel",
+                    idx, total_targets
+                ),
+            )
+            .await;
+            progress::emit(
+                "done",
+                "warn",
+                "Auto-search cancelled",
+                Some("Series was removed from the library".to_string()),
+                true,
+            )
+            .await;
+            return Ok(auto_search::AutoSearchReport {
+                grabbed,
+                skipped,
+                quality_profile: cfg.quality_profile,
+            });
+        }
         let label = auto_search::target_label(&target);
         let is_upgrade = matches!(&target, auto_search::SearchTarget::Episode(n) if upgrade_classifications.contains_key(n));
         progress::emit(

--- a/src/handlers/library/search/interactive.rs
+++ b/src/handlers/library/search/interactive.rs
@@ -267,6 +267,7 @@ pub async fn search_batch_releases(
                 }],
                 skipped: vec![],
                 quality_profile: cfg.quality_profile,
+                cancelled: false,
             }))
         }
     }

--- a/src/handlers/library/search/mod.rs
+++ b/src/handlers/library/search/mod.rs
@@ -37,6 +37,7 @@ mod interactive;
 #[cfg(test)]
 mod tests;
 
+pub(crate) use auto_search::series_still_in_library;
 pub use auto_search::{
     __path_auto_search_episode, __path_auto_search_series, AutoSearchQuery, auto_search_episode,
     auto_search_series, run_auto_search_targets,

--- a/src/handlers/library/search/tests/mod.rs
+++ b/src/handlers/library/search/tests/mod.rs
@@ -903,3 +903,83 @@ mod pure_helpers {
         assert_eq!(display_title_for_progress(&detail), "");
     }
 }
+
+// ── series_still_in_library (issue #102) ──────────────────────────────
+//
+// The cascade-stop guard at the top of run_auto_search_targets_with_
+// upgrades' per-target loop. Tests pin the three states the guard
+// distinguishes: no-series-bound, present, and removed. Without the
+// guard, removing a series mid-loop kept queueing per-episode grabs.
+
+#[cfg(test)]
+mod cascade_stop_tests {
+    use sqlx::SqlitePool;
+
+    use super::super::auto_search::series_still_in_library;
+    use crate::models::series;
+
+    async fn seed_series(db: &SqlitePool, anilist_id: i64, title: &str) -> i64 {
+        let (id, _) = series::upsert(
+            db,
+            series::SeriesCore {
+                anilist_id,
+                mal_id: None,
+                title,
+                title_romaji: title,
+                title_english: title,
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2020),
+                end_year: Some(2020),
+            },
+        )
+        .await
+        .expect("upsert");
+        id
+    }
+
+    #[tokio::test]
+    async fn none_series_id_short_circuits_to_true() {
+        // The search-before-add flow doesn't bind a series_id; the
+        // guard must let it through unchanged. Otherwise every
+        // anonymous "preview search" call would terminate after the
+        // first target.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        assert!(series_still_in_library(&db, None).await);
+    }
+
+    #[tokio::test]
+    async fn present_series_returns_true() {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        let id = seed_series(&db, 12345, "Test Show").await;
+        assert!(series_still_in_library(&db, Some(id)).await);
+    }
+
+    #[tokio::test]
+    async fn removed_series_returns_false_so_loop_breaks() {
+        // The load-bearing case: user removes the series mid-loop.
+        // The next iteration's guard call must return false so the
+        // outer loop stops queueing per-episode grabs.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        let id = seed_series(&db, 12345, "Removed Show").await;
+        series::remove(&db, id).await.expect("remove");
+        assert!(!series_still_in_library(&db, Some(id)).await);
+    }
+
+    #[tokio::test]
+    async fn nonexistent_series_id_returns_false() {
+        // Defensive: if the caller passes a bogus id (race between
+        // `series_id_for_grab` resolution and the loop entry), the
+        // guard should treat it as "not in library" rather than
+        // erroring out.
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        assert!(!series_still_in_library(&db, Some(999_999)).await);
+    }
+}

--- a/src/services/auto_search/aliases.rs
+++ b/src/services/auto_search/aliases.rs
@@ -596,6 +596,75 @@ pub fn dedupe_strings(values: Vec<String>) -> Vec<String> {
     out
 }
 
+/// Issue #103: protect short-named series ("Nichijou", "Bocchi") from
+/// substring false positives. For an alias that boils down to a single
+/// content token, the substring-contains shortcut and the alias-anchored
+/// `token_overlap_ratio` both grant 1.0 to ANY release whose title
+/// contains that token — including unrelated shows whose names happen
+/// to share a Japanese word in common ("nichijou" = "everyday", a word
+/// that appears in many slice-of-life titles). Existing
+/// `sibling_match_rejects` only catches relatives in the AL graph; an
+/// unrelated show isn't reachable that way.
+///
+/// This helper requires that the release's content tokens (title minus
+/// pure-numeric metadata like episode numbers and years) don't
+/// substantially exceed the alias's content tokens. Tolerance scales
+/// with alias length so multi-token aliases stay permissive (a season
+/// subtitle adds expected surplus) while 1-2 token aliases get a tight
+/// budget. Returns `true` to keep the alias as a viable match;
+/// `false` to discard this alias-vs-release pairing.
+fn passes_content_surplus_check(
+    title_tokens: &HashSet<String>,
+    alias_tokens: &HashSet<String>,
+) -> bool {
+    let is_metadata_number = |t: &str| -> bool {
+        // Pure-digit tokens in the episode/year range. Mixed
+        // alphanumeric tokens (codecs like "h264", resolutions like
+        // "1280x720") can leak in if the bracket strip missed them
+        // and the filter list doesn't catch them — those count as
+        // surplus and the tolerance absorbs a couple. Keeping this
+        // narrow avoids over-stripping legitimate alias tokens like
+        // "0" in "Jujutsu Kaisen 0".
+        match t.parse::<i32>() {
+            Ok(n) => (1..=9999).contains(&n),
+            Err(_) => false,
+        }
+    };
+    let title_content: HashSet<&String> = title_tokens
+        .iter()
+        .filter(|t| !is_metadata_number(t))
+        .collect();
+    let alias_content: HashSet<&String> = alias_tokens
+        .iter()
+        .filter(|t| !is_metadata_number(t))
+        .collect();
+
+    if alias_content.is_empty() {
+        // Pure-numeric alias is degenerate; defer to caller's other
+        // matchers rather than reject here.
+        return true;
+    }
+
+    let surplus = title_content.difference(&alias_content).count();
+
+    // Tolerance scales with alias length:
+    //   1 alias token  → at most 1 surplus content token. "Nichijou"
+    //                    + episode + group = OK; "Otonari no
+    //                    Nichijou" = 2 surplus tokens, REJECT.
+    //   2 alias tokens → at most 3 surplus content tokens. "Sword
+    //                    Art Online: Alicization" adds "alicization"
+    //                    + minor metadata, still under 3.
+    //   3+ alias tokens → unlimited. Existing 0.6-ratio gate carries
+    //                     the load; multi-token aliases are
+    //                     specific enough to not hit the bug.
+    let tolerance = match alias_content.len() {
+        1 => 1,
+        2 => 3,
+        _ => usize::MAX,
+    };
+    surplus <= tolerance
+}
+
 pub fn matches_target(
     title: &str,
     aliases: &[String],
@@ -610,8 +679,14 @@ pub fn matches_target(
 
     let alias_match = aliases.iter().any(|alias| {
         let normalized_alias = normalize_title(alias);
-        normalized_title.contains(&normalized_alias)
-            || token_overlap_ratio(&title_tokens, &token_set(&normalized_alias)) >= 0.6
+        let alias_tokens = token_set(&normalized_alias);
+        let raw_match = normalized_title.contains(&normalized_alias)
+            || token_overlap_ratio(&title_tokens, &alias_tokens) >= 0.6;
+        // Issue #103 — short aliases substring-match unrelated shows
+        // sharing a token. Require the title's content tokens not to
+        // substantially exceed the alias's; see
+        // `passes_content_surplus_check` for the tolerance schedule.
+        raw_match && passes_content_surplus_check(&title_tokens, &alias_tokens)
     });
 
     if !alias_match {
@@ -715,6 +790,78 @@ mod tests {
             segments.iter().any(|s| s == "Main Title Two"),
             "multi-word leading portion should be kept, got {:?}",
             segments
+        );
+    }
+
+    #[test]
+    fn matches_target_rejects_unrelated_show_sharing_short_alias_token() {
+        // Issue #103 — the short-named series bug. A user tracking a
+        // 1-token alias (the canonical case is "Nichijou", a Japanese
+        // word meaning "everyday" that shows up in many slice-of-life
+        // title fragments) used to match every release whose title
+        // contained that token, including totally unrelated shows.
+        //
+        // Synthetic shapes here so the test isn't tied to any real
+        // title — `passes_content_surplus_check` rejects when the
+        // release has more than 1 surplus content token beyond a
+        // single-token alias.
+        let aliases = vec!["Shortname".to_string()];
+        let no_siblings = SiblingRejectPrecompute::build(&aliases, &[]);
+
+        // The legit release: alias is the only content token aside
+        // from the group + episode. Surplus = 1 (group), at tolerance.
+        let legit = "[Group] Shortname - 12 [BD 1080p].mkv";
+        assert!(
+            matches_target(
+                legit,
+                &aliases,
+                &no_siblings,
+                &SearchTarget::Episode(12),
+                0,
+                false,
+                0
+            ),
+            "real release should still match"
+        );
+
+        // The false-positive: an unrelated show whose title shares
+        // the short alias token but adds 2+ content words. Surplus
+        // exceeds the 1-tolerance for a 1-token alias.
+        let false_positive = "[Group] Some Other Show no Shortname - 12 [BD 1080p].mkv";
+        assert!(
+            !matches_target(
+                false_positive,
+                &aliases,
+                &no_siblings,
+                &SearchTarget::Episode(12),
+                0,
+                false,
+                0
+            ),
+            "unrelated show sharing the short alias token must be rejected"
+        );
+    }
+
+    #[test]
+    fn matches_target_two_token_alias_keeps_legit_subtitle() {
+        // Symmetry guard: a 2-token alias must still accept a release
+        // whose title carries an extra subtitle word. Tolerance for
+        // 2-token aliases is 3 surplus, so a release with one
+        // additional subtitle word is well within budget.
+        let aliases = vec!["Sword Art".to_string()]; // synthetic 2-tok
+        let no_siblings = SiblingRejectPrecompute::build(&aliases, &[]);
+        let legit = "[Group] Sword Art Online - Alicization - 12 [BD 1080p].mkv";
+        assert!(
+            matches_target(
+                legit,
+                &aliases,
+                &no_siblings,
+                &SearchTarget::Episode(12),
+                0,
+                false,
+                0
+            ),
+            "2-token alias should accept a related release with extra subtitle words"
         );
     }
 

--- a/src/services/auto_search/aliases.rs
+++ b/src/services/auto_search/aliases.rs
@@ -34,6 +34,14 @@ pub fn normalize_title(input: &str) -> String {
     cleaned
         .split_whitespace()
         .filter(|token| {
+            // Universal release-side noise tokens — same shape as
+            // resolution/codec markers. Container extensions (mkv /
+            // mp4 / mka) survive the bracket strip because a `.` is
+            // converted to whitespace, leaving the extension as a
+            // bare token. They're release metadata, not content;
+            // dropping them frees the 1-token-alias surplus budget
+            // (issue #103) for legitimate variants like `Episode`
+            // markers and `v2` revisions.
             !matches!(
                 *token,
                 "1080p"
@@ -49,6 +57,9 @@ pub fn normalize_title(input: &str) -> String {
                     | "dual"
                     | "audio"
                     | "multisub"
+                    | "mkv"
+                    | "mp4"
+                    | "mka"
             )
         })
         .collect::<Vec<_>>()
@@ -839,6 +850,45 @@ mod tests {
                 0
             ),
             "unrelated show sharing the short alias token must be rejected"
+        );
+    }
+
+    #[test]
+    fn matches_target_short_alias_accepts_release_with_episode_marker() {
+        // PR #104 review: the 1-token alias tolerance is 1 surplus.
+        // `mkv` was eating the budget, so a release shape with one
+        // extra word like `Episode` would get rejected even though
+        // it's clearly the target's release. Add `mkv`/`mp4`/`mka`
+        // to normalize_title's filter list to free the slot. Pin
+        // the legit case here.
+        let aliases = vec!["Shortname".to_string()];
+        let no_siblings = SiblingRejectPrecompute::build(&aliases, &[]);
+        let with_episode_marker = "[Group] Shortname Episode 12 [BD 1080p].mkv";
+        assert!(
+            matches_target(
+                with_episode_marker,
+                &aliases,
+                &no_siblings,
+                &SearchTarget::Episode(12),
+                0,
+                false,
+                0
+            ),
+            "legit release with extra `Episode` marker must still match"
+        );
+        // The v2 / revision form is a similar shape.
+        let with_revision = "Shortname - 12 v2 [BD].mkv";
+        assert!(
+            matches_target(
+                with_revision,
+                &aliases,
+                &no_siblings,
+                &SearchTarget::Episode(12),
+                0,
+                false,
+                0
+            ),
+            "release with v2 revision must still match"
         );
     }
 

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -65,6 +65,13 @@ pub struct AutoSearchReport {
     pub grabbed: Vec<AutoSearchHit>,
     pub skipped: Vec<String>,
     pub quality_profile: String,
+    /// Set when the per-target loop was stopped by an external
+    /// signal (currently: series removed from library — see issue
+    /// #102). The wrapper `emit_auto_search_terminal` short-circuits
+    /// on this so the cascade-stop path's "cancelled" toast doesn't
+    /// get overwritten by a generic terminal event.
+    #[serde(default)]
+    pub cancelled: bool,
 }
 
 /// Return all scored candidates for an episode target without grabbing anything.

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -99,6 +99,15 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             continue;
         }
 
+        // Issue #102 — the tracked snapshot was pulled at the top of
+        // the sweep; a series removed mid-iteration would still be
+        // checked (and any upgrade hit grabbed). Re-read the row each
+        // iteration so a removed series stops the cascade promptly.
+        if !crate::handlers::library::search::series_still_in_library(&state.db, Some(row.id)).await
+        {
+            continue;
+        }
+
         let disk_files = media::scan_series_folder(&cfg.media_root, &row.folder_name).await;
         if disk_files.is_empty() {
             continue;


### PR DESCRIPTION
## Summary

Two fixes from a stress test (issues #102 and #103). Both narrowly scoped.

### #102 — auto-search cascade-stop on series removal
A "monitor all" series triggers a per-target loop in
\`run_auto_search_targets_with_upgrades\`. Targets are materialized up
front, so removing the series mid-loop didn't stop the cascade —
every remaining episode still went through Nyaa search and a
download-client add even though there was no library row to attach
the result to.

Fix: \`series_still_in_library()\` guard at the top of each iteration.
On removal, log the cancel, emit a terminal "cancelled" progress
event, and return the partial report. \`None\` series_id (search-
before-add flow) short-circuits to \`true\` so anonymous preview
searches are unaffected. Same shape applied to
\`services::upgrade::run_once\` (whose tracked snapshot has the
parallel issue).

### #103 — short-alias false positives
A 1-token alias like "Nichijou" (a Japanese word common in slice-
of-life subtitles) used to gate-pass any release whose title
contained that token, including unrelated shows whose names share
the word. Both the substring-contains shortcut and the alias-
anchored \`token_overlap_ratio\` (\`common / |alias|\`) returned 1.0
against any title carrying the token. The existing
\`sibling_match_rejects\` only catches relatives in the AL graph; an
unrelated show isn't reachable that way.

Fix: content-surplus gate inside \`matches_target\`'s per-alias arm.
After stripping pure-numeric metadata (episode numbers, years), the
title's content tokens can exceed the alias's by at most:
- 1 surplus for 1-token aliases ("Nichijou")
- 3 surplus for 2-token aliases ("Sword Art Online")
- unlimited for 3+ token aliases (the existing 0.6-ratio gate
  carries them)

The bug only materializes for short aliases; multi-token aliases are
specific enough not to need the extra gate. The existing JJK/SAO
sibling-rejection tests still pass.

### Note on the queued-grabs tab portion of #102
The cascade-stop fix addresses the bug behavior; the visibility
feature (a Downloads tab listing in-flight grabs with cancel
buttons) is unimplemented and can land separately if still wanted.

## Test plan
- [x] cargo build --workspace --locked
- [x] cargo test --workspace --locked --features test-support (1508 passed; 22 ignored)
- [x] cargo clippy --workspace --all-targets --features test-support -- -D warnings
- [x] cargo fmt --all -- --check

🤖 Generated with [Claude Code](https://claude.com/claude-code)