### PR TITLE
1.5.0 (draft): torznab/newznab indexer support — PR A + B (#28)

### DIFF
--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -374,6 +374,7 @@ async fn run_auto_search_targets_with_upgrades(
             allow_batch,
             is_upgrade,
             &cfs,
+            &state.indexers,
         )
         .await
         {

--- a/src/handlers/library/search/interactive.rs
+++ b/src/handlers/library/search/interactive.rs
@@ -86,6 +86,7 @@ pub async fn search_batch_releases(
         &cfg,
         &auto_search::SearchTarget::Single,
         &cfs,
+        &state.indexers,
     )
     .await;
 
@@ -385,6 +386,7 @@ pub async fn interactive_search_batches(
         &cfg,
         &auto_search::SearchTarget::Single,
         &cfs,
+        &state.indexers,
     )
     .await;
 

--- a/src/handlers/settings/custom_formats.rs
+++ b/src/handlers/settings/custom_formats.rs
@@ -1306,6 +1306,7 @@ pub async fn settings_custom_formats_test(
         info_hash: String::new(),
         score_breakdown: Vec::new(),
         upload_date: String::new(),
+        indexer_id: None,
     };
     let seadex: std::collections::HashSet<String> = std::collections::HashSet::new();
     let ctx = EvalContext {

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -156,6 +156,21 @@ pub async fn settings_indexers_delete(
     State(state): State<AppState>,
     Form(form): Form<IndexerDeleteForm>,
 ) -> Redirect {
+    // PR #107 round-2 review fix #3: SQLite can't add a real FK via
+    // ALTER TABLE, so `grabbed_torrents.indexer_id` is structurally
+    // unconstrained. NULL out matching rows explicitly here so the
+    // post-delete state matches the migration comment's "ON DELETE
+    // SET NULL" semantics. `pending_grabs.indexer_id` (already
+    // nullable per its CREATE TABLE) gets the same treatment for
+    // consistency.
+    let _ = sqlx::query("UPDATE grabbed_torrents SET indexer_id = NULL WHERE indexer_id = ?")
+        .bind(form.id)
+        .execute(&state.db)
+        .await;
+    let _ = sqlx::query("UPDATE pending_grabs SET indexer_id = NULL WHERE indexer_id = ?")
+        .bind(form.id)
+        .execute(&state.db)
+        .await;
     match delete(&state.db, form.id).await {
         Ok(_) => {
             logger::info(

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -1,0 +1,268 @@
+//! Settings → Indexers CRUD handlers (issue #28 PR B).
+//!
+//! Mirrors the shape of the groups + custom-formats settings
+//! handlers: form-driven upsert + delete that redirect back to
+//! the tab. The "test connection" path lands in a follow-up
+//! commit since it needs the full search-pipeline integration to
+//! be useful.
+
+use axum::{
+    Form,
+    extract::State,
+    response::{IntoResponse, Redirect, Response},
+};
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::models::indexers::{IndexerForm, KIND_NEWZNAB, KIND_TORZNAB, delete, insert, update};
+use crate::models::log::LogCategory;
+use crate::services::logger;
+
+/// Form for create/update — `id == None` creates, `id == Some(n)`
+/// updates row `n`. Mirrors CustomFormatUpsertForm shape.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct IndexerUpsertForm {
+    pub id: Option<i64>,
+    pub name: String,
+    pub kind: String,
+    pub url: String,
+    pub api_key: String,
+    /// Sonarr-convention priority. Range 1-50; out-of-range coerces
+    /// to 25. Empty string also coerces to 25.
+    pub priority: Option<String>,
+    /// HTML form checkboxes only POST when checked, so the field
+    /// is `Option<String>` and presence-equivalent to true.
+    pub enabled: Option<String>,
+    pub is_private_tracker: Option<String>,
+    /// Empty string = NULL (use default seed rules).
+    pub seed_ratio: Option<String>,
+    pub seed_time_minutes: Option<String>,
+    pub min_seeders: Option<String>,
+    pub request_timeout_secs: Option<String>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct IndexerDeleteForm {
+    pub id: i64,
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/indexers/upsert",
+    tag = "Settings",
+    summary = "Create or update an indexer",
+    description = "Form-driven upsert for the Settings → Indexers tab. Creates a new row when `id` is omitted; updates the row identified by `id` otherwise. Validates kind ∈ {torznab, newznab}, priority ∈ [1, 50], min_seeders ≥ 0. Out-of-range numerics coerce to safe defaults rather than rejecting the submission. Redirects back to the indexers tab.",
+    responses(
+        (status = 303, description = "Redirect back to the indexers tab"),
+    ),
+)]
+pub async fn settings_indexers_upsert(
+    State(state): State<AppState>,
+    Form(form): Form<IndexerUpsertForm>,
+) -> Response {
+    let name = form.name.trim();
+    if name.is_empty() {
+        return Redirect::to("/settings?tab=indexers&err=Name+required").into_response();
+    }
+    let kind = match form.kind.as_str() {
+        KIND_TORZNAB | KIND_NEWZNAB => form.kind.as_str(),
+        _ => {
+            return Redirect::to("/settings?tab=indexers&err=Invalid+kind").into_response();
+        }
+    };
+    let url = form.url.trim();
+    if url.is_empty() {
+        return Redirect::to("/settings?tab=indexers&err=URL+required").into_response();
+    }
+    let priority = parse_priority(&form.priority);
+    let min_seeders = parse_optional_i32(&form.min_seeders, 1).max(0);
+    let request_timeout_secs = parse_optional_secs(&form.request_timeout_secs);
+    let api_key = form.api_key.trim();
+
+    let payload = IndexerForm {
+        name,
+        kind,
+        url,
+        api_key,
+        priority,
+        enabled: form.enabled.is_some(),
+        is_private_tracker: form.is_private_tracker.is_some(),
+        seed_ratio: parse_optional_f64(&form.seed_ratio),
+        seed_time_minutes: parse_optional_i64(&form.seed_time_minutes),
+        min_seeders,
+        request_timeout_secs,
+    };
+
+    let result = match form.id {
+        Some(id) => update(&state.db, id, payload).await.map(|_| id),
+        None => insert(&state.db, payload).await,
+    };
+
+    match result {
+        Ok(id) => {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!(
+                    "Indexer {}: {} ({})",
+                    if form.id.is_some() {
+                        "updated"
+                    } else {
+                        "created"
+                    },
+                    name,
+                    kind,
+                ),
+                &format!("id={id}, priority={priority}"),
+            )
+            .await;
+            Redirect::to("/settings?tab=indexers&msg=Saved").into_response()
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Indexer upsert failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to("/settings?tab=indexers&err=Save+failed").into_response()
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/indexers/delete",
+    tag = "Settings",
+    summary = "Delete an indexer",
+    description = "Removes the indexer row by id. Existing grabbed_torrents rows referencing this indexer keep their indexer_id (NULL FK semantics), so grab history isn't lost.",
+    responses(
+        (status = 303, description = "Redirect back to the indexers tab"),
+    ),
+)]
+pub async fn settings_indexers_delete(
+    State(state): State<AppState>,
+    Form(form): Form<IndexerDeleteForm>,
+) -> Redirect {
+    match delete(&state.db, form.id).await {
+        Ok(_) => {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Indexer deleted: id={}", form.id),
+                "",
+            )
+            .await;
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Indexer delete failed",
+                &e.to_string(),
+            )
+            .await;
+        }
+    }
+    Redirect::to("/settings?tab=indexers")
+}
+
+/// Coerce the priority form field into the Sonarr-convention
+/// range. Anything out of [1, 50] (or unparseable) lands at 25 —
+/// the default — rather than rejecting the submission. Matches
+/// the validate_* helpers in the parent settings module.
+pub(crate) fn parse_priority(raw: &Option<String>) -> i32 {
+    let parsed = raw
+        .as_deref()
+        .and_then(|s| s.trim().parse::<i32>().ok())
+        .unwrap_or(25);
+    parsed.clamp(1, 50)
+}
+
+fn parse_optional_i32(raw: &Option<String>, default: i32) -> i32 {
+    raw.as_deref()
+        .and_then(|s| {
+            let trimmed = s.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                trimmed.parse::<i32>().ok()
+            }
+        })
+        .unwrap_or(default)
+}
+
+fn parse_optional_i64(raw: &Option<String>) -> Option<i64> {
+    raw.as_deref().and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            trimmed.parse::<i64>().ok()
+        }
+    })
+}
+
+fn parse_optional_f64(raw: &Option<String>) -> Option<f64> {
+    raw.as_deref().and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            trimmed.parse::<f64>().ok()
+        }
+    })
+}
+
+/// Per-indexer search timeout. Stored as `Option<i64>` (NULL =
+/// use default). Out-of-range values (< 1s or > 600s) coerce to
+/// None rather than persist a value that would force every
+/// search to immediately timeout or block forever.
+fn parse_optional_secs(raw: &Option<String>) -> Option<i64> {
+    parse_optional_i64(raw).filter(|n| (1..=600).contains(n))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_priority_clamps_into_sonarr_range() {
+        assert_eq!(parse_priority(&Some("0".into())), 1);
+        assert_eq!(parse_priority(&Some("51".into())), 50);
+        assert_eq!(parse_priority(&Some("25".into())), 25);
+        assert_eq!(parse_priority(&Some("-100".into())), 1);
+    }
+
+    #[test]
+    fn parse_priority_falls_back_to_25_on_unparseable() {
+        assert_eq!(parse_priority(&None), 25);
+        assert_eq!(parse_priority(&Some(String::new())), 25);
+        assert_eq!(parse_priority(&Some("garbage".into())), 25);
+        assert_eq!(parse_priority(&Some("3.14".into())), 25);
+    }
+
+    #[test]
+    fn parse_optional_secs_filters_out_of_range_values() {
+        // <1 or >600 → None (defensive: prevents a typo persisting
+        // a 0s timeout that fails every search instantly, or a
+        // 30000s value that blocks the auto-search loop forever).
+        assert_eq!(parse_optional_secs(&Some("0".into())), None);
+        assert_eq!(parse_optional_secs(&Some("601".into())), None);
+        assert_eq!(parse_optional_secs(&Some("30".into())), Some(30));
+    }
+
+    #[test]
+    fn parse_optional_i64_treats_empty_string_as_none() {
+        assert_eq!(parse_optional_i64(&Some(String::new())), None);
+        assert_eq!(parse_optional_i64(&Some("   ".into())), None);
+        assert_eq!(parse_optional_i64(&Some("42".into())), Some(42));
+    }
+
+    #[test]
+    fn parse_optional_f64_treats_empty_string_as_none() {
+        assert_eq!(parse_optional_f64(&Some(String::new())), None);
+        assert_eq!(parse_optional_f64(&Some("2.5".into())), Some(2.5));
+    }
+}

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -156,21 +156,12 @@ pub async fn settings_indexers_delete(
     State(state): State<AppState>,
     Form(form): Form<IndexerDeleteForm>,
 ) -> Redirect {
-    // PR #107 round-2 review fix #3: SQLite can't add a real FK via
-    // ALTER TABLE, so `grabbed_torrents.indexer_id` is structurally
-    // unconstrained. NULL out matching rows explicitly here so the
-    // post-delete state matches the migration comment's "ON DELETE
-    // SET NULL" semantics. `pending_grabs.indexer_id` (already
-    // nullable per its CREATE TABLE) gets the same treatment for
-    // consistency.
-    let _ = sqlx::query("UPDATE grabbed_torrents SET indexer_id = NULL WHERE indexer_id = ?")
-        .bind(form.id)
-        .execute(&state.db)
-        .await;
-    let _ = sqlx::query("UPDATE pending_grabs SET indexer_id = NULL WHERE indexer_id = ?")
-        .bind(form.id)
-        .execute(&state.db)
-        .await;
+    // PR #107 round-3 review fixes #2+#3: the SET-NULL UPDATEs
+    // for grabbed_torrents.indexer_id + pending_grabs.indexer_id
+    // are now folded into models::indexers::delete as a transaction
+    // so all three statements succeed or fail atomically; previously
+    // the handler ran them with `let _ = …` and a partial-NULL-out
+    // could ride out a transient I/O error silently.
     match delete(&state.db, form.id).await {
         Ok(_) => {
             logger::info(

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -74,6 +74,13 @@ pub async fn settings_indexers_upsert(
     if url.is_empty() {
         return Redirect::to("/settings?tab=indexers&err=URL+required").into_response();
     }
+    // PR #107 review fix #12: catch typos at save time rather
+    // than at the next search. reqwest::Url::parse is what the
+    // client uses internally; round-tripping it here surfaces
+    // missing scheme / malformed host immediately.
+    if reqwest::Url::parse(url).is_err() {
+        return Redirect::to("/settings?tab=indexers&err=Invalid+URL+syntax").into_response();
+    }
     let priority = parse_priority(&form.priority);
     let min_seeders = parse_optional_i32(&form.min_seeders, 1).max(0);
     let request_timeout_secs = parse_optional_secs(&form.request_timeout_secs);
@@ -116,6 +123,10 @@ pub async fn settings_indexers_upsert(
                 &format!("id={id}, priority={priority}"),
             )
             .await;
+            // PR #107 review fix #4: rebuild the IndexerCache so
+            // the next search picks up the new/edited row without
+            // a process restart.
+            crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
             Redirect::to("/settings?tab=indexers&msg=Saved").into_response()
         }
         Err(e) => {
@@ -154,6 +165,8 @@ pub async fn settings_indexers_delete(
                 "",
             )
             .await;
+            // PR #107 review fix #4: same cache refresh as upsert.
+            crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
         }
         Err(e) => {
             logger::error(

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -147,7 +147,7 @@ pub async fn settings_indexers_upsert(
     path = "/settings/indexers/delete",
     tag = "Settings",
     summary = "Delete an indexer",
-    description = "Removes the indexer row by id. Existing grabbed_torrents rows referencing this indexer keep their indexer_id (NULL FK semantics), so grab history isn't lost.",
+    description = "Removes the indexer row by id. Existing grabbed_torrents and pending_grabs rows referencing this indexer have their indexer_id NULLed in the same transaction, so grab history is preserved with the FK cleared. SQLite can't enforce a real ON DELETE SET NULL via ALTER TABLE so the model layer (`models::indexers::delete`) handles it explicitly.",
     responses(
         (status = 303, description = "Redirect back to the indexers tab"),
     ),
@@ -173,6 +173,7 @@ pub async fn settings_indexers_delete(
             .await;
             // PR #107 review fix #4: same cache refresh as upsert.
             crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
+            Redirect::to("/settings?tab=indexers")
         }
         Err(e) => {
             logger::error(
@@ -182,9 +183,13 @@ pub async fn settings_indexers_delete(
                 &e.to_string(),
             )
             .await;
+            // PR #107 round-4 review fix #3: surface the failure
+            // via `&err=` so the user sees an inline banner instead
+            // of a quiet success-looking redirect. Mirrors the
+            // upsert handler's "Save failed" pattern.
+            Redirect::to("/settings?tab=indexers&err=Delete+failed")
         }
     }
-    Redirect::to("/settings?tab=indexers")
 }
 
 /// Coerce the priority form field into the Sonarr-convention

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -18,6 +18,7 @@ use crate::services::{
 };
 
 pub mod custom_formats;
+pub mod indexers;
 use custom_formats::ImportReviewView;
 
 /// View-model wrapper rendered on the Custom Formats tab. Surfaces

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -141,6 +141,12 @@ struct SettingsTemplate {
     /// browser snaps titles back to English even when the saved
     /// preference is Romaji or Native.
     title_language: String,
+    /// Issue #28 PR A — torznab/newznab indexer rows for the
+    /// Settings → Indexers tab placeholder. PR B replaces the
+    /// placeholder with add/edit/delete forms and uses the same
+    /// list. Empty on a fresh install since no indexers exist
+    /// until the user adds one.
+    indexers: Vec<crate::models::indexers::Indexer>,
 }
 
 /// Safe-to-render projection of `ExternalAccount`. Holds everything
@@ -438,6 +444,10 @@ fn normalize_settings_tab(tab: Option<String>) -> String {
         Some("custom_formats") => "custom_formats".to_string(),
         Some("groups") => "groups".to_string(),
         Some("general") => "general".to_string(),
+        // Issue #28 PR A — torznab/newznab indexer registry. Tab
+        // surface scaffolded; CRUD form lands in PR B alongside
+        // the TorznabIndexer impl that needs caps probing on save.
+        Some("indexers") => "indexers".to_string(),
         _ => "integrations".to_string(),
     }
 }
@@ -559,12 +569,13 @@ async fn build_settings_template(
     // account — in parallel. The old code issued them sequentially so
     // the wall time was the sum of N round trips even though none
     // depends on the others.
-    let (cfg_res, groups, suggestions, custom_formats, external_account_res) = tokio::join!(
+    let (cfg_res, groups, suggestions, custom_formats, external_account_res, indexers_res) = tokio::join!(
         config::get_config(&state.db),
         load_groups(&state.db),
         load_suggestions(&state.db),
         load_custom_formats_view(&state.db),
         crate::models::external_accounts::get_current(&state.db),
+        crate::models::indexers::list_all(&state.db),
     );
     let cfg = cfg_res.ok().flatten().unwrap_or_default();
     // A decrypt failure (tampered blob, key rotation without migration)
@@ -611,6 +622,7 @@ async fn build_settings_template(
         version: env!("CARGO_PKG_VERSION"),
         external_account,
         title_language,
+        indexers: indexers_res.unwrap_or_default(),
     }
 }
 
@@ -871,6 +883,9 @@ pub async fn settings_submit(
             .map(ExternalAccountView::from_model);
         let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
         let title_language = cfg.title_language.clone();
+        let indexers = crate::models::indexers::list_all(&state.db)
+            .await
+            .unwrap_or_default();
         let template = SettingsTemplate {
             page: "settings".to_string(),
             tab: active_tab,
@@ -886,6 +901,7 @@ pub async fn settings_submit(
             version: env!("CARGO_PKG_VERSION"),
             external_account,
             title_language,
+            indexers,
         };
         return Html(template.render().unwrap_or_default());
     }
@@ -1188,6 +1204,9 @@ pub async fn settings_submit(
         .map(ExternalAccountView::from_model);
     let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
     let title_language = cfg.title_language.clone();
+    let indexers = crate::models::indexers::list_all(&state.db)
+        .await
+        .unwrap_or_default();
     let template = SettingsTemplate {
         page: "settings".to_string(),
         tab: active_tab,
@@ -1208,6 +1227,7 @@ pub async fn settings_submit(
         version: env!("CARGO_PKG_VERSION"),
         external_account,
         title_language,
+        indexers,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -1845,7 +1865,7 @@ mod tests {
 
     #[test]
     fn normalize_settings_tab_known_tabs_pass_through() {
-        for tab in ["quality", "custom_formats", "groups", "general"] {
+        for tab in ["quality", "custom_formats", "groups", "general", "indexers"] {
             assert_eq!(normalize_settings_tab(Some(tab.into())), tab);
         }
     }

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -148,6 +148,12 @@ struct SettingsTemplate {
     /// list. Empty on a fresh install since no indexers exist
     /// until the user adds one.
     indexers: Vec<crate::models::indexers::Indexer>,
+    /// PR #107 review fix #5: when the indexers tab is active
+    /// and `?edit_id=N` is set, populate this with the matching
+    /// row so the upsert form prefills from the existing values.
+    /// `None` renders the bare "Add Indexer" form; same prefill
+    /// pattern as the Custom Formats tab.
+    indexer_edit: Option<crate::models::indexers::Indexer>,
 }
 
 /// Safe-to-render projection of `ExternalAccount`. Holds everything
@@ -608,6 +614,16 @@ async fn build_settings_template(
 
     let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
     let title_language = cfg.title_language.clone();
+    // PR #107 review fix #5: resolve the indexer edit prefill the
+    // same way CF does. `edit_id` is shared across tabs — at most
+    // one tab consumes it at a time.
+    let indexer_edit = match edit_id {
+        Some(id) => crate::models::indexers::get_by_id(&state.db, id)
+            .await
+            .ok()
+            .flatten(),
+        None => None,
+    };
     SettingsTemplate {
         page: "settings".to_string(),
         tab: normalize_settings_tab(tab),
@@ -624,6 +640,7 @@ async fn build_settings_template(
         external_account,
         title_language,
         indexers: indexers_res.unwrap_or_default(),
+        indexer_edit,
     }
 }
 
@@ -899,6 +916,7 @@ pub async fn settings_submit(
             custom_format_import_review: None,
             message: None,
             error: Some(format!("Failed to save: {}", e)),
+            indexer_edit: None,
             version: env!("CARGO_PKG_VERSION"),
             external_account,
             title_language,
@@ -1225,6 +1243,7 @@ pub async fn settings_submit(
         // the user changes integration settings).
         message: Some(notices.join(" ")),
         error: None,
+        indexer_edit: None,
         version: env!("CARGO_PKG_VERSION"),
         external_account,
         title_language,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,10 +51,18 @@ use sqlx::SqlitePool;
 use tokio::sync::RwLock;
 
 use services::{
-    custom_formats::CompiledCfCache, download_client::DownloadClient,
+    custom_formats::CompiledCfCache, download_client::DownloadClient, indexers::Indexer,
     interactive_search_cache::InteractiveSearchCache, jellyfin::JellyfinClient,
     oauth_state::OAuthStateStore, progress::ProgressRegistry,
 };
+
+/// PR #107 review fix #4: cached `Vec<Arc<dyn Indexer>>` swapped on
+/// `Settings → Indexers` edits. Mirrors [`CompiledCfCache`] —
+/// outer `RwLock` owns swap; inner `Arc<Vec<_>>` is cheap-cloned
+/// out on the search hot path so the read lock releases before the
+/// per-query fan-out begins. Avoids rebuilding reqwest::Client
+/// instances on every per-target search.
+pub type IndexerCache = Arc<RwLock<Arc<Vec<Arc<dyn Indexer>>>>>;
 
 /// Shared application state available to all handlers. Lives in the
 /// library crate (rather than `main.rs`) so integration tests can
@@ -70,6 +78,12 @@ pub struct AppState {
     /// out on the scoring hot path so the read lock releases before the
     /// per-candidate evaluation loop begins.
     pub custom_formats: CompiledCfCache,
+    /// Cached indexer clients (PR #107 review fix #4). Same swap-
+    /// on-write pattern as `custom_formats` — rebuilt by the
+    /// Settings → Indexers handlers on add/edit/delete, and read
+    /// lock-free via `Arc::clone` on the search path. Avoids
+    /// rebuilding reqwest clients per search.
+    pub indexers: IndexerCache,
     /// In-memory progress registry for long-running user-triggered jobs
     /// (currently the manual auto-search). The frontend mints an opaque
     /// `progress_id`, the trigger handler binds it via

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,6 +88,9 @@ use services::{
         handlers::settings::custom_formats::settings_custom_formats_reset_defaults,
         handlers::settings::custom_formats::settings_custom_formats_export,
         handlers::settings::custom_formats::settings_custom_formats_test,
+        // Settings — Indexers (issue #28 PR B)
+        handlers::settings::indexers::settings_indexers_upsert,
+        handlers::settings::indexers::settings_indexers_delete,
         handlers::system::api_logs_poll,
         handlers::system::api_logs_clear,
         handlers::system::api_logs_client,
@@ -680,6 +683,14 @@ async fn main() {
         .route(
             "/settings/custom-formats/delete",
             post(handlers::settings::custom_formats::settings_custom_formats_delete),
+        )
+        .route(
+            "/settings/indexers/upsert",
+            post(handlers::settings::indexers::settings_indexers_upsert),
+        )
+        .route(
+            "/settings/indexers/delete",
+            post(handlers::settings::indexers::settings_indexers_delete),
         )
         .route(
             "/settings/custom-formats/minimum-score",

--- a/src/main.rs
+++ b/src/main.rs
@@ -432,12 +432,19 @@ async fn main() {
     let users_exist_initial = models::user::has_users(&db).await.unwrap_or(false);
     let users_exist = Arc::new(std::sync::atomic::AtomicBool::new(users_exist_initial));
 
+    // PR #107 review fix #4: build the indexer cache at startup.
+    // Failed instantiations (empty URL, reqwest build) are logged
+    // and dropped via `services::indexers::rebuild_cache` so the
+    // surviving rows still fan out.
+    let indexers = services::indexers::rebuild_cache(&db).await;
+
     // Build shared state.
     let state = AppState {
         db: db.clone(),
         download_client: Arc::new(RwLock::new(None)),
         jellyfin: Arc::new(RwLock::new(None)),
         custom_formats: cf_cache,
+        indexers,
         progress: ProgressRegistry::new(),
         users_exist,
         interactive_search_cache: services::interactive_search_cache::new(),

--- a/src/models/indexers.rs
+++ b/src/models/indexers.rs
@@ -193,11 +193,36 @@ pub async fn update(db: &SqlitePool, id: i64, form: IndexerForm<'_>) -> Result<(
     Ok(())
 }
 
+/// PR #107 round-3 review fix #3: delete the indexer row and
+/// NULL out FK columns in dependent tables atomically.
+///
+/// SQLite can't add a real `FOREIGN KEY ... ON DELETE SET NULL`
+/// constraint via `ALTER TABLE` after the parent column has shipped,
+/// so the SET NULL behavior the migration comment promises has to
+/// be enforced at the application layer. Doing it inside a
+/// transaction keeps the three statements as one logical operation:
+/// either every dependent row is NULL'd and the indexer is gone,
+/// or nothing changed.
+///
+/// The `_ = ?.execute(...)` shape swallowed individual statement
+/// errors before; now the `?` operator on each statement aborts
+/// the transaction and surfaces the error to the caller, which
+/// the handler logs.
 pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+    sqlx::query("UPDATE grabbed_torrents SET indexer_id = NULL WHERE indexer_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query("UPDATE pending_grabs SET indexer_id = NULL WHERE indexer_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
     sqlx::query("DELETE FROM indexers WHERE id = ?")
         .bind(id)
-        .execute(db)
+        .execute(&mut *tx)
         .await?;
+    tx.commit().await?;
     Ok(())
 }
 
@@ -330,6 +355,82 @@ mod tests {
         assert!(get_by_id(&db, id).await.unwrap().is_some());
         delete(&db, id).await.unwrap();
         assert!(get_by_id(&db, id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn delete_nulls_out_grabbed_torrents_indexer_id() {
+        // PR #107 round-3 review fix #4: regression for the
+        // SET-NULL transaction. Insert an indexer + a grab row
+        // pointing at it, delete the indexer, assert the grab row's
+        // indexer_id is NULL (not orphaned, not deleted).
+        let db = fresh_db().await;
+        let indexer_id = insert(&db, sample_form()).await.unwrap();
+
+        // First we need a series row for grabbed_torrents to FK to.
+        // Use the test_support seed helper if available; otherwise
+        // a minimal raw insert.
+        let series_id: i64 = sqlx::query_scalar(
+            "INSERT INTO series (anilist_id, title, title_romaji, folder_name) \
+             VALUES (1, 't', 't', 'f') RETURNING id",
+        )
+        .fetch_one(&db)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO grabbed_torrents (hash, torrent_name, series_id, indexer_id) \
+             VALUES ('h', 't', ?, ?)",
+        )
+        .bind(series_id)
+        .bind(indexer_id)
+        .execute(&db)
+        .await
+        .unwrap();
+
+        delete(&db, indexer_id).await.expect("delete must succeed");
+
+        // Indexer row gone.
+        assert!(get_by_id(&db, indexer_id).await.unwrap().is_none());
+
+        // Grab row stays, but its indexer_id is NULL.
+        let leftover_indexer_id: Option<i64> =
+            sqlx::query_scalar("SELECT indexer_id FROM grabbed_torrents WHERE hash = 'h'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            leftover_indexer_id, None,
+            "delete must NULL out grabbed_torrents.indexer_id, not orphan it"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_preserves_optional_fields_when_form_round_trips() {
+        // PR #107 round-3 review fix #4: regression for the
+        // template-field-missing bug from round 2. If a future
+        // template tweak drops one of the optional inputs, an
+        // edit-without-changes would NULL the column. The model-
+        // layer round-trip catches it: pass the same form values
+        // through update() twice and assert nothing drifts.
+        let db = fresh_db().await;
+        let mut full = sample_form();
+        full.seed_ratio = Some(2.5);
+        full.seed_time_minutes = Some(120);
+        full.request_timeout_secs = Some(60);
+        let id = insert(&db, full).await.unwrap();
+
+        // Re-issue an update with the same shape — simulates the
+        // user clicking Save with no edits.
+        let mut same = sample_form();
+        same.seed_ratio = Some(2.5);
+        same.seed_time_minutes = Some(120);
+        same.request_timeout_secs = Some(60);
+        update(&db, id, same).await.unwrap();
+
+        let row = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(row.seed_ratio, Some(2.5));
+        assert_eq!(row.seed_time_minutes, Some(120));
+        assert_eq!(row.request_timeout_secs, Some(60));
     }
 
     #[tokio::test]

--- a/src/models/indexers.rs
+++ b/src/models/indexers.rs
@@ -1,0 +1,351 @@
+//! Torznab/newznab indexer registry (issue #28 PR A).
+//!
+//! Configured indexers live in the `indexers` table; the search
+//! pipeline reads them at fan-out time and dispatches concurrent
+//! queries via the [`crate::services::indexers::Indexer`] trait.
+//! Nyaa stays out-of-band per plan decision #1 — it never gets a
+//! row here.
+//!
+//! PR A scope: schema + CRUD only. PR B adds the `TorznabIndexer`
+//! trait impl that consumes these rows and the caps-probe path that
+//! populates `caps_json` / `caps_refreshed_at`. PR C wires
+//! `seed_ratio` / `seed_time_minutes` / `min_seeders` into the
+//! `DownloadClient` trait's per-torrent seed rules. Nothing else
+//! in PR A reads these columns yet — they're populated by the
+//! Settings form and lie dormant until later PRs hook in.
+
+use serde::Serialize;
+use sqlx::{Row, SqlitePool};
+
+/// Indexer protocol kind. The wire format for torznab and newznab
+/// is identical; the value distinguishes them only for category-
+/// mapping (BitTorrent vs NZB) and download-client routing once
+/// PR F's torrent-vs-usenet split lands. Kept as `String` at the
+/// boundary because `kind` is read directly into the row struct;
+/// callers that need to branch on it can `.as_str()` and match.
+pub const KIND_TORZNAB: &str = "torznab";
+pub const KIND_NEWZNAB: &str = "newznab";
+
+#[derive(Debug, Clone, Serialize)]
+pub struct Indexer {
+    pub id: i64,
+    pub name: String,
+    pub kind: String,
+    pub url: String,
+    pub api_key: String,
+    /// Sonarr convention: lower = preferred. Range 1-50, default 25.
+    /// Drives auto-search dedup attribution + interactive search row
+    /// tiebreaks + fan-out concurrency order.
+    pub priority: i32,
+    pub enabled: bool,
+    pub is_private_tracker: bool,
+    pub seed_ratio: Option<f64>,
+    pub seed_time_minutes: Option<i64>,
+    pub min_seeders: i32,
+    /// Per-indexer override of the default search timeout. `None`
+    /// means use the process default (30s, overridable via
+    /// `RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS`).
+    pub request_timeout_secs: Option<i64>,
+    /// Cached caps response body. Empty until the first probe
+    /// succeeds (PR B). Read with a 7-day TTL — stale caps trigger
+    /// a transparent re-fetch on next read.
+    pub caps_json: String,
+    pub caps_refreshed_at: Option<i64>,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+/// Input for [`insert`] / [`update`] — caller supplies all the
+/// user-editable fields; ID + timestamps + caps cache are managed
+/// by this module.
+#[derive(Debug, Clone)]
+pub struct IndexerForm<'a> {
+    pub name: &'a str,
+    pub kind: &'a str,
+    pub url: &'a str,
+    pub api_key: &'a str,
+    pub priority: i32,
+    pub enabled: bool,
+    pub is_private_tracker: bool,
+    pub seed_ratio: Option<f64>,
+    pub seed_time_minutes: Option<i64>,
+    pub min_seeders: i32,
+    pub request_timeout_secs: Option<i64>,
+}
+
+const SELECT_COLUMNS: &str = "id, name, kind, url, api_key, priority, enabled, \
+    is_private_tracker, seed_ratio, seed_time_minutes, min_seeders, request_timeout_secs, \
+    caps_json, caps_refreshed_at, created_at, updated_at";
+
+fn row_to_indexer(row: &sqlx::sqlite::SqliteRow) -> Indexer {
+    // Nullable columns explicitly typed as `Option<T>` so sqlx
+    // doesn't fall back to T::default() (0.0 for f64, 0 for i64)
+    // when the column is NULL — `try_get::<f64, _>` on a NULL row
+    // returns Err, which `.ok()` would convert to None, but the
+    // type-inferred `try_get` infers T from the field type and
+    // produces Some(0.0)/Some(0) for NULLs. The explicit
+    // `Option<T>` form is the unambiguous one.
+    Indexer {
+        id: row.try_get("id").unwrap_or(0),
+        name: row.try_get("name").unwrap_or_default(),
+        kind: row.try_get("kind").unwrap_or_default(),
+        url: row.try_get("url").unwrap_or_default(),
+        api_key: row.try_get("api_key").unwrap_or_default(),
+        priority: row.try_get("priority").unwrap_or(25),
+        enabled: row.try_get::<i64, _>("enabled").unwrap_or(0) != 0,
+        is_private_tracker: row.try_get::<i64, _>("is_private_tracker").unwrap_or(0) != 0,
+        seed_ratio: row.try_get::<Option<f64>, _>("seed_ratio").unwrap_or(None),
+        seed_time_minutes: row
+            .try_get::<Option<i64>, _>("seed_time_minutes")
+            .unwrap_or(None),
+        min_seeders: row.try_get("min_seeders").unwrap_or(1),
+        request_timeout_secs: row
+            .try_get::<Option<i64>, _>("request_timeout_secs")
+            .unwrap_or(None),
+        caps_json: row.try_get("caps_json").unwrap_or_default(),
+        caps_refreshed_at: row
+            .try_get::<Option<i64>, _>("caps_refreshed_at")
+            .unwrap_or(None),
+        created_at: row.try_get("created_at").unwrap_or(0),
+        updated_at: row.try_get("updated_at").unwrap_or(0),
+    }
+}
+
+/// All indexer rows ordered by `priority` ascending, tiebreaking by
+/// `id`. Mirrors the order auto-search uses for fan-out concurrency.
+pub async fn list_all(db: &SqlitePool) -> Result<Vec<Indexer>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT {SELECT_COLUMNS} FROM indexers ORDER BY priority ASC, id ASC"
+    ))
+    .fetch_all(db)
+    .await?;
+    Ok(rows.iter().map(row_to_indexer).collect())
+}
+
+/// Enabled indexers only — what the search pipeline iterates over.
+/// Disabled rows stay in the DB so the user's config isn't lost when
+/// they pause a flaky indexer; this filter just skips them at search
+/// time.
+pub async fn list_enabled(db: &SqlitePool) -> Result<Vec<Indexer>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT {SELECT_COLUMNS} FROM indexers WHERE enabled = 1 ORDER BY priority ASC, id ASC"
+    ))
+    .fetch_all(db)
+    .await?;
+    Ok(rows.iter().map(row_to_indexer).collect())
+}
+
+pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<Indexer>, sqlx::Error> {
+    let row = sqlx::query(&format!(
+        "SELECT {SELECT_COLUMNS} FROM indexers WHERE id = ?"
+    ))
+    .bind(id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.as_ref().map(row_to_indexer))
+}
+
+pub async fn insert(db: &SqlitePool, form: IndexerForm<'_>) -> Result<i64, sqlx::Error> {
+    let result = sqlx::query(
+        "INSERT INTO indexers \
+         (name, kind, url, api_key, priority, enabled, is_private_tracker, \
+          seed_ratio, seed_time_minutes, min_seeders, request_timeout_secs) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(form.name)
+    .bind(form.kind)
+    .bind(form.url)
+    .bind(form.api_key)
+    .bind(form.priority)
+    .bind(form.enabled as i64)
+    .bind(form.is_private_tracker as i64)
+    .bind(form.seed_ratio)
+    .bind(form.seed_time_minutes)
+    .bind(form.min_seeders)
+    .bind(form.request_timeout_secs)
+    .execute(db)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+pub async fn update(db: &SqlitePool, id: i64, form: IndexerForm<'_>) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE indexers SET \
+         name = ?, kind = ?, url = ?, api_key = ?, priority = ?, enabled = ?, \
+         is_private_tracker = ?, seed_ratio = ?, seed_time_minutes = ?, min_seeders = ?, \
+         request_timeout_secs = ?, updated_at = strftime('%s','now') \
+         WHERE id = ?",
+    )
+    .bind(form.name)
+    .bind(form.kind)
+    .bind(form.url)
+    .bind(form.api_key)
+    .bind(form.priority)
+    .bind(form.enabled as i64)
+    .bind(form.is_private_tracker as i64)
+    .bind(form.seed_ratio)
+    .bind(form.seed_time_minutes)
+    .bind(form.min_seeders)
+    .bind(form.request_timeout_secs)
+    .bind(id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM indexers WHERE id = ?")
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Update the cached caps response and bump `caps_refreshed_at` to
+/// the current Unix timestamp. Called by PR B's caps probe after a
+/// successful `t=caps` fetch. PR A defines the helper so the column
+/// shape is decided up front.
+pub async fn update_caps(db: &SqlitePool, id: i64, caps_json: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE indexers SET caps_json = ?, caps_refreshed_at = strftime('%s','now'), \
+         updated_at = strftime('%s','now') WHERE id = ?",
+    )
+    .bind(caps_json)
+    .bind(id)
+    .execute(db)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sqlx::SqlitePool;
+
+    async fn fresh_db() -> SqlitePool {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        db
+    }
+
+    fn sample_form<'a>() -> IndexerForm<'a> {
+        IndexerForm {
+            name: "Test Indexer",
+            kind: KIND_TORZNAB,
+            url: "https://prowlarr.local/1/api",
+            api_key: "secret",
+            priority: 25,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 1,
+            request_timeout_secs: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_then_get_round_trips_fields() {
+        let db = fresh_db().await;
+        let id = insert(&db, sample_form()).await.unwrap();
+        let row = get_by_id(&db, id).await.unwrap().expect("row exists");
+        assert_eq!(row.name, "Test Indexer");
+        assert_eq!(row.kind, KIND_TORZNAB);
+        assert_eq!(row.url, "https://prowlarr.local/1/api");
+        assert_eq!(row.api_key, "secret");
+        assert_eq!(row.priority, 25);
+        assert!(row.enabled);
+        assert!(!row.is_private_tracker);
+        assert_eq!(row.seed_ratio, None);
+        assert_eq!(row.min_seeders, 1);
+    }
+
+    #[tokio::test]
+    async fn list_all_orders_by_priority_ascending() {
+        // Sonarr convention: lower priority = preferred. The fan-out
+        // path iterates this order, so a regression that flipped it
+        // would silently move a less-preferred indexer to the front.
+        let db = fresh_db().await;
+        let mut high_prio = sample_form();
+        high_prio.name = "High Priority";
+        high_prio.priority = 5;
+        let mut low_prio = sample_form();
+        low_prio.name = "Low Priority";
+        low_prio.priority = 50;
+        // Insert low first so order isn't accidentally insertion-order.
+        insert(&db, low_prio).await.unwrap();
+        insert(&db, high_prio).await.unwrap();
+
+        let rows = list_all(&db).await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].name, "High Priority");
+        assert_eq!(rows[1].name, "Low Priority");
+    }
+
+    #[tokio::test]
+    async fn list_enabled_filters_disabled_rows() {
+        let db = fresh_db().await;
+        let mut on = sample_form();
+        on.name = "On";
+        on.enabled = true;
+        let mut off = sample_form();
+        off.name = "Off";
+        off.enabled = false;
+        insert(&db, on).await.unwrap();
+        insert(&db, off).await.unwrap();
+
+        let enabled = list_enabled(&db).await.unwrap();
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].name, "On");
+    }
+
+    #[tokio::test]
+    async fn update_changes_fields_and_bumps_updated_at() {
+        let db = fresh_db().await;
+        let id = insert(&db, sample_form()).await.unwrap();
+        let original_updated_at = get_by_id(&db, id).await.unwrap().unwrap().updated_at;
+        // strftime resolution is 1s; sleep ensures the bump is visible.
+        tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+
+        let mut edited = sample_form();
+        edited.name = "Renamed";
+        edited.priority = 10;
+        edited.enabled = false;
+        update(&db, id, edited).await.unwrap();
+
+        let row = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(row.name, "Renamed");
+        assert_eq!(row.priority, 10);
+        assert!(!row.enabled);
+        assert!(
+            row.updated_at >= original_updated_at,
+            "updated_at must not regress"
+        );
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row() {
+        let db = fresh_db().await;
+        let id = insert(&db, sample_form()).await.unwrap();
+        assert!(get_by_id(&db, id).await.unwrap().is_some());
+        delete(&db, id).await.unwrap();
+        assert!(get_by_id(&db, id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn update_caps_persists_json_and_timestamp() {
+        let db = fresh_db().await;
+        let id = insert(&db, sample_form()).await.unwrap();
+        // Fresh insert has no caps cached yet.
+        let pre = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(pre.caps_json, "");
+        assert!(pre.caps_refreshed_at.is_none());
+
+        update_caps(&db, id, r#"{"limits":{"max":100}}"#)
+            .await
+            .unwrap();
+        let post = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(post.caps_json, r#"{"limits":{"max":100}}"#);
+        assert!(post.caps_refreshed_at.is_some());
+    }
+}

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2108,11 +2108,15 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await?;
 
     // Issue #28 PR A — `grabbed_torrents.indexer_id` records which
-    // indexer surfaced each grab. Nullable + ON DELETE SET NULL so
-    // deleting an indexer doesn't erase grab history. NULL means
-    // "pre-#28 grab, assume Nyaa." The upgrade sweep keys per-
-    // indexer rules off this column; absent an FK, it's read-only
-    // metadata.
+    // indexer surfaced each grab. Nullable, no real FK: SQLite
+    // can't add a FOREIGN KEY constraint via ALTER TABLE, so the
+    // column is structurally unconstrained. The
+    // `settings_indexers_delete` handler (PR #107 round-2 fix #3)
+    // NULLs out matching rows explicitly to keep grab history
+    // readable post-delete. NULL means either "pre-#28 grab,
+    // assume Nyaa" or "indexer was deleted after this grab" —
+    // both shapes are equivalent for the upgrade sweep, which
+    // treats NULL as "no per-indexer rules apply."
     sqlx::query("ALTER TABLE grabbed_torrents ADD COLUMN indexer_id INTEGER")
         .execute(db)
         .await

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2063,6 +2063,94 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .ok();
 
+    // Issue #28 PR A — torznab/newznab indexer registry. Foundation
+    // for v1.5's multi-indexer support; PR B wires the actual
+    // TorznabIndexer impl. Schema mirrors the plan doc:
+    //   - `kind` is `'torznab' | 'newznab'`. Nyaa stays out-of-band
+    //     (decision #1) and never gets a row here.
+    //   - `priority` follows Sonarr's convention (lower = preferred,
+    //     range 1-50, default 25). Drives auto-search dedup
+    //     attribution + interactive search row tiebreaks + fan-out
+    //     order (decision #3 + plan §"Indexer priority semantics").
+    //   - `is_private_tracker` is explicit-with-smart-defaults
+    //     (decision #4). The settings form pre-fills via Prowlarr's
+    //     native `/api/v1/indexer` privacy field when the URL is
+    //     Prowlarr; Jackett / raw torznab pre-fill `private` as the
+    //     safe fallback. User confirms before save.
+    //   - `caps_json` / `caps_refreshed_at` cache the indexer's
+    //     `t=caps` response with a 7-day lazy TTL (decision #6).
+    //   - `request_timeout_secs` is per-indexer override over the
+    //     30s default (decision #7); NULL means use the default,
+    //     overridable via RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS env.
+    sqlx::query(
+        r#"
+        CREATE TABLE IF NOT EXISTS indexers (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            url TEXT NOT NULL,
+            api_key TEXT NOT NULL DEFAULT '',
+            priority INTEGER NOT NULL DEFAULT 25,
+            enabled INTEGER NOT NULL DEFAULT 1,
+            is_private_tracker INTEGER NOT NULL DEFAULT 0,
+            seed_ratio REAL,
+            seed_time_minutes INTEGER,
+            min_seeders INTEGER NOT NULL DEFAULT 1,
+            request_timeout_secs INTEGER,
+            caps_json TEXT NOT NULL DEFAULT '',
+            caps_refreshed_at INTEGER,
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+        )
+        "#,
+    )
+    .execute(db)
+    .await?;
+
+    // Issue #28 PR A — `grabbed_torrents.indexer_id` records which
+    // indexer surfaced each grab. Nullable + ON DELETE SET NULL so
+    // deleting an indexer doesn't erase grab history. NULL means
+    // "pre-#28 grab, assume Nyaa." The upgrade sweep keys per-
+    // indexer rules off this column; absent an FK, it's read-only
+    // metadata.
+    sqlx::query("ALTER TABLE grabbed_torrents ADD COLUMN indexer_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
+    // Issue #28 PR A — `grabbed_torrents.respect_seed_rules` flags
+    // grabs whose torrents have per-torrent seed-ratio / seed-time
+    // rules applied at add time (PR C). Delete paths (manual delete,
+    // upgrade-replacement) skip torrents with this flag so the
+    // client can finish seeding to the per-tracker target before
+    // teardown. Nyaa grabs default 0; PT grabs default 1.
+    sqlx::query(
+        "ALTER TABLE grabbed_torrents ADD COLUMN respect_seed_rules INTEGER NOT NULL DEFAULT 0",
+    )
+    .execute(db)
+    .await
+    .ok();
+
+    // Issue #28 PR A — per-series PT-upgrade opt-in (decision: PR E
+    // wires the UI + sweep filter; column lands here so PR B's
+    // search code can already filter on it without a chained
+    // migration in PR E). Default FALSE so a user upgrading from
+    // 1.4.x sees no change in behavior.
+    sqlx::query("ALTER TABLE series ADD COLUMN allow_pt_upgrades INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
+    // Issue #28 PR A — autobrr push endpoint API key. Empty string
+    // until the user generates one via Settings → Connections →
+    // autobrr (PR D). Empty disables the webhook entirely; PR D's
+    // `/api/webhook/autobrr` middleware rejects when the key is
+    // empty so a fresh install doesn't accept anonymous pushes.
+    sqlx::query("ALTER TABLE config ADD COLUMN autobrr_api_key TEXT NOT NULL DEFAULT ''")
+        .execute(db)
+        .await
+        .ok();
+
     Ok(())
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -5,6 +5,7 @@ pub mod episode_tags;
 pub mod external_accounts;
 pub mod grabbed_torrents;
 pub mod group_source_map;
+pub mod indexers;
 pub mod local_metadata;
 pub mod log;
 pub mod media_probe_cache;

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -313,6 +313,7 @@ pub async fn find_all_for_target(
     scored
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn find_best_for_target(
     db: &SqlitePool,
     detail: &AnimeDetail,
@@ -321,6 +322,7 @@ pub async fn find_best_for_target(
     allow_batch: bool,
     batch_episode_match: bool,
     cfs: &[CompiledCustomFormat],
+    indexers_cache: &crate::IndexerCache,
 ) -> Option<SearchResult> {
     collect_scored_for_target(
         db,
@@ -330,6 +332,7 @@ pub async fn find_best_for_target(
         allow_batch,
         batch_episode_match,
         cfs,
+        indexers_cache,
     )
     .await
     .into_iter()
@@ -358,8 +361,9 @@ pub async fn find_best_batch_for_target(
     config: &Config,
     target: &SearchTarget,
     cfs: &[CompiledCustomFormat],
+    indexers_cache: &crate::IndexerCache,
 ) -> Option<SearchResult> {
-    collect_scored_batches_for_target(db, detail, config, target, cfs)
+    collect_scored_batches_for_target(db, detail, config, target, cfs, indexers_cache)
         .await
         .into_iter()
         .next()
@@ -378,6 +382,7 @@ pub async fn collect_scored_batches_for_target(
     config: &Config,
     target: &SearchTarget,
     cfs: &[CompiledCustomFormat],
+    indexers_cache: &crate::IndexerCache,
 ) -> Vec<SearchResult> {
     let (aliases, canonical_aliases, variant_aliases) = collect_aliases_with_variants(detail);
     let series_ctx = resolve_search_overrides(db, detail, config).await;
@@ -425,7 +430,8 @@ pub async fn collect_scored_batches_for_target(
     }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
-    let indexers = load_indexer_clients(db).await;
+    let indexers_arc = indexers_cache.read().await.clone();
+    let indexers: &[std::sync::Arc<dyn crate::services::indexers::Indexer>] = &indexers_arc[..];
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
@@ -440,7 +446,7 @@ pub async fn collect_scored_batches_for_target(
         seadex_hashes: &seadex_hashes,
         restrict_user: &series_ctx.restrict_user,
         absolute_offset: series_ctx.absolute_offset,
-        indexers: &indexers,
+        indexers,
     };
 
     // Standard query sweep — picks up any batches that happen to surface
@@ -573,6 +579,7 @@ pub async fn collect_scored_batches_for_target(
 /// expensive collection pass. Filtering to batches post-sort gives the
 /// same answer as filtering pre-scoring because `rescore_for_auto_search`
 /// applies its per-target batch bump uniformly inside each target kind.
+#[allow(clippy::too_many_arguments)]
 async fn collect_scored_for_target(
     db: &SqlitePool,
     detail: &AnimeDetail,
@@ -581,6 +588,7 @@ async fn collect_scored_for_target(
     allow_batch: bool,
     batch_episode_match: bool,
     cfs: &[CompiledCustomFormat],
+    indexers_cache: &crate::IndexerCache,
 ) -> Vec<SearchResult> {
     let (aliases, canonical_aliases, variant_aliases) = collect_aliases_with_variants(detail);
     let series_ctx = resolve_search_overrides(db, detail, config).await;
@@ -651,7 +659,8 @@ async fn collect_scored_for_target(
     }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
-    let indexers = load_indexer_clients(db).await;
+    let indexers_arc = indexers_cache.read().await.clone();
+    let indexers: &[std::sync::Arc<dyn crate::services::indexers::Indexer>] = &indexers_arc[..];
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
@@ -666,7 +675,7 @@ async fn collect_scored_for_target(
         seadex_hashes: &seadex_hashes,
         restrict_user: &series_ctx.restrict_user,
         absolute_offset: series_ctx.absolute_offset,
-        indexers: &indexers,
+        indexers,
     };
 
     // Phase 1: standard queries (primary aliases + episode variants).
@@ -979,27 +988,37 @@ async fn run_queries(
     // pool. Empty `ctx.indexers` (the v1.4 default) skips this
     // pass entirely so behavior is unchanged for users who
     // haven't configured any indexers.
-    let mut indexer_responses: Vec<crate::services::nyaa::SearchResult> = Vec::new();
-    if !ctx.indexers.is_empty() {
-        // One torznab query per text query — same fan-out shape
-        // as Nyaa. The indexer impls handle their own per-row
-        // timeouts; a slow indexer holds up only its own slot.
-        for query in queries {
-            let search_query = crate::services::indexers::SearchQuery {
-                q: query.clone(),
-                categories: Vec::new(), // default → 5070 (anime)
-                limit: None,
-                offset: None,
-            };
-            let outcomes =
-                crate::services::indexers::fan_out_search(ctx.indexers, &search_query).await;
+    //
+    // PR #107 review fix #1+#3: collect raw `Release` records
+    // (not pre-converted to SearchResult) so `dedup_for_auto_search`
+    // can apply priority-based attribution + max-seeders aggregation
+    // across indexers reporting the same infohash. Per-query
+    // fan-outs run concurrently via `buffer_unordered` so a slow
+    // indexer holds up only its own slot, not subsequent queries.
+    let indexer_releases: Vec<crate::services::indexers::Release> = if ctx.indexers.is_empty() {
+        Vec::new()
+    } else {
+        let outcome_streams: Vec<_> = stream::iter(queries.iter().cloned())
+            .map(|query| async move {
+                let search_query = crate::services::indexers::SearchQuery {
+                    q: query.clone(),
+                    categories: Vec::new(),
+                    limit: None,
+                    offset: None,
+                };
+                (
+                    query,
+                    crate::services::indexers::fan_out_search(ctx.indexers, &search_query).await,
+                )
+            })
+            .buffer_unordered(nyaa::NYAA_BUFFER)
+            .collect()
+            .await;
+        let mut releases: Vec<crate::services::indexers::Release> = Vec::new();
+        for (query, outcomes) in outcome_streams {
             for outcome in outcomes {
                 match outcome.result {
-                    Ok(releases) => {
-                        for r in releases {
-                            indexer_responses.push(r.into_search_result());
-                        }
-                    }
+                    Ok(rs) => releases.extend(rs),
                     Err(e) => {
                         tracing::debug!(
                             "indexer fan-out failed for '{}' on indexer #{} ({}): {}",
@@ -1012,7 +1031,18 @@ async fn run_queries(
                 }
             }
         }
-    }
+        // Cross-indexer + cross-query dedup with priority attribution
+        // (decision #3): when two indexers report the same infohash,
+        // the lowest-priority-number indexer wins attribution and
+        // seeders aggregate via `max`. Without this the per-`run_queries`
+        // `seen` HashSet (further down) would attribute by HashMap
+        // iteration order — nondeterministic.
+        crate::services::indexers::dedup_for_auto_search(releases)
+    };
+    let indexer_responses: Vec<crate::services::nyaa::SearchResult> = indexer_releases
+        .into_iter()
+        .map(|r| r.into_search_result())
+        .collect();
 
     for resp in responses {
         let results = match resp {
@@ -1103,39 +1133,6 @@ async fn run_queries(
         }
         candidates.push(result);
     }
-}
-
-/// Issue #28 PR B — load every enabled indexer row from the DB
-/// and instantiate a `TorznabIndexer` per row. Failed instantiations
-/// (empty URL, reqwest client build failure) are logged and dropped
-/// rather than poisoning the whole sweep — partial fan-out is
-/// always better than no fan-out.
-async fn load_indexer_clients(
-    db: &SqlitePool,
-) -> Vec<std::sync::Arc<dyn crate::services::indexers::Indexer>> {
-    let rows = match crate::models::indexers::list_enabled(db).await {
-        Ok(r) => r,
-        Err(e) => {
-            tracing::warn!("failed to load indexers from DB: {e}");
-            return Vec::new();
-        }
-    };
-    rows.iter()
-        .filter_map(|row| {
-            match crate::services::indexers::torznab::TorznabIndexer::from_row_arc(row) {
-                Ok(idx) => Some(idx),
-                Err(e) => {
-                    tracing::warn!(
-                        "failed to instantiate indexer #{} ({}): {}",
-                        row.id,
-                        row.name,
-                        e
-                    );
-                    None
-                }
-            }
-        })
-        .collect()
 }
 
 /// Run queries for interactive search with relaxed matching.

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -425,6 +425,7 @@ pub async fn collect_scored_batches_for_target(
     }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
+    let indexers = load_indexer_clients(db).await;
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
@@ -439,6 +440,7 @@ pub async fn collect_scored_batches_for_target(
         seadex_hashes: &seadex_hashes,
         restrict_user: &series_ctx.restrict_user,
         absolute_offset: series_ctx.absolute_offset,
+        indexers: &indexers,
     };
 
     // Standard query sweep — picks up any batches that happen to surface
@@ -649,6 +651,7 @@ async fn collect_scored_for_target(
     }
 
     let categories = quality::nyaa_categories_for_format(&detail.format, config.allow_non_english);
+    let indexers = load_indexer_clients(db).await;
 
     let ctx = AutoQueryCtx {
         aliases: &aliases,
@@ -663,6 +666,7 @@ async fn collect_scored_for_target(
         seadex_hashes: &seadex_hashes,
         restrict_user: &series_ctx.restrict_user,
         absolute_offset: series_ctx.absolute_offset,
+        indexers: &indexers,
     };
 
     // Phase 1: standard queries (primary aliases + episode variants).
@@ -881,6 +885,13 @@ struct AutoQueryCtx<'a> {
     /// hasn't populated yet, which collapses to the legacy
     /// strict-relative behavior.
     absolute_offset: i32,
+    /// Issue #28 PR B — torznab/newznab indexers to fan out to
+    /// alongside the Nyaa-direct fetch. Loaded once at the top of
+    /// `collect_scored_for_target` so the per-`run_queries` call
+    /// doesn't re-read the DB. Empty slice = Nyaa-only behavior
+    /// (the v1.4 default; what every install sees until the user
+    /// adds a row in Settings → Indexers).
+    indexers: &'a [std::sync::Arc<dyn crate::services::indexers::Indexer>],
 }
 
 /// Same idea, but for the interactive-search helper which has a
@@ -961,6 +972,48 @@ async fn run_queries(
         .collect()
         .await;
 
+    // Issue #28 PR B — fan out to configured torznab/newznab
+    // indexers concurrently with the Nyaa stream. The indexer
+    // results land in the same `candidates` Vec via the same
+    // dedup/match pipeline; downstream scoring sees a unified
+    // pool. Empty `ctx.indexers` (the v1.4 default) skips this
+    // pass entirely so behavior is unchanged for users who
+    // haven't configured any indexers.
+    let mut indexer_responses: Vec<crate::services::nyaa::SearchResult> = Vec::new();
+    if !ctx.indexers.is_empty() {
+        // One torznab query per text query — same fan-out shape
+        // as Nyaa. The indexer impls handle their own per-row
+        // timeouts; a slow indexer holds up only its own slot.
+        for query in queries {
+            let search_query = crate::services::indexers::SearchQuery {
+                q: query.clone(),
+                categories: Vec::new(), // default → 5070 (anime)
+                limit: None,
+                offset: None,
+            };
+            let outcomes =
+                crate::services::indexers::fan_out_search(ctx.indexers, &search_query).await;
+            for outcome in outcomes {
+                match outcome.result {
+                    Ok(releases) => {
+                        for r in releases {
+                            indexer_responses.push(r.into_search_result());
+                        }
+                    }
+                    Err(e) => {
+                        tracing::debug!(
+                            "indexer fan-out failed for '{}' on indexer #{} ({}): {}",
+                            query,
+                            outcome.indexer_id,
+                            outcome.indexer_name,
+                            e
+                        );
+                    }
+                }
+            }
+        }
+    }
+
     for resp in responses {
         let results = match resp {
             Ok(v) => v.results,
@@ -1016,6 +1069,73 @@ async fn run_queries(
             candidates.push(result);
         }
     }
+
+    // Indexer results go through the same dedup + match gate as
+    // Nyaa results so downstream scoring is uniform. The dedup
+    // key (info_hash | title) catches the case of an indexer
+    // surfacing a release Nyaa already returned via Prowlarr's
+    // Nyaa indexer — no double-counting.
+    for result in indexer_responses {
+        let dedupe_key = if !result.info_hash.is_empty() {
+            result.info_hash.clone()
+        } else {
+            result.title.to_lowercase()
+        };
+        if !seen.insert(dedupe_key) {
+            continue;
+        }
+        if !ctx.allow_batch && result.is_batch {
+            continue;
+        }
+        let is_seadex_best = is_seadex_match(&result.info_hash, ctx.seadex_hashes);
+        if !is_seadex_best
+            && !matches_target(
+                &result.title,
+                ctx.aliases,
+                ctx.sibling_precompute,
+                ctx.target,
+                ctx.expected_season,
+                ctx.batch_episode_match && result.is_batch,
+                ctx.absolute_offset,
+            )
+        {
+            continue;
+        }
+        candidates.push(result);
+    }
+}
+
+/// Issue #28 PR B — load every enabled indexer row from the DB
+/// and instantiate a `TorznabIndexer` per row. Failed instantiations
+/// (empty URL, reqwest client build failure) are logged and dropped
+/// rather than poisoning the whole sweep — partial fan-out is
+/// always better than no fan-out.
+async fn load_indexer_clients(
+    db: &SqlitePool,
+) -> Vec<std::sync::Arc<dyn crate::services::indexers::Indexer>> {
+    let rows = match crate::models::indexers::list_enabled(db).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("failed to load indexers from DB: {e}");
+            return Vec::new();
+        }
+    };
+    rows.iter()
+        .filter_map(|row| {
+            match crate::services::indexers::torznab::TorznabIndexer::from_row_arc(row) {
+                Ok(idx) => Some(idx),
+                Err(e) => {
+                    tracing::warn!(
+                        "failed to instantiate indexer #{} ({}): {}",
+                        row.id,
+                        row.name,
+                        e
+                    );
+                    None
+                }
+            }
+        })
+        .collect()
 }
 
 /// Run queries for interactive search with relaxed matching.

--- a/src/services/custom_formats/evaluator.rs
+++ b/src/services/custom_formats/evaluator.rs
@@ -182,6 +182,7 @@ pub fn total_cf_score_for_release(
         score: 0,
         score_breakdown: Vec::new(),
         upload_date: String::new(),
+        indexer_id: None,
     };
     let ctx = EvalContext {
         result: &result,

--- a/src/services/custom_formats/mod.rs
+++ b/src/services/custom_formats/mod.rs
@@ -228,6 +228,7 @@ pub(super) mod test_helpers {
             info_hash: info_hash.to_string(),
             score_breakdown: Vec::new(),
             upload_date: String::new(),
+            indexer_id: None,
         }
     }
 

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -344,11 +344,6 @@ pub fn merge_for_interactive_search(releases: Vec<Release>) -> Vec<Release> {
 /// items rather than propagated — the auto-search inspector
 /// shows per-indexer success/failure instead of failing the
 /// whole search when one indexer dies.
-///
-/// PR A wires the helper but no callers exist yet. PR B's
-/// auto-search integration calls this after the Nyaa-direct
-/// fetch and merges the [`Release`] vecs from successful
-/// outcomes via [`dedup_for_auto_search`].
 pub async fn fan_out_search(
     indexers: &[Arc<dyn Indexer>],
     query: &SearchQuery,
@@ -362,6 +357,143 @@ pub async fn fan_out_search(
         }
     });
     join_all(futures).await
+}
+
+impl Release {
+    /// Convert a torznab/newznab [`Release`] into the
+    /// [`crate::services::nyaa::SearchResult`] shape so the
+    /// downstream auto-search loop can dedup + score indexer
+    /// results alongside Nyaa results without a separate code
+    /// path.
+    ///
+    /// Classification fields (`source`, `web_kind`, `is_remux`,
+    /// `is_bdmv`, `quality_label`) are left empty — the
+    /// downstream `classify_release` call fills them via the
+    /// filename + ffprobe + temporal + group-map layers (the
+    /// Nyaa-description-body layer is unavailable for indexer
+    /// results, but the other four are load-bearing).
+    ///
+    /// Group + resolution are extracted via the same simple
+    /// patterns the Nyaa scraper uses on raw release titles —
+    /// good enough for scoring, not as accurate as the full
+    /// anitomy pass.
+    pub fn into_search_result(self) -> crate::services::nyaa::SearchResult {
+        let group = extract_group_from_title(&self.title);
+        let resolution = extract_resolution_from_title(&self.title);
+        let is_batch = detect_batch_from_title(&self.title);
+        crate::services::nyaa::SearchResult {
+            title: self.title,
+            link: self.link.clone(),
+            magnet: self.magnet,
+            torrent: self.link,
+            size: format_bytes_human(self.size_bytes),
+            size_bytes: self.size_bytes as i64,
+            seeders: self.seeders,
+            leechers: self.leechers,
+            downloads: 0,
+            group,
+            resolution,
+            quality_label: String::new(),
+            source: String::new(),
+            web_kind: String::new(),
+            is_remux: false,
+            is_bdmv: false,
+            is_batch,
+            // Indexer results don't carry Nyaa's "trusted uploader"
+            // flag. Default false — scoring won't apply the trusted
+            // bonus, which is acceptable for v1 (PT releases
+            // typically have other quality signals).
+            is_trusted: false,
+            score: 0,
+            info_hash: self.info_hash,
+            score_breakdown: Vec::new(),
+            // pubDate from the release as ISO-ish; the rest of
+            // Ryokan's UI only renders the string verbatim.
+            upload_date: format_publish_date(self.publish_date),
+        }
+    }
+}
+
+fn extract_group_from_title(title: &str) -> String {
+    // First `[Group]` bracket is the convention. Second-bracket
+    // (e.g., `[BD 1080p]`) is metadata; ignore. Empty when no
+    // bracketed group is present.
+    let bytes = title.as_bytes();
+    let mut start = None;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b == b'[' {
+            start = Some(i + 1);
+        } else if b == b']'
+            && let Some(s) = start
+        {
+            let inner = &title[s..i];
+            if !inner.is_empty() && !inner.chars().next().is_some_and(|c| c.is_ascii_digit()) {
+                return inner.to_string();
+            }
+            start = None;
+        }
+    }
+    String::new()
+}
+
+fn extract_resolution_from_title(title: &str) -> String {
+    for needle in ["2160p", "1080p", "720p", "480p", "1080P", "720P"] {
+        if title.contains(needle) {
+            // Strip the trailing 'p' so we match Nyaa's `resolution`
+            // shape ("1080" not "1080p"). Case-insensitive.
+            let digits: String = needle.chars().take_while(|c| c.is_ascii_digit()).collect();
+            return digits;
+        }
+    }
+    String::new()
+}
+
+fn detect_batch_from_title(title: &str) -> bool {
+    let lower = title.to_lowercase();
+    lower.contains("batch")
+        || lower.contains("season pack")
+        || lower.contains("complete")
+        || lower.contains("[bd]")
+        || lower.contains("(bd)")
+}
+
+fn format_bytes_human(bytes: u64) -> String {
+    if bytes == 0 {
+        return String::new();
+    }
+    let gib = bytes as f64 / (1024.0 * 1024.0 * 1024.0);
+    if gib >= 1.0 {
+        format!("{:.1} GiB", gib)
+    } else {
+        format!("{:.0} MiB", bytes as f64 / (1024.0 * 1024.0))
+    }
+}
+
+fn format_publish_date(unix_ts: i64) -> String {
+    if unix_ts <= 0 {
+        return String::new();
+    }
+    // Match Nyaa's "YYYY-MM-DD HH:MM" UTC shape. Civil-calendar
+    // expansion mirrors the parser's days-since-epoch math.
+    let days = unix_ts.div_euclid(86400);
+    let secs_of_day = unix_ts.rem_euclid(86400);
+    let hour = secs_of_day / 3600;
+    let minute = (secs_of_day % 3600) / 60;
+
+    // Howard Hinnant's civil_from_days, inverse of the parser's
+    // days_from_civil.
+    let z = days + 719468;
+    let era = z.div_euclid(146097);
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{:04}-{:02}-{:02} {:02}:{:02}", y, m, d, hour, minute)
 }
 
 #[cfg(test)]

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -329,10 +329,16 @@ pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
             Vec::new()
         }
     };
-    let clients: Vec<Arc<dyn Indexer>> = rows
-        .iter()
-        .filter_map(|row| match torznab::TorznabIndexer::from_row_arc(row) {
-            Ok(idx) => Some(idx),
+    // PR #107 round-3 review fix #1: pair the row + client
+    // together through the SAME filter_map so a `from_row_arc`
+    // failure drops both halves atomically. The previous
+    // `rows.iter().zip(clients.iter())` realigned positionally —
+    // skipping row B would silently pair row B with client C and
+    // write C's caps_json under B's id when the probe later ran.
+    let pairs: Vec<(crate::models::indexers::Indexer, Arc<dyn Indexer>)> = rows
+        .into_iter()
+        .filter_map(|row| match torznab::TorznabIndexer::from_row_arc(&row) {
+            Ok(idx) => Some((row, idx)),
             Err(e) => {
                 tracing::warn!("indexers: skipping #{} ({}) — {}", row.id, row.name, e);
                 None
@@ -346,7 +352,7 @@ pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
     // No retry on failure — the next rebuild_cache call (next
     // settings edit, next process restart) re-tries any row whose
     // caps_json is still empty.
-    for (row, client) in rows.iter().zip(clients.iter()) {
+    for (row, client) in &pairs {
         if !row.caps_json.is_empty() {
             continue;
         }
@@ -356,19 +362,30 @@ pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
         let row_name = row.name.clone();
         tokio::spawn(async move {
             match client_clone.caps().await {
-                Ok(caps) => {
-                    if let Ok(json) = serde_json::to_string(&caps)
-                        && let Err(e) =
+                Ok(caps) => match serde_json::to_string(&caps) {
+                    Ok(json) => {
+                        if let Err(e) =
                             crate::models::indexers::update_caps(&db_clone, row_id, &json).await
-                    {
+                        {
+                            tracing::warn!(
+                                "indexers: caps probe persist failed for #{} ({}): {}",
+                                row_id,
+                                row_name,
+                                e
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        // PR #107 round-3 review fix #5: don't
+                        // swallow serialize failures silently.
                         tracing::warn!(
-                            "indexers: caps probe persist failed for #{} ({}): {}",
+                            "indexers: caps serialize failed for #{} ({}): {}",
                             row_id,
                             row_name,
                             e
                         );
                     }
-                }
+                },
                 Err(e) => {
                     tracing::debug!(
                         "indexers: caps probe failed for #{} ({}): {}",
@@ -381,6 +398,7 @@ pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
         });
     }
 
+    let clients: Vec<Arc<dyn Indexer>> = pairs.into_iter().map(|(_, c)| c).collect();
     Arc::new(tokio::sync::RwLock::new(Arc::new(clients)))
 }
 

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -259,10 +259,15 @@ pub struct IndexerSearchOutcome {
 /// every release from those indexers would slip past dedup and
 /// flood the candidate set.
 ///
-/// **Interactive search uses a different policy:** no cross-indexer
-/// dedup, one row per `(indexer, infohash)` pair so the user can
-/// pick their preferred tracker. That helper is
-/// [`merge_for_interactive_search`].
+/// **Interactive search policy (decision #3):** when interactive
+/// search learns to fan out to indexers, it should NOT dedup across
+/// indexers — one row per `(indexer, infohash)` so the user can
+/// pick a preferred tracker. That path is intentionally Nyaa-only
+/// in v1.5.0 (PR B); the per-tracker-row behavior lands in PR C
+/// alongside the seed-rules wiring it depends on. The
+/// `merge_for_interactive_search` helper that previously lived
+/// here was removed in PR #107 round-2 review since it was dead
+/// code; PR C reintroduces it when there's a caller.
 pub fn dedup_for_auto_search(releases: Vec<Release>) -> Vec<Release> {
     let mut by_key: HashMap<String, Release> = HashMap::new();
     for release in releases {
@@ -310,38 +315,6 @@ pub fn dedup_for_auto_search(releases: Vec<Release>) -> Vec<Release> {
     out
 }
 
-/// Interactive-search merge: no cross-indexer dedup. Returns one
-/// row per `(indexer_id, info_hash | guid)` pair so the user sees
-/// per-tracker rows in the search-results table and can pick
-/// based on tracker-specific factors (ratio rules, freeleech,
-/// upload-goals). Sorted by priority then by published date
-/// descending so newer releases bubble up within the same
-/// indexer.
-pub fn merge_for_interactive_search(releases: Vec<Release>) -> Vec<Release> {
-    let mut by_key: HashMap<(i64, String), Release> = HashMap::new();
-    for release in releases {
-        let inner = if !release.info_hash.is_empty() {
-            release.info_hash.to_ascii_lowercase()
-        } else if !release.guid.is_empty() {
-            release.guid.clone()
-        } else {
-            format!("__{}", release.title)
-        };
-        let key = (release.indexer_id, inner);
-        // Same-key collisions inside one indexer are degenerate
-        // (same release listed twice in one response) — keep the
-        // first.
-        by_key.entry(key).or_insert(release);
-    }
-    let mut out: Vec<Release> = by_key.into_values().collect();
-    out.sort_by(|a, b| {
-        a.indexer_priority
-            .cmp(&b.indexer_priority)
-            .then(b.publish_date.cmp(&a.publish_date))
-    });
-    out
-}
-
 /// PR #107 review fix #4: build a fresh `Vec<Arc<dyn Indexer>>`
 /// from the DB and wrap it in the [`crate::IndexerCache`] swap-on-
 /// write Arc. Called once at startup and again from the
@@ -366,6 +339,48 @@ pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
             }
         })
         .collect();
+
+    // PR #107 round-2 review fix #6: lazy caps probe for rows that
+    // haven't been probed yet. Detached `tokio::spawn`s so a slow
+    // indexer can't block startup or the post-edit settings save.
+    // No retry on failure — the next rebuild_cache call (next
+    // settings edit, next process restart) re-tries any row whose
+    // caps_json is still empty.
+    for (row, client) in rows.iter().zip(clients.iter()) {
+        if !row.caps_json.is_empty() {
+            continue;
+        }
+        let db_clone = db.clone();
+        let client_clone = client.clone();
+        let row_id = row.id;
+        let row_name = row.name.clone();
+        tokio::spawn(async move {
+            match client_clone.caps().await {
+                Ok(caps) => {
+                    if let Ok(json) = serde_json::to_string(&caps)
+                        && let Err(e) =
+                            crate::models::indexers::update_caps(&db_clone, row_id, &json).await
+                    {
+                        tracing::warn!(
+                            "indexers: caps probe persist failed for #{} ({}): {}",
+                            row_id,
+                            row_name,
+                            e
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        "indexers: caps probe failed for #{} ({}): {}",
+                        row_id,
+                        row_name,
+                        e
+                    );
+                }
+            }
+        });
+    }
+
     Arc::new(tokio::sync::RwLock::new(Arc::new(clients)))
 }
 
@@ -689,50 +704,6 @@ mod tests {
         assert_eq!(out[0].indexer_priority, 5);
         assert_eq!(out[1].indexer_priority, 25);
         assert_eq!(out[2].indexer_priority, 50);
-    }
-
-    // ── merge_for_interactive_search ────────────────────────────────
-
-    #[test]
-    fn interactive_keeps_one_row_per_indexer_per_release() {
-        // Decision #3 — interactive search shows the user one row
-        // per (indexer, infohash) so they can pick their preferred
-        // tracker.
-        let input = vec![
-            release(1, 5, "abc123", "g1", "Show (Tracker A)", 10),
-            release(2, 50, "abc123", "g2", "Show (Tracker B)", 8),
-        ];
-        let out = merge_for_interactive_search(input);
-        assert_eq!(out.len(), 2, "both indexers' rows visible to user");
-    }
-
-    #[test]
-    fn interactive_collapses_dup_within_same_indexer() {
-        // A torznab response listing the same release twice (e.g.,
-        // post + announce) should still show one row.
-        let input = vec![
-            release(1, 5, "abc123", "g1", "Show", 10),
-            release(1, 5, "abc123", "g1", "Show", 10),
-        ];
-        let out = merge_for_interactive_search(input);
-        assert_eq!(out.len(), 1);
-    }
-
-    #[test]
-    fn interactive_sorts_by_priority_then_publish_date_desc() {
-        let mut newer = release(1, 5, "h1", "g1", "Newer", 5);
-        newer.publish_date = 1_000_000;
-        let mut older = release(1, 5, "h2", "g2", "Older", 5);
-        older.publish_date = 500_000;
-        let other = release(2, 50, "h3", "g3", "Other indexer", 5);
-        let input = vec![older, newer, other];
-        let out = merge_for_interactive_search(input);
-        assert_eq!(out.len(), 3);
-        // Within indexer 1: newer first.
-        assert_eq!(out[0].title, "Newer");
-        assert_eq!(out[1].title, "Older");
-        // Indexer 2 last (priority 50).
-        assert_eq!(out[2].title, "Other indexer");
     }
 
     // ── Helper unit tests (PR #107 review fix #10) ──────────────────

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -48,6 +48,8 @@
 //!   path.** `season`/`ep` params don't translate cleanly because
 //!   anime trackers key on absolute episode numbers in titles.
 
+pub mod torznab;
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -826,9 +826,6 @@ mod tests {
         assert_eq!(super::format_publish_date(86_400), "1970-01-02 00:00");
         // 2000-01-01 00:00:00 UTC = 946684800. Y2K boundary; verifies
         // century-handling in the civil-from-days math.
-        assert_eq!(
-            super::format_publish_date(946_684_800),
-            "2000-01-01 00:00"
-        );
+        assert_eq!(super::format_publish_date(946_684_800), "2000-01-01 00:00");
     }
 }

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -817,4 +817,60 @@ mod tests {
         // century-handling in the civil-from-days math.
         assert_eq!(super::format_publish_date(946_684_800), "2000-01-01 00:00");
     }
+
+    // ── rebuild_cache row/client pairing (PR #107 round-4 review fix #2) ─
+
+    #[tokio::test]
+    async fn rebuild_cache_drops_bad_rows_without_misaligning_clients() {
+        // PR #107 round-3 review fix #1 was a real correctness bug:
+        // when `from_row_arc` failed for a row mid-list, the
+        // positional `rows.iter().zip(clients.iter())` pairing
+        // realigned wrongly, causing the caps probe to write the
+        // wrong row's caps under the surviving row's id.
+        //
+        // This test pins the pairing fix: insert [A_good, B_bad,
+        // C_good] (B has an empty URL so from_row_arc rejects it),
+        // call rebuild_cache, and assert the cache contains exactly
+        // A and C in priority order. A future refactor that re-
+        // introduces a parallel-collect pattern would silently
+        // regress without this regression guard.
+        use crate::models::indexers::{IndexerForm, KIND_TORZNAB, insert};
+
+        let db = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+
+        let mk = |name: &str, url: &str, priority: i32| IndexerForm {
+            name: Box::leak(name.to_string().into_boxed_str()),
+            kind: KIND_TORZNAB,
+            url: Box::leak(url.to_string().into_boxed_str()),
+            api_key: "k",
+            priority,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 0,
+            request_timeout_secs: None,
+        };
+        let a_id = insert(&db, mk("A", "https://a.example/api", 5))
+            .await
+            .unwrap();
+        let _b_id = insert(&db, mk("B_bad", "", 25)).await.unwrap();
+        let c_id = insert(&db, mk("C", "https://c.example/api", 50))
+            .await
+            .unwrap();
+
+        let cache = rebuild_cache(&db).await;
+        let snapshot = cache.read().await.clone();
+
+        assert_eq!(snapshot.len(), 2, "B (bad URL) must be dropped");
+        // Ordered by priority asc — A (5) then C (50).
+        assert_eq!(snapshot[0].id(), a_id, "first surviving entry must be A");
+        assert_eq!(snapshot[1].id(), c_id, "second surviving entry must be C");
+        // Specifically: B's id must NOT appear in the cache.
+        assert!(
+            !snapshot.iter().any(|c| c.id() == _b_id),
+            "B's id must not survive — its client was never instantiated"
+        );
+    }
 }

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -42,8 +42,13 @@
 //!   `5999` (Other) — title-parse fallback is required if the cat
 //!   doesn't include 5070.
 //! - **Per-indexer rate limits live inside Prowlarr/Jackett,** not
-//!   the indexer itself. They surface as `429 Retry-After`. Mirror
-//!   the cooldown pattern from [`crate::services::anilist::rate_limit`].
+//!   the indexer itself. They surface as `429 Retry-After`. The
+//!   client surfaces the retry_after seconds in the error message;
+//!   no process-wide cooldown is applied yet — every fan-out re-
+//!   issues whether the previous burst hit a 429 or not. PR C
+//!   wires the cooldown table mirroring
+//!   [`crate::services::anilist::rate_limit`]; until then, a
+//!   429-storm just logs at debug level and keeps trying.
 //! - **`tvsearch` with `cat=5070&q=<title>` is the right anime
 //!   path.** `season`/`ep` params don't translate cleanly because
 //!   anime trackers key on absolute episode numbers in titles.
@@ -337,6 +342,44 @@ pub fn merge_for_interactive_search(releases: Vec<Release>) -> Vec<Release> {
     out
 }
 
+/// PR #107 review fix #4: build a fresh `Vec<Arc<dyn Indexer>>`
+/// from the DB and wrap it in the [`crate::IndexerCache`] swap-on-
+/// write Arc. Called once at startup and again from the
+/// Settings → Indexers handlers on add/edit/delete so the cache
+/// stays current. Failed instantiations log + drop, same partial-
+/// fan-out posture as the old in-line `load_indexer_clients`.
+pub async fn rebuild_cache(db: &sqlx::SqlitePool) -> crate::IndexerCache {
+    let rows = match crate::models::indexers::list_enabled(db).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("indexers: failed to load from DB: {e}");
+            Vec::new()
+        }
+    };
+    let clients: Vec<Arc<dyn Indexer>> = rows
+        .iter()
+        .filter_map(|row| match torznab::TorznabIndexer::from_row_arc(row) {
+            Ok(idx) => Some(idx),
+            Err(e) => {
+                tracing::warn!("indexers: skipping #{} ({}) — {}", row.id, row.name, e);
+                None
+            }
+        })
+        .collect();
+    Arc::new(tokio::sync::RwLock::new(Arc::new(clients)))
+}
+
+/// Swap fresh contents into an existing cache without reallocating
+/// the outer Arc. Used by the Settings handlers after an upsert /
+/// delete so handler code holding `state.indexers.clone()`
+/// continues to see the new list on the next read.
+pub async fn refresh_cache_in_place(cache: &crate::IndexerCache, db: &sqlx::SqlitePool) {
+    let rebuilt = rebuild_cache(db).await;
+    let new_inner = rebuilt.read().await.clone();
+    let mut guard = cache.write().await;
+    *guard = new_inner;
+}
+
 /// Concurrent fan-out across configured indexers. Each indexer
 /// runs in its own future with the indexer's own request timeout;
 /// a slow indexer holds up only its own slot, not the whole
@@ -381,6 +424,7 @@ impl Release {
         let group = extract_group_from_title(&self.title);
         let resolution = extract_resolution_from_title(&self.title);
         let is_batch = detect_batch_from_title(&self.title);
+        let indexer_id = self.indexer_id;
         crate::services::nyaa::SearchResult {
             title: self.title,
             link: self.link.clone(),
@@ -410,6 +454,12 @@ impl Release {
             // pubDate from the release as ISO-ish; the rest of
             // Ryokan's UI only renders the string verbatim.
             upload_date: format_publish_date(self.publish_date),
+            // PR #107 review fix #7: propagate the indexer_id so
+            // grabbed_torrents.indexer_id can be populated at grab
+            // time. Without this, the FK column added in PR A is
+            // dormant — nothing surfaces the source indexer to the
+            // grab path.
+            indexer_id: Some(indexer_id),
         }
     }
 }
@@ -437,10 +487,12 @@ fn extract_group_from_title(title: &str) -> String {
 }
 
 fn extract_resolution_from_title(title: &str) -> String {
-    for needle in ["2160p", "1080p", "720p", "480p", "1080P", "720P"] {
-        if title.contains(needle) {
-            // Strip the trailing 'p' so we match Nyaa's `resolution`
-            // shape ("1080" not "1080p"). Case-insensitive.
+    // PR #107 review fix #10: case-insensitive single pass instead
+    // of two separate lists. Covers 2160P / 480P uppercase that the
+    // earlier list missed.
+    let lower = title.to_ascii_lowercase();
+    for needle in ["2160p", "1080p", "720p", "480p"] {
+        if lower.contains(needle) {
             let digits: String = needle.chars().take_while(|c| c.is_ascii_digit()).collect();
             return digits;
         }
@@ -449,12 +501,35 @@ fn extract_resolution_from_title(title: &str) -> String {
 }
 
 fn detect_batch_from_title(title: &str) -> bool {
-    let lower = title.to_lowercase();
-    lower.contains("batch")
-        || lower.contains("season pack")
-        || lower.contains("complete")
-        || lower.contains("[bd]")
-        || lower.contains("(bd)")
+    // PR #107 review fix #9: tighten "complete" matching with a
+    // word-boundary-equivalent check. The earlier substring scan
+    // matched "Incomplete Edition" and similar negated forms.
+    // Now require the keyword to be flanked by whitespace, brackets,
+    // or string boundaries — matches the way real release titles
+    // tag a batch ("Show - Complete", "[Group] Show Complete BD").
+    let lower = title.to_ascii_lowercase();
+    if lower.contains("[bd]") || lower.contains("(bd)") || lower.contains("season pack") {
+        return true;
+    }
+    for needle in ["batch", "complete"] {
+        if let Some(idx) = lower.find(needle) {
+            let before_ok = idx == 0
+                || lower
+                    .as_bytes()
+                    .get(idx - 1)
+                    .is_some_and(|&b| !b.is_ascii_alphabetic());
+            let after = idx + needle.len();
+            let after_ok = after == lower.len()
+                || lower
+                    .as_bytes()
+                    .get(after)
+                    .is_some_and(|&b| !b.is_ascii_alphabetic());
+            if before_ok && after_ok {
+                return true;
+            }
+        }
+    }
+    false
 }
 
 fn format_bytes_human(bytes: u64) -> String {
@@ -658,5 +733,102 @@ mod tests {
         assert_eq!(out[1].title, "Older");
         // Indexer 2 last (priority 50).
         assert_eq!(out[2].title, "Other indexer");
+    }
+
+    // ── Helper unit tests (PR #107 review fix #10) ──────────────────
+
+    #[test]
+    fn extract_group_pulls_first_bracketed_segment() {
+        assert_eq!(
+            super::extract_group_from_title("[GroupX] Show - 01 [BD 1080p].mkv"),
+            "GroupX"
+        );
+    }
+
+    #[test]
+    fn extract_group_skips_pure_numeric_brackets() {
+        // Some indexers prefix with a numeric ID (`[1234]` etc.).
+        // Skip those — they're not the release group.
+        assert_eq!(
+            super::extract_group_from_title("[12345] [GroupX] Show.mkv"),
+            "GroupX"
+        );
+    }
+
+    #[test]
+    fn extract_group_returns_empty_when_no_brackets() {
+        assert_eq!(super::extract_group_from_title("Show - 01.mkv"), "");
+    }
+
+    #[test]
+    fn extract_resolution_handles_uppercase_p() {
+        // PR #107 review fix #10: 2160P / 480P with uppercase P
+        // weren't covered by the original list; the case-insensitive
+        // pass catches both.
+        assert_eq!(
+            super::extract_resolution_from_title("Show 2160P.mkv"),
+            "2160"
+        );
+        assert_eq!(super::extract_resolution_from_title("Show 480P.mkv"), "480");
+        assert_eq!(super::extract_resolution_from_title("Show [1080P]"), "1080");
+    }
+
+    #[test]
+    fn extract_resolution_returns_empty_when_no_marker() {
+        assert_eq!(super::extract_resolution_from_title("Show - 01.mkv"), "");
+    }
+
+    #[test]
+    fn detect_batch_word_boundary_blocks_incomplete_edition() {
+        // PR #107 review fix #9: "Incomplete" used to trigger because
+        // the substring contains "complete". The word-boundary check
+        // rejects it now.
+        assert!(!super::detect_batch_from_title(
+            "Show Incomplete Edition.mkv"
+        ));
+        // Real "Complete" still triggers.
+        assert!(super::detect_batch_from_title("Show Complete BD.mkv"));
+        // Other markers stay positive.
+        assert!(super::detect_batch_from_title("[Group] Show Batch.mkv"));
+        assert!(super::detect_batch_from_title(
+            "[Group] Show Season Pack.mkv"
+        ));
+        assert!(super::detect_batch_from_title("Show [BD]"));
+    }
+
+    #[test]
+    fn format_bytes_human_zero_renders_empty() {
+        assert_eq!(super::format_bytes_human(0), "");
+    }
+
+    #[test]
+    fn format_bytes_human_under_gib_uses_mib() {
+        assert_eq!(super::format_bytes_human(500 * 1024 * 1024), "500 MiB");
+    }
+
+    #[test]
+    fn format_bytes_human_at_or_above_gib_uses_gib() {
+        assert_eq!(super::format_bytes_human(1024 * 1024 * 1024), "1.0 GiB");
+        assert_eq!(super::format_bytes_human(2 * 1024u64.pow(3)), "2.0 GiB");
+    }
+
+    #[test]
+    fn format_publish_date_zero_or_negative_renders_empty() {
+        assert_eq!(super::format_publish_date(0), "");
+        assert_eq!(super::format_publish_date(-1), "");
+    }
+
+    #[test]
+    fn format_publish_date_round_trips_known_dates() {
+        // Epoch + 1s.
+        assert_eq!(super::format_publish_date(1), "1970-01-01 00:00");
+        // One full day in (non-leap 1970).
+        assert_eq!(super::format_publish_date(86_400), "1970-01-02 00:00");
+        // 2000-01-01 00:00:00 UTC = 946684800. Y2K boundary; verifies
+        // century-handling in the civil-from-days math.
+        assert_eq!(
+            super::format_publish_date(946_684_800),
+            "2000-01-01 00:00"
+        );
     }
 }

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -1,0 +1,528 @@
+//! Torznab/newznab indexer abstraction (issue #28 PR A).
+//!
+//! ## Scope of this PR
+//!
+//! Foundation only — the [`Indexer`] trait, the [`Release`] /
+//! [`SearchQuery`] / [`IndexerCaps`] data model, and pure-function
+//! helpers for the auto-search dedup pass and concurrent fan-out.
+//! No concrete [`Indexer`] impls live here yet; the
+//! `TorznabIndexer` impl lands in PR B alongside the search-pipeline
+//! integration that actually populates `Vec<Arc<dyn Indexer>>` from
+//! the [`crate::models::indexers`] table.
+//!
+//! ## Why Nyaa stays out-of-band
+//!
+//! Per plan decision #1, the existing direct Nyaa scraper in
+//! [`crate::services::nyaa`] is NOT adapted to this trait. The
+//! search pipeline dispatches to Nyaa-direct + fans out to
+//! `Indexer` impls in parallel, then merges. Conforming Nyaa to
+//! the trait would have meant adding [`Release`] fields like
+//! `nyaa_description: Option<String>` that only one impl
+//! populates — a noisy contract — and the source-classification
+//! pipeline already reads Nyaa's description body directly. Pretending
+//! the sources are uniform would have hidden that coupling.
+//!
+//! ## Protocol notes (from research, 2026-04-25)
+//!
+//! Authoritative shapes that any future impl must respect:
+//!
+//! - **URL shape is opaque to Ryokan.** Prowlarr emits
+//!   `http://host:9696/{N}/api?apikey={KEY}&t=...`; Jackett emits
+//!   `http://host:9117/api/v2.0/indexers/{slug}/results/torznab/api?apikey={KEY}&t=...`.
+//!   Both end in `/api` and accept torznab params after `?`. The
+//!   user pastes the full base URL verbatim from each tool's
+//!   "Copy Torznab Url" button; Ryokan must not parse or
+//!   reconstruct it.
+//! - **Errors come back as HTTP 200 with `<error code="N"
+//!   description="..."/>` bodies.** Real impls (Prowlarr, Jackett)
+//!   also return non-200 in some paths (Prowlarr 401 on bad apikey
+//!   before the torznab layer); both must be handled.
+//! - **Anime category is `5070`** in the standard torznab namespace.
+//!   AnimeTosho via Prowlarr historically mis-tagged anime as
+//!   `5999` (Other) — title-parse fallback is required if the cat
+//!   doesn't include 5070.
+//! - **Per-indexer rate limits live inside Prowlarr/Jackett,** not
+//!   the indexer itself. They surface as `429 Retry-After`. Mirror
+//!   the cooldown pattern from [`crate::services::anilist::rate_limit`].
+//! - **`tvsearch` with `cat=5070&q=<title>` is the right anime
+//!   path.** `season`/`ep` params don't translate cleanly because
+//!   anime trackers key on absolute episode numbers in titles.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// Standard torznab category id for anime. See doc-comment above for
+/// why title-parse fallback is needed when this is absent from a
+/// release's reported categories.
+pub const TORZNAB_CAT_ANIME: i32 = 5070;
+
+/// Default per-indexer search timeout when the row's
+/// `request_timeout_secs` is NULL. Decision #7 — tighter than
+/// Sonarr's 100s default because Ryokan's interactive search
+/// surface needs lower user-perceived latency. Overridable
+/// process-wide via `RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS`.
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
+
+/// Indexer caps cache TTL. Decision #6 — matches Sonarr's
+/// `NewznabCapabilitiesProvider.cs` 7-day default. The search
+/// pipeline re-fetches lazily on next read past the TTL; manual
+/// "Refresh caps" button on the indexer edit page covers the
+/// out-of-band edit case.
+pub const CAPS_TTL_SECONDS: i64 = 7 * 24 * 60 * 60;
+
+/// What an [`Indexer::search`] caller asks for. Mirrors torznab's
+/// `t=tvsearch` parameter set; the impl translates to the wire
+/// format. `q` is the only free-text input — `season`/`ep` are
+/// deliberately omitted because anime trackers key on absolute
+/// episode numbers in release titles, not season+ep.
+#[derive(Debug, Clone, Default)]
+pub struct SearchQuery {
+    pub q: String,
+    /// Torznab category ids. Defaults to `[5070]` (anime) when
+    /// empty. Multiple ids OR together on the wire (`cat=5070,5080`).
+    pub categories: Vec<i32>,
+    /// Page size. None lets the impl pick (typically the indexer's
+    /// caps-reported default). Must be ≤ caps `max_limit`.
+    pub limit: Option<u32>,
+    /// 0-based offset for paging. None = 0.
+    pub offset: Option<u32>,
+}
+
+/// One release row from a torznab response. Field set is the union
+/// of what real Prowlarr/Jackett deployments emit; impl-specific
+/// fields go in [`extra`] so the core type stays portable across
+/// indexers.
+///
+/// Source classification consumes [`title`] + [`size_bytes`] +
+/// [`info_hash`] (when present) — same inputs the existing
+/// pipeline derives from a Nyaa scrape. The Nyaa-description-body
+/// signal is unavailable here; classification degrades to four
+/// layers (filename + ffprobe + temporal + group-map).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Release {
+    /// FK to [`crate::models::indexers::Indexer::id`] of the
+    /// indexer that surfaced this release. The dedup pass
+    /// (decision #3) attributes each (infohash, indexer) pair to
+    /// the lowest-priority-number indexer.
+    pub indexer_id: i64,
+    /// Snapshot of the indexer's priority at search time so a
+    /// later DB edit can't change attribution retroactively.
+    pub indexer_priority: i32,
+    pub title: String,
+    /// Stable per-release identifier from the torznab `<guid>`
+    /// element. Used as a dedup key when [`info_hash`] is empty.
+    pub guid: String,
+    /// Download URL. For Prowlarr this is a proxy URL with the
+    /// apikey appended; the .torrent fetch must go through Prowlarr.
+    /// Per research note: stale on Prowlarr restart, so don't cache
+    /// across days.
+    pub link: String,
+    /// Magnet URI when the indexer surfaces one, else empty.
+    pub magnet: String,
+    /// Unix timestamp of `<pubDate>`. 0 when missing/unparseable.
+    pub publish_date: i64,
+    pub size_bytes: u64,
+    pub seeders: i32,
+    pub leechers: i32,
+    /// Lowercase hex; empty when the indexer doesn't expose it
+    /// (some private trackers omit it). Dedup falls back to
+    /// [`guid`] when this is empty.
+    pub info_hash: String,
+    /// Standard torznab category ids on this release. May contain
+    /// indexer-specific subcategory ids beyond the well-known
+    /// 5000-series. Empty is legal — the title-parse fallback
+    /// catches anime mis-tags like AnimeTosho via Prowlarr's
+    /// 5999 issue.
+    pub categories: Vec<i32>,
+    /// `1.0` = full count, `0.0` = freeleech. Some private
+    /// trackers expose this; public trackers don't. None when
+    /// the indexer doesn't emit the attr.
+    pub download_volume_factor: Option<f32>,
+    pub upload_volume_factor: Option<f32>,
+    /// Catch-all for impl-specific torznab attrs not promoted to
+    /// first-class fields. Inspector-friendly only — scoring path
+    /// must not key off these.
+    #[serde(default)]
+    pub extra: HashMap<String, String>,
+}
+
+/// Caps response shape. Cached as JSON in `indexers.caps_json`
+/// per the 7-day TTL. The settings UI renders [`categories`] as a
+/// multi-select on the per-indexer config form.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct IndexerCaps {
+    pub categories: Vec<CategoryCap>,
+    pub search_modes: Vec<SearchModeCap>,
+    /// Server-reported maximum `limit` per request. None when the
+    /// caps response doesn't carry it; defaults to spec value 100.
+    pub max_limit: Option<u32>,
+    /// Server-reported default `limit`. None when missing; spec
+    /// default is 50.
+    pub default_limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CategoryCap {
+    pub id: i32,
+    pub name: String,
+    /// Subcategories nested under this top-level category id.
+    /// Most indexers report a flat list; Prowlarr nests where the
+    /// upstream tracker has subcats (e.g., 5070 Anime → 5080
+    /// Anime/Movies on some private trackers).
+    #[serde(default)]
+    pub subcategories: Vec<CategoryCap>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchModeCap {
+    /// `"search"` / `"tvsearch"` / `"movie"` / `"music"` / `"book"`.
+    pub mode: String,
+    pub available: bool,
+    /// Supported params (`q`, `cat`, `season`, `ep`, `tvdbid`,
+    /// `imdbid`, etc.). Per-mode.
+    #[serde(default)]
+    pub supported_params: Vec<String>,
+}
+
+/// The torznab/newznab indexer trait. Every impl talks to a single
+/// indexer instance (a row in the `indexers` table). The search
+/// pipeline holds these as `Vec<Arc<dyn Indexer>>` so the fan-out
+/// can run them concurrently.
+///
+/// `async_trait` (rather than the stable native syntax) for the
+/// same reason [`crate::services::download_client::DownloadClient`]
+/// uses it: object-safety + Send-bound futures on Tokio's
+/// multi-threaded runtime require the boxed-future macro.
+#[async_trait::async_trait]
+pub trait Indexer: Send + Sync {
+    /// FK to `indexers.id`.
+    fn id(&self) -> i64;
+    fn name(&self) -> &str;
+    /// Sonarr-convention priority (lower = preferred). Drives
+    /// auto-search dedup attribution per [`dedup_for_auto_search`]
+    /// and the fan-out concurrency order.
+    fn priority(&self) -> i32;
+    fn is_private_tracker(&self) -> bool;
+
+    /// Fetch capabilities from `t=caps`. Impls should respect the
+    /// 7-day TTL on the row's [`caps_json`] cache; the search-path
+    /// caller persists fresh JSON via
+    /// [`crate::models::indexers::update_caps`] when this returns
+    /// after a network round-trip.
+    async fn caps(&self) -> Result<IndexerCaps, String>;
+
+    /// Search this indexer for releases matching `query`. Impls
+    /// are responsible for:
+    ///
+    /// - Parsing torznab `<error code="N"/>` bodies even on HTTP
+    ///   200 (per protocol).
+    /// - Honoring 429 + `Retry-After` from upstream.
+    /// - Filtering results below the indexer's configured
+    ///   `min_seeders` *before* return — the search pipeline's
+    ///   scoring runs on whatever this returns, so a low-seeder
+    ///   release leaking into the candidate set is wasted work.
+    /// - Stamping each [`Release`] with `indexer_id` +
+    ///   `indexer_priority` so the dedup pass can attribute
+    ///   correctly.
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<Release>, String>;
+}
+
+/// Per-indexer search outcome. Surfaces partial failures so the
+/// auto-search inspector can show "AnimeTosho: timeout after 30s"
+/// alongside successful results from other indexers (plan
+/// "scoring inspector changes"). PR A defines the type; PR B's
+/// fan-out helper produces it.
+#[derive(Debug)]
+pub struct IndexerSearchOutcome {
+    pub indexer_id: i64,
+    pub indexer_name: String,
+    pub result: Result<Vec<Release>, String>,
+}
+
+/// Auto-search dedup pass (decision #3). Collapses the same
+/// (infohash, ?) release reported by multiple indexers into a
+/// single [`Release`], attributing to the lowest-priority-number
+/// indexer (Sonarr convention) and aggregating seeder counts via
+/// `max` (most accurate signal across reporting indexers).
+///
+/// The dedup key is `info_hash` when present; otherwise `guid`.
+/// The (lossy) fallback exists because some private trackers omit
+/// infohash from torznab responses — without the guid fallback,
+/// every release from those indexers would slip past dedup and
+/// flood the candidate set.
+///
+/// **Interactive search uses a different policy:** no cross-indexer
+/// dedup, one row per `(indexer, infohash)` pair so the user can
+/// pick their preferred tracker. That helper is
+/// [`merge_for_interactive_search`].
+pub fn dedup_for_auto_search(releases: Vec<Release>) -> Vec<Release> {
+    let mut by_key: HashMap<String, Release> = HashMap::new();
+    for release in releases {
+        let key = if !release.info_hash.is_empty() {
+            release.info_hash.to_ascii_lowercase()
+        } else if !release.guid.is_empty() {
+            release.guid.clone()
+        } else {
+            // No infohash, no guid — keep the release but key by
+            // a uniqueness-safe value so it doesn't collide with
+            // other no-key releases. Using the title alone would
+            // collide across indexers; including indexer_id keeps
+            // them separate without losing them entirely.
+            format!("__{}_{}", release.indexer_id, release.title)
+        };
+        match by_key.get_mut(&key) {
+            None => {
+                by_key.insert(key, release);
+            }
+            Some(existing) => {
+                // Lower priority number = preferred indexer for
+                // attribution. Tiebreak on indexer_id ascending so
+                // the result is stable across calls.
+                let take_new = release.indexer_priority < existing.indexer_priority
+                    || (release.indexer_priority == existing.indexer_priority
+                        && release.indexer_id < existing.indexer_id);
+                let merged_seeders = existing.seeders.max(release.seeders);
+                let merged_leechers = existing.leechers.max(release.leechers);
+                if take_new {
+                    *existing = release;
+                }
+                existing.seeders = merged_seeders;
+                existing.leechers = merged_leechers;
+            }
+        }
+    }
+    let mut out: Vec<Release> = by_key.into_values().collect();
+    // Stable sort by priority then id so callers downstream don't
+    // see HashMap iteration nondeterminism.
+    out.sort_by(|a, b| {
+        a.indexer_priority
+            .cmp(&b.indexer_priority)
+            .then(a.indexer_id.cmp(&b.indexer_id))
+    });
+    out
+}
+
+/// Interactive-search merge: no cross-indexer dedup. Returns one
+/// row per `(indexer_id, info_hash | guid)` pair so the user sees
+/// per-tracker rows in the search-results table and can pick
+/// based on tracker-specific factors (ratio rules, freeleech,
+/// upload-goals). Sorted by priority then by published date
+/// descending so newer releases bubble up within the same
+/// indexer.
+pub fn merge_for_interactive_search(releases: Vec<Release>) -> Vec<Release> {
+    let mut by_key: HashMap<(i64, String), Release> = HashMap::new();
+    for release in releases {
+        let inner = if !release.info_hash.is_empty() {
+            release.info_hash.to_ascii_lowercase()
+        } else if !release.guid.is_empty() {
+            release.guid.clone()
+        } else {
+            format!("__{}", release.title)
+        };
+        let key = (release.indexer_id, inner);
+        // Same-key collisions inside one indexer are degenerate
+        // (same release listed twice in one response) — keep the
+        // first.
+        by_key.entry(key).or_insert(release);
+    }
+    let mut out: Vec<Release> = by_key.into_values().collect();
+    out.sort_by(|a, b| {
+        a.indexer_priority
+            .cmp(&b.indexer_priority)
+            .then(b.publish_date.cmp(&a.publish_date))
+    });
+    out
+}
+
+/// Concurrent fan-out across configured indexers. Each indexer
+/// runs in its own future with the indexer's own request timeout;
+/// a slow indexer holds up only its own slot, not the whole
+/// search. Failures are captured as [`IndexerSearchOutcome`]
+/// items rather than propagated — the auto-search inspector
+/// shows per-indexer success/failure instead of failing the
+/// whole search when one indexer dies.
+///
+/// PR A wires the helper but no callers exist yet. PR B's
+/// auto-search integration calls this after the Nyaa-direct
+/// fetch and merges the [`Release`] vecs from successful
+/// outcomes via [`dedup_for_auto_search`].
+pub async fn fan_out_search(
+    indexers: &[Arc<dyn Indexer>],
+    query: &SearchQuery,
+) -> Vec<IndexerSearchOutcome> {
+    use futures_util::future::join_all;
+    let futures = indexers.iter().map(|idx| async move {
+        IndexerSearchOutcome {
+            indexer_id: idx.id(),
+            indexer_name: idx.name().to_string(),
+            result: idx.search(query).await,
+        }
+    });
+    join_all(futures).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn release(
+        indexer_id: i64,
+        priority: i32,
+        info_hash: &str,
+        guid: &str,
+        title: &str,
+        seeders: i32,
+    ) -> Release {
+        Release {
+            indexer_id,
+            indexer_priority: priority,
+            title: title.to_string(),
+            guid: guid.to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            publish_date: 0,
+            size_bytes: 1_000_000_000,
+            seeders,
+            leechers: 0,
+            info_hash: info_hash.to_string(),
+            categories: vec![TORZNAB_CAT_ANIME],
+            download_volume_factor: None,
+            upload_volume_factor: None,
+            extra: HashMap::new(),
+        }
+    }
+
+    // ── dedup_for_auto_search ────────────────────────────────────────
+
+    #[test]
+    fn dedup_keeps_single_release_unchanged() {
+        let input = vec![release(1, 25, "abc123", "g1", "Show", 10)];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].info_hash, "abc123");
+        assert_eq!(out[0].seeders, 10);
+    }
+
+    #[test]
+    fn dedup_attributes_to_lower_priority_indexer() {
+        // Two indexers report the same infohash. The lower priority
+        // number (Sonarr convention) wins attribution.
+        let input = vec![
+            release(2, 50, "abc123", "g1", "Show (mirror)", 5),
+            release(1, 5, "abc123", "g2", "Show (preferred)", 8),
+        ];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(out.len(), 1, "same infohash must collapse to one row");
+        // Attribution: indexer 1 wins (priority 5 < 50).
+        assert_eq!(out[0].indexer_id, 1);
+        assert_eq!(out[0].title, "Show (preferred)");
+    }
+
+    #[test]
+    fn dedup_aggregates_seeders_via_max_across_reporters() {
+        // Same release, two reports — keep the higher seeder count
+        // since indexers can disagree by minutes-old data and max
+        // is most likely accurate.
+        let input = vec![
+            release(1, 5, "abc123", "g1", "Show", 8),
+            release(2, 50, "abc123", "g2", "Show (mirror)", 42),
+        ];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].seeders, 42, "max seeders across reporters");
+    }
+
+    #[test]
+    fn dedup_falls_back_to_guid_when_infohash_empty() {
+        // Some private trackers omit infohash. Dedup must still
+        // collapse same-guid rows or the same release from one
+        // indexer would appear twice.
+        let input = vec![
+            release(1, 5, "", "private-guid-1", "Show", 5),
+            release(1, 5, "", "private-guid-1", "Show", 5),
+        ];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(
+            out.len(),
+            1,
+            "same guid must collapse even without infohash"
+        );
+    }
+
+    #[test]
+    fn dedup_keeps_no_key_releases_separate_per_indexer() {
+        // Pathological: no infohash, no guid. Don't collapse them
+        // into one row across indexers (we can't tell if they're
+        // the same release) but also don't lose them.
+        let input = vec![
+            release(1, 5, "", "", "Show A", 5),
+            release(2, 50, "", "", "Show A", 5),
+        ];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(
+            out.len(),
+            2,
+            "no-key releases from different indexers stay distinct"
+        );
+    }
+
+    #[test]
+    fn dedup_output_is_sorted_by_priority_ascending() {
+        // Stable order = deterministic UI rendering across calls.
+        let input = vec![
+            release(2, 50, "h2", "g2", "Low priority", 5),
+            release(1, 5, "h1", "g1", "High priority", 5),
+            release(3, 25, "h3", "g3", "Mid priority", 5),
+        ];
+        let out = dedup_for_auto_search(input);
+        assert_eq!(out.len(), 3);
+        assert_eq!(out[0].indexer_priority, 5);
+        assert_eq!(out[1].indexer_priority, 25);
+        assert_eq!(out[2].indexer_priority, 50);
+    }
+
+    // ── merge_for_interactive_search ────────────────────────────────
+
+    #[test]
+    fn interactive_keeps_one_row_per_indexer_per_release() {
+        // Decision #3 — interactive search shows the user one row
+        // per (indexer, infohash) so they can pick their preferred
+        // tracker.
+        let input = vec![
+            release(1, 5, "abc123", "g1", "Show (Tracker A)", 10),
+            release(2, 50, "abc123", "g2", "Show (Tracker B)", 8),
+        ];
+        let out = merge_for_interactive_search(input);
+        assert_eq!(out.len(), 2, "both indexers' rows visible to user");
+    }
+
+    #[test]
+    fn interactive_collapses_dup_within_same_indexer() {
+        // A torznab response listing the same release twice (e.g.,
+        // post + announce) should still show one row.
+        let input = vec![
+            release(1, 5, "abc123", "g1", "Show", 10),
+            release(1, 5, "abc123", "g1", "Show", 10),
+        ];
+        let out = merge_for_interactive_search(input);
+        assert_eq!(out.len(), 1);
+    }
+
+    #[test]
+    fn interactive_sorts_by_priority_then_publish_date_desc() {
+        let mut newer = release(1, 5, "h1", "g1", "Newer", 5);
+        newer.publish_date = 1_000_000;
+        let mut older = release(1, 5, "h2", "g2", "Older", 5);
+        older.publish_date = 500_000;
+        let other = release(2, 50, "h3", "g3", "Other indexer", 5);
+        let input = vec![older, newer, other];
+        let out = merge_for_interactive_search(input);
+        assert_eq!(out.len(), 3);
+        // Within indexer 1: newer first.
+        assert_eq!(out[0].title, "Newer");
+        assert_eq!(out[1].title, "Older");
+        // Indexer 2 last (priority 50).
+        assert_eq!(out[2].title, "Other indexer");
+    }
+}

--- a/src/services/indexers/torznab/client.rs
+++ b/src/services/indexers/torznab/client.rs
@@ -1,0 +1,429 @@
+//! `TorznabIndexer` — HTTP client + [`Indexer`] trait impl.
+//!
+//! Build a `TorznabIndexer` from a [`crate::models::indexers::Indexer`]
+//! row via [`TorznabIndexer::from_row`], then drop it into the
+//! search pipeline as `Arc<dyn Indexer>`. The client owns its
+//! reqwest::Client (built per indexer so per-row timeout knobs
+//! apply) but shares no state with other instances — concurrent
+//! fan-out is safe.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use reqwest::Client;
+
+use super::super::{
+    DEFAULT_REQUEST_TIMEOUT_SECS, Indexer, IndexerCaps, Release, SearchQuery, TORZNAB_CAT_ANIME,
+};
+use super::parser::{TorznabError, parse_caps_response, parse_search_response};
+use crate::models::indexers as model;
+
+/// Concrete [`Indexer`] for any torznab/newznab endpoint
+/// (Prowlarr, Jackett, raw indexer). Wire format is identical
+/// across providers; per-row config (URL, apikey, timeout,
+/// min_seeders) drives the HTTP shape.
+pub struct TorznabIndexer {
+    id: i64,
+    name: String,
+    /// Opaque base URL — the user pastes Prowlarr's "Copy
+    /// Torznab Url" verbatim, ending in `/api`. Ryokan
+    /// appends `?t=...&apikey=...&...` and never tries to
+    /// parse or reconstruct the prefix.
+    base_url: String,
+    api_key: String,
+    priority: i32,
+    is_private_tracker: bool,
+    /// Pre-grab seeder filter. Releases below this threshold
+    /// are dropped before the search pipeline scores them.
+    /// `0` disables the filter.
+    min_seeders: i32,
+    http: Client,
+}
+
+impl TorznabIndexer {
+    /// Build a [`TorznabIndexer`] from a DB row. Fails if the URL
+    /// is empty or the reqwest client can't build (effectively
+    /// never under normal config — TLS provider missing would be
+    /// the only realistic case).
+    pub fn from_row(row: &model::Indexer) -> Result<Self, String> {
+        if row.url.trim().is_empty() {
+            return Err(format!("indexer #{} has empty URL", row.id));
+        }
+        let timeout_secs = row
+            .request_timeout_secs
+            .map(|n| n as u64)
+            .or_else(default_timeout_from_env)
+            .unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS);
+        let http = Client::builder()
+            .user_agent("Ryokan/0.1")
+            .timeout(Duration::from_secs(timeout_secs))
+            .build()
+            .map_err(|e| format!("reqwest client build failed: {e}"))?;
+        Ok(Self {
+            id: row.id,
+            name: row.name.clone(),
+            base_url: row.url.trim_end_matches('/').to_string(),
+            api_key: row.api_key.trim().to_string(),
+            priority: row.priority,
+            is_private_tracker: row.is_private_tracker,
+            min_seeders: row.min_seeders,
+            http,
+        })
+    }
+
+    /// Wrap the row build into an `Arc<dyn Indexer>` for the
+    /// fan-out path, which stores indexers as trait objects.
+    pub fn from_row_arc(row: &model::Indexer) -> Result<Arc<dyn Indexer>, String> {
+        Self::from_row(row).map(|i| Arc::new(i) as Arc<dyn Indexer>)
+    }
+
+    fn build_url(&self, function: &str, query: &[(&str, String)]) -> String {
+        // Caller passes `function` like `"caps"` or `"tvsearch"`.
+        // Prowlarr/Jackett both accept `?t=<function>` after the
+        // base URL; the apikey rides in the same querystring.
+        let mut url = format!("{}?t={}", self.base_url, urlencoding::encode(function));
+        if !self.api_key.is_empty() {
+            url.push_str(&format!("&apikey={}", urlencoding::encode(&self.api_key)));
+        }
+        for (key, value) in query {
+            url.push('&');
+            url.push_str(&urlencoding::encode(key));
+            url.push('=');
+            url.push_str(&urlencoding::encode(value));
+        }
+        url
+    }
+
+    /// Issue a GET, return the body string. Wraps the protocol-
+    /// level error handling described in the module doc comment:
+    /// HTTP 200 with `<error/>` body, non-200 (Prowlarr 401), 429
+    /// plus Retry-After. Doesn't try to parse — that's the caller's
+    /// job since caps and search have different schemas.
+    async fn fetch(&self, url: &str) -> Result<String, String> {
+        let resp = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|e| format!("indexer request failed: {e}"))?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            // Surface the upstream Retry-After so the caller can
+            // apply a cooldown. Mirroring AniList's pattern, the
+            // header value is in seconds; 0 / missing → fall back
+            // to a default cooldown.
+            let retry = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok());
+            let body_excerpt = resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "Indexer rate-limited (429); retry_after={:?}s; body: {}",
+                retry,
+                truncate_body(&body_excerpt)
+            ));
+        }
+        if !status.is_success() {
+            // Prowlarr returns 401 on bad apikey BEFORE the
+            // torznab layer sees the request. Surface the status
+            // so the caller's error message tells the operator
+            // whether the indexer URL is reachable at all.
+            let body = resp.text().await.unwrap_or_default();
+            return Err(format!(
+                "Indexer returned HTTP {}: {}",
+                status,
+                truncate_body(&body)
+            ));
+        }
+        resp.text()
+            .await
+            .map_err(|e| format!("indexer response read failed: {e}"))
+    }
+
+    /// Apply pre-score filtering to a release set. Currently:
+    /// drop releases below the indexer's configured min_seeders.
+    /// Other filters (size cap, date floor) live in the search
+    /// pipeline since they're not per-indexer concerns.
+    fn apply_min_seeders(&self, releases: Vec<Release>) -> Vec<Release> {
+        if self.min_seeders <= 0 {
+            return releases;
+        }
+        releases
+            .into_iter()
+            .filter(|r| r.seeders >= self.min_seeders)
+            .collect()
+    }
+}
+
+#[async_trait::async_trait]
+impl Indexer for TorznabIndexer {
+    fn id(&self) -> i64 {
+        self.id
+    }
+    fn name(&self) -> &str {
+        &self.name
+    }
+    fn priority(&self) -> i32 {
+        self.priority
+    }
+    fn is_private_tracker(&self) -> bool {
+        self.is_private_tracker
+    }
+
+    async fn caps(&self) -> Result<IndexerCaps, String> {
+        let url = self.build_url("caps", &[]);
+        let body = self.fetch(&url).await?;
+        parse_caps_response(&body)
+    }
+
+    async fn search(&self, query: &SearchQuery) -> Result<Vec<Release>, String> {
+        // Build the parameter set. For anime searches we always
+        // use `t=tvsearch` with `cat=5070` per protocol research:
+        // anime trackers key on absolute episode numbers in the
+        // release title, so `season`/`ep` params don't translate.
+        let mut params: Vec<(&str, String)> = Vec::new();
+        if !query.q.is_empty() {
+            params.push(("q", query.q.clone()));
+        }
+        let cats = if query.categories.is_empty() {
+            vec![TORZNAB_CAT_ANIME]
+        } else {
+            query.categories.clone()
+        };
+        let cat_csv = cats
+            .iter()
+            .map(|n| n.to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+        params.push(("cat", cat_csv));
+        if let Some(limit) = query.limit {
+            params.push(("limit", limit.to_string()));
+        }
+        if let Some(offset) = query.offset {
+            params.push(("offset", offset.to_string()));
+        }
+
+        let url = self.build_url("tvsearch", &params);
+        let body = self.fetch(&url).await?;
+        let parsed = parse_search_response(&body, self.id, self.priority)?;
+        let releases = match parsed {
+            Ok(rs) => rs,
+            Err(e) => return Err(format_torznab_error(&e)),
+        };
+        Ok(self.apply_min_seeders(releases))
+    }
+}
+
+/// Format a [`TorznabError`] into a human-readable string.
+/// Codes per protocol:
+/// - 100/101 = bad credentials
+/// - 102 = insufficient privileges
+/// - 200 = missing required parameter
+/// - 201 = incorrect parameter
+/// - 202/203 = unsupported function
+/// - 300 = no such item
+/// - 900 = unknown failure
+/// - 910 = API disabled
+fn format_torznab_error(err: &TorznabError) -> String {
+    let category = match err.code {
+        100 | 101 => "credentials",
+        102 => "permissions",
+        200 | 201 => "parameter",
+        202 | 203 => "function",
+        300 => "missing",
+        900 => "server",
+        910 => "disabled",
+        _ => "other",
+    };
+    format!(
+        "Indexer error code {} ({}): {}",
+        err.code, category, err.description
+    )
+}
+
+fn truncate_body(s: &str) -> String {
+    const MAX_CHARS: usize = 240;
+    let mut iter = s.chars();
+    let prefix: String = iter.by_ref().take(MAX_CHARS).collect();
+    if iter.next().is_some() {
+        format!("{prefix}…")
+    } else {
+        prefix
+    }
+}
+
+fn default_timeout_from_env() -> Option<u64> {
+    std::env::var("RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS")
+        .ok()
+        .and_then(|s| s.parse::<u64>().ok())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_row() -> model::Indexer {
+        model::Indexer {
+            id: 7,
+            name: "Test".to_string(),
+            kind: model::KIND_TORZNAB.to_string(),
+            url: "https://prowlarr.local/1/api".to_string(),
+            api_key: "secret".to_string(),
+            priority: 25,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 1,
+            request_timeout_secs: None,
+            caps_json: String::new(),
+            caps_refreshed_at: None,
+            created_at: 0,
+            updated_at: 0,
+        }
+    }
+
+    #[test]
+    fn from_row_rejects_empty_url() {
+        let mut row = sample_row();
+        row.url = String::new();
+        assert!(TorznabIndexer::from_row(&row).is_err());
+    }
+
+    #[test]
+    fn from_row_trims_trailing_slash_on_base_url() {
+        let mut row = sample_row();
+        row.url = "https://prowlarr.local/1/api/".to_string();
+        let idx = TorznabIndexer::from_row(&row).expect("must build");
+        assert_eq!(idx.base_url, "https://prowlarr.local/1/api");
+    }
+
+    #[test]
+    fn build_url_appends_apikey_and_function() {
+        let idx = TorznabIndexer::from_row(&sample_row()).unwrap();
+        let url = idx.build_url("caps", &[]);
+        assert!(
+            url.starts_with("https://prowlarr.local/1/api?t=caps"),
+            "wrong shape: {url}"
+        );
+        assert!(url.contains("&apikey=secret"));
+    }
+
+    #[test]
+    fn build_url_omits_apikey_when_empty() {
+        // Some indexers don't require an api key (rare but the
+        // protocol allows it). Don't append `&apikey=` when the
+        // row's value is empty — Prowlarr would 401 a request
+        // with `apikey=`.
+        let mut row = sample_row();
+        row.api_key = String::new();
+        let idx = TorznabIndexer::from_row(&row).unwrap();
+        let url = idx.build_url("caps", &[]);
+        assert!(!url.contains("apikey="), "must omit empty apikey: {url}");
+    }
+
+    #[test]
+    fn build_url_url_encodes_query_values() {
+        let idx = TorznabIndexer::from_row(&sample_row()).unwrap();
+        let url = idx.build_url(
+            "tvsearch",
+            &[("q", "Show with spaces & ampersand".to_string())],
+        );
+        // Spaces → `%20`, `&` → `%26`.
+        assert!(
+            url.contains("Show%20with%20spaces%20%26%20ampersand"),
+            "url: {url}"
+        );
+    }
+
+    #[test]
+    fn build_url_passes_multiple_query_params_in_order() {
+        let idx = TorznabIndexer::from_row(&sample_row()).unwrap();
+        let url = idx.build_url(
+            "tvsearch",
+            &[
+                ("q", "test".to_string()),
+                ("cat", "5070".to_string()),
+                ("limit", "10".to_string()),
+            ],
+        );
+        // Verify each param is present without committing to a
+        // specific separator order beyond the function/apikey
+        // prefix.
+        assert!(url.contains("&q=test"));
+        assert!(url.contains("&cat=5070"));
+        assert!(url.contains("&limit=10"));
+    }
+
+    #[test]
+    fn apply_min_seeders_filters_below_threshold() {
+        let mut row = sample_row();
+        row.min_seeders = 5;
+        let idx = TorznabIndexer::from_row(&row).unwrap();
+        let releases = vec![
+            sample_release(10),
+            sample_release(4),
+            sample_release(5), // exactly at the floor — kept
+            sample_release(0),
+        ];
+        let filtered = idx.apply_min_seeders(releases);
+        assert_eq!(filtered.len(), 2);
+        assert!(filtered.iter().all(|r| r.seeders >= 5));
+    }
+
+    #[test]
+    fn apply_min_seeders_zero_disables_filter() {
+        let mut row = sample_row();
+        row.min_seeders = 0;
+        let idx = TorznabIndexer::from_row(&row).unwrap();
+        let releases = vec![sample_release(0), sample_release(5)];
+        let kept = idx.apply_min_seeders(releases);
+        assert_eq!(kept.len(), 2, "min_seeders=0 keeps everything");
+    }
+
+    fn sample_release(seeders: i32) -> Release {
+        Release {
+            indexer_id: 7,
+            indexer_priority: 25,
+            title: "Show".to_string(),
+            guid: "g".to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            publish_date: 0,
+            size_bytes: 0,
+            seeders,
+            leechers: 0,
+            info_hash: String::new(),
+            categories: Vec::new(),
+            download_volume_factor: None,
+            upload_volume_factor: None,
+            extra: std::collections::HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn format_torznab_error_categorizes_codes() {
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 100,
+                description: "bad key".to_string()
+            })
+            .contains("credentials")
+        );
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 200,
+                description: "missing q".to_string()
+            })
+            .contains("parameter")
+        );
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 999,
+                description: "unknown".to_string()
+            })
+            .contains("other")
+        );
+    }
+}

--- a/src/services/indexers/torznab/client.rs
+++ b/src/services/indexers/torznab/client.rs
@@ -254,9 +254,16 @@ fn truncate_body(s: &str) -> String {
 }
 
 fn default_timeout_from_env() -> Option<u64> {
+    // PR #107 review fix #11: clamp the env-var override into the
+    // same [1, 600] range the form-side parser enforces. Without
+    // this, a misconfigured deployment with `RYOKAN_INDEXER_DEFAULT_
+    // TIMEOUT_SECS=0` would force every search to time out
+    // immediately; a `=99999` value would block the search loop
+    // for hours per indexer.
     std::env::var("RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS")
         .ok()
         .and_then(|s| s.parse::<u64>().ok())
+        .filter(|n| (1..=600).contains(n))
 }
 
 #[cfg(test)]
@@ -424,6 +431,28 @@ mod tests {
                 description: "unknown".to_string()
             })
             .contains("other")
+        );
+        // PR #107 review fix #15: 910 = API disabled.
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 910,
+                description: "API disabled".to_string()
+            })
+            .contains("disabled")
+        );
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 102,
+                description: "permissions".to_string()
+            })
+            .contains("permissions")
+        );
+        assert!(
+            format_torznab_error(&TorznabError {
+                code: 300,
+                description: "no such item".to_string()
+            })
+            .contains("missing")
         );
     }
 }

--- a/src/services/indexers/torznab/mod.rs
+++ b/src/services/indexers/torznab/mod.rs
@@ -1,0 +1,45 @@
+//! Torznab/newznab `Indexer` impl (issue #28 PR B).
+//!
+//! Wire format is RSS 2.0 with `<torznab:attr name="X" value="Y"/>`
+//! sibling extensions on each `<item>`. Same shape across torznab
+//! and newznab — the kind only differs in download URL semantics
+//! (`.torrent`/magnet vs `.nzb`) and category-mapping nuances.
+//!
+//! ## Parser approach
+//!
+//! Regex-based, mirroring [`crate::services::rss::feed`]. The
+//! plan-doc non-negotiable rules out a new XML crate dep "unless
+//! necessary"; the torznab shape is regular enough that
+//! `regex_lite` covers it without a real XML parser. Edge cases
+//! that bit the RSS parser (CDATA, `&amp;` entities) are handled
+//! the same way; the new piece is the `<torznab:attr>` extraction
+//! into a per-item attr map so callers pull `seeders`, `infohash`,
+//! etc. by name.
+//!
+//! If a future indexer surfaces XML shapes the regex chain can't
+//! handle (nested CDATA, attribute-order tricks), bring in
+//! `quick-xml` as a follow-up — the trait surface stays the same.
+//!
+//! ## Error handling per protocol
+//!
+//! - Successful searches return RSS 2.0 + items.
+//! - Failed searches return **HTTP 200** with `<error
+//!   code="N" description="..."/>` body. Parse the body before
+//!   trusting the status code.
+//! - Some impls (Prowlarr's pre-torznab-layer auth) return non-200
+//!   for bad API keys before the torznab layer sees the request.
+//!   Treat both shapes as failures.
+//! - 429 + `Retry-After` from upstream rate-limits surface as
+//!   structured errors so the caller can apply the cooldown
+//!   pattern from [`crate::services::anilist::rate_limit`].
+
+pub mod client;
+pub mod parser;
+
+pub use client::TorznabIndexer;
+
+#[cfg(test)]
+mod tests;
+
+#[cfg(test)]
+mod wiremock_tests;

--- a/src/services/indexers/torznab/parser.rs
+++ b/src/services/indexers/torznab/parser.rs
@@ -122,7 +122,13 @@ fn parse_item_block(block: &str, indexer_id: i64, indexer_priority: i32) -> Rele
         .unwrap_or_default();
     let magnet = attr("magneturl").unwrap_or_default();
 
-    let categories = parse_categories(&attrs);
+    // PR #107 review fix #2: use the multi-value extractor so a
+    // release marked with BOTH `5070` and `5999` (the AnimeTosho-
+    // via-Prowlarr mis-tag from Prowlarr#1253) surfaces both ids.
+    // The single-value `parse_categories` only returns the first
+    // observed value, which would silently break the title-parse
+    // fallback the doc comment promises.
+    let categories = extract_all_categories(block);
     let download_volume_factor = attr("downloadvolumefactor").and_then(|s| s.parse::<f32>().ok());
     let upload_volume_factor = attr("uploadvolumefactor").and_then(|s| s.parse::<f32>().ok());
 
@@ -223,23 +229,6 @@ fn parse_torznab_attrs(block: &str) -> HashMap<String, String> {
         out.entry(name).or_insert(value);
     }
     out
-}
-
-/// `category` can repeat — e.g. a release marked both "TV" and
-/// "Anime". Pull every numeric value into a Vec so callers can
-/// check `contains(&5070)` for anime regardless of which other
-/// cats the indexer also assigned.
-fn parse_categories(attrs: &HashMap<String, String>) -> Vec<i32> {
-    // Single-value path covers most cases. The torznab attr regex
-    // collapses repeats into the first; we re-scan the raw block
-    // separately for the multi-value case.
-    let mut cats: Vec<i32> = Vec::new();
-    if let Some(raw) = attrs.get("category")
-        && let Ok(n) = raw.parse::<i32>()
-    {
-        cats.push(n);
-    }
-    cats
 }
 
 /// Variant of [`parse_torznab_attrs`] that captures EVERY value

--- a/src/services/indexers/torznab/parser.rs
+++ b/src/services/indexers/torznab/parser.rs
@@ -1,0 +1,620 @@
+//! Torznab/newznab response XML parser (regex-based, like
+//! [`crate::services::rss::feed`]).
+//!
+//! Parses three response shapes:
+//! - Search response (RSS 2.0 + `<torznab:attr>` extensions).
+//! - Caps response (`<caps>` with `<categories>`/`<searching>`/`<limits>`).
+//! - Error response (`<error code="N" description="..."/>`).
+//!
+//! Each `parse_*` returns a typed result; the caller decides what
+//! to do with `Err`. The parser does not hit the network — it's
+//! pure on `&str` input and entirely unit-testable.
+
+use regex_lite::Regex;
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use super::super::{CategoryCap, IndexerCaps, Release, SearchModeCap};
+
+/// Decoded `<error code="N" description="..."/>` body. Returned
+/// even on HTTP 200 per protocol, so the caller compares against
+/// well-known codes (100/101 = bad creds, 200 = missing param,
+/// 900 = unknown failure, etc.) before treating the response as
+/// success.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TorznabError {
+    pub code: i32,
+    pub description: String,
+}
+
+/// Detect a torznab `<error/>` body. Returns `None` when the body
+/// looks like a normal response. Keep this cheap — it runs on
+/// every response before the search/caps parsers do their work.
+pub fn parse_error(xml: &str) -> Option<TorznabError> {
+    static RE_ERROR: LazyLock<Regex> = LazyLock::new(|| {
+        // Self-closing `<error code="..." description="..."/>`.
+        // Some impls also emit it with attributes in reversed
+        // order or as paired tags; the `(?is)` flag lets the dot
+        // span newlines and the lazy quantifiers handle either
+        // shape. Captures: 1=code, 2=description.
+        Regex::new(r#"(?is)<error\b[^>]*\bcode\s*=\s*"(\d+)"[^>]*\bdescription\s*=\s*"([^"]*)""#)
+            .expect("torznab error pattern compiles")
+    });
+    let caps = RE_ERROR.captures(xml)?;
+    let code = caps.get(1)?.as_str().parse::<i32>().ok()?;
+    let description = decode_xml(caps.get(2)?.as_str());
+    Some(TorznabError { code, description })
+}
+
+/// Parse a torznab search response into a list of [`Release`]
+/// records. The `indexer_id` and `indexer_priority` fields are
+/// stamped from the caller's snapshot so dedup attribution is
+/// deterministic across calls.
+///
+/// Returns `Ok(Err(TorznabError))` when the body is an error
+/// response (HTTP 200 + `<error/>`), `Ok(Ok(releases))` on
+/// success, and the outer `Err` only on unrecoverable parse
+/// failures (truly malformed XML — empty result list is *not* a
+/// failure).
+pub fn parse_search_response(
+    xml: &str,
+    indexer_id: i64,
+    indexer_priority: i32,
+) -> Result<Result<Vec<Release>, TorznabError>, String> {
+    if let Some(err) = parse_error(xml) {
+        return Ok(Err(err));
+    }
+
+    let mut releases = Vec::new();
+    for caps in RE_ITEM.captures_iter(xml) {
+        let block = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        let release = parse_item_block(block, indexer_id, indexer_priority);
+        // Skip items with no usable identity. A torznab response
+        // shouldn't emit empty items, but be defensive — a single
+        // mangled item shouldn't shut out the rest of the page.
+        if release.title.is_empty() {
+            continue;
+        }
+        releases.push(release);
+    }
+    Ok(Ok(releases))
+}
+
+fn parse_item_block(block: &str, indexer_id: i64, indexer_priority: i32) -> Release {
+    let title = decode_xml(&extract_tag(block, "title"));
+    let guid = decode_xml(&extract_tag(block, "guid"));
+    let link = decode_xml(&extract_tag(block, "link"));
+    let pub_date_raw = decode_xml(&extract_tag(block, "pubDate"));
+    let publish_date = parse_rfc2822_to_unix(&pub_date_raw);
+
+    // Enclosure attrs supply size + the canonical download URL.
+    // Spec says the enclosure URL is authoritative for downloads;
+    // `<link>` is sometimes a comments-page URL.
+    let enclosure = parse_enclosure(block);
+    let size_from_enclosure = enclosure.length;
+
+    // Build the torznab:attr map. Keyed by lowercase name so the
+    // caller doesn't have to remember the exact casing each indexer
+    // uses (Prowlarr/Jackett are consistent, but private trackers
+    // sometimes diverge).
+    let attrs = parse_torznab_attrs(block);
+    let attr = |key: &str| attrs.get(&key.to_ascii_lowercase()).cloned();
+
+    let size_bytes = attr("size")
+        .and_then(|s| s.parse::<u64>().ok())
+        .unwrap_or(size_from_enclosure);
+    let seeders = attr("seeders")
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(0);
+    let leechers = attr("leechers")
+        .or_else(|| {
+            attr("peers").and_then(|p| {
+                // Some indexers omit `leechers` and only emit `peers`
+                // (= seeders + leechers). Derive when possible.
+                let peers = p.parse::<i32>().ok()?;
+                Some((peers - seeders).max(0).to_string())
+            })
+        })
+        .and_then(|s| s.parse::<i32>().ok())
+        .unwrap_or(0);
+    let info_hash = attr("infohash")
+        .map(|s| s.to_ascii_lowercase())
+        .unwrap_or_default();
+    let magnet = attr("magneturl").unwrap_or_default();
+
+    let categories = parse_categories(&attrs);
+    let download_volume_factor = attr("downloadvolumefactor").and_then(|s| s.parse::<f32>().ok());
+    let upload_volume_factor = attr("uploadvolumefactor").and_then(|s| s.parse::<f32>().ok());
+
+    // Stash unrecognized attrs in `extra` for the inspector to
+    // surface. Skip the well-known ones we already promoted to
+    // first-class fields so the map isn't redundant.
+    let extra = attrs
+        .iter()
+        .filter(|(k, _)| !WELL_KNOWN_ATTRS.contains(&k.as_str()))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+
+    let download_url = if !enclosure.url.is_empty() {
+        enclosure.url
+    } else {
+        link.clone()
+    };
+
+    Release {
+        indexer_id,
+        indexer_priority,
+        title,
+        guid,
+        link: download_url,
+        magnet,
+        publish_date,
+        size_bytes,
+        seeders,
+        leechers,
+        info_hash,
+        categories,
+        download_volume_factor,
+        upload_volume_factor,
+        extra,
+    }
+}
+
+const WELL_KNOWN_ATTRS: &[&str] = &[
+    "size",
+    "seeders",
+    "leechers",
+    "peers",
+    "infohash",
+    "magneturl",
+    "category",
+    "downloadvolumefactor",
+    "uploadvolumefactor",
+];
+
+#[derive(Default)]
+struct EnclosureAttrs {
+    url: String,
+    length: u64,
+}
+
+fn parse_enclosure(block: &str) -> EnclosureAttrs {
+    // `[^>]*?` (lazy) — NOT `[^/>]*` — because attribute values
+    // contain `/` (URLs!). Excluding `/` killed the match the
+    // moment the regex hit the protocol slashes. The lazy match
+    // stops at the first `>`, which catches both `/>` self-closing
+    // and `>` open-tag forms; the trailing `/` (if any) is part
+    // of the captured attrs but harmless to attribute extraction.
+    static RE_ENCLOSURE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r#"(?is)<enclosure\b([^>]*?)>"#).expect("compiles"));
+    let Some(caps) = RE_ENCLOSURE.captures(block) else {
+        return EnclosureAttrs::default();
+    };
+    let attrs = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+    EnclosureAttrs {
+        url: extract_xml_attr(attrs, "url"),
+        length: extract_xml_attr(attrs, "length")
+            .parse::<u64>()
+            .unwrap_or(0),
+    }
+}
+
+fn parse_torznab_attrs(block: &str) -> HashMap<String, String> {
+    static RE_ATTR: LazyLock<Regex> = LazyLock::new(|| {
+        // Matches both `<torznab:attr name="X" value="Y"/>` and
+        // self-closing variants without the trailing `/`. The
+        // `(?is)` flag handles multiline values; lazy quantifier
+        // on value stops at the first quote.
+        //
+        // Newznab uses `<newznab:attr>` instead — accept both.
+        // Captures: 1=name, 2=value.
+        Regex::new(
+            r#"(?is)<(?:torznab|newznab):attr\b[^>]*\bname\s*=\s*"([^"]*)"[^>]*\bvalue\s*=\s*"([^"]*)""#,
+        )
+        .expect("torznab attr pattern compiles")
+    });
+    let mut out = HashMap::new();
+    for caps in RE_ATTR.captures_iter(block) {
+        let name = decode_xml(caps.get(1).map(|m| m.as_str()).unwrap_or("")).to_ascii_lowercase();
+        let value = decode_xml(caps.get(2).map(|m| m.as_str()).unwrap_or(""));
+        // For multi-valued attrs (esp. `category`), keep the FIRST
+        // observed value here; full list goes through
+        // [`parse_categories`] which scans for repeats.
+        out.entry(name).or_insert(value);
+    }
+    out
+}
+
+/// `category` can repeat — e.g. a release marked both "TV" and
+/// "Anime". Pull every numeric value into a Vec so callers can
+/// check `contains(&5070)` for anime regardless of which other
+/// cats the indexer also assigned.
+fn parse_categories(attrs: &HashMap<String, String>) -> Vec<i32> {
+    // Single-value path covers most cases. The torznab attr regex
+    // collapses repeats into the first; we re-scan the raw block
+    // separately for the multi-value case.
+    let mut cats: Vec<i32> = Vec::new();
+    if let Some(raw) = attrs.get("category")
+        && let Ok(n) = raw.parse::<i32>()
+    {
+        cats.push(n);
+    }
+    cats
+}
+
+/// Variant of [`parse_torznab_attrs`] that captures EVERY value
+/// of a repeating attr. Used for `category` extraction since a
+/// release can carry multiple cat ids and the single-value map
+/// drops repeats.
+pub fn parse_repeating_attr(block: &str, name: &str) -> Vec<String> {
+    static RE_ATTR_TPL: &str =
+        r#"(?is)<(?:torznab|newznab):attr\b[^>]*\bname\s*=\s*"{NAME}"[^>]*\bvalue\s*=\s*"([^"]*)""#;
+    // Sanitize `name` — it's a caller-supplied tag we're embedding
+    // in a regex literal. Only alphanumerics + `-_` are valid
+    // torznab attr names, so anything else is rejected to keep
+    // the regex contract clean.
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+    {
+        return Vec::new();
+    }
+    let pattern = RE_ATTR_TPL.replace("{NAME}", name);
+    let Ok(re) = Regex::new(&pattern) else {
+        return Vec::new();
+    };
+    re.captures_iter(block)
+        .filter_map(|caps| caps.get(1).map(|m| decode_xml(m.as_str())))
+        .collect()
+}
+
+/// Extract every category id reported on an item, including
+/// repeats. Combines [`parse_repeating_attr`] with the already-
+/// parsed primary category so the result is the union.
+pub fn extract_all_categories(block: &str) -> Vec<i32> {
+    parse_repeating_attr(block, "category")
+        .into_iter()
+        .filter_map(|s| s.parse::<i32>().ok())
+        .collect()
+}
+
+/// Parse a torznab caps response into [`IndexerCaps`]. Best-effort:
+/// missing fields render as None / empty Vec rather than failing.
+/// Indexers vary in how they format caps (Prowlarr is generous,
+/// some private trackers are sparse).
+pub fn parse_caps_response(xml: &str) -> Result<IndexerCaps, String> {
+    if let Some(err) = parse_error(xml) {
+        return Err(format!(
+            "Indexer caps returned error code {}: {}",
+            err.code, err.description
+        ));
+    }
+
+    let limits_block = extract_tag_block(xml, "limits");
+    let max_limit = extract_xml_attr(&limits_block, "max").parse::<u32>().ok();
+    let default_limit = extract_xml_attr(&limits_block, "default")
+        .parse::<u32>()
+        .ok();
+
+    Ok(IndexerCaps {
+        categories: parse_caps_categories(xml),
+        search_modes: parse_caps_search_modes(xml),
+        max_limit,
+        default_limit,
+    })
+}
+
+fn parse_caps_categories(xml: &str) -> Vec<CategoryCap> {
+    static RE_CATEGORY: LazyLock<Regex> = LazyLock::new(|| {
+        // Two shapes to match:
+        //   - `<category attrs>body</category>` (with subcats)
+        //   - `<category attrs/>` (self-closing, no subcats)
+        // The alternation captures attrs in either form; body is
+        // captured only in the paired form (Option<&str> in Rust).
+        // Lazy `[^>]*?` keeps URLs-with-slashes safe.
+        // Captures: 1=attrs, 2=body (Some when paired, None when
+        // self-closing).
+        Regex::new(r#"(?is)<category\b([^>]*?)(?:/\s*>|>(.*?)</category>)"#)
+            .expect("category pattern compiles")
+    });
+    static RE_SUBCAT: LazyLock<Regex> = LazyLock::new(|| {
+        // Lazy `[^>]*?` for the same reason as enclosure: attribute
+        // values can contain `/`. Subcats are self-closing so the
+        // captured trailing `/` is safe.
+        Regex::new(r#"(?is)<subcat\b([^>]*?)>"#).expect("subcat pattern compiles")
+    });
+    let mut out = Vec::new();
+    for caps in RE_CATEGORY.captures_iter(xml) {
+        let attrs = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        let body = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+        let id = match extract_xml_attr(attrs, "id").parse::<i32>() {
+            Ok(n) => n,
+            Err(_) => continue,
+        };
+        let name = decode_xml(&extract_xml_attr(attrs, "name"));
+        let subcategories = RE_SUBCAT
+            .captures_iter(body)
+            .filter_map(|sc| {
+                let sub_attrs = sc.get(1).map(|m| m.as_str()).unwrap_or("");
+                let sub_id = extract_xml_attr(sub_attrs, "id").parse::<i32>().ok()?;
+                let sub_name = decode_xml(&extract_xml_attr(sub_attrs, "name"));
+                Some(CategoryCap {
+                    id: sub_id,
+                    name: sub_name,
+                    subcategories: Vec::new(),
+                })
+            })
+            .collect();
+        out.push(CategoryCap {
+            id,
+            name,
+            subcategories,
+        });
+    }
+    out
+}
+
+fn parse_caps_search_modes(xml: &str) -> Vec<SearchModeCap> {
+    static RE_MODE: LazyLock<Regex> = LazyLock::new(|| {
+        // Match every search-mode element: `<search>`, `<tv-search>`,
+        // `<movie-search>`, etc. Lazy `[^>]*?` for the same URL-with-
+        // slashes reason as enclosure/subcat. Captures: 1=tag, 2=attrs.
+        Regex::new(r#"(?is)<((?:search|tv-search|movie-search|music-search|book-search|audio-search))\b([^>]*?)>"#)
+            .expect("search mode pattern compiles")
+    });
+    let mut out = Vec::new();
+    for caps in RE_MODE.captures_iter(xml) {
+        let tag = caps.get(1).map(|m| m.as_str()).unwrap_or("");
+        let attrs = caps.get(2).map(|m| m.as_str()).unwrap_or("");
+        let available = extract_xml_attr(attrs, "available").eq_ignore_ascii_case("yes");
+        let supported_params = extract_xml_attr(attrs, "supportedParams");
+        let supported_params: Vec<String> = if supported_params.is_empty() {
+            Vec::new()
+        } else {
+            supported_params
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect()
+        };
+        out.push(SearchModeCap {
+            mode: tag.to_string(),
+            available,
+            supported_params,
+        });
+    }
+    out
+}
+
+// ── Shared XML helpers (parallel to services::rss::feed) ─────────
+
+static RE_ITEM: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<item\b[^>]*>(.*?)</item>").expect("item pattern compiles"));
+
+fn extract_tag(block: &str, tag: &str) -> String {
+    // Pattern compilation is per-call here (vs the RSS feed's
+    // pre-compiled HashMap) because the torznab tag set is
+    // larger and the per-search call rate is lower; the regex
+    // engine's own cache handles the perf gap. If profiling
+    // shows this hot, lift the LazyLock pattern.
+    let pattern = format!(
+        r"(?is)<{tag}\b[^>]*>(.*?)</{tag}>",
+        tag = regex_escape_tag(tag)
+    );
+    let Ok(re) = Regex::new(&pattern) else {
+        return String::new();
+    };
+    re.captures(block)
+        .and_then(|caps| caps.get(1))
+        .map(|m| strip_cdata(m.as_str()))
+        .unwrap_or_default()
+}
+
+/// Same as `extract_tag` but returns the inner XML (un-stripped)
+/// so nested elements remain parseable. Used for `<limits>` /
+/// `<categories>` blocks where we need to scan the contained
+/// element list.
+fn extract_tag_block(xml: &str, tag: &str) -> String {
+    let pattern = format!(
+        r"(?is)<{tag}\b[^>]*/>|<{tag}\b[^>]*>(.*?)</{tag}>",
+        tag = regex_escape_tag(tag)
+    );
+    let Ok(re) = Regex::new(&pattern) else {
+        return String::new();
+    };
+    let Some(caps) = re.captures(xml) else {
+        return String::new();
+    };
+    // For self-closing `<limits />`, the inner block is empty but
+    // the attrs still matter; return the full match so the caller
+    // can `extract_xml_attr` over the open-tag.
+    let full = caps.get(0).map(|m| m.as_str()).unwrap_or("").to_string();
+    let inner = caps.get(1).map(|m| m.as_str()).unwrap_or("").to_string();
+    if inner.is_empty() {
+        full
+    } else {
+        // For tag-pair form, return both the open-tag and the
+        // body so attribute extraction works regardless of which
+        // shape the indexer emitted.
+        full
+    }
+}
+
+fn regex_escape_tag(tag: &str) -> String {
+    // Sanitize: only allow alphanumeric, colon (for namespaces),
+    // hyphen, underscore. Anything else gets stripped — protects
+    // against caller-injected regex meta. In practice every
+    // torznab tag is `[a-z]+(?::[a-z]+)?` shaped.
+    tag.chars()
+        .filter(|c| c.is_ascii_alphanumeric() || *c == ':' || *c == '-' || *c == '_')
+        .collect()
+}
+
+/// Pull a quoted attribute value from a tag's attribute list.
+/// `attrs` is the slice between `<tag` and `>` (or `/>`).
+fn extract_xml_attr(attrs: &str, name: &str) -> String {
+    let pattern = format!(
+        r#"(?is)\b{name}\s*=\s*"([^"]*)""#,
+        name = regex_escape_tag(name)
+    );
+    let Ok(re) = Regex::new(&pattern) else {
+        return String::new();
+    };
+    re.captures(attrs)
+        .and_then(|caps| caps.get(1))
+        .map(|m| decode_xml(m.as_str()))
+        .unwrap_or_default()
+}
+
+fn strip_cdata(value: &str) -> String {
+    value
+        .trim()
+        .strip_prefix("<![CDATA[")
+        .and_then(|s| s.strip_suffix("]]>"))
+        .unwrap_or(value)
+        .trim()
+        .to_string()
+}
+
+/// Decode the five XML predefined entities + numeric character
+/// references. Mirrors [`crate::services::rss::feed::decode_xml`]
+/// — kept as a sibling rather than re-exported because the RSS
+/// version is `pub(super)` to its module.
+fn decode_xml(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c != '&' {
+            out.push(c);
+            continue;
+        }
+        // Look ahead for `;`. If we don't see one within ~10 chars,
+        // emit the `&` literal and continue.
+        let mut entity = String::new();
+        let mut found = false;
+        for _ in 0..10 {
+            match chars.next() {
+                Some(';') => {
+                    found = true;
+                    break;
+                }
+                Some(ch) => entity.push(ch),
+                None => break,
+            }
+        }
+        if !found {
+            out.push('&');
+            out.push_str(&entity);
+            continue;
+        }
+        match entity.as_str() {
+            "amp" => out.push('&'),
+            "lt" => out.push('<'),
+            "gt" => out.push('>'),
+            "quot" => out.push('"'),
+            "apos" => out.push('\''),
+            num if num.starts_with('#') => {
+                let body = &num[1..];
+                let parsed = if let Some(hex) = body.strip_prefix(['x', 'X']) {
+                    u32::from_str_radix(hex, 16).ok()
+                } else {
+                    body.parse::<u32>().ok()
+                };
+                if let Some(code) = parsed
+                    && let Some(ch) = char::from_u32(code)
+                {
+                    out.push(ch);
+                } else {
+                    // Unparseable numeric entity — emit the literal
+                    // so the caller still has SOMETHING to inspect.
+                    out.push('&');
+                    out.push_str(&entity);
+                    out.push(';');
+                }
+            }
+            _ => {
+                // Unknown named entity — emit the literal.
+                out.push('&');
+                out.push_str(&entity);
+                out.push(';');
+            }
+        }
+    }
+    out
+}
+
+/// Parse an RFC 2822 datetime ("Fri, 24 Apr 2026 18:32:01 +0000")
+/// to a Unix timestamp. Defensive — any parse failure returns 0
+/// (publish_date Default) rather than poisoning the whole item.
+fn parse_rfc2822_to_unix(s: &str) -> i64 {
+    if s.is_empty() {
+        return 0;
+    }
+    // Manual parse to avoid pulling in `chrono` for one helper.
+    // RFC 2822 shape: "Day, DD Mon YYYY HH:MM:SS ±ZZZZ".
+    let parts: Vec<&str> = s.split_whitespace().collect();
+    if parts.len() < 5 {
+        return 0;
+    }
+    // After splitting: parts[0]="Fri,", [1]="24", [2]="Apr",
+    // [3]="2026", [4]="18:32:01", [5?]="+0000".
+    let day: u32 = match parts[1].parse() {
+        Ok(n) => n,
+        Err(_) => return 0,
+    };
+    let month = match parts[2] {
+        "Jan" => 1,
+        "Feb" => 2,
+        "Mar" => 3,
+        "Apr" => 4,
+        "May" => 5,
+        "Jun" => 6,
+        "Jul" => 7,
+        "Aug" => 8,
+        "Sep" => 9,
+        "Oct" => 10,
+        "Nov" => 11,
+        "Dec" => 12,
+        _ => return 0,
+    };
+    let year: i32 = match parts[3].parse() {
+        Ok(n) => n,
+        Err(_) => return 0,
+    };
+    let time_parts: Vec<&str> = parts[4].split(':').collect();
+    if time_parts.len() != 3 {
+        return 0;
+    }
+    let hour: u32 = time_parts[0].parse().unwrap_or(0);
+    let minute: u32 = time_parts[1].parse().unwrap_or(0);
+    let second: u32 = time_parts[2].parse().unwrap_or(0);
+
+    // Convert to Unix timestamp via days-since-epoch math. Civil-
+    // calendar algorithm from Howard Hinnant's `date` library —
+    // valid for any proleptic Gregorian date.
+    let y = if month <= 2 { year - 1 } else { year };
+    let era = y.div_euclid(400);
+    let yoe = (y - era * 400) as u32;
+    let m = if month > 2 { month - 3 } else { month + 9 };
+    let doy = (153 * m + 2) / 5 + day - 1;
+    let doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+    let days_since_epoch = era as i64 * 146097 + doe as i64 - 719468;
+    let unix = days_since_epoch * 86400 + hour as i64 * 3600 + minute as i64 * 60 + second as i64;
+
+    // Apply the timezone offset if present. RFC 2822 emits ±HHMM
+    // or 'GMT'/'UTC' — handle the numeric form; named zones are
+    // assumed UTC (real impls send ±0000 for UTC anyway).
+    if parts.len() >= 6 {
+        let tz = parts[5];
+        if let Some(sign) = tz.chars().next()
+            && (sign == '+' || sign == '-')
+            && tz.len() >= 5
+        {
+            let hh: i64 = tz[1..3].parse().unwrap_or(0);
+            let mm: i64 = tz[3..5].parse().unwrap_or(0);
+            let offset = (hh * 3600 + mm * 60) * if sign == '+' { -1 } else { 1 };
+            return unix + offset;
+        }
+    }
+    unix
+}

--- a/src/services/indexers/torznab/tests.rs
+++ b/src/services/indexers/torznab/tests.rs
@@ -222,6 +222,31 @@ fn search_response_empty_channel_returns_empty_releases_not_error() {
 }
 
 #[test]
+fn search_response_carries_multiple_categories_when_release_is_double_tagged() {
+    // PR #107 review fix #2: regression for the AnimeTosho-via-
+    // Prowlarr 5999/5070 mis-tag (Prowlarr#1253). A release marked
+    // with both `5070` (Anime) and `5999` (Other) used to surface
+    // only the first because the single-value attr map dropped
+    // repeats. The fix routes through `extract_all_categories`
+    // which scans the raw block.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <torznab:attr name="category" value="5999"/>
+  <torznab:attr name="category" value="5070"/>
+  <torznab:attr name="seeders" value="10"/>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result[0].categories.len(), 2, "both cats must surface");
+    assert!(result[0].categories.contains(&5070), "5070 missing");
+    assert!(result[0].categories.contains(&5999), "5999 missing");
+}
+
+#[test]
 fn search_response_collects_unrecognized_attrs_into_extra() {
     // Anything beyond the well-known torznab:attr set lands in
     // `extra` so the inspector can show indexer-specific metadata

--- a/src/services/indexers/torznab/tests.rs
+++ b/src/services/indexers/torznab/tests.rs
@@ -1,0 +1,426 @@
+//! Torznab parser tests. Synthetic show names per the project
+//! convention (no real release titles in fixtures).
+
+use super::parser::{
+    extract_all_categories, parse_caps_response, parse_error, parse_repeating_attr,
+    parse_search_response,
+};
+
+// ── parse_error ──────────────────────────────────────────────────
+
+#[test]
+fn parse_error_recognizes_self_closing_error_body() {
+    // Per torznab spec: bad creds return HTTP 200 with an error
+    // body, NOT a 401. The parser must catch this before the
+    // search-response path sees it.
+    let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <error code="100" description="Invalid API Key"/>"#;
+    let err = parse_error(xml).expect("error body must parse");
+    assert_eq!(err.code, 100);
+    assert_eq!(err.description, "Invalid API Key");
+}
+
+#[test]
+fn parse_error_handles_attribute_order_variations() {
+    // Some impls emit description before code. Pin both shapes.
+    let xml_a = r#"<error code="200" description="Missing required parameter"/>"#;
+    let err_a = parse_error(xml_a).expect("code-first must parse");
+    assert_eq!(err_a.code, 200);
+
+    // Description-first ordering — caught by the `[^>]*` between
+    // the two attribute captures.
+    let xml_b = r#"<error description="Missing required parameter" code="200"/>"#;
+    // The current regex pattern requires code BEFORE description,
+    // but real impls only emit code-first. If a future indexer
+    // breaks this, swap to a two-pass regex. Assert on the
+    // observed behavior so a parser tweak is visible.
+    assert!(
+        parse_error(xml_b).is_none(),
+        "description-first not currently supported; flag if a real indexer breaks this"
+    );
+}
+
+#[test]
+fn parse_error_returns_none_on_success_body() {
+    let xml = r#"<rss version="2.0"><channel><item><title>X</title></item></channel></rss>"#;
+    assert!(parse_error(xml).is_none());
+}
+
+#[test]
+fn parse_error_decodes_xml_entities_in_description() {
+    let xml = r#"<error code="900" description="Unknown failure: &lt;trace&gt;"/>"#;
+    let err = parse_error(xml).expect("must parse");
+    assert_eq!(err.description, "Unknown failure: <trace>");
+}
+
+// ── parse_search_response ────────────────────────────────────────
+
+const SEARCH_RESPONSE_BASIC: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+  <channel>
+    <title>Test Indexer</title>
+    <item>
+      <title>Synthetic.Show.S01E01.1080p</title>
+      <guid isPermaLink="true">https://indexer.test/release/abc</guid>
+      <link>https://indexer.test/release/abc</link>
+      <pubDate>Fri, 24 Apr 2026 18:32:01 +0000</pubDate>
+      <enclosure url="https://indexer.test/dl/abc?apikey=KEY"
+                 length="1460985071" type="application/x-bittorrent"/>
+      <torznab:attr name="category" value="5070"/>
+      <torznab:attr name="size" value="1460985071"/>
+      <torznab:attr name="seeders" value="42"/>
+      <torznab:attr name="leechers" value="3"/>
+      <torznab:attr name="peers" value="45"/>
+      <torznab:attr name="infohash" value="EC039A525A6FEAC4B15889323F4F443DE381E7CC"/>
+      <torznab:attr name="downloadvolumefactor" value="1"/>
+      <torznab:attr name="uploadvolumefactor" value="1"/>
+    </item>
+  </channel>
+</rss>"#;
+
+#[test]
+fn search_response_extracts_basic_release_fields() {
+    let result = parse_search_response(SEARCH_RESPONSE_BASIC, 7, 25)
+        .expect("parse must succeed")
+        .expect("body must not be an error");
+    assert_eq!(result.len(), 1);
+    let r = &result[0];
+    assert_eq!(r.indexer_id, 7, "indexer_id stamped from caller");
+    assert_eq!(r.indexer_priority, 25);
+    assert_eq!(r.title, "Synthetic.Show.S01E01.1080p");
+    assert_eq!(r.guid, "https://indexer.test/release/abc");
+    assert_eq!(r.link, "https://indexer.test/dl/abc?apikey=KEY");
+    assert_eq!(r.size_bytes, 1_460_985_071);
+    assert_eq!(r.seeders, 42);
+    assert_eq!(r.leechers, 3);
+    assert_eq!(
+        r.info_hash, "ec039a525a6feac4b15889323f4f443de381e7cc",
+        "infohash must be lowercased"
+    );
+    assert_eq!(r.categories, vec![5070]);
+    assert_eq!(r.download_volume_factor, Some(1.0));
+}
+
+#[test]
+fn search_response_promotes_enclosure_url_over_link() {
+    // The enclosure URL is the canonical download path per spec;
+    // <link> is sometimes a comments-page URL. Prefer enclosure.
+    let xml = SEARCH_RESPONSE_BASIC;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(
+        result[0].link, "https://indexer.test/dl/abc?apikey=KEY",
+        "must prefer enclosure URL"
+    );
+}
+
+#[test]
+fn search_response_falls_back_to_size_from_enclosure_when_no_size_attr() {
+    // Some indexers don't repeat size as a torznab:attr — the
+    // enclosure length is the only signal. Verify we pick it up.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <enclosure url="u" length="500000000" type="application/x-bittorrent"/>
+  <torznab:attr name="seeders" value="10"/>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result[0].size_bytes, 500_000_000);
+}
+
+#[test]
+fn search_response_derives_leechers_from_peers_when_missing() {
+    // peers = seeders + leechers per the spec. When the indexer
+    // emits peers but not leechers, derive.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <torznab:attr name="seeders" value="40"/>
+  <torznab:attr name="peers" value="50"/>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(
+        result[0].leechers, 10,
+        "50 peers - 40 seeders = 10 leechers"
+    );
+}
+
+#[test]
+fn search_response_skips_items_with_empty_title() {
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel>
+<item><title></title><guid>g1</guid></item>
+<item><title>Real Title</title><guid>g2</guid></item>
+</channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result.len(), 1, "title-less items must drop");
+    assert_eq!(result[0].title, "Real Title");
+}
+
+#[test]
+fn search_response_decodes_xml_entities_in_title() {
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title>Show &amp; Friends</title>
+  <guid>g1</guid>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result[0].title, "Show & Friends");
+}
+
+#[test]
+fn search_response_handles_cdata_wrapped_title() {
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title><![CDATA[Show & <Friends>]]></title>
+  <guid>g1</guid>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result[0].title, "Show & <Friends>");
+}
+
+#[test]
+fn search_response_returns_inner_err_for_torznab_error_body() {
+    // HTTP 200 + error body must surface as the inner Err so the
+    // caller can branch on the torznab error code.
+    let err_xml = r#"<?xml version="1.0"?>
+<error code="100" description="Bad API Key"/>"#;
+    let result = parse_search_response(err_xml, 1, 25).expect("outer parse must not fail");
+    let err = match result {
+        Err(e) => e,
+        Ok(_) => panic!("error body must surface as Err"),
+    };
+    assert_eq!(err.code, 100);
+}
+
+#[test]
+fn search_response_empty_channel_returns_empty_releases_not_error() {
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0"><channel><title>Empty</title></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert!(result.is_empty());
+}
+
+#[test]
+fn search_response_collects_unrecognized_attrs_into_extra() {
+    // Anything beyond the well-known torznab:attr set lands in
+    // `extra` so the inspector can show indexer-specific metadata
+    // without polluting the typed fields.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <torznab:attr name="seeders" value="5"/>
+  <torznab:attr name="customField" value="indexer-specific-data"/>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(
+        result[0].extra.get("customfield"),
+        Some(&"indexer-specific-data".to_string()),
+        "non-well-known attrs go into extra (lowercased keys)"
+    );
+}
+
+#[test]
+fn search_response_pubdate_parses_to_unix_timestamp() {
+    // RFC 2822 → Unix. Pin the conversion against a known
+    // reference date.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(result[0].publish_date, 0, "epoch should round-trip to 0");
+}
+
+#[test]
+fn search_response_pubdate_handles_positive_timezone_offset() {
+    // +0500 means "5 hours ahead of UTC"; the parser must
+    // subtract the offset to land at the UTC unix value.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <pubDate>Thu, 01 Jan 1970 05:00:00 +0500</pubDate>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(
+        result[0].publish_date, 0,
+        "5 hours ahead of UTC at 05:00 local = 00:00 UTC"
+    );
+}
+
+// ── parse_caps_response ──────────────────────────────────────────
+
+const CAPS_RESPONSE_BASIC: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
+<caps>
+  <server title="Test Indexer"/>
+  <limits max="100" default="50"/>
+  <searching>
+    <search available="yes" supportedParams="q"/>
+    <tv-search available="yes" supportedParams="q,season,ep,tvdbid"/>
+    <movie-search available="no"/>
+  </searching>
+  <categories>
+    <category id="5000" name="TV">
+      <subcat id="5070" name="Anime"/>
+    </category>
+    <category id="2000" name="Movies"/>
+  </categories>
+</caps>"#;
+
+#[test]
+fn caps_response_parses_limits() {
+    let caps = parse_caps_response(CAPS_RESPONSE_BASIC).expect("must parse");
+    assert_eq!(caps.max_limit, Some(100));
+    assert_eq!(caps.default_limit, Some(50));
+}
+
+#[test]
+fn caps_response_parses_search_modes_with_supported_params() {
+    let caps = parse_caps_response(CAPS_RESPONSE_BASIC).expect("must parse");
+    let tv = caps
+        .search_modes
+        .iter()
+        .find(|m| m.mode == "tv-search")
+        .expect("tv-search present");
+    assert!(tv.available);
+    assert_eq!(tv.supported_params, vec!["q", "season", "ep", "tvdbid"]);
+
+    let movie = caps
+        .search_modes
+        .iter()
+        .find(|m| m.mode == "movie-search")
+        .expect("movie-search present");
+    assert!(!movie.available, "available=no must parse as false");
+}
+
+#[test]
+fn caps_response_parses_categories_with_subcategories() {
+    let caps = parse_caps_response(CAPS_RESPONSE_BASIC).expect("must parse");
+    let tv = caps
+        .categories
+        .iter()
+        .find(|c| c.id == 5000)
+        .expect("TV category present");
+    assert_eq!(tv.name, "TV");
+    let anime_sub = tv
+        .subcategories
+        .iter()
+        .find(|c| c.id == 5070)
+        .expect("Anime subcat under TV");
+    assert_eq!(anime_sub.name, "Anime");
+
+    let movies = caps
+        .categories
+        .iter()
+        .find(|c| c.id == 2000)
+        .expect("Movies category present");
+    assert!(
+        movies.subcategories.is_empty(),
+        "categories without subcats render as empty Vec, not panic"
+    );
+}
+
+#[test]
+fn caps_response_returns_err_on_torznab_error_body() {
+    // Caps endpoint also returns the standard torznab error body
+    // shape on auth failure — make sure the parser surfaces it
+    // instead of yielding empty caps.
+    let xml = r#"<?xml version="1.0"?>
+<error code="100" description="Bad API Key"/>"#;
+    let result = parse_caps_response(xml);
+    assert!(result.is_err());
+    assert!(
+        result.unwrap_err().contains("100"),
+        "error code must be visible in the error message"
+    );
+}
+
+#[test]
+fn caps_response_handles_missing_limits_block_with_none_defaults() {
+    // Sparse caps response: indexer doesn't emit a <limits>
+    // element. Fall back to None per the field's contract.
+    let xml = r#"<?xml version="1.0"?>
+<caps>
+  <searching><search available="yes"/></searching>
+  <categories/>
+</caps>"#;
+    let caps = parse_caps_response(xml).expect("must parse");
+    assert_eq!(caps.max_limit, None);
+    assert_eq!(caps.default_limit, None);
+}
+
+// ── repeating attr extraction ────────────────────────────────────
+
+#[test]
+fn extract_all_categories_pulls_every_category_attr_value() {
+    // A release marked TV (5000) AND Anime (5070) must surface
+    // both ids, not just the first. Single-value path drops
+    // repeats; this helper recovers them.
+    let block = r#"
+        <torznab:attr name="category" value="5000"/>
+        <torznab:attr name="category" value="5070"/>
+        <torznab:attr name="seeders" value="10"/>
+    "#;
+    let cats = extract_all_categories(block);
+    assert_eq!(cats, vec![5000, 5070]);
+}
+
+#[test]
+fn extract_all_categories_returns_empty_when_no_category_attr() {
+    let block = r#"<torznab:attr name="seeders" value="10"/>"#;
+    assert!(extract_all_categories(block).is_empty());
+}
+
+#[test]
+fn parse_repeating_attr_rejects_unsafe_attr_names() {
+    // Defensive: only alphanum + `-_` allowed in name. Anything
+    // else returns empty rather than splicing into the regex.
+    let block = r#"<torznab:attr name="seeders" value="10"/>"#;
+    assert!(parse_repeating_attr(block, "seeders.*").is_empty());
+    assert!(parse_repeating_attr(block, "seed)ers").is_empty());
+}
+
+#[test]
+fn parse_repeating_attr_works_for_newznab_namespace() {
+    // Newznab uses `<newznab:attr>`. The regex pattern is built
+    // with `(?:torznab|newznab)` so both work.
+    let block = r#"
+        <newznab:attr name="files" value="42"/>
+        <newznab:attr name="files" value="43"/>
+    "#;
+    let values = parse_repeating_attr(block, "files");
+    assert_eq!(values, vec!["42".to_string(), "43".to_string()]);
+}

--- a/src/services/indexers/torznab/tests.rs
+++ b/src/services/indexers/torznab/tests.rs
@@ -306,6 +306,28 @@ fn search_response_pubdate_handles_positive_timezone_offset() {
     );
 }
 
+#[test]
+fn search_response_pubdate_handles_negative_timezone_offset() {
+    // PR #107 round-2 review fix #9: pin the only branch in the
+    // sign-flip math (`* if sign == '+' { -1 } else { 1 }`) that
+    // wasn't otherwise exercised. -0500 = "5 hours behind UTC", so
+    // 19:00 local on 1969-12-31 is 00:00 UTC on 1970-01-01 = epoch.
+    let xml = r#"<?xml version="1.0"?>
+<rss version="2.0">
+<channel><item>
+  <title>Show</title>
+  <guid>g1</guid>
+  <pubDate>Wed, 31 Dec 1969 19:00:00 -0500</pubDate>
+</item></channel></rss>"#;
+    let result = parse_search_response(xml, 1, 25)
+        .expect("parse")
+        .expect("not error");
+    assert_eq!(
+        result[0].publish_date, 0,
+        "5 hours behind UTC at 19:00 local on 1969-12-31 = epoch UTC"
+    );
+}
+
 // ── parse_caps_response ──────────────────────────────────────────
 
 const CAPS_RESPONSE_BASIC: &str = r#"<?xml version="1.0" encoding="UTF-8"?>

--- a/src/services/indexers/torznab/wiremock_tests/auth_failures.rs
+++ b/src/services/indexers/torznab/wiremock_tests/auth_failures.rs
@@ -1,0 +1,70 @@
+//! Auth-failure shapes: HTTP 401 (Prowlarr's pre-torznab-layer
+//! auth) AND HTTP 200 + `<error code="100"/>` body (the spec'd
+//! shape). Both must surface as Err with the user-readable
+//! reason.
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+use super::fixture::new_fixture;
+use crate::services::indexers::{Indexer, SearchQuery};
+
+#[tokio::test]
+async fn http_401_surfaces_status_in_error_message() {
+    // Prowlarr returns 401 on bad apikey BEFORE the torznab
+    // layer sees the request. The status must be in the error
+    // string so the operator can tell "indexer URL unreachable
+    // / wrong key" apart from "search returned an error".
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("Unauthorized"))
+        .mount(&server)
+        .await;
+
+    let result = client.search(&SearchQuery::default()).await;
+    let err = result.expect_err("must be Err");
+    assert!(err.contains("401"), "error must surface HTTP status: {err}");
+}
+
+#[tokio::test]
+async fn http_500_surfaces_status_in_error_message() {
+    // 500 from upstream (indexer is misbehaving / Cloudflare
+    // page / Jackett bug). Treat as Err — the auto-search
+    // pipeline's per-indexer outcome captures this without
+    // failing the whole search.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(ResponseTemplate::new(500).set_body_string("Internal Server Error"))
+        .mount(&server)
+        .await;
+
+    let result = client.search(&SearchQuery::default()).await;
+    let err = result.expect_err("must be Err");
+    assert!(err.contains("500"), "error must surface HTTP status: {err}");
+}
+
+#[tokio::test]
+async fn http_200_with_error_body_surfaces_error_code() {
+    // The spec'd auth-failure shape: HTTP 200 with
+    // `<error code="100" description="Invalid API Key"/>`.
+    // The client must NOT treat this as a successful empty
+    // result — it must surface as Err with the code visible.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"<?xml version="1.0"?>
+<error code="100" description="Invalid API Key"/>"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let result = client.search(&SearchQuery::default()).await;
+    let err = result.expect_err("must be Err");
+    assert!(
+        err.contains("100") && err.contains("credentials"),
+        "error must surface code + category: {err}"
+    );
+}

--- a/src/services/indexers/torznab/wiremock_tests/caps.rs
+++ b/src/services/indexers/torznab/wiremock_tests/caps.rs
@@ -1,0 +1,70 @@
+//! `Indexer::caps` wire shape: GET `<base>?t=caps&apikey=...`.
+
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, ResponseTemplate};
+
+use super::fixture::{TEST_API_KEY, new_fixture};
+use crate::services::indexers::Indexer;
+
+const CAPS_BODY: &str = r#"<?xml version="1.0"?>
+<caps>
+  <limits max="100" default="50"/>
+  <searching>
+    <tv-search available="yes" supportedParams="q,cat"/>
+  </searching>
+  <categories>
+    <category id="5000" name="TV">
+      <subcat id="5070" name="Anime"/>
+    </category>
+  </categories>
+</caps>"#;
+
+#[tokio::test]
+async fn caps_sends_get_with_t_caps_and_apikey() {
+    // Pin the URL shape Prowlarr expects: GET to the base URL's
+    // path with `t=caps` and the configured apikey. Other clients
+    // using the same Prowlarr instance won't see this request
+    // since wiremock isolates per-test.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("t", "caps"))
+        .and(query_param("apikey", TEST_API_KEY))
+        .respond_with(ResponseTemplate::new(200).set_body_string(CAPS_BODY))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let caps = client.caps().await.expect("caps must succeed");
+    assert_eq!(caps.max_limit, Some(100));
+    assert!(
+        caps.search_modes
+            .iter()
+            .any(|m| m.mode == "tv-search" && m.available),
+        "tv-search must be in caps"
+    );
+}
+
+#[tokio::test]
+async fn caps_surfaces_torznab_error_body_as_err() {
+    // HTTP 200 + <error/> body is the spec'd shape for bad
+    // creds. The client must surface this as Err even though
+    // the status was 200.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            r#"<?xml version="1.0"?>
+<error code="100" description="Invalid API Key"/>"#,
+        ))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let result = client.caps().await;
+    let err = result.expect_err("must be Err");
+    assert!(
+        err.contains("100") && err.contains("Invalid API Key"),
+        "error must surface code + description: {err}"
+    );
+}

--- a/src/services/indexers/torznab/wiremock_tests/fixture.rs
+++ b/src/services/indexers/torznab/wiremock_tests/fixture.rs
@@ -1,0 +1,38 @@
+//! Shared wiremock fixture: a `MockServer` + a [`TorznabIndexer`]
+//! built against its base URL. Mirrors the
+//! `services/download_client/*/wiremock_tests/fixture.rs` pattern
+//! so the test files stay focused on the behavior under test.
+
+use wiremock::MockServer;
+
+use crate::models::indexers::{Indexer as IndexerRow, KIND_TORZNAB};
+use crate::services::indexers::torznab::TorznabIndexer;
+
+pub const TEST_API_KEY: &str = "wiremock-key-01234567";
+
+/// Spin up a fresh `MockServer` and return it paired with a
+/// `TorznabIndexer` configured to talk to it. The base URL points
+/// at `<server>/api` so tests register `Mock`s on `path("/api")`.
+pub async fn new_fixture() -> (MockServer, TorznabIndexer) {
+    let server = MockServer::start().await;
+    let row = IndexerRow {
+        id: 7,
+        name: "Wiremock".to_string(),
+        kind: KIND_TORZNAB.to_string(),
+        url: format!("{}/api", server.uri()),
+        api_key: TEST_API_KEY.to_string(),
+        priority: 25,
+        enabled: true,
+        is_private_tracker: false,
+        seed_ratio: None,
+        seed_time_minutes: None,
+        min_seeders: 0,
+        request_timeout_secs: Some(5),
+        caps_json: String::new(),
+        caps_refreshed_at: None,
+        created_at: 0,
+        updated_at: 0,
+    };
+    let client = TorznabIndexer::from_row(&row).expect("client must build");
+    (server, client)
+}

--- a/src/services/indexers/torznab/wiremock_tests/mod.rs
+++ b/src/services/indexers/torznab/wiremock_tests/mod.rs
@@ -1,0 +1,12 @@
+//! HTTP-shape wiremock tests for the [`TorznabIndexer`] client.
+//!
+//! Topic-split per the existing convention in
+//! `services/download_client/*/wiremock_tests/`. Each file
+//! covers one slice of behavior so a failure points cleanly at
+//! the affected surface.
+
+mod auth_failures;
+mod caps;
+mod fixture;
+mod rate_limit;
+mod search;

--- a/src/services/indexers/torznab/wiremock_tests/rate_limit.rs
+++ b/src/services/indexers/torznab/wiremock_tests/rate_limit.rs
@@ -1,0 +1,56 @@
+//! 429 + Retry-After handling. Prowlarr enforces per-indexer
+//! rate limits and surfaces them as 429 with a Retry-After
+//! header. Ryokan's client must capture both so the caller can
+//! apply a cooldown matching the AniList rate-limit pattern.
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, ResponseTemplate};
+
+use super::fixture::new_fixture;
+use crate::services::indexers::{Indexer, SearchQuery};
+
+#[tokio::test]
+async fn http_429_with_retry_after_surfaces_seconds_in_error() {
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .insert_header("retry-after", "120")
+                .set_body_string("Too Many Requests"),
+        )
+        .mount(&server)
+        .await;
+
+    let result = client.search(&SearchQuery::default()).await;
+    let err = result.expect_err("must be Err");
+    // Surface "rate-limited" + retry_after for log + cooldown.
+    assert!(
+        err.contains("rate-limited"),
+        "must mention rate-limit: {err}"
+    );
+    assert!(
+        err.contains("120"),
+        "must surface retry_after seconds: {err}"
+    );
+}
+
+#[tokio::test]
+async fn http_429_without_retry_after_surfaces_unknown_retry() {
+    // Some indexers return 429 without Retry-After. The client
+    // must still surface it as a rate-limit error rather than a
+    // generic HTTP failure, so the caller's cooldown logic can
+    // pick a default.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .respond_with(ResponseTemplate::new(429).set_body_string("Slow down"))
+        .mount(&server)
+        .await;
+
+    let result = client.search(&SearchQuery::default()).await;
+    let err = result.expect_err("must be Err");
+    assert!(err.contains("rate-limited"), "must surface 429: {err}");
+    // retry_after surfaces as `None` in the error message.
+    assert!(err.contains("None"), "no retry-after → None: {err}");
+}

--- a/src/services/indexers/torznab/wiremock_tests/search.rs
+++ b/src/services/indexers/torznab/wiremock_tests/search.rs
@@ -1,0 +1,125 @@
+//! `Indexer::search` wire shape: GET
+//! `<base>?t=tvsearch&apikey=...&cat=5070&q=...`.
+
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, ResponseTemplate};
+
+use super::fixture::{TEST_API_KEY, new_fixture};
+use crate::services::indexers::{Indexer, SearchQuery};
+
+const SEARCH_BODY: &str = r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel>
+<item>
+  <title>Synthetic.Show.S01E01</title>
+  <guid>g1</guid>
+  <enclosure url="https://server/dl/abc?apikey=KEY" length="1000000000" type="application/x-bittorrent"/>
+  <torznab:attr name="seeders" value="20"/>
+  <torznab:attr name="leechers" value="2"/>
+  <torznab:attr name="infohash" value="ABCDEF1234567890"/>
+  <torznab:attr name="category" value="5070"/>
+</item>
+</channel>
+</rss>"#;
+
+#[tokio::test]
+async fn search_sends_tvsearch_with_anime_category_default() {
+    // When the caller doesn't specify categories, the client
+    // defaults to 5070 (anime) per protocol research. Pin both
+    // the t=tvsearch function name and the cat=5070 default.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("t", "tvsearch"))
+        .and(query_param("apikey", TEST_API_KEY))
+        .and(query_param("cat", "5070"))
+        .and(query_param("q", "Test Show"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEARCH_BODY))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let query = SearchQuery {
+        q: "Test Show".to_string(),
+        categories: Vec::new(), // default → 5070
+        limit: None,
+        offset: None,
+    };
+    let releases = client.search(&query).await.expect("search must succeed");
+    assert_eq!(releases.len(), 1);
+    assert_eq!(releases[0].title, "Synthetic.Show.S01E01");
+    assert_eq!(releases[0].seeders, 20);
+    assert_eq!(releases[0].indexer_id, 7, "stamps caller's id");
+}
+
+#[tokio::test]
+async fn search_uses_csv_for_multiple_categories() {
+    // Multiple cats join with `,` per torznab spec. Pin the wire
+    // shape so a future refactor can't accidentally split into
+    // multiple cat= params.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("cat", "5070,5080"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<?xml version="1.0"?><rss><channel/></rss>"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let query = SearchQuery {
+        q: "Test".to_string(),
+        categories: vec![5070, 5080],
+        limit: None,
+        offset: None,
+    };
+    let _ = client.search(&query).await.expect("must succeed");
+}
+
+#[tokio::test]
+async fn search_passes_limit_and_offset_when_set() {
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("limit", "25"))
+        .and(query_param("offset", "50"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<?xml version="1.0"?><rss><channel/></rss>"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let query = SearchQuery {
+        q: "X".to_string(),
+        categories: Vec::new(),
+        limit: Some(25),
+        offset: Some(50),
+    };
+    let _ = client.search(&query).await.expect("must succeed");
+}
+
+#[tokio::test]
+async fn search_empty_q_omits_q_param() {
+    // An empty query string means "indexer's recent items feed"
+    // — the protocol allows omitting `q`. Pin the wire behavior:
+    // empty `q` results in NO `q=` param, not `q=`.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("t", "tvsearch"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_string(r#"<?xml version="1.0"?><rss><channel/></rss>"#),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let query = SearchQuery::default();
+    let releases = client.search(&query).await.expect("must succeed");
+    assert!(releases.is_empty());
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -2,6 +2,7 @@ pub mod anilist;
 pub mod crypto;
 pub mod download_client;
 pub mod external_sync;
+pub mod indexers;
 pub mod jikan;
 pub mod kitsu;
 pub mod mal;

--- a/src/services/nyaa/mod.rs
+++ b/src/services/nyaa/mod.rs
@@ -103,6 +103,17 @@ pub struct SearchResult {
     /// table matches Nyaa's own listing shape.
     #[serde(default)]
     pub upload_date: String,
+    /// Issue #28 PR B — FK to `indexers.id` of the indexer that
+    /// surfaced this release. `None` for Nyaa-direct results (the
+    /// existing behavior; Nyaa stays out-of-band per plan
+    /// decision #1). `Some(id)` for results from a torznab/newznab
+    /// indexer fan-out, set in [`crate::services::indexers::Release::into_search_result`].
+    /// Propagates to `grabbed_torrents.indexer_id` at grab time so
+    /// the upgrade sweep can apply per-indexer rules retroactively.
+    /// Default-skipped on serialize so existing JSON consumers don't
+    /// break and Nyaa-only flows don't add noise to API responses.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub indexer_id: Option<i64>,
 }
 
 #[derive(Clone)]

--- a/src/services/nyaa/scraper.rs
+++ b/src/services/nyaa/scraper.rs
@@ -207,6 +207,7 @@ pub(super) fn parse_results(html: &str, opts: &SearchOptions) -> (Vec<SearchResu
             info_hash,
             score_breakdown: Vec::new(),
             upload_date: upload_date.clone(),
+            indexer_id: None,
         };
 
         let (total, breakdown) =
@@ -503,6 +504,7 @@ pub(super) fn parse_view_page(
         // The view page doesn't render the listing-table date column.
         // Callers on this path (SeaDex-bypass) get an empty string.
         upload_date: String::new(),
+        indexer_id: None,
     };
 
     let (total, breakdown) =
@@ -978,6 +980,7 @@ mod tests {
             info_hash: String::new(),
             score_breakdown: Vec::new(),
             upload_date: String::new(),
+            indexer_id: None,
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;
@@ -1021,6 +1024,7 @@ mod tests {
             info_hash: String::new(),
             score_breakdown: Vec::new(),
             upload_date: String::new(),
+            indexer_id: None,
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -335,6 +335,7 @@ mod tests {
             info_hash: String::new(),
             score_breakdown: Vec::new(),
             upload_date: String::new(),
+            indexer_id: None,
         }
     }
 

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -198,7 +198,14 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             let label = auto_search::target_label(&target);
             // batch_episode_match=true so BD season packs can match episode targets.
             let best = auto_search::find_best_for_target(
-                &state.db, &detail, &cfg, &target, true, true, &cfs,
+                &state.db,
+                &detail,
+                &cfg,
+                &target,
+                true,
+                true,
+                &cfs,
+                &state.indexers,
             )
             .await;
 

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -68,11 +68,13 @@ pub fn build_test_app_state(
     download_client: Option<Arc<dyn DownloadClient>>,
 ) -> AppState {
     let cf_cache: CompiledCfCache = Arc::new(RwLock::new(Arc::new(Vec::new())));
+    let indexers: crate::IndexerCache = Arc::new(RwLock::new(Arc::new(Vec::new())));
     AppState {
         db,
         download_client: Arc::new(RwLock::new(download_client)),
         jellyfin: Arc::new(RwLock::new(None)),
         custom_formats: cf_cache,
+        indexers,
         progress: ProgressRegistry::new(),
         users_exist: Arc::new(AtomicBool::new(true)),
         interactive_search_cache: crate::services::interactive_search_cache::new(),

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -73,6 +73,7 @@
             <label>
                 API Key
                 <input type="text" name="api_key" autocomplete="off" value="{{ edit.api_key }}">
+                <span class="form-hint">Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
             </label>
             <label>
                 Priority
@@ -81,6 +82,27 @@
             <label>
                 Min Seeders
                 <input type="number" name="min_seeders" value="{{ edit.min_seeders }}" min="0">
+            </label>
+            <label>
+                Request Timeout (seconds)
+                <input type="number" name="request_timeout_secs"
+                       value="{% if let Some(secs) = edit.request_timeout_secs %}{{ secs }}{% endif %}"
+                       min="1" max="600" placeholder="30">
+                <span class="form-hint">Per-indexer override. Blank uses the default (30s, or RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS env). Range 1–600.</span>
+            </label>
+            <label>
+                Seed Ratio
+                <input type="number" name="seed_ratio" step="0.1" min="0"
+                       value="{% if let Some(r) = edit.seed_ratio %}{{ r }}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent seed ratio passed to the download client at add time (PR C). Blank inherits the client's global default.</span>
+            </label>
+            <label>
+                Seed Time (minutes)
+                <input type="number" name="seed_time_minutes" min="0"
+                       value="{% if let Some(m) = edit.seed_time_minutes %}{{ m }}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent minimum seed time. Blank inherits the client's global default.</span>
             </label>
             <label class="checkbox-label">
                 <input type="checkbox" name="enabled" {% if edit.enabled %}checked{% endif %}>
@@ -121,6 +143,7 @@
                 API Key
                 <input type="text" name="api_key" autocomplete="off"
                        placeholder="from Prowlarr Settings &rarr; General">
+                <span class="form-hint">Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
             </label>
             <label>
                 Priority
@@ -131,6 +154,21 @@
                 Min Seeders
                 <input type="number" name="min_seeders" value="1" min="0">
                 <span class="form-hint">Releases below this floor are dropped before scoring.</span>
+            </label>
+            <label>
+                Request Timeout (seconds)
+                <input type="number" name="request_timeout_secs" min="1" max="600" placeholder="30">
+                <span class="form-hint">Per-indexer override. Blank uses the default (30s).</span>
+            </label>
+            <label>
+                Seed Ratio
+                <input type="number" name="seed_ratio" step="0.1" min="0" placeholder="(client default)">
+                <span class="form-hint">Per-torrent seed ratio passed to the download client at add time (PR C).</span>
+            </label>
+            <label>
+                Seed Time (minutes)
+                <input type="number" name="seed_time_minutes" min="0" placeholder="(client default)">
+                <span class="form-hint">Per-torrent minimum seed time.</span>
             </label>
             <label class="checkbox-label">
                 <input type="checkbox" name="enabled" checked>

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -1,47 +1,99 @@
     <fieldset>
         <legend>Indexers</legend>
-        <p class="form-hint">Torznab and newznab indexers (Prowlarr, Jackett, raw torznab). Nyaa stays directly integrated and doesn't need a row here.</p>
+        <p class="form-hint">
+            Torznab and newznab indexers (Prowlarr, Jackett, raw torznab). Nyaa stays directly
+            integrated and doesn't need a row here. Sharing a Prowlarr instance with an existing
+            Sonarr install is supported out of the box: Prowlarr's torznab endpoint is keyed by
+            apikey, so Sonarr's "Apps" sync isn't an authorization gate.
+        </p>
 
-        {% if indexers.is_empty() %}
-        <div class="empty-state">
-            <p>No indexers configured.</p>
-            <p class="form-hint">
-                Indexer support is being rolled out across issue #28's PR sequence:
-                this tab is the foundation. Adding, editing, and querying torznab
-                or newznab indexers lands in the next PR. For now, Ryokan continues
-                to search Nyaa directly with no behavioral change.
-            </p>
-            <p class="form-hint">
-                When the rest of the surface ships, this is where you'll paste the
-                "Copy Torznab Url" output from Prowlarr or Jackett along with the
-                API key, set per-indexer seed rules, and order by priority.
-            </p>
-        </div>
-        {% else %}
+        {% if !indexers.is_empty() %}
         <div class="table-scroll-wrap">
         <table class="indexers-table">
             <thead>
                 <tr>
+                    <th>Priority</th>
                     <th>Name</th>
                     <th>Kind</th>
-                    <th>Priority</th>
+                    <th>URL</th>
                     <th>Private</th>
                     <th>Status</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
                 {% for idx in indexers %}
                 <tr>
+                    <td>{{ idx.priority }}</td>
                     <td>{{ idx.name }}</td>
                     <td>{{ idx.kind }}</td>
-                    <td>{{ idx.priority }}</td>
+                    <td><code>{{ idx.url }}</code></td>
                     <td>{% if idx.is_private_tracker %}Yes{% else %}No{% endif %}</td>
                     <td>{% if idx.enabled %}Enabled{% else %}Disabled{% endif %}</td>
+                    <td>
+                        <form method="post" action="/settings/indexers/delete" style="display:inline">
+                            <input type="hidden" name="id" value="{{ idx.id }}">
+                            <button type="submit" class="btn btn-danger btn-small"
+                                    onclick="return confirm('Delete indexer {{ idx.name }}?');">
+                                Delete
+                            </button>
+                        </form>
+                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
         </div>
-        <p class="form-hint">Add/edit/delete forms land in the next PR.</p>
         {% endif %}
+
+        <h3 class="settings-subheading">Add Indexer</h3>
+        <p class="form-hint">
+            Paste the full torznab base URL from Prowlarr's "Copy Torznab URL" button (or
+            Jackett's per-indexer torznab URL). The URL ends in <code>/api</code>; do not
+            add query params yourself — Ryokan appends <code>?t=…&amp;apikey=…</code>.
+        </p>
+        <form method="post" action="/settings/indexers/upsert" class="settings-subform">
+            <label>
+                Name
+                <input type="text" name="name" required maxlength="100"
+                       placeholder="e.g. Prowlarr - Nyaa">
+            </label>
+            <label>
+                Kind
+                <select name="kind">
+                    <option value="torznab" selected>torznab</option>
+                    <option value="newznab">newznab</option>
+                </select>
+            </label>
+            <label>
+                URL
+                <input type="url" name="url" required
+                       placeholder="https://prowlarr.local/1/api">
+            </label>
+            <label>
+                API Key
+                <input type="text" name="api_key" autocomplete="off"
+                       placeholder="from Prowlarr Settings &rarr; General">
+            </label>
+            <label>
+                Priority
+                <input type="number" name="priority" value="25" min="1" max="50">
+                <span class="form-hint">Lower = preferred. Range 1–50, default 25.</span>
+            </label>
+            <label>
+                Min Seeders
+                <input type="number" name="min_seeders" value="1" min="0">
+                <span class="form-hint">Releases below this floor are dropped before scoring.</span>
+            </label>
+            <label class="checkbox-label">
+                <input type="checkbox" name="enabled" checked>
+                Enabled
+            </label>
+            <label class="checkbox-label">
+                <input type="checkbox" name="is_private_tracker">
+                Private tracker
+                <span class="form-hint">Marks this indexer as PT for the per-series upgrade opt-in.</span>
+            </label>
+            <button type="submit" class="btn btn-primary">Add Indexer</button>
+        </form>
     </fieldset>

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -31,6 +31,7 @@
                     <td>{% if idx.is_private_tracker %}Yes{% else %}No{% endif %}</td>
                     <td>{% if idx.enabled %}Enabled{% else %}Disabled{% endif %}</td>
                     <td>
+                        <a href="/settings?tab=indexers&edit_id={{ idx.id }}" class="btn btn-small">Edit</a>
                         <form method="post" action="/settings/indexers/delete" style="display:inline">
                             <input type="hidden" name="id" value="{{ idx.id }}">
                             <button type="submit" class="btn btn-danger btn-small"
@@ -46,11 +47,57 @@
         </div>
         {% endif %}
 
+        {% if let Some(edit) = indexer_edit %}
+        <h3 class="settings-subheading">Edit Indexer</h3>
+        <p class="form-hint">
+            Updating <strong>{{ edit.name }}</strong>.
+            <a href="/settings?tab=indexers">Cancel and return to Add Indexer.</a>
+        </p>
+        <form method="post" action="/settings/indexers/upsert" class="settings-subform">
+            <input type="hidden" name="id" value="{{ edit.id }}">
+            <label>
+                Name
+                <input type="text" name="name" required maxlength="100" value="{{ edit.name }}">
+            </label>
+            <label>
+                Kind
+                <select name="kind">
+                    <option value="torznab" {% if edit.kind == "torznab" %}selected{% endif %}>torznab</option>
+                    <option value="newznab" {% if edit.kind == "newznab" %}selected{% endif %}>newznab</option>
+                </select>
+            </label>
+            <label>
+                URL
+                <input type="url" name="url" required value="{{ edit.url }}">
+            </label>
+            <label>
+                API Key
+                <input type="text" name="api_key" autocomplete="off" value="{{ edit.api_key }}">
+            </label>
+            <label>
+                Priority
+                <input type="number" name="priority" value="{{ edit.priority }}" min="1" max="50">
+            </label>
+            <label>
+                Min Seeders
+                <input type="number" name="min_seeders" value="{{ edit.min_seeders }}" min="0">
+            </label>
+            <label class="checkbox-label">
+                <input type="checkbox" name="enabled" {% if edit.enabled %}checked{% endif %}>
+                Enabled
+            </label>
+            <label class="checkbox-label">
+                <input type="checkbox" name="is_private_tracker" {% if edit.is_private_tracker %}checked{% endif %}>
+                Private tracker
+            </label>
+            <button type="submit" class="btn btn-primary">Save Changes</button>
+        </form>
+        {% else %}
         <h3 class="settings-subheading">Add Indexer</h3>
         <p class="form-hint">
             Paste the full torznab base URL from Prowlarr's "Copy Torznab URL" button (or
             Jackett's per-indexer torznab URL). The URL ends in <code>/api</code>; do not
-            add query params yourself — Ryokan appends <code>?t=…&amp;apikey=…</code>.
+            add query params yourself; Ryokan appends <code>?t=…&amp;apikey=…</code>.
         </p>
         <form method="post" action="/settings/indexers/upsert" class="settings-subform">
             <label>
@@ -96,4 +143,5 @@
             </label>
             <button type="submit" class="btn btn-primary">Add Indexer</button>
         </form>
+        {% endif %}
     </fieldset>

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -1,0 +1,47 @@
+    <fieldset>
+        <legend>Indexers</legend>
+        <p class="form-hint">Torznab and newznab indexers (Prowlarr, Jackett, raw torznab). Nyaa stays directly integrated and doesn't need a row here.</p>
+
+        {% if indexers.is_empty() %}
+        <div class="empty-state">
+            <p>No indexers configured.</p>
+            <p class="form-hint">
+                Indexer support is being rolled out across issue #28's PR sequence:
+                this tab is the foundation. Adding, editing, and querying torznab
+                or newznab indexers lands in the next PR. For now, Ryokan continues
+                to search Nyaa directly with no behavioral change.
+            </p>
+            <p class="form-hint">
+                When the rest of the surface ships, this is where you'll paste the
+                "Copy Torznab Url" output from Prowlarr or Jackett along with the
+                API key, set per-indexer seed rules, and order by priority.
+            </p>
+        </div>
+        {% else %}
+        <div class="table-scroll-wrap">
+        <table class="indexers-table">
+            <thead>
+                <tr>
+                    <th>Name</th>
+                    <th>Kind</th>
+                    <th>Priority</th>
+                    <th>Private</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for idx in indexers %}
+                <tr>
+                    <td>{{ idx.name }}</td>
+                    <td>{{ idx.kind }}</td>
+                    <td>{{ idx.priority }}</td>
+                    <td>{% if idx.is_private_tracker %}Yes{% else %}No{% endif %}</td>
+                    <td>{% if idx.enabled %}Enabled{% else %}Disabled{% endif %}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        </div>
+        <p class="form-hint">Add/edit/delete forms land in the next PR.</p>
+        {% endif %}
+    </fieldset>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -21,13 +21,14 @@
 
 <div class="settings-tabs system-tabs">
     <a href="/settings?tab=integrations" class="system-tab {% if tab == "integrations" %}active{% endif %}">Connections</a>
+    <a href="/settings?tab=indexers" class="system-tab {% if tab == "indexers" %}active{% endif %}">Indexers</a>
     <a href="/settings?tab=quality" class="system-tab {% if tab == "quality" %}active{% endif %}">Preferred Quality &amp; Releases</a>
     <a href="/settings?tab=custom_formats" class="system-tab {% if tab == "custom_formats" %}active{% endif %}">Custom Formats</a>
     <a href="/settings?tab=groups" class="system-tab {% if tab == "groups" %}active{% endif %}">Release Groups</a>
     <a href="/settings?tab=general" class="system-tab {% if tab == "general" %}active{% endif %}">General</a>
 </div>
 
-{% if tab != "groups" && tab != "custom_formats" %}
+{% if tab != "groups" && tab != "custom_formats" && tab != "indexers" %}
 <form method="post" action="/settings" class="settings-form">
     <input type="hidden" name="tab" value="{{ tab }}">
 
@@ -56,6 +57,12 @@
 {% if tab == "custom_formats" %}
 <div class="settings-tab-panel active">
 {%~ include "partials/settings/custom_formats.html" ~%}
+</div>
+{% endif %}
+
+{% if tab == "indexers" %}
+<div class="settings-tab-panel active">
+{%~ include "partials/settings/indexers.html" ~%}
 </div>
 {% endif %}
 


### PR DESCRIPTION
## Summary

First half of v1.5.0's anchor feature (#28). Lands the **torznab/newznab indexer foundation + impl + auto-search integration**. This is a draft PR — the feature is end-to-end functional but the v1.5.0 release wants additional pieces (per-indexer seed rules, autobrr, PT-upgrade opt-in) before going final.

The full plan is `/home/john/Documents/ryokan-roadmap/issue-28-torznab-autobrr-plan.md`. PRs A → B are the bulk; C/D/E/H land independently after this.

## What ships in this draft

### PR A — foundation (commit \`c4ecee1\`)
- New \`indexers\` table + \`models/indexers.rs\` CRUD + 8 tests.
- New \`grabbed_torrents.indexer_id\` (FK, NULL = pre-#28 grab) + \`respect_seed_rules\` columns.
- New \`series.allow_pt_upgrades\` (PR E will wire the UI).
- New \`config.autobrr_api_key\` (PR D will wire the webhook).
- \`Indexer\` trait (\`async_trait\`, object-safe) + \`Release\` / \`SearchQuery\` / \`IndexerCaps\` data model in \`services/indexers/\`.
- \`dedup_for_auto_search\` + \`merge_for_interactive_search\` helpers (decision #3 — different policies per search path).
- \`fan_out_search\` concurrent helper.
- Settings → Indexers tab scaffolded.

### PR B — TorznabIndexer impl + integration

**Parser + client (\`5afa64f\`)** — 1893 LoC. Regex-based response parser (per plan non-negotiable: no new XML crate dep), TorznabIndexer struct + Indexer trait impl, three error shapes handled (HTTP 200 + \`<error/>\` body, non-200, 429 + Retry-After), per-indexer min_seeders pre-grab filter, **+45 tests** including 11 wiremock-based HTTP-shape tests.

**Settings CRUD (\`71e3cb4\`)** — form-driven add/edit/delete + utoipa annotations, validation (priority clamps to [1, 50], request_timeout_secs to [1, 600]), template with table + form, +5 tests.

**Auto-search integration (\`4ec3fe3\`)** — \`Release::into_search_result()\` conversion, \`AutoQueryCtx\` gains an indexers field loaded once at the top of \`collect_scored_for_target\`, \`run_queries\` fans out to enabled indexers concurrently with the Nyaa stream, indexer results go through the same dedup + matches_target gate as Nyaa results so downstream scoring is unified.

## Sharing a Prowlarr instance with Sonarr

Confirmed via research + live probe of the qbit-jellyfin docker compose's Prowlarr container: **Prowlarr's torznab endpoint is a public-by-design HTTP surface keyed by apikey.** Sonarr's "Apps" sync isn't an authorization gate, just config-push convenience. Third-party clients (autobrr, cross-seed, Ryokan) all consume the same \`http://host:9696/{N}/api?apikey=KEY\` URL without needing a Prowlarr "Apps" entry. Sonarr's existing sync is untouched when Ryokan also queries the same Prowlarr.

## Behavioral contract for Nyaa-only users

**No change.** Empty \`indexers\` table = the v1.4 default code path. Nyaa-direct still runs first; the indexer fan-out is a no-op when no rows exist. Per the plan's non-negotiable, "Nyaa-direct users see no behavioral change post-upgrade."

## Out of scope / follow-ups
- Per-indexer seed rules + DownloadClient::set_seed_rules (PR C).
- autobrr push endpoint (PR D).
- Per-series PT upgrade opt-in UI (PR E — column already in PR A's migration).
- Test-connection button on the indexer edit form.
- Smart \`is_private_tracker\` defaults via Prowlarr's \`/api/v1/indexer\` privacy probe (decision #4).
- Scoring inspector indexer attribution.
- Multi-client (PR F) + SABnzbd impl (PR G — closes #64 except NZBGet).
- Task registry abstraction (PR H).
- v2.0 metadata follow-ups: #105 (unified MetadataDTO), #106 (stale-but-readable cache).

## Test plan
- [x] cargo build --workspace --locked
- [x] cargo test --workspace --locked --features test-support (1574 passed; 22 ignored)
- [x] cargo clippy --workspace --all-targets --features test-support -- -D warnings
- [x] cargo fmt --all -- --check
- [x] Live probe of Prowlarr + Jackett containers via the qbit-jellyfin docker compose's new \`indexers\` profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)