### PR TITLE
1.5.0 (draft): multi-download-client + per-series PT upgrade (#28 PR E + F)

### DIFF
--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -148,7 +148,7 @@ pub async fn downloads_page(
         .unwrap_or_else(|| "english".to_string());
 
     let (queue, queue_error) = if tab == "queue" {
-        let client = state.download_client.read().await.clone();
+        let client = state.default_download_client().await;
         match client {
             Some(c) => match c.list_scoped().await {
                 Ok(mut torrents) => {
@@ -243,16 +243,10 @@ pub async fn api_pause_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentActionForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let client = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
     client
         .pause(&form.hash)
         .await
@@ -276,16 +270,10 @@ pub async fn api_resume_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentActionForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let client = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
     client
         .resume(&form.hash)
         .await
@@ -309,16 +297,10 @@ pub async fn api_delete_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentDeleteForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let client = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
     client
         .delete(&form.hash, form.delete_files)
         .await

--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -204,14 +204,10 @@ async fn require_download_client(
     std::sync::Arc<dyn crate::services::download_client::DownloadClient>,
     (StatusCode, String),
 > {
-    let guard = state.download_client.read().await;
-    guard
-        .as_ref()
-        .ok_or((
-            StatusCode::BAD_REQUEST,
-            "Download client not configured".to_string(),
-        ))
-        .cloned()
+    state.default_download_client().await.ok_or((
+        StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))
 }
 
 #[utoipa::path(

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -18,8 +18,8 @@ use super::reconcile::reconcile_all_fallback_entries;
 use super::search::{AutoSearchQuery, auto_search_series};
 use super::{
     AddSeriesForm, BulkManualOverrideForm, ReclassifyEpisodeForm, RemoveSeriesForm,
-    SetAllowUpgradesForm, SetEpisodeMonitoringForm, SetFolderForm, SetManualOverrideForm,
-    SetMonitoringForm, SetSearchOverridesForm,
+    SetAllowPtUpgradesForm, SetAllowUpgradesForm, SetEpisodeMonitoringForm, SetFolderForm,
+    SetManualOverrideForm, SetMonitoringForm, SetSearchOverridesForm,
 };
 
 #[utoipa::path(
@@ -672,6 +672,46 @@ pub async fn set_allow_upgrades(
         "ok": true,
         "series_id": form.series_id,
         "allow_upgrades": form.allow,
+    })))
+}
+
+/// Issue #28 PR E — toggle the per-series PT upgrade opt-in.
+/// Default off; the upgrade sweep won't grab a private-tracker
+/// release as the chosen upgrade for this series unless the
+/// flag is on. Initial grabs and manual searches aren't gated.
+#[utoipa::path(
+    post,
+    path = "/api/library/allow-pt-upgrades",
+    tag = "Library",
+    summary = "Toggle series PT upgrade opt-in",
+    description = "Enable or disable private-tracker-sourced upgrades for a single tracked series. Default off — when off, the upgrade sweep skips upgrade candidates whose source indexer is marked private (`indexers.is_private_tracker = 1`). Initial grabs and manual searches aren't affected.",
+    request_body = SetAllowPtUpgradesForm,
+    responses(
+        (status = 200, description = "PT upgrade opt-in toggled", body = serde_json::Value),
+        (status = 500, description = "Database error"),
+    ),
+)]
+pub async fn set_allow_pt_upgrades(
+    State(state): State<AppState>,
+    Json(form): Json<SetAllowPtUpgradesForm>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    series::update_allow_pt_upgrades(&state.db, form.series_id, form.allow)
+        .await
+        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    logger::info(
+        &state.db,
+        LogCategory::Library,
+        &format!(
+            "PT upgrade opt-in for series {} set to {}",
+            form.series_id, form.allow
+        ),
+        "",
+    )
+    .await;
+    Ok(Json(serde_json::json!({
+        "ok": true,
+        "series_id": form.series_id,
+        "allow_pt_upgrades": form.allow,
     })))
 }
 
@@ -1467,6 +1507,124 @@ mod tests {
             )
             .await;
             assert_eq!(body["allow_upgrades"], true);
+        }
+
+        // ─── set_allow_pt_upgrades (#28 PR E) ─────────────────────
+
+        #[tokio::test]
+        async fn set_allow_pt_upgrades_persists_flag_and_defaults_off() {
+            let db = in_memory_pool().await;
+            let series_id = seed_series(&db, 41, "Show").await;
+            let state = build_test_app_state(db.clone(), None);
+
+            // Default state — series.allow_pt_upgrades should be 0
+            // even though we haven't called the toggle yet. Pin the
+            // default-off invariant so a future migration that
+            // changes the column default to 1 has to be deliberate.
+            let stored: i64 =
+                sqlx::query_scalar("SELECT allow_pt_upgrades FROM series WHERE id = ?")
+                    .bind(series_id)
+                    .fetch_one(&db)
+                    .await
+                    .unwrap();
+            assert_eq!(stored, 0, "PT upgrade opt-in must default OFF");
+
+            // Flip on.
+            let body: serde_json::Value = ok_json(
+                set_allow_pt_upgrades(
+                    State(state.clone()),
+                    AxumJson(super::super::SetAllowPtUpgradesForm {
+                        series_id,
+                        allow: true,
+                    }),
+                )
+                .await,
+            )
+            .await;
+            assert_eq!(body["allow_pt_upgrades"], true);
+            let stored: i64 =
+                sqlx::query_scalar("SELECT allow_pt_upgrades FROM series WHERE id = ?")
+                    .bind(series_id)
+                    .fetch_one(&db)
+                    .await
+                    .unwrap();
+            assert_eq!(stored, 1);
+
+            // Flip off.
+            let body: serde_json::Value = ok_json(
+                set_allow_pt_upgrades(
+                    State(state),
+                    AxumJson(super::super::SetAllowPtUpgradesForm {
+                        series_id,
+                        allow: false,
+                    }),
+                )
+                .await,
+            )
+            .await;
+            assert_eq!(body["allow_pt_upgrades"], false);
+            let stored: i64 =
+                sqlx::query_scalar("SELECT allow_pt_upgrades FROM series WHERE id = ?")
+                    .bind(series_id)
+                    .fetch_one(&db)
+                    .await
+                    .unwrap();
+            assert_eq!(stored, 0);
+        }
+
+        #[tokio::test]
+        async fn set_allow_pt_upgrades_independent_of_allow_upgrades() {
+            // The two flags are orthogonal — flipping one shouldn't
+            // affect the other. Pin the invariant since both columns
+            // live on the same row and a stray UPDATE on the wrong
+            // column would silently ride out under simpler tests.
+            let db = in_memory_pool().await;
+            let series_id = seed_series(&db, 42, "Show").await;
+            let state = build_test_app_state(db.clone(), None);
+
+            // allow_upgrades on, allow_pt_upgrades on.
+            ok_json(
+                set_allow_upgrades(
+                    State(state.clone()),
+                    AxumJson(super::super::SetAllowUpgradesForm {
+                        series_id,
+                        allow: true,
+                    }),
+                )
+                .await,
+            )
+            .await;
+            ok_json(
+                set_allow_pt_upgrades(
+                    State(state.clone()),
+                    AxumJson(super::super::SetAllowPtUpgradesForm {
+                        series_id,
+                        allow: true,
+                    }),
+                )
+                .await,
+            )
+            .await;
+            // Now flip allow_upgrades off; allow_pt_upgrades must
+            // stay on.
+            ok_json(
+                set_allow_upgrades(
+                    State(state),
+                    AxumJson(super::super::SetAllowUpgradesForm {
+                        series_id,
+                        allow: false,
+                    }),
+                )
+                .await,
+            )
+            .await;
+            let row: (i64, i64) =
+                sqlx::query_as("SELECT allow_upgrades, allow_pt_upgrades FROM series WHERE id = ?")
+                    .bind(series_id)
+                    .fetch_one(&db)
+                    .await
+                    .unwrap();
+            assert_eq!(row, (0, 1), "allow_pt_upgrades must persist independently");
         }
 
         // ─── set_search_overrides ────────────────────────────────

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -286,7 +286,7 @@ pub async fn remove_series(
         };
 
         if !hashes.is_empty() {
-            let client_opt = state.download_client.read().await.clone();
+            let client_opt = state.default_download_client().await;
             if let Some(client) = client_opt {
                 for (_id, hash) in &hashes {
                     if hash.is_empty() {
@@ -560,7 +560,7 @@ pub async fn set_monitoring(
     // so narrowing transitions (`all → missing`) are a natural no-op.
     if mode != monitoring::MonitorMode::None
         && summary.monitored_count > 0
-        && state.download_client.read().await.is_some()
+        && state.default_download_client().await.is_some()
     {
         let cfg = config::get_config(&state.db).await.ok().flatten();
         let auto_grab_on_add = cfg.as_ref().map(|c| c.auto_grab_on_add).unwrap_or(true);

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -139,7 +139,7 @@ pub async fn delete_episode_file(
                     .unwrap_or_default();
             let mut qbit_removed: Vec<String> = Vec::new();
             if !imported_grabs.is_empty() {
-                let client = state.download_client.read().await.as_ref().cloned();
+                let client = state.default_download_client().await;
                 if let Some(client) = client {
                     for grab in &imported_grabs {
                         if grab.is_batch {
@@ -347,7 +347,7 @@ pub async fn cancel_pending_episode(
         "cancel_pending_episode: matching grabs"
     );
 
-    let client = state.download_client.read().await.as_ref().cloned();
+    let client = state.default_download_client().await;
 
     let mut removed_count = 0;
     let mut torrent_failures: Vec<String> = Vec::new();
@@ -491,7 +491,7 @@ pub async fn mark_episode_failed(
         grabbed_torrents::find_imported_for_episode(&state.db, series_id, episode_number).await
         && !old_grabs.is_empty()
     {
-        let client = { state.download_client.read().await.as_ref().cloned() };
+        let client = { state.default_download_client().await };
         if let Some(client) = client {
             for old in &old_grabs {
                 if old.hash.is_empty() {
@@ -595,8 +595,8 @@ pub async fn episode_download_progress(
             .unwrap_or_default();
 
     let client = {
-        let guard = state.download_client.read().await;
-        match guard.as_ref() {
+        let client = state.default_download_client().await;
+        match client.as_ref() {
             Some(c) => c.clone(),
             None => return Ok(Json(Vec::new())),
         }

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -124,6 +124,18 @@ struct SeriesTemplate {
     /// Phase 4: series-level upgrade opt-in. Rendered as a checkbox on the
     /// series detail page; toggled via POST /api/library/allow-upgrades.
     allow_upgrades: bool,
+    /// Issue #28 PR E — per-series PT upgrade opt-in. Default off. The
+    /// upgrade sweep skips a candidate when its source indexer is private
+    /// and this is false. Toggled via POST /api/library/allow-pt-upgrades.
+    /// Rendered inside an "Advanced" collapsible since most users won't
+    /// flip it.
+    allow_pt_upgrades: bool,
+    /// Issue #28 PR E — `true` when at least one configured indexer
+    /// has `is_private_tracker = 1`. Drives a UI hint: when the user
+    /// has zero PT indexers, the PT-upgrade toggle reads "no private
+    /// trackers configured" instead of being a dangling enabled
+    /// control that affects nothing.
+    any_private_indexer: bool,
     /// #23 — Per-series custom Nyaa query tokens. Empty string means
     /// "use the global default in config." Rendered in the Advanced
     /// search panel on the series detail page.
@@ -278,6 +290,17 @@ pub struct SetEpisodeMonitoringForm {
 
 #[derive(Deserialize, utoipa::ToSchema)]
 pub struct SetAllowUpgradesForm {
+    series_id: i64,
+    allow: bool,
+}
+
+/// Issue #28 PR E — per-series PT upgrade opt-in form. Same shape
+/// as [`SetAllowUpgradesForm`] but toggles the second-axis flag
+/// (`series.allow_pt_upgrades`) that gates whether the upgrade
+/// sweep is allowed to grab a private-tracker release for this
+/// series. Default off; user opts in per series.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct SetAllowPtUpgradesForm {
     series_id: i64,
     allow: bool,
 }

--- a/src/handlers/library/pages.rs
+++ b/src/handlers/library/pages.rs
@@ -510,6 +510,21 @@ pub async fn series_detail(
 
     let all_monitored = ep_total > 0 && monitored_count >= ep_total;
     let allow_upgrades = db_series.as_ref().map(|s| s.allow_upgrades).unwrap_or(true);
+    // PR E — default off (untracked series have no upgrade sweep
+    // anyway, so the default is moot for the .unwrap_or() branch).
+    let allow_pt_upgrades = db_series
+        .as_ref()
+        .map(|s| s.allow_pt_upgrades)
+        .unwrap_or(false);
+    // Surface a hint when the user has zero PT indexers configured —
+    // the toggle would do nothing in that case so the UI reads "no
+    // PT indexers configured" instead of dangling enabled.
+    let any_private_indexer = state
+        .indexers
+        .read()
+        .await
+        .iter()
+        .any(|i| i.is_private_tracker());
     let custom_query_tokens = db_series
         .as_ref()
         .map(|s| s.custom_query_tokens.clone())
@@ -563,6 +578,8 @@ pub async fn series_detail(
         monitored_count,
         all_monitored,
         allow_upgrades,
+        allow_pt_upgrades,
+        any_private_indexer,
         custom_query_tokens,
         restrict_to_uploader,
         default_custom_query_tokens,

--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -261,16 +261,10 @@ async fn run_auto_search_targets_with_upgrades(
         crate::services::source::ClassificationResult,
     >,
 ) -> Result<auto_search::AutoSearchReport, (axum::http::StatusCode, String)> {
-    let qbit = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let qbit = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
 
     let cfg = config::get_config(&state.db)
         .await

--- a/src/handlers/library/search/grab.rs
+++ b/src/handlers/library/search/grab.rs
@@ -64,16 +64,10 @@ pub async fn grab_batch_result(
         ));
     }
 
-    let qbit = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let qbit = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
 
     // Same selective-file path as `grab_interactive_result`: narrow
     // a megapack to just the target if it has its own subtitle or
@@ -273,16 +267,10 @@ pub async fn grab_interactive_result(
         ));
     }
 
-    let qbit = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let qbit = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
 
     // If the target is a multi-part entry ("Kizumonogatari II") OR a
     // subtitled season of a franchise ("Stardust Crusaders"), try the

--- a/src/handlers/library/search/grab.rs
+++ b/src/handlers/library/search/grab.rs
@@ -64,7 +64,7 @@ pub async fn grab_batch_result(
         ));
     }
 
-    let qbit = state.default_download_client().await.ok_or((
+    let (qbit, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -162,6 +162,14 @@ pub async fn grab_batch_result(
         .await
         .ok()
         .flatten();
+        if let Some(gid) = grab_id {
+            let _ = crate::models::grabbed_torrents::set_download_client(
+                &state.db,
+                gid,
+                Some(dispatch_client_id),
+            )
+            .await;
+        }
         for ep_num in &ep_nums {
             let _ = episode_tags::record_grab(
                 &state.db,
@@ -267,7 +275,7 @@ pub async fn grab_interactive_result(
         ));
     }
 
-    let qbit = state.default_download_client().await.ok_or((
+    let (qbit, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -356,7 +364,7 @@ pub async fn grab_interactive_result(
 
     if let Some(sid) = series_id {
         // Interactive single-episode grab — not a batch by definition.
-        let _ = crate::models::grabbed_torrents::record_grab(
+        let grab_id = crate::models::grabbed_torrents::record_grab(
             &state.db,
             &info_hash,
             &title,
@@ -364,7 +372,17 @@ pub async fn grab_interactive_result(
             &[episode_number],
             false,
         )
-        .await;
+        .await
+        .ok()
+        .flatten();
+        if let Some(gid) = grab_id {
+            let _ = crate::models::grabbed_torrents::set_download_client(
+                &state.db,
+                gid,
+                Some(dispatch_client_id),
+            )
+            .await;
+        }
         let _ = episode_tags::record_grab(
             &state.db,
             sid,

--- a/src/handlers/library/search/interactive.rs
+++ b/src/handlers/library/search/interactive.rs
@@ -90,33 +90,27 @@ pub async fn search_batch_releases(
     )
     .await;
 
-    let qbit = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or({
-                if let Some(h) = &progress_handle {
-                    // Fire-and-forget: we're about to Err-return, so the
-                    // toast is the only surface that tells the user why.
-                    let h = h.clone();
-                    tokio::spawn(async move {
-                        h.emit(
-                            "error",
-                            "error",
-                            "Download client not configured",
-                            None,
-                            true,
-                        )
-                        .await;
-                    });
-                }
-                (
-                    axum::http::StatusCode::BAD_REQUEST,
-                    "Download client not configured".to_string(),
+    let qbit = state.default_download_client().await.ok_or({
+        if let Some(h) = &progress_handle {
+            // Fire-and-forget: we're about to Err-return, so the
+            // toast is the only surface that tells the user why.
+            let h = h.clone();
+            tokio::spawn(async move {
+                h.emit(
+                    "error",
+                    "error",
+                    "Download client not configured",
+                    None,
+                    true,
                 )
-            })?
-            .clone()
-    };
+                .await;
+            });
+        }
+        (
+            axum::http::StatusCode::BAD_REQUEST,
+            "Download client not configured".to_string(),
+        )
+    })?;
 
     match best {
         None => {

--- a/src/handlers/radarr_compat/system.rs
+++ b/src/handlers/radarr_compat/system.rs
@@ -75,7 +75,7 @@ pub async fn create_tag(Json(body): Json<TagBody>) -> Json<Tag> {
 pub async fn list_download_clients(
     State(state): State<AppState>,
 ) -> Json<Vec<DownloadClientEntry>> {
-    let client = state.download_client.read().await.clone();
+    let client = state.default_download_client().await;
     let Some(client) = client else {
         return Json(vec![]);
     };

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -279,7 +279,7 @@ pub async fn grab_release(
     State(state): State<AppState>,
     Json(form): Json<GrabForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = state.default_download_client().await.ok_or((
+    let (client, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -349,6 +349,14 @@ pub async fn grab_release(
             .await
             .ok()
             .flatten();
+            if let Some(gid) = grab_id {
+                let _ = crate::models::grabbed_torrents::set_download_client(
+                    &state_task.db,
+                    gid,
+                    Some(dispatch_client_id),
+                )
+                .await;
+            }
 
             // Populate episode_quality_tags so the series page shows
             // each grabbed episode in 'grabbed' state right away.

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -279,16 +279,10 @@ pub async fn grab_release(
     State(state): State<AppState>,
     Json(form): Json<GrabForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let client = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
 
     let form_hash = form.info_hash.clone().unwrap_or_default();
     let info_hash = if !form_hash.is_empty() {
@@ -479,16 +473,10 @@ pub async fn get_torrents(
     Json<Vec<crate::services::download_client::DownloadItem>>,
     (axum::http::StatusCode, String),
 > {
-    let client = {
-        let guard = state.download_client.read().await;
-        guard
-            .as_ref()
-            .ok_or((
-                axum::http::StatusCode::BAD_REQUEST,
-                "Download client not configured".to_string(),
-            ))?
-            .clone()
-    };
+    let client = state.default_download_client().await.ok_or((
+        axum::http::StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
 
     let torrents = client
         .list_scoped()

--- a/src/handlers/settings/download_clients.rs
+++ b/src/handlers/settings/download_clients.rs
@@ -282,12 +282,12 @@ pub struct DownloadClientTestForm {
 )]
 pub async fn settings_download_clients_test(
     Json(form): Json<DownloadClientTestForm>,
-) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, Json<serde_json::Value>)> {
     let url = form.url.trim();
     if url.is_empty() {
         return Err((
             axum::http::StatusCode::BAD_REQUEST,
-            serde_json::json!({"ok": false, "message": "URL required"}).to_string(),
+            Json(serde_json::json!({"ok": false, "message": "URL required"})),
         ));
     }
     let client: std::sync::Arc<dyn DownloadClient> = match form.kind.as_str() {
@@ -317,11 +317,10 @@ pub async fn settings_download_clients_test(
         other => {
             return Err((
                 axum::http::StatusCode::BAD_REQUEST,
-                serde_json::json!({
+                Json(serde_json::json!({
                     "ok": false,
                     "message": format!("Unknown client kind: {other}"),
-                })
-                .to_string(),
+                })),
             ));
         }
     };
@@ -329,11 +328,11 @@ pub async fn settings_download_clients_test(
     match client.test().await {
         Ok(version) => Ok(Json(serde_json::json!({
             "ok": true,
-            "message": format!("Connected — {version}"),
+            "message": format!("Connected; {version}"),
         }))),
         Err(err) => Err((
             axum::http::StatusCode::BAD_GATEWAY,
-            serde_json::json!({"ok": false, "message": err}).to_string(),
+            Json(serde_json::json!({"ok": false, "message": err})),
         )),
     }
 }

--- a/src/handlers/settings/download_clients.rs
+++ b/src/handlers/settings/download_clients.rs
@@ -1,0 +1,665 @@
+//! Settings → Connections → Downloads CRUD handlers (multi-client
+//! refactor). Companion module to `models::download_clients`.
+//!
+//! Surface mirrors the indexers handler shape: form-driven upsert +
+//! delete + set-default that redirect back to the Connections tab.
+//! A separate JSON test endpoint at `/api/download-clients/test`
+//! lets the user verify a configuration before saving without
+//! mutating any DB row.
+
+use axum::{
+    Form, Json,
+    extract::State,
+    response::{IntoResponse, Redirect, Response},
+};
+use serde::Deserialize;
+
+use crate::AppState;
+use crate::models::download_clients::{DownloadClientForm, delete, insert, set_default, update};
+use crate::models::log::LogCategory;
+use crate::services::download_client::{
+    DownloadClient, deluge, qbittorrent, rtorrent, transmission,
+};
+use crate::services::logger;
+
+/// `kind` discriminators accepted on the form. Mirrors the values
+/// `services::download_client::rebuild_clients_cache` dispatches on
+/// — keep these strings in sync if a new client is added.
+const KIND_QBITTORRENT: &str = "qbittorrent";
+const KIND_DELUGE: &str = "deluge";
+const KIND_TRANSMISSION: &str = "transmission";
+const KIND_RTORRENT: &str = "rtorrent";
+
+fn is_known_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        KIND_QBITTORRENT | KIND_DELUGE | KIND_TRANSMISSION | KIND_RTORRENT
+    )
+}
+
+/// Form payload for create/update. `id == None` creates a new row;
+/// `Some(n)` updates row `n`. Empty / unsanitized strings — the
+/// model layer trims and trims_end_matches('/') the URL +
+/// download_path before persisting.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct DownloadClientUpsertForm {
+    pub id: Option<i64>,
+    pub name: String,
+    pub kind: String,
+    pub url: String,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    /// Label / category — qBit category, Deluge label, etc.
+    #[serde(default)]
+    pub label: String,
+    #[serde(default)]
+    pub download_path: String,
+    /// Checkbox semantics: only POSTed when checked.
+    pub enabled: Option<String>,
+    pub is_default: Option<String>,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct DownloadClientIdForm {
+    pub id: i64,
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/download-clients/upsert",
+    tag = "Settings",
+    summary = "Create or update a download client",
+    description = "Form-driven upsert for the Connections → Downloads list. Creates a new row when `id` is omitted; updates the row identified by `id` otherwise. Validates kind ∈ {qbittorrent, deluge, transmission, rtorrent}. Refreshes the in-process pool so the new/edited client is usable on the next grab without a process restart.",
+    responses(
+        (status = 303, description = "Redirect back to the Connections tab"),
+    ),
+)]
+pub async fn settings_download_clients_upsert(
+    State(state): State<AppState>,
+    Form(form): Form<DownloadClientUpsertForm>,
+) -> Response {
+    let name = form.name.trim();
+    if name.is_empty() {
+        return Redirect::to("/settings?tab=integrations&err=Name+required").into_response();
+    }
+    if !is_known_kind(&form.kind) {
+        return Redirect::to("/settings?tab=integrations&err=Invalid+client+kind").into_response();
+    }
+    let url = form.url.trim();
+    if url.is_empty() {
+        return Redirect::to("/settings?tab=integrations&err=URL+required").into_response();
+    }
+    if reqwest::Url::parse(url).is_err() {
+        return Redirect::to("/settings?tab=integrations&err=Invalid+URL+syntax").into_response();
+    }
+
+    let payload = DownloadClientForm {
+        name,
+        kind: form.kind.as_str(),
+        url,
+        username: form.username.trim(),
+        password: &form.password,
+        label: form.label.trim(),
+        download_path: form.download_path.as_str(),
+        enabled: form.enabled.is_some(),
+        is_default: form.is_default.is_some(),
+    };
+
+    let result = match form.id {
+        Some(id) => update(&state.db, id, payload).await.map(|_| id),
+        None => insert(&state.db, payload).await,
+    };
+
+    match result {
+        Ok(id) => {
+            let verb = if form.id.is_some() {
+                "updated"
+            } else {
+                "added"
+            };
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Download client {verb}: {name} ({})", form.kind),
+                &format!("id={id}"),
+            )
+            .await;
+            crate::services::download_client::rebuild_clients_cache(
+                &state.download_clients,
+                &state.db,
+            )
+            .await;
+            let msg = urlencoding::encode(&format!("Download client '{name}' {verb}")).into_owned();
+            Redirect::to(&format!("/settings?tab=integrations&msg={msg}")).into_response()
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Download client upsert failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to("/settings?tab=integrations&err=Save+failed").into_response()
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/download-clients/delete",
+    tag = "Settings",
+    summary = "Delete a download client",
+    description = "Removes the download_clients row by id. Indexer pins (`indexers.download_client_id`) and the Nyaa pin (`config.nyaa_download_client_id`) that referenced it are NULLed in the same transaction so dangling pins don't silently fall through to the default at grab time.",
+    responses(
+        (status = 303, description = "Redirect back to the Connections tab"),
+    ),
+)]
+pub async fn settings_download_clients_delete(
+    State(state): State<AppState>,
+    Form(form): Form<DownloadClientIdForm>,
+) -> Redirect {
+    let display_name = crate::models::download_clients::get_by_id(&state.db, form.id)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.name)
+        .unwrap_or_else(|| format!("id={}", form.id));
+    match delete(&state.db, form.id).await {
+        Ok(_) => {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!("Download client deleted: {display_name} (id={})", form.id),
+                "",
+            )
+            .await;
+            crate::services::download_client::rebuild_clients_cache(
+                &state.download_clients,
+                &state.db,
+            )
+            .await;
+            crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
+            let msg = urlencoding::encode(&format!("Download client '{display_name}' deleted"))
+                .into_owned();
+            Redirect::to(&format!("/settings?tab=integrations&msg={msg}"))
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Download client delete failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to("/settings?tab=integrations&err=Delete+failed")
+        }
+    }
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/download-clients/set-default",
+    tag = "Settings",
+    summary = "Mark a download client as the default",
+    description = "Flips `is_default = 1` on the targeted row and clears the flag on every other row in one transaction. Used by the per-row \"Set default\" button on the Connections → Downloads list.",
+    responses(
+        (status = 303, description = "Redirect back to the Connections tab"),
+    ),
+)]
+pub async fn settings_download_clients_set_default(
+    State(state): State<AppState>,
+    Form(form): Form<DownloadClientIdForm>,
+) -> Redirect {
+    let display_name = crate::models::download_clients::get_by_id(&state.db, form.id)
+        .await
+        .ok()
+        .flatten()
+        .map(|r| r.name)
+        .unwrap_or_else(|| format!("id={}", form.id));
+    match set_default(&state.db, form.id).await {
+        Ok(_) => {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                &format!(
+                    "Default download client set: {display_name} (id={})",
+                    form.id
+                ),
+                "",
+            )
+            .await;
+            crate::services::download_client::rebuild_clients_cache(
+                &state.download_clients,
+                &state.db,
+            )
+            .await;
+            let msg =
+                urlencoding::encode(&format!("'{display_name}' is now the default")).into_owned();
+            Redirect::to(&format!("/settings?tab=integrations&msg={msg}"))
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Download client set-default failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to("/settings?tab=integrations&err=Save+failed")
+        }
+    }
+}
+
+/// JSON form for the inline "Test connection" button on the
+/// Connections → Downloads add/edit form. Doesn't touch the DB.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct DownloadClientTestForm {
+    pub kind: String,
+    pub url: String,
+    #[serde(default)]
+    pub username: String,
+    #[serde(default)]
+    pub password: String,
+    #[serde(default)]
+    pub label: String,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/download-clients/test",
+    tag = "System",
+    summary = "Test a download client configuration",
+    description = "Instantiates the requested client kind with the provided credentials and runs its `test()` method. Doesn't persist anything. The Connections → Downloads add/edit form calls this before saving so the user gets immediate feedback on bad URLs / wrong passwords / missing categories.",
+    request_body = DownloadClientTestForm,
+    responses(
+        (status = 200, description = "Connection successful", body = serde_json::Value),
+        (status = 400, description = "Unknown client kind"),
+        (status = 502, description = "Connection failed"),
+    ),
+)]
+pub async fn settings_download_clients_test(
+    Json(form): Json<DownloadClientTestForm>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    let url = form.url.trim();
+    if url.is_empty() {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            serde_json::json!({"ok": false, "message": "URL required"}).to_string(),
+        ));
+    }
+    let client: std::sync::Arc<dyn DownloadClient> = match form.kind.as_str() {
+        KIND_QBITTORRENT => std::sync::Arc::new(qbittorrent::QbitClient::new(
+            url,
+            form.username.trim(),
+            &form.password,
+            form.label.trim(),
+        )),
+        KIND_DELUGE => std::sync::Arc::new(deluge::DelugeClient::new(
+            url,
+            &form.password,
+            form.label.trim(),
+        )),
+        KIND_TRANSMISSION => std::sync::Arc::new(transmission::TransmissionClient::new(
+            url,
+            form.username.trim(),
+            &form.password,
+            form.label.trim(),
+        )),
+        KIND_RTORRENT => std::sync::Arc::new(rtorrent::RtorrentClient::new(
+            url,
+            form.username.trim(),
+            &form.password,
+            form.label.trim(),
+        )),
+        other => {
+            return Err((
+                axum::http::StatusCode::BAD_REQUEST,
+                serde_json::json!({
+                    "ok": false,
+                    "message": format!("Unknown client kind: {other}"),
+                })
+                .to_string(),
+            ));
+        }
+    };
+
+    match client.test().await {
+        Ok(version) => Ok(Json(serde_json::json!({
+            "ok": true,
+            "message": format!("Connected — {version}"),
+        }))),
+        Err(err) => Err((
+            axum::http::StatusCode::BAD_GATEWAY,
+            serde_json::json!({"ok": false, "message": err}).to_string(),
+        )),
+    }
+}
+
+/// Form payload for the small "Pin Nyaa to client" selector on
+/// the Indexers tab. Empty string = NULL (use default).
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct NyaaPinForm {
+    pub download_client_id: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/settings/indexers/nyaa-pin",
+    tag = "Settings",
+    summary = "Pin or unpin Nyaa to a specific download client",
+    description = "Sets `config.nyaa_download_client_id` to the selected client id, or NULL when no client is selected. The Indexers tab shows this as a small dropdown above the indexer list.",
+    responses(
+        (status = 303, description = "Redirect back to the Indexers tab"),
+    ),
+)]
+pub async fn settings_indexers_nyaa_pin(
+    State(state): State<AppState>,
+    Form(form): Form<NyaaPinForm>,
+) -> Redirect {
+    let pin: Option<i64> = form.download_client_id.as_deref().and_then(|s| {
+        let trimmed = s.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            trimmed.parse::<i64>().ok()
+        }
+    });
+    let result = sqlx::query("UPDATE config SET nyaa_download_client_id = ? WHERE id = 1")
+        .bind(pin)
+        .execute(&state.db)
+        .await;
+    match result {
+        Ok(_) => {
+            logger::info(
+                &state.db,
+                LogCategory::System,
+                "Nyaa pin updated",
+                &format!("download_client_id={pin:?}"),
+            )
+            .await;
+            Redirect::to("/settings?tab=indexers&msg=Nyaa+pin+updated")
+        }
+        Err(e) => {
+            logger::error(
+                &state.db,
+                LogCategory::System,
+                "Nyaa pin update failed",
+                &e.to_string(),
+            )
+            .await;
+            Redirect::to("/settings?tab=indexers&err=Save+failed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::download_clients::{DownloadClientForm, get_by_id, get_default, list_all};
+    use crate::test_support::{build_test_app_state, in_memory_pool};
+    use axum::extract::{Form, State};
+
+    fn upsert_form(id: Option<i64>, name: &str) -> DownloadClientUpsertForm {
+        DownloadClientUpsertForm {
+            id,
+            name: name.to_string(),
+            kind: "qbittorrent".to_string(),
+            url: "http://localhost:8080".to_string(),
+            username: "u".to_string(),
+            password: "p".to_string(),
+            label: "anime".to_string(),
+            download_path: "/downloads".to_string(),
+            enabled: Some("on".to_string()),
+            is_default: None,
+        }
+    }
+
+    fn extract_location(resp: axum::response::Response) -> String {
+        resp.headers()
+            .get("location")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.to_string())
+            .unwrap_or_default()
+    }
+
+    #[tokio::test]
+    async fn upsert_insert_persists_row_and_redirects_back() {
+        let db = in_memory_pool().await;
+        let state = build_test_app_state(db, None);
+        let resp = settings_download_clients_upsert(
+            State(state.clone()),
+            Form(upsert_form(None, "Local qBit")),
+        )
+        .await;
+        let location = extract_location(resp);
+        assert!(location.contains("tab=integrations"));
+        assert!(location.contains("msg="));
+
+        let rows = list_all(&state.db).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "Local qBit");
+        assert_eq!(rows[0].kind, "qbittorrent");
+    }
+
+    #[tokio::test]
+    async fn upsert_update_renames_existing_row() {
+        let db = in_memory_pool().await;
+        let id = crate::models::download_clients::insert(
+            &db,
+            DownloadClientForm {
+                name: "Original",
+                kind: "qbittorrent",
+                url: "http://localhost:8080",
+                username: "",
+                password: "",
+                label: "",
+                download_path: "",
+                enabled: true,
+                is_default: false,
+            },
+        )
+        .await
+        .unwrap();
+        let state = build_test_app_state(db, None);
+        let _ = settings_download_clients_upsert(
+            State(state.clone()),
+            Form(upsert_form(Some(id), "Renamed")),
+        )
+        .await;
+        let row = get_by_id(&state.db, id).await.unwrap().unwrap();
+        assert_eq!(row.name, "Renamed");
+    }
+
+    #[tokio::test]
+    async fn upsert_rejects_invalid_kind() {
+        let db = in_memory_pool().await;
+        let state = build_test_app_state(db, None);
+        let mut form = upsert_form(None, "Bad");
+        form.kind = "premiumize".to_string();
+        let resp = settings_download_clients_upsert(State(state.clone()), Form(form)).await;
+        let location = extract_location(resp);
+        assert!(location.contains("err=Invalid+client+kind"));
+        assert_eq!(list_all(&state.db).await.unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn upsert_rejects_blank_name() {
+        let db = in_memory_pool().await;
+        let state = build_test_app_state(db, None);
+        let resp =
+            settings_download_clients_upsert(State(state.clone()), Form(upsert_form(None, "  ")))
+                .await;
+        assert!(extract_location(resp).contains("err=Name+required"));
+    }
+
+    #[tokio::test]
+    async fn upsert_rejects_malformed_url() {
+        let db = in_memory_pool().await;
+        let state = build_test_app_state(db, None);
+        let mut form = upsert_form(None, "qbit");
+        form.url = "not a url".into();
+        let resp = settings_download_clients_upsert(State(state), Form(form)).await;
+        assert!(extract_location(resp).contains("err=Invalid+URL+syntax"));
+    }
+
+    #[tokio::test]
+    async fn delete_removes_row_and_nulls_indexer_pins() {
+        let db = in_memory_pool().await;
+        let id = crate::models::download_clients::insert(
+            &db,
+            DownloadClientForm {
+                name: "X",
+                kind: "qbittorrent",
+                url: "http://x",
+                username: "",
+                password: "",
+                label: "",
+                download_path: "",
+                enabled: true,
+                is_default: true,
+            },
+        )
+        .await
+        .unwrap();
+        // Pin an indexer to the soon-to-be-deleted client.
+        crate::models::indexers::insert(
+            &db,
+            crate::models::indexers::IndexerForm {
+                name: "AB",
+                kind: crate::models::indexers::KIND_TORZNAB,
+                url: "https://prowlarr.local/1/api",
+                api_key: "k",
+                priority: 25,
+                enabled: true,
+                is_private_tracker: true,
+                seed_ratio: None,
+                seed_time_minutes: None,
+                min_seeders: 0,
+                request_timeout_secs: None,
+                download_client_id: Some(id),
+            },
+        )
+        .await
+        .unwrap();
+        let state = build_test_app_state(db, None);
+        let _ = settings_download_clients_delete(
+            State(state.clone()),
+            Form(DownloadClientIdForm { id }),
+        )
+        .await;
+        assert!(get_by_id(&state.db, id).await.unwrap().is_none());
+        let pin: Option<i64> =
+            sqlx::query_scalar("SELECT download_client_id FROM indexers WHERE name = 'AB'")
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert!(
+            pin.is_none(),
+            "indexer pin must be NULLed when client deleted"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_default_promotes_one_row_and_demotes_others() {
+        let db = in_memory_pool().await;
+        let a = crate::models::download_clients::insert(
+            &db,
+            DownloadClientForm {
+                name: "A",
+                kind: "qbittorrent",
+                url: "http://a",
+                username: "",
+                password: "",
+                label: "",
+                download_path: "",
+                enabled: true,
+                is_default: true,
+            },
+        )
+        .await
+        .unwrap();
+        let b = crate::models::download_clients::insert(
+            &db,
+            DownloadClientForm {
+                name: "B",
+                kind: "deluge",
+                url: "http://b",
+                username: "",
+                password: "",
+                label: "",
+                download_path: "",
+                enabled: true,
+                is_default: false,
+            },
+        )
+        .await
+        .unwrap();
+        let state = build_test_app_state(db, None);
+        let _ = settings_download_clients_set_default(
+            State(state.clone()),
+            Form(DownloadClientIdForm { id: b }),
+        )
+        .await;
+        let default_row = get_default(&state.db).await.unwrap().unwrap();
+        assert_eq!(default_row.id, b);
+        let a_row = get_by_id(&state.db, a).await.unwrap().unwrap();
+        assert!(!a_row.is_default);
+    }
+
+    #[tokio::test]
+    async fn nyaa_pin_persists_id_when_set_and_clears_when_blank() {
+        let db = in_memory_pool().await;
+        let id = crate::models::download_clients::insert(
+            &db,
+            DownloadClientForm {
+                name: "qbit",
+                kind: "qbittorrent",
+                url: "http://qbit",
+                username: "",
+                password: "",
+                label: "",
+                download_path: "",
+                enabled: true,
+                is_default: false,
+            },
+        )
+        .await
+        .unwrap();
+        // Ensure config row exists (built-test-app-state doesn't seed one).
+        let _ = sqlx::query("INSERT OR IGNORE INTO config (id) VALUES (1)")
+            .execute(&db)
+            .await;
+        let state = build_test_app_state(db, None);
+
+        let _ = settings_indexers_nyaa_pin(
+            State(state.clone()),
+            Form(NyaaPinForm {
+                download_client_id: Some(id.to_string()),
+            }),
+        )
+        .await;
+        let pinned: Option<i64> =
+            sqlx::query_scalar("SELECT nyaa_download_client_id FROM config WHERE id = 1")
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert_eq!(pinned, Some(id));
+
+        let _ = settings_indexers_nyaa_pin(
+            State(state.clone()),
+            Form(NyaaPinForm {
+                download_client_id: Some(String::new()),
+            }),
+        )
+        .await;
+        let pinned: Option<i64> =
+            sqlx::query_scalar("SELECT nyaa_download_client_id FROM config WHERE id = 1")
+                .fetch_one(&state.db)
+                .await
+                .unwrap();
+        assert!(pinned.is_none());
+    }
+}

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -39,6 +39,10 @@ pub struct IndexerUpsertForm {
     pub seed_time_minutes: Option<String>,
     pub min_seeders: Option<String>,
     pub request_timeout_secs: Option<String>,
+    /// Multi-client routing pin — id of the row in
+    /// `download_clients` this indexer routes to. Empty
+    /// string = NULL (use the default client at grab time).
+    pub download_client_id: Option<String>,
 }
 
 #[derive(Deserialize, utoipa::ToSchema)]
@@ -98,6 +102,7 @@ pub async fn settings_indexers_upsert(
         seed_time_minutes: parse_optional_i64(&form.seed_time_minutes),
         min_seeders,
         request_timeout_secs,
+        download_client_id: parse_optional_i64(&form.download_client_id),
     };
 
     let result = match form.id {
@@ -333,6 +338,7 @@ mod tests {
                 seed_time_minutes: None,
                 min_seeders: Some("1".to_string()),
                 request_timeout_secs: None,
+                download_client_id: None,
             }
         }
 
@@ -370,6 +376,7 @@ mod tests {
                     seed_time_minutes: None,
                     min_seeders: 1,
                     request_timeout_secs: None,
+                    download_client_id: None,
                 },
             )
             .await
@@ -403,6 +410,7 @@ mod tests {
                     seed_time_minutes: None,
                     min_seeders: 1,
                     request_timeout_secs: None,
+                    download_client_id: None,
                 },
             )
             .await

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -19,6 +19,7 @@ use crate::services::{
 
 pub mod autobrr_key;
 pub mod custom_formats;
+pub mod download_clients;
 pub mod indexers;
 use custom_formats::ImportReviewView;
 
@@ -169,6 +170,14 @@ struct SettingsTemplate {
     /// generic blank form (which is what the user sees if
     /// they bypass the picker).
     indexer_seed: Option<&'static crate::services::indexer_catalog::SeededIndexer>,
+    /// Multi-client refactor — every configured download client
+    /// for the Connections tab list. Sorted default-first then
+    /// case-insensitive by name (see `models::download_clients::list_all`).
+    download_clients: Vec<crate::models::download_clients::DownloadClientRow>,
+    /// Prefill for the Edit Download Client form when
+    /// `?tab=integrations&edit_id=N` is set. Mirrors the
+    /// `indexer_edit` pattern. `None` renders the bare Add form.
+    download_client_edit: Option<crate::models::download_clients::DownloadClientRow>,
 }
 
 /// Safe-to-render projection of `ExternalAccount`. Holds everything
@@ -597,13 +606,22 @@ async fn build_settings_template(
     // account — in parallel. The old code issued them sequentially so
     // the wall time was the sum of N round trips even though none
     // depends on the others.
-    let (cfg_res, groups, suggestions, custom_formats, external_account_res, indexers_res) = tokio::join!(
+    let (
+        cfg_res,
+        groups,
+        suggestions,
+        custom_formats,
+        external_account_res,
+        indexers_res,
+        download_clients_res,
+    ) = tokio::join!(
         config::get_config(&state.db),
         load_groups(&state.db),
         load_suggestions(&state.db),
         load_custom_formats_view(&state.db),
         crate::models::external_accounts::get_current(&state.db),
         crate::models::indexers::list_all(&state.db),
+        crate::models::download_clients::list_all(&state.db),
     );
     let cfg = cfg_res.ok().flatten().unwrap_or_default();
     // A decrypt failure (tampered blob, key rotation without migration)
@@ -657,6 +675,11 @@ async fn build_settings_template(
     } else {
         None
     };
+    let download_clients = download_clients_res.unwrap_or_default();
+    let download_client_edit = match edit_id {
+        Some(id) => download_clients.iter().find(|r| r.id == id).cloned(),
+        None => None,
+    };
     SettingsTemplate {
         page: "settings".to_string(),
         tab: normalize_settings_tab(tab),
@@ -676,6 +699,8 @@ async fn build_settings_template(
         indexer_edit,
         indexer_catalog: crate::services::indexer_catalog::SEEDED,
         indexer_seed,
+        download_clients,
+        download_client_edit,
     }
 }
 
@@ -923,6 +948,12 @@ pub async fn settings_submit(
                 .as_ref()
                 .map(|c| c.external_sync_interval_minutes),
         ),
+        // The Nyaa pin is owned by the dedicated `/settings/indexers/nyaa-pin`
+        // endpoint, not the bulk save form. Preserve whatever the existing
+        // row holds so a Settings save on any tab doesn't clobber it.
+        nyaa_download_client_id: existing_cfg
+            .as_ref()
+            .and_then(|c| c.nyaa_download_client_id),
     };
 
     let active_tab = normalize_settings_tab(form.tab.clone());
@@ -948,6 +979,9 @@ pub async fn settings_submit(
         let indexers = crate::models::indexers::list_all(&state.db)
             .await
             .unwrap_or_default();
+        let download_clients = crate::models::download_clients::list_all(&state.db)
+            .await
+            .unwrap_or_default();
         let template = SettingsTemplate {
             page: "settings".to_string(),
             tab: active_tab,
@@ -967,6 +1001,8 @@ pub async fn settings_submit(
             indexers,
             indexer_catalog: crate::services::indexer_catalog::SEEDED,
             indexer_seed: None,
+            download_clients,
+            download_client_edit: None,
         };
         return Html(template.render().unwrap_or_default());
     }
@@ -974,250 +1010,25 @@ pub async fn settings_submit(
     logger::info(&state.db, LogCategory::System, "Settings saved", "").await;
     let mut notices: Vec<String> = vec!["Settings saved.".to_string()];
 
-    // #63 Phase 2 — client-switch handling. If the user changed
-    // `active_client` on this save, any `grabbed_torrents` rows still
-    // in `state='pending'` point at the OLD client (Ryokan is about
-    // to stop talking to it). Three things need to happen, in order:
-    //
-    //   1. **Delete only the in-flight torrents from the OLD client.**
-    //      An `state='pending'` row at this point is either
-    //      mid-download OR complete-but-not-yet-imported. Deleting
-    //      the mid-download ones is the user's intent ("cancel my
-    //      in-flight grabs"). Deleting the completed-but-not-yet-
-    //      imported ones would wipe finished files the user almost
-    //      certainly wants to keep — they're identical to an already-
-    //      imported torrent from the user's perspective; the only
-    //      difference is post-processing didn't happen to run yet.
-    //      So we gate the delete on `!is_complete()` from the old
-    //      client's view.
-    //
-    //   2. **Mark ALL pending rows as `failed` regardless of delete
-    //      outcome.** The old client is about to disappear from
-    //      AppState; Ryokan can't track these grabs anymore. They
-    //      need to drop out of the partial UNIQUE index on `(hash)
-    //      WHERE state IN ('pending','imported')` so a re-grab in
-    //      the new client can't dedupe against them. Completed
-    //      torrents the user wants to keep stay on the old client's
-    //      disk; Ryokan just forgets about them. The user can still
-    //      see the files manually.
-    //
-    //   3. **Swap the AppState Arc** (further down in the
-    //      `active_tab == "integrations"` block).
-    //
-    // Delete happens BEFORE the Arc swap because the read lock still
-    // holds the OLD client's Arc at this point.
-    if active_tab == "integrations"
-        && let Some(old) = existing_cfg.as_ref()
-        && old.active_client != cfg.active_client
-    {
-        let pending = crate::models::grabbed_torrents::get_all_pending(&state.db)
-            .await
-            .unwrap_or_default();
-
-        if !pending.is_empty()
-            && let Some(old_client) = state.download_client.read().await.clone()
-        {
-            // Build a hash → state_kind map from the old client's
-            // current view. `list_scoped` returns only Ryokan-owned
-            // torrents, which is a superset of our pending grabs in
-            // the steady state. Failure to fetch == treat as empty
-            // map (can't determine completion); we'll skip deletion
-            // to be safe and let the user clean up manually, and
-            // surface that in the UI notice so they know to look.
-            let list_scoped_result = old_client.list_scoped().await;
-            let list_scoped_failed = list_scoped_result.is_err();
-            let states: std::collections::HashMap<
-                String,
-                crate::services::download_client::DownloadItemState,
-            > = list_scoped_result
-                .unwrap_or_default()
-                .into_iter()
-                .map(|t| (t.hash.to_lowercase(), t.state_kind))
-                .collect();
-
-            if list_scoped_failed {
-                notices.push(format!(
-                    "Couldn't reach {} to cancel in-flight torrents — verify and clean up manually if any were still downloading.",
-                    old.active_client,
-                ));
-            }
-
-            let mut deleted = 0usize;
-            let mut skipped_complete = 0usize;
-            let mut delete_failures: Vec<String> = Vec::new();
-            for grab in &pending {
-                if grab.hash.is_empty() {
-                    continue;
-                }
-                let hash_lc = grab.hash.to_lowercase();
-                // Only delete the torrent if the old client reports
-                // it's NOT complete. Missing from the map (e.g. user
-                // already deleted it manually in the old client, or
-                // `list_scoped` failed) also skips deletion — we'd
-                // rather leave a dangling download-client row than
-                // delete a completed file the user wanted to keep.
-                match states.get(&hash_lc) {
-                    Some(state) if !state.is_complete() => {
-                        match old_client.delete(&hash_lc, true).await {
-                            Ok(()) => deleted += 1,
-                            Err(e) => delete_failures.push(format!("{}: {}", grab.torrent_name, e)),
-                        }
-                    }
-                    Some(_) => skipped_complete += 1,
-                    None => {
-                        // Not in the old client's list. Could be
-                        // already manually removed, could be that
-                        // list_scoped failed. Either way, skip
-                        // deletion — no action we can take that's
-                        // safer than leaving it alone.
-                    }
-                }
-            }
-            if deleted > 0 {
-                logger::info(
-                    &state.db,
-                    LogCategory::System,
-                    &format!(
-                        "Cancelled {deleted} in-flight grab(s) from {} during client switch",
-                        old.active_client
-                    ),
-                    "",
-                )
-                .await;
-            }
-            if skipped_complete > 0 {
-                logger::info(
-                    &state.db,
-                    LogCategory::System,
-                    &format!(
-                        "Left {skipped_complete} completed grab(s) on {} intact during client switch — files preserved",
-                        old.active_client
-                    ),
-                    "",
-                )
-                .await;
-            }
-            if !delete_failures.is_empty() {
-                logger::warn(
-                    &state.db,
-                    LogCategory::System,
-                    &format!(
-                        "{} in-flight grab(s) could not be deleted from {} — DB state still flipped",
-                        delete_failures.len(),
-                        old.active_client
-                    ),
-                    &delete_failures.join("; "),
-                )
-                .await;
-            }
-        }
-
-        let n = crate::models::grabbed_torrents::mark_all_pending_failed(&state.db)
-            .await
-            .unwrap_or(0);
-
-        // Clear the per-episode "grabbed" UI state for every canceled
-        // grab. `grabbed_torrents.state='failed'` alone isn't enough —
-        // the series page reads `episode_quality_tags.state` for the
-        // UI checkmark / badge, and the existing manual-cancel paths
-        // (`handlers::library::episodes::cancel_pending_episode`,
-        // `services::post_processing::run_once_inner` on stale-torrent
-        // reconciliation) both call `episode_tags::clear_tags_for_removal`
-        // alongside their mark-removed calls. The client-switch path
-        // has to mirror that: without this, episodes sit forever in
-        // "grabbed" state with no backing torrent.
-        for grab in &pending {
-            let _ = crate::models::episode_tags::clear_tags_for_removal(
-                &state.db,
-                grab.series_id,
-                &grab.episode_numbers,
-            )
-            .await;
-        }
-
-        if n > 0 {
-            logger::info(
-                &state.db,
-                LogCategory::System,
-                &format!("Marked {n} pending grabs as failed after client switch"),
-                &format!("old={}, new={}", old.active_client, cfg.active_client),
-            )
-            .await;
-            notices.push(format!(
-                "Client changed from {} to {}; {n} pending grab{} released (in-flight downloads cancelled on {}; any completed files preserved).",
-                old.active_client,
-                cfg.active_client,
-                if n == 1 { "" } else { "s" },
-                old.active_client,
-            ));
-        }
-    }
+    // Multi-client routing — client switching now happens through
+    // the dedicated `/settings/download-clients/*` CRUD endpoints,
+    // not through the bulk Settings save. Pending-grab cancellation
+    // on row delete / disable lives in those handlers instead.
+    // The legacy single-slot switch detection that used to live
+    // here is gone — `cfg.active_client` is no longer the source
+    // of truth, and the bulk POST doesn't change download-client
+    // routing as a side effect.
+    let _ = &existing_cfg; // legacy compat: still read elsewhere
 
     if active_tab == "integrations" {
-        let (client_label, configured, client_url) = match cfg.active_client.as_str() {
-            "deluge" => (
-                "Deluge",
-                !cfg.deluge_url.is_empty(),
-                cfg.deluge_url.as_str(),
-            ),
-            "transmission" => (
-                "Transmission",
-                !cfg.transmission_url.is_empty(),
-                cfg.transmission_url.as_str(),
-            ),
-            "rtorrent" => (
-                "rTorrent",
-                !cfg.rtorrent_url.is_empty(),
-                cfg.rtorrent_url.as_str(),
-            ),
-            _ => (
-                "qBittorrent",
-                !cfg.qbit_url.is_empty(),
-                cfg.qbit_url.as_str(),
-            ),
-        };
-        if configured {
-            let client = crate::services::download_client::build_download_client(&cfg);
-            if let Some(client) = client {
-                match client.test().await {
-                    Ok(version) => {
-                        // `LogCategory::QBit` is reused here for
-                        // every download client for now — log
-                        // message body carries the real client name
-                        // in "Connected to X Y.Z", so filtering by
-                        // category still surfaces the events. A
-                        // dedicated `LogCategory::DownloadClient`
-                        // would be cleaner but churns every existing
-                        // qBit log entry's category too; Phase 3
-                        // cleanup.
-                        logger::info(
-                            &state.db,
-                            LogCategory::QBit,
-                            &format!("Connected to {client_label} {version}"),
-                            client_url,
-                        )
-                        .await;
-                        notices.push(format!("{client_label} connected ({version})."));
-                        *state.download_client.write().await = Some(client);
-                    }
-                    Err(e) => {
-                        logger::error(
-                            &state.db,
-                            LogCategory::QBit,
-                            &format!("{client_label} connection failed"),
-                            &e,
-                        )
-                        .await;
-                        *state.download_client.write().await = None;
-                        notices.push(format!("{client_label} connection failed: {e}."));
-                    }
-                }
-            } else {
-                *state.download_client.write().await = None;
-            }
-        } else {
-            *state.download_client.write().await = None;
-        }
+        // Multi-client routing: download-client edits go through
+        // dedicated `/settings/download-clients/*` CRUD endpoints
+        // (which call `rebuild_clients_cache` themselves). The
+        // legacy single-slot test-on-save logic is gone — the
+        // bulk settings POST no longer touches client state. We
+        // keep the legacy `qbit_url` etc. form fields wired so a
+        // user with a stale browser tab doesn't blank them out
+        // on save, but they don't drive runtime behavior.
 
         if !cfg.jellyfin_url.is_empty() && !cfg.jellyfin_api_key.is_empty() {
             let client = JellyfinClient::new(&cfg.jellyfin_url, &cfg.jellyfin_api_key);
@@ -1272,6 +1083,9 @@ pub async fn settings_submit(
     let indexers = crate::models::indexers::list_all(&state.db)
         .await
         .unwrap_or_default();
+    let download_clients = crate::models::download_clients::list_all(&state.db)
+        .await
+        .unwrap_or_default();
     let template = SettingsTemplate {
         page: "settings".to_string(),
         tab: active_tab,
@@ -1296,6 +1110,8 @@ pub async fn settings_submit(
         indexers,
         indexer_catalog: crate::services::indexer_catalog::SEEDED,
         indexer_seed: None,
+        download_clients,
+        download_client_edit: None,
     };
     Html(template.render().unwrap_or_default())
 }
@@ -1472,7 +1288,7 @@ pub async fn jellyfin_test(
 )]
 pub async fn api_health(State(state): State<AppState>) -> Json<serde_json::Value> {
     let download_client_status = {
-        let client = state.download_client.read().await.clone();
+        let client = state.default_download_client().await;
         match client {
             Some(c) => {
                 // Emit `type` on both Ok and Err so the template JS
@@ -2169,6 +1985,7 @@ mod tests {
                     seed_time_minutes: None,
                     min_seeders: 1,
                     request_timeout_secs: None,
+                    download_client_id: None,
                 },
             )
             .await

--- a/src/handlers/sonarr_compat/system.rs
+++ b/src/handlers/sonarr_compat/system.rs
@@ -73,7 +73,7 @@ pub async fn list_tags() -> Json<Vec<Tag>> {
 pub async fn list_download_clients(
     State(state): State<AppState>,
 ) -> Json<Vec<DownloadClientEntry>> {
-    let client = state.download_client.read().await.clone();
+    let client = state.default_download_client().await;
     let Some(client) = client else {
         return Json(vec![]);
     };

--- a/src/handlers/webhook/autobrr.rs
+++ b/src/handlers/webhook/autobrr.rs
@@ -327,8 +327,8 @@ pub async fn webhook_autobrr(
     // to the default. `indexer_id` is `Some(_)` here because the
     // earlier guard returned `skipped()` if the indexer wasn't
     // configured.
-    let client = match state.client_for_indexer(indexer_id).await {
-        Some(c) => c,
+    let (client, dispatch_client_id) = match state.client_for_indexer_with_id(indexer_id).await {
+        Some(t) => t,
         None => {
             logger::error(
                 &state.db,
@@ -389,6 +389,12 @@ pub async fn webhook_autobrr(
         .await;
         let _ =
             grabbed_torrents::set_indexer_attribution(&state.db, gid, indexer_id, respected).await;
+        // Stamp the client this grab landed on so post-processing
+        // routes `list_scoped` / `get_files` to the same place. NULL
+        // would force fall-through to the current default — wrong
+        // when the grab actually went to a non-default client.
+        let _ =
+            grabbed_torrents::set_download_client(&state.db, gid, Some(dispatch_client_id)).await;
     }
 
     let outcome_label = match add_outcome {

--- a/src/handlers/webhook/autobrr.rs
+++ b/src/handlers/webhook/autobrr.rs
@@ -322,8 +322,12 @@ pub async fn webhook_autobrr(
     };
     let (series, ep_nums) = matched;
 
-    // Hand off to the download client.
-    let client = match state.download_client.read().await.as_ref().cloned() {
+    // Hand off to the download client. Multi-client routing —
+    // resolve via the matched indexer's pin first, then fall through
+    // to the default. `indexer_id` is `Some(_)` here because the
+    // earlier guard returned `skipped()` if the indexer wasn't
+    // configured.
+    let client = match state.client_for_indexer(indexer_id).await {
         Some(c) => c,
         None => {
             logger::error(

--- a/src/handlers/webhook/tests/autobrr.rs
+++ b/src/handlers/webhook/tests/autobrr.rs
@@ -43,6 +43,7 @@ async fn seed_indexer(db: &SqlitePool, name: &str) -> i64 {
             seed_time_minutes: None,
             min_seeders: 0,
             request_timeout_secs: None,
+            download_client_id: None,
         },
     )
     .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,13 +64,43 @@ use services::{
 /// instances on every per-target search.
 pub type IndexerCache = Arc<RwLock<Arc<Vec<Arc<dyn Indexer>>>>>;
 
+/// Multi-client routing — pair of (id-keyed map of live trait
+/// impls, default client id). Both swap atomically when the
+/// cache is rebuilt by [`services::download_client::rebuild_clients_cache`]
+/// on Settings → Connections → Downloads edits. Lookup at grab
+/// time is a `HashMap::get` against the inner `Arc` — read lock
+/// releases before the dispatch.
+///
+/// `default_id` is the row id of the `is_default = 1` row at
+/// build time. `None` when no client is configured (fresh
+/// install) or when every row was disabled. The pin-resolution
+/// helpers ([`AppState::client_for_indexer`] etc.) fall back to
+/// `default_id` when no pin matches.
+#[derive(Default)]
+pub struct DownloadClientPool {
+    pub clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>>,
+    pub default_id: Option<i64>,
+}
+
+/// Same swap-on-write shape as `IndexerCache` / `CompiledCfCache`
+/// — outer `RwLock` owns the swap; inner `Arc<DownloadClientPool>`
+/// is cheap-cloned out on the grab-dispatch path so the read
+/// lock releases before any HTTP calls.
+pub type DownloadClientsCache = Arc<RwLock<Arc<DownloadClientPool>>>;
+
 /// Shared application state available to all handlers. Lives in the
 /// library crate (rather than `main.rs`) so integration tests can
 /// build instances of it without depending on the binary.
 #[derive(Clone)]
 pub struct AppState {
     pub db: SqlitePool,
-    pub download_client: Arc<RwLock<Option<Arc<dyn DownloadClient>>>>,
+    /// Multi-client routing pool. Replaced the single-slot
+    /// `download_client` field — see [`DownloadClientPool`].
+    /// Rebuilt on Settings → Downloads add/edit/delete via
+    /// `services::download_client::rebuild_clients_cache`. Pin
+    /// resolution at grab time goes through
+    /// [`AppState::client_for_indexer`].
+    pub download_clients: DownloadClientsCache,
     pub jellyfin: Arc<RwLock<Option<JellyfinClient>>>,
     /// Compiled Custom Formats, loaded once at startup and rebuilt on
     /// CF create/update/delete via `custom_formats::rebuild_cf_cache`.
@@ -119,6 +149,69 @@ pub struct AppState {
     /// Ryokan was last restarted, which made the pill useless as a
     /// liveness signal.
     pub start_time: chrono::DateTime<chrono::Utc>,
+}
+
+impl AppState {
+    /// Resolve a download client for a grab attributable to
+    /// `indexer_id`. Pin chain:
+    ///
+    /// 1. The indexer row's `download_client_id`, if set.
+    /// 2. The pool's default client id.
+    /// 3. None — caller surfaces "no download client configured."
+    ///
+    /// Reads the indexer's pin from the `IndexerCache` snapshot
+    /// (no DB roundtrip on the grab path). Falls through to
+    /// the default when the pinned client id no longer exists
+    /// (e.g. user deleted the client without re-pinning the
+    /// indexer somehow — shouldn't happen because `delete()`
+    /// NULLs the pin, but the fall-through keeps grabs flowing
+    /// rather than 500ing).
+    pub async fn client_for_indexer(
+        &self,
+        indexer_id: Option<i64>,
+    ) -> Option<Arc<dyn DownloadClient>> {
+        let pool = self.download_clients.read().await.clone();
+        if let Some(id) = indexer_id {
+            // Look up the indexer's pin from the indexer cache.
+            let indexers = self.indexers.read().await.clone();
+            if let Some(idx) = indexers.iter().find(|i| i.id() == id)
+                && let Some(pinned) = idx.download_client_id()
+                && let Some(client) = pool.clients.get(&pinned)
+            {
+                return Some(client.clone());
+            }
+        }
+        // Fall through to default.
+        pool.default_id
+            .and_then(|id| pool.clients.get(&id).cloned())
+    }
+
+    /// Resolve a download client for the built-in Nyaa search
+    /// (no `indexers` row). Reads
+    /// `config.nyaa_download_client_id` and falls back to the
+    /// default. Caller must pass the current config so the
+    /// helper doesn't fire a DB query per grab.
+    pub async fn client_for_nyaa(&self, nyaa_pin: Option<i64>) -> Option<Arc<dyn DownloadClient>> {
+        let pool = self.download_clients.read().await.clone();
+        if let Some(pinned) = nyaa_pin
+            && let Some(client) = pool.clients.get(&pinned)
+        {
+            return Some(client.clone());
+        }
+        pool.default_id
+            .and_then(|id| pool.clients.get(&id).cloned())
+    }
+
+    /// Default client — used by paths that don't have an
+    /// indexer / Nyaa pin context (post-processing on a grab
+    /// whose indexer was deleted, manual grabs, etc.). Same
+    /// resolution as the helpers above with a None pin: just
+    /// the default.
+    pub async fn default_download_client(&self) -> Option<Arc<dyn DownloadClient>> {
+        let pool = self.download_clients.read().await.clone();
+        pool.default_id
+            .and_then(|id| pool.clients.get(&id).cloned())
+    }
 }
 
 impl FromRef<AppState> for SqlitePool {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,20 +170,33 @@ impl AppState {
         &self,
         indexer_id: Option<i64>,
     ) -> Option<Arc<dyn DownloadClient>> {
+        self.client_for_indexer_with_id(indexer_id)
+            .await
+            .map(|(c, _)| c)
+    }
+
+    /// Same resolution as [`Self::client_for_indexer`] but also
+    /// returns the resolved `download_clients.id` so callers can
+    /// stamp it on `grabbed_torrents.download_client_id`.
+    /// Post-processing routes per-grab through that id back to the
+    /// owning client.
+    pub async fn client_for_indexer_with_id(
+        &self,
+        indexer_id: Option<i64>,
+    ) -> Option<(Arc<dyn DownloadClient>, i64)> {
         let pool = self.download_clients.read().await.clone();
         if let Some(id) = indexer_id {
-            // Look up the indexer's pin from the indexer cache.
             let indexers = self.indexers.read().await.clone();
             if let Some(idx) = indexers.iter().find(|i| i.id() == id)
                 && let Some(pinned) = idx.download_client_id()
                 && let Some(client) = pool.clients.get(&pinned)
             {
-                return Some(client.clone());
+                return Some((client.clone(), pinned));
             }
         }
-        // Fall through to default.
-        pool.default_id
-            .and_then(|id| pool.clients.get(&id).cloned())
+        let default_id = pool.default_id?;
+        let client = pool.clients.get(&default_id)?.clone();
+        Some((client, default_id))
     }
 
     /// Resolve a download client for the built-in Nyaa search
@@ -192,14 +205,24 @@ impl AppState {
     /// default. Caller must pass the current config so the
     /// helper doesn't fire a DB query per grab.
     pub async fn client_for_nyaa(&self, nyaa_pin: Option<i64>) -> Option<Arc<dyn DownloadClient>> {
+        self.client_for_nyaa_with_id(nyaa_pin).await.map(|(c, _)| c)
+    }
+
+    /// Same resolution as [`Self::client_for_nyaa`] but also returns
+    /// the resolved `download_clients.id` for grab-row stamping.
+    pub async fn client_for_nyaa_with_id(
+        &self,
+        nyaa_pin: Option<i64>,
+    ) -> Option<(Arc<dyn DownloadClient>, i64)> {
         let pool = self.download_clients.read().await.clone();
         if let Some(pinned) = nyaa_pin
             && let Some(client) = pool.clients.get(&pinned)
         {
-            return Some(client.clone());
+            return Some((client.clone(), pinned));
         }
-        pool.default_id
-            .and_then(|id| pool.clients.get(&id).cloned())
+        let default_id = pool.default_id?;
+        let client = pool.clients.get(&default_id)?.clone();
+        Some((client, default_id))
     }
 
     /// Default client — used by paths that don't have an
@@ -208,9 +231,28 @@ impl AppState {
     /// resolution as the helpers above with a None pin: just
     /// the default.
     pub async fn default_download_client(&self) -> Option<Arc<dyn DownloadClient>> {
+        self.default_download_client_with_id().await.map(|(c, _)| c)
+    }
+
+    /// Same resolution as [`Self::default_download_client`] but also
+    /// returns the resolved id for grab-row stamping. Mirror of the
+    /// `_with_id` helpers above.
+    pub async fn default_download_client_with_id(&self) -> Option<(Arc<dyn DownloadClient>, i64)> {
         let pool = self.download_clients.read().await.clone();
-        pool.default_id
-            .and_then(|id| pool.clients.get(&id).cloned())
+        let default_id = pool.default_id?;
+        let client = pool.clients.get(&default_id)?.clone();
+        Some((client, default_id))
+    }
+
+    /// Look up a specific client by `download_clients.id`. Used by
+    /// post-processing's per-grab routing — `grabbed_torrents.download_client_id`
+    /// stamps the row, and this helper resolves it back to the live
+    /// client. Returns None when the row referenced was deleted from
+    /// the pool (e.g. user removed the client mid-import); caller
+    /// should fall back to default.
+    pub async fn client_by_id(&self, id: i64) -> Option<Arc<dyn DownloadClient>> {
+        let pool = self.download_clients.read().await.clone();
+        pool.clients.get(&id).cloned()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ use services::{
         handlers::library::crud::set_monitoring,
         handlers::library::crud::set_episode_monitoring,
         handlers::library::crud::set_allow_upgrades,
+        handlers::library::crud::set_allow_pt_upgrades,
         handlers::library::crud::set_search_overrides,
         handlers::library::crud::set_manual_override,
         handlers::library::crud::reclassify_episode,
@@ -545,6 +546,10 @@ async fn main() {
         .route(
             "/api/library/allow-upgrades",
             post(handlers::library::crud::set_allow_upgrades),
+        )
+        .route(
+            "/api/library/allow-pt-upgrades",
+            post(handlers::library::crud::set_allow_pt_upgrades),
         )
         .route(
             "/api/library/search-overrides",

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,12 @@ use services::{
         // Settings — Indexers (issue #28 PR B)
         handlers::settings::indexers::settings_indexers_upsert,
         handlers::settings::indexers::settings_indexers_delete,
+        // Settings — Download clients (multi-client refactor)
+        handlers::settings::download_clients::settings_download_clients_upsert,
+        handlers::settings::download_clients::settings_download_clients_delete,
+        handlers::settings::download_clients::settings_download_clients_set_default,
+        handlers::settings::download_clients::settings_download_clients_test,
+        handlers::settings::download_clients::settings_indexers_nyaa_pin,
         // Settings — autobrr API key rotation (issue #28 PR D)
         handlers::settings::autobrr_key::settings_autobrr_regenerate_key,
         // Webhooks (issue #28 PR D)
@@ -148,6 +154,10 @@ use services::{
         handlers::downloads::BlocklistRemoveForm,
         handlers::settings::QbitTestForm,
         handlers::settings::JellyfinTestForm,
+        handlers::settings::download_clients::DownloadClientUpsertForm,
+        handlers::settings::download_clients::DownloadClientIdForm,
+        handlers::settings::download_clients::DownloadClientTestForm,
+        handlers::settings::download_clients::NyaaPinForm,
         handlers::settings::custom_formats::CustomFormatUpsertForm,
         handlers::settings::custom_formats::CfTestRequest,
         handlers::settings::custom_formats::CustomFormatDeleteForm,
@@ -444,9 +454,11 @@ async fn main() {
     let indexers = services::indexers::rebuild_cache(&db).await;
 
     // Build shared state.
+    let download_clients: ryokan::DownloadClientsCache =
+        Arc::new(RwLock::new(Arc::new(ryokan::DownloadClientPool::default())));
     let state = AppState {
         db: db.clone(),
-        download_client: Arc::new(RwLock::new(None)),
+        download_clients: download_clients.clone(),
         jellyfin: Arc::new(RwLock::new(None)),
         custom_formats: cf_cache,
         indexers,
@@ -457,20 +469,20 @@ async fn main() {
         start_time: chrono::Utc::now(),
     };
 
-    // Initialize download client from saved config. Branches on
-    // `config.active_client` — the per-client credential columns
-    // (qbit_*, deluge_*) coexist on the same `config` row so a user
-    // can switch between them in Settings without losing the other's
-    // setup. Phase 3+ will add transmission/rtorrent arms here.
-    if let Ok(Some(config)) = models::config::get_config(&db).await {
-        let client = services::download_client::build_download_client(&config);
-        if client.is_some() {
-            *state.download_client.write().await = client;
-        }
-        if !config.jellyfin_url.is_empty() && !config.jellyfin_api_key.is_empty() {
-            let client = JellyfinClient::new(&config.jellyfin_url, &config.jellyfin_api_key);
-            *state.jellyfin.write().await = Some(client);
-        }
+    // Initialize the multi-client pool from `download_clients` rows.
+    // Pre-multi-client installs ran their migration's seed-default
+    // backfill at startup (above), so by the time this runs there
+    // should be either zero rows (fresh install — pool stays empty
+    // until the user adds a row in Settings → Connections →
+    // Downloads) or one row with `is_default = 1` mirroring the
+    // legacy `active_client` choice.
+    services::download_client::rebuild_clients_cache(&state.download_clients, &db).await;
+    if let Ok(Some(config)) = models::config::get_config(&db).await
+        && !config.jellyfin_url.is_empty()
+        && !config.jellyfin_api_key.is_empty()
+    {
+        let client = JellyfinClient::new(&config.jellyfin_url, &config.jellyfin_api_key);
+        *state.jellyfin.write().await = Some(client);
     }
 
     // Routes that don't require auth. The CSRF layer applies to POSTs here
@@ -707,6 +719,26 @@ async fn main() {
         .route(
             "/settings/indexers/delete",
             post(handlers::settings::indexers::settings_indexers_delete),
+        )
+        .route(
+            "/settings/indexers/nyaa-pin",
+            post(handlers::settings::download_clients::settings_indexers_nyaa_pin),
+        )
+        .route(
+            "/settings/download-clients/upsert",
+            post(handlers::settings::download_clients::settings_download_clients_upsert),
+        )
+        .route(
+            "/settings/download-clients/delete",
+            post(handlers::settings::download_clients::settings_download_clients_delete),
+        )
+        .route(
+            "/settings/download-clients/set-default",
+            post(handlers::settings::download_clients::settings_download_clients_set_default),
+        )
+        .route(
+            "/api/download-clients/test",
+            post(handlers::settings::download_clients::settings_download_clients_test),
         )
         .route(
             "/settings/autobrr/regenerate-key",

--- a/src/models/config.rs
+++ b/src/models/config.rs
@@ -137,6 +137,12 @@ pub struct Config {
     /// also enforces the range on input. No-op when no external
     /// account is linked, regardless of the value.
     pub external_sync_interval_minutes: i32,
+    /// Multi-client routing — id of the `download_clients` row to
+    /// route built-in Nyaa search hits through. `None` falls back
+    /// to whichever row holds `is_default = 1`. Surfaced as a
+    /// dropdown on the Indexers tab; stored alongside the row's
+    /// `download_client_id` pin to preserve the same shape.
+    pub nyaa_download_client_id: Option<i64>,
 }
 
 impl Default for Config {
@@ -197,6 +203,7 @@ impl Default for Config {
             default_restrict_to_uploader: String::new(),
             grab_preview_mode: "batches_only".to_string(),
             external_sync_interval_minutes: 30,
+            nyaa_download_client_id: None,
         }
     }
 }
@@ -258,6 +265,7 @@ struct ConfigRow {
     default_restrict_to_uploader: String,
     grab_preview_mode: String,
     external_sync_interval_minutes: i64,
+    nyaa_download_client_id: Option<i64>,
 }
 
 /// Cheap title-language lookup with a safe default. Used by every page
@@ -279,7 +287,7 @@ pub async fn get_title_language(db: &SqlitePool) -> String {
 /// Get the singleton config row.
 pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> {
     let row: Option<ConfigRow> = sqlx::query_as(
-        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, autobrr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader, grab_preview_mode, external_sync_interval_minutes FROM config WHERE id = 1",
+        "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path, deluge_url, deluge_password, deluge_label, deluge_download_path, transmission_url, transmission_user, transmission_password, transmission_label, transmission_download_path, rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, rtorrent_download_path, jellyfin_url, jellyfin_api_key, preferred_groups, blocked_groups, preferred_resolution, preferred_source, cutoff_source, cutoff_resolution, quality_profile, quality_cutoff, finished_series_quality, media_root, title_language, force_mal_fallback, rss_enabled, rss_interval_minutes, force_kitsu_fallback, post_processing_enabled, post_processing_mode, auto_grab_on_add, search_on_monitoring_change, prefer_subs, allow_non_english, sonarr_enabled, sonarr_api_key, radarr_enabled, radarr_api_key, autobrr_api_key, upgrade_search_enabled, custom_format_minimum_score, seadex_enabled, default_custom_query_tokens, default_restrict_to_uploader, grab_preview_mode, external_sync_interval_minutes, nyaa_download_client_id FROM config WHERE id = 1",
     )
     .fetch_optional(db)
     .await?;
@@ -340,6 +348,7 @@ pub async fn get_config(db: &SqlitePool) -> Result<Option<Config>, sqlx::Error> 
         default_restrict_to_uploader: r.default_restrict_to_uploader,
         grab_preview_mode: r.grab_preview_mode,
         external_sync_interval_minutes: r.external_sync_interval_minutes as i32,
+        nyaa_download_client_id: r.nyaa_download_client_id,
     }))
 }
 

--- a/src/models/download_clients.rs
+++ b/src/models/download_clients.rs
@@ -1,0 +1,427 @@
+//! Multi-client routing — one row per *configured* download
+//! client. Replaces the pre-multi-client single-slot config
+//! (`config.active_client` + per-kind credentials columns) with
+//! a row-per-client shape so a user can run "Local qBit" +
+//! "Seedbox Deluge" + "NzbGeek SAB" simultaneously, and pin
+//! individual indexers (or the built-in Nyaa search) to specific
+//! clients.
+//!
+//! Pin resolution at grab time:
+//! 1. `indexer.download_client_id` if the grab is attributable
+//!    to a torznab indexer row.
+//! 2. `config.nyaa_download_client_id` for built-in Nyaa hits.
+//! 3. The row marked `is_default = 1`.
+//! 4. Otherwise — surface "no download client configured."
+//!
+//! The `kind` column matches the values
+//! `services::download_client::build_torrent_client` /
+//! `build_usenet_client` accept (`"qbittorrent" | "deluge" |
+//! "transmission" | "rtorrent"` for now; SAB lands later).
+//! Validation lives at the form layer; reads here trust the DB
+//! to hold a known value.
+
+use sqlx::{Row, SqlitePool};
+
+/// Row shape for `download_clients`. Mirrors the schema 1:1; no
+/// derived columns.
+#[derive(Debug, Clone)]
+pub struct DownloadClientRow {
+    pub id: i64,
+    pub name: String,
+    pub kind: String,
+    pub url: String,
+    pub username: String,
+    pub password: String,
+    pub label: String,
+    pub download_path: String,
+    pub enabled: bool,
+    pub is_default: bool,
+}
+
+/// Insert/update payload — `&str` rather than `String` so the
+/// caller can pass borrowed slices without an extra clone. Same
+/// shape as the trait constructors expect.
+pub struct DownloadClientForm<'a> {
+    pub name: &'a str,
+    pub kind: &'a str,
+    pub url: &'a str,
+    pub username: &'a str,
+    pub password: &'a str,
+    pub label: &'a str,
+    pub download_path: &'a str,
+    pub enabled: bool,
+    pub is_default: bool,
+}
+
+const SELECT_COLS: &str = "id, name, kind, url, username, password, label, \
+                           download_path, enabled, is_default";
+
+fn map_row(r: sqlx::sqlite::SqliteRow) -> DownloadClientRow {
+    DownloadClientRow {
+        id: r.get("id"),
+        name: r.get("name"),
+        kind: r.get("kind"),
+        url: r.get("url"),
+        username: r.try_get("username").unwrap_or_default(),
+        password: r.try_get("password").unwrap_or_default(),
+        label: r.try_get("label").unwrap_or_default(),
+        download_path: r.try_get("download_path").unwrap_or_default(),
+        enabled: r
+            .try_get::<i64, _>("enabled")
+            .map(|v| v != 0)
+            .unwrap_or(true),
+        is_default: r
+            .try_get::<i64, _>("is_default")
+            .map(|v| v != 0)
+            .unwrap_or(false),
+    }
+}
+
+pub async fn list_all(db: &SqlitePool) -> Result<Vec<DownloadClientRow>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT {SELECT_COLS} FROM download_clients ORDER BY is_default DESC, name COLLATE NOCASE"
+    ))
+    .fetch_all(db)
+    .await?;
+    Ok(rows.into_iter().map(map_row).collect())
+}
+
+/// Used by the cache builder — only enabled rows get
+/// instantiated as live trait impls. Disabled rows survive in
+/// the DB so a user can toggle them back on without re-entering
+/// credentials.
+pub async fn list_enabled(db: &SqlitePool) -> Result<Vec<DownloadClientRow>, sqlx::Error> {
+    let rows = sqlx::query(&format!(
+        "SELECT {SELECT_COLS} FROM download_clients WHERE enabled = 1 ORDER BY id"
+    ))
+    .fetch_all(db)
+    .await?;
+    Ok(rows.into_iter().map(map_row).collect())
+}
+
+pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<DownloadClientRow>, sqlx::Error> {
+    let row = sqlx::query(&format!(
+        "SELECT {SELECT_COLS} FROM download_clients WHERE id = ?"
+    ))
+    .bind(id)
+    .fetch_optional(db)
+    .await?;
+    Ok(row.map(map_row))
+}
+
+/// The current default client, if any. NULL when no client has
+/// been added yet (fresh install) or when a manual DB edit
+/// cleared every `is_default = 1`.
+pub async fn get_default(db: &SqlitePool) -> Result<Option<DownloadClientRow>, sqlx::Error> {
+    let row = sqlx::query(&format!(
+        "SELECT {SELECT_COLS} FROM download_clients WHERE is_default = 1 LIMIT 1"
+    ))
+    .fetch_optional(db)
+    .await?;
+    Ok(row.map(map_row))
+}
+
+/// Insert a new row. If `form.is_default` is true, the existing
+/// default (if any) is cleared in the same transaction so the
+/// invariant "exactly one row has is_default = 1" stays
+/// recoverable. Returns the new row's id.
+pub async fn insert(db: &SqlitePool, form: DownloadClientForm<'_>) -> Result<i64, sqlx::Error> {
+    let mut tx = db.begin().await?;
+    if form.is_default {
+        sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1")
+            .execute(&mut *tx)
+            .await?;
+    }
+    let id: i64 = sqlx::query_scalar(
+        "INSERT INTO download_clients
+             (name, kind, url, username, password, label, download_path, enabled, is_default)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+         RETURNING id",
+    )
+    .bind(form.name.trim())
+    .bind(form.kind)
+    .bind(form.url.trim())
+    .bind(form.username)
+    .bind(form.password)
+    .bind(form.label)
+    .bind(form.download_path.trim().trim_end_matches('/'))
+    .bind(if form.enabled { 1_i64 } else { 0_i64 })
+    .bind(if form.is_default { 1_i64 } else { 0_i64 })
+    .fetch_one(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(id)
+}
+
+pub async fn update(
+    db: &SqlitePool,
+    id: i64,
+    form: DownloadClientForm<'_>,
+) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+    if form.is_default {
+        sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1 AND id != ?")
+            .bind(id)
+            .execute(&mut *tx)
+            .await?;
+    }
+    sqlx::query(
+        "UPDATE download_clients
+         SET name = ?, kind = ?, url = ?, username = ?, password = ?, label = ?,
+             download_path = ?, enabled = ?, is_default = ?,
+             updated_at = strftime('%s','now')
+         WHERE id = ?",
+    )
+    .bind(form.name.trim())
+    .bind(form.kind)
+    .bind(form.url.trim())
+    .bind(form.username)
+    .bind(form.password)
+    .bind(form.label)
+    .bind(form.download_path.trim().trim_end_matches('/'))
+    .bind(if form.enabled { 1_i64 } else { 0_i64 })
+    .bind(if form.is_default { 1_i64 } else { 0_i64 })
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Delete the row and NULL out every dangling pin in one
+/// transaction. Pins live on `indexers.download_client_id` and
+/// `config.nyaa_download_client_id`. Without the NULL-out, FK-less
+/// SQLite would leave dangling ids that resolve to None at routing
+/// time (silent fall-through to default; surprising) and the row
+/// would still appear in queries that join on the pin.
+///
+/// If the deleted row was the default, the caller is responsible
+/// for picking a new default (or accepting "no default until the
+/// user picks one"). Most user-facing flows just leave the
+/// default empty and let the user pick from the remaining rows.
+pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+    sqlx::query("UPDATE indexers SET download_client_id = NULL WHERE download_client_id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        "UPDATE config SET nyaa_download_client_id = NULL WHERE nyaa_download_client_id = ?",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query("DELETE FROM download_clients WHERE id = ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+/// Mark `id` as the default and clear every other row's flag.
+/// Idempotent — calling on an already-default row is a no-op
+/// at the value level (still does two UPDATEs that touch zero
+/// rows).
+pub async fn set_default(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
+    let mut tx = db.begin().await?;
+    sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1 AND id != ?")
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+    sqlx::query(
+        "UPDATE download_clients SET is_default = 1, updated_at = strftime('%s','now') WHERE id = ?",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::in_memory_pool;
+
+    fn form<'a>(name: &'a str, kind: &'a str, url: &'a str) -> DownloadClientForm<'a> {
+        DownloadClientForm {
+            name,
+            kind,
+            url,
+            username: "",
+            password: "",
+            label: "",
+            download_path: "",
+            enabled: true,
+            is_default: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_roundtrip() {
+        let db = in_memory_pool().await;
+        let id = insert(
+            &db,
+            form("Local qBit", "qbittorrent", "http://localhost:8080"),
+        )
+        .await
+        .unwrap();
+        let row = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(row.name, "Local qBit");
+        assert_eq!(row.kind, "qbittorrent");
+        assert_eq!(row.url, "http://localhost:8080");
+        assert!(row.enabled);
+        assert!(!row.is_default);
+    }
+
+    #[tokio::test]
+    async fn insert_with_is_default_clears_prior_default() {
+        let db = in_memory_pool().await;
+        let mut f = form("First", "qbittorrent", "http://1");
+        f.is_default = true;
+        let first = insert(&db, f).await.unwrap();
+
+        let mut f2 = form("Second", "deluge", "http://2");
+        f2.is_default = true;
+        let second = insert(&db, f2).await.unwrap();
+
+        // Only `second` should still be default.
+        let first_row = get_by_id(&db, first).await.unwrap().unwrap();
+        let second_row = get_by_id(&db, second).await.unwrap().unwrap();
+        assert!(!first_row.is_default, "first must lose its default flag");
+        assert!(second_row.is_default);
+
+        let default_row = get_default(&db).await.unwrap().unwrap();
+        assert_eq!(default_row.id, second);
+    }
+
+    #[tokio::test]
+    async fn set_default_is_idempotent_and_unique() {
+        let db = in_memory_pool().await;
+        let a = insert(&db, form("A", "qbittorrent", "http://a"))
+            .await
+            .unwrap();
+        let b = insert(&db, form("B", "deluge", "http://b")).await.unwrap();
+
+        set_default(&db, a).await.unwrap();
+        set_default(&db, a).await.unwrap(); // idempotent
+        let default_row = get_default(&db).await.unwrap().unwrap();
+        assert_eq!(default_row.id, a);
+
+        set_default(&db, b).await.unwrap();
+        // Only one row has is_default = 1.
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM download_clients WHERE is_default = 1")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn delete_nulls_out_indexer_and_nyaa_pins() {
+        let db = in_memory_pool().await;
+        let id = insert(&db, form("X", "qbittorrent", "http://x"))
+            .await
+            .unwrap();
+
+        // Create an indexer row pinned to this client.
+        sqlx::query(
+            "INSERT INTO indexers (name, kind, url, api_key, download_client_id) \
+             VALUES ('AB', 'torznab', 'http://prowlarr/1/api', 'k', ?)",
+        )
+        .bind(id)
+        .execute(&db)
+        .await
+        .unwrap();
+
+        // Pin Nyaa to it as well (config row needs to exist first).
+        sqlx::query("INSERT INTO config (id) VALUES (1)")
+            .execute(&db)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE config SET nyaa_download_client_id = ? WHERE id = 1")
+            .bind(id)
+            .execute(&db)
+            .await
+            .unwrap();
+
+        delete(&db, id).await.unwrap();
+
+        // Pin columns are NULL.
+        let indexer_pin: Option<i64> =
+            sqlx::query_scalar("SELECT download_client_id FROM indexers WHERE name = 'AB'")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert!(
+            indexer_pin.is_none(),
+            "indexer pin must be NULLed on delete"
+        );
+
+        let nyaa_pin: Option<i64> =
+            sqlx::query_scalar("SELECT nyaa_download_client_id FROM config WHERE id = 1")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert!(nyaa_pin.is_none(), "Nyaa pin must be NULLed on delete");
+
+        // Row itself is gone.
+        assert!(get_by_id(&db, id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn list_enabled_filters_disabled_rows() {
+        let db = in_memory_pool().await;
+        insert(&db, form("On", "qbittorrent", "http://a"))
+            .await
+            .unwrap();
+        let mut off = form("Off", "deluge", "http://b");
+        off.enabled = false;
+        insert(&db, off).await.unwrap();
+
+        let enabled = list_enabled(&db).await.unwrap();
+        assert_eq!(enabled.len(), 1);
+        assert_eq!(enabled[0].name, "On");
+    }
+
+    #[tokio::test]
+    async fn update_round_trip() {
+        let db = in_memory_pool().await;
+        let id = insert(&db, form("Initial", "qbittorrent", "http://1"))
+            .await
+            .unwrap();
+        let mut f = form("Renamed", "deluge", "http://2");
+        f.username = "u";
+        f.password = "p";
+        f.label = "ryokan";
+        update(&db, id, f).await.unwrap();
+        let row = get_by_id(&db, id).await.unwrap().unwrap();
+        assert_eq!(row.name, "Renamed");
+        assert_eq!(row.kind, "deluge");
+        assert_eq!(row.url, "http://2");
+        assert_eq!(row.username, "u");
+        assert_eq!(row.password, "p");
+        assert_eq!(row.label, "ryokan");
+    }
+
+    #[tokio::test]
+    async fn list_all_orders_default_first_then_alphabetical() {
+        let db = in_memory_pool().await;
+        insert(&db, form("zeta", "qbittorrent", "http://z"))
+            .await
+            .unwrap();
+        insert(&db, form("alpha", "deluge", "http://a"))
+            .await
+            .unwrap();
+        let mut def = form("middle", "transmission", "http://m");
+        def.is_default = true;
+        insert(&db, def).await.unwrap();
+
+        let rows = list_all(&db).await.unwrap();
+        assert_eq!(rows[0].name, "middle"); // default first
+        assert_eq!(rows[1].name, "alpha"); // then case-insensitive name
+        assert_eq!(rows[2].name, "zeta");
+    }
+}

--- a/src/models/download_clients.rs
+++ b/src/models/download_clients.rs
@@ -141,9 +141,12 @@ pub async fn insert(db: &SqlitePool, form: DownloadClientForm<'_>) -> Result<i64
     .bind(form.name.trim())
     .bind(form.kind)
     .bind(form.url.trim())
-    .bind(form.username)
+    .bind(form.username.trim())
+    // Don't `.trim()` password — leading/trailing whitespace can be
+    // intentional (passphrase generators, rare but real) and silently
+    // dropping it would lock a user out of their own client.
     .bind(form.password)
-    .bind(form.label)
+    .bind(form.label.trim())
     .bind(form.download_path.trim().trim_end_matches('/'))
     .bind(if form.enabled { 1_i64 } else { 0_i64 })
     .bind(if form.is_default { 1_i64 } else { 0_i64 })
@@ -175,9 +178,9 @@ pub async fn update(
     .bind(form.name.trim())
     .bind(form.kind)
     .bind(form.url.trim())
-    .bind(form.username)
+    .bind(form.username.trim())
     .bind(form.password)
-    .bind(form.label)
+    .bind(form.label.trim())
     .bind(form.download_path.trim().trim_end_matches('/'))
     .bind(if form.enabled { 1_i64 } else { 0_i64 })
     .bind(if form.is_default { 1_i64 } else { 0_i64 })
@@ -220,9 +223,11 @@ pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
 }
 
 /// Mark `id` as the default and clear every other row's flag.
-/// Idempotent — calling on an already-default row is a no-op
-/// at the value level (still does two UPDATEs that touch zero
-/// rows).
+/// Idempotent at the `is_default` value level (a re-call on an
+/// already-default row leaves the flag at 1); `updated_at` is
+/// bumped on every call regardless. Tighten the second UPDATE to
+/// `WHERE is_default = 0` if a strict no-op-on-repeat semantics is
+/// ever needed for an audit-log trigger.
 pub async fn set_default(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     let mut tx = db.begin().await?;
     sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1 AND id != ?")

--- a/src/models/download_clients.rs
+++ b/src/models/download_clients.rs
@@ -192,11 +192,20 @@ pub async fn update(
 }
 
 /// Delete the row and NULL out every dangling pin in one
-/// transaction. Pins live on `indexers.download_client_id` and
-/// `config.nyaa_download_client_id`. Without the NULL-out, FK-less
-/// SQLite would leave dangling ids that resolve to None at routing
-/// time (silent fall-through to default; surprising) and the row
-/// would still appear in queries that join on the pin.
+/// transaction. Pins live on `indexers.download_client_id`,
+/// `config.nyaa_download_client_id`, and
+/// `grabbed_torrents.download_client_id`. Without the NULL-out,
+/// FK-less SQLite would leave dangling ids that resolve to None
+/// at routing time (silent fall-through to default; surprising)
+/// and the row would still appear in queries that join on the
+/// pin. The `grabbed_torrents` NULL-out specifically prevents
+/// pending grabs from getting orphaned forever — `run_once`
+/// short-circuits when it can't resolve the stamped id, so a
+/// stale stamp would skip both the import path AND the 60s
+/// stale-mark grace window. NULLing the stamp lets the next
+/// post-processing pass either match the grab against the
+/// current default's `list_scoped` (unlikely — wrong client) or
+/// fall through to the stale path and mark it `removed`.
 ///
 /// If the deleted row was the default, the caller is responsible
 /// for picking a new default (or accepting "no default until the
@@ -210,6 +219,12 @@ pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
         .await?;
     sqlx::query(
         "UPDATE config SET nyaa_download_client_id = NULL WHERE nyaa_download_client_id = ?",
+    )
+    .bind(id)
+    .execute(&mut *tx)
+    .await?;
+    sqlx::query(
+        "UPDATE grabbed_torrents SET download_client_id = NULL WHERE download_client_id = ?",
     )
     .bind(id)
     .execute(&mut *tx)
@@ -374,6 +389,86 @@ mod tests {
 
         // Row itself is gone.
         assert!(get_by_id(&db, id).await.unwrap().is_none());
+    }
+
+    /// Pre-PR-109-review-2 regression: pending grabs stamped to a
+    /// soon-to-be-deleted client used to keep their stamp after
+    /// `delete()`, which orphaned the grab forever in
+    /// `post_processing::run_once` (the loop's `clients.get(&id)`
+    /// returned None, the `continue` skipped past the 60s stale
+    /// check, and the grab stayed `pending` indefinitely). Lock the
+    /// fix by inserting a pending grab + deleting its client + asserting
+    /// the column is NULL afterward. A null stamp lets the next
+    /// post-processing pass fall through to default and reach the
+    /// stale path.
+    #[tokio::test]
+    async fn delete_nulls_out_grabbed_torrents_stamp() {
+        use crate::models::series::{self, SeriesCore};
+
+        let db = in_memory_pool().await;
+        let id = insert(&db, form("X", "qbittorrent", "http://x"))
+            .await
+            .unwrap();
+
+        // Seed a series + a pending grab stamped to this client.
+        let (series_id, _) = series::upsert(
+            &db,
+            SeriesCore {
+                anilist_id: 1,
+                mal_id: None,
+                title: "Show",
+                title_romaji: "Show",
+                title_english: "Show",
+                title_native: "",
+                cover_url: "",
+                format: "TV",
+                status: "FINISHED",
+                episodes: Some(12),
+                season_year: Some(2024),
+                end_year: Some(2024),
+            },
+        )
+        .await
+        .expect("series upsert");
+        let grab_id = crate::models::grabbed_torrents::record_grab(
+            &db,
+            "deadbeef",
+            "[Group] Show - 01.mkv",
+            series_id,
+            &[1],
+            false,
+        )
+        .await
+        .expect("record")
+        .expect("inserted");
+        crate::models::grabbed_torrents::set_download_client(&db, grab_id, Some(id))
+            .await
+            .expect("stamp");
+
+        // Pre-condition.
+        let stamped: Option<i64> =
+            sqlx::query_scalar("SELECT download_client_id FROM grabbed_torrents WHERE id = ?")
+                .bind(grab_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(stamped, Some(id));
+
+        // Delete the client — the cascade should NULL the stamp.
+        delete(&db, id).await.unwrap();
+
+        let stamp_after: Option<i64> =
+            sqlx::query_scalar("SELECT download_client_id FROM grabbed_torrents WHERE id = ?")
+                .bind(grab_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert!(
+            stamp_after.is_none(),
+            "grabbed_torrents.download_client_id must be NULLed on delete \
+             so post_processing falls through to default and reaches the \
+             stale-mark path; otherwise pending grabs orphan forever"
+        );
     }
 
     #[tokio::test]

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -16,6 +16,12 @@ pub struct GrabbedTorrent {
     /// pre-download pass used — otherwise the "finished 1+ year ago +
     /// batch → BluRay" rule never fires on library-sweep reclassifies.
     pub is_batch: bool,
+    /// Multi-client refactor — id of the `download_clients` row this
+    /// grab was dispatched to. NULL on legacy rows (pre-multi-client
+    /// upgrade) and on grabs whose pin resolution returned None.
+    /// Post-processing routes `list_scoped` / `get_files` against the
+    /// recorded client; falls back to the current default when NULL.
+    pub download_client_id: Option<i64>,
 }
 
 /// Record a torrent grab for post-processing.
@@ -329,7 +335,9 @@ pub async fn get_is_batch_by_name(
 /// Get all grabs that have not yet been processed.
 pub async fn get_all_pending(db: &SqlitePool) -> Result<Vec<GrabbedTorrent>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, COALESCE(is_batch, 0) AS is_batch FROM grabbed_torrents WHERE state = 'pending' ORDER BY grabbed_at ASC",
+        "SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, \
+                COALESCE(is_batch, 0) AS is_batch, download_client_id \
+         FROM grabbed_torrents WHERE state = 'pending' ORDER BY grabbed_at ASC",
     )
     .fetch_all(db)
     .await?;
@@ -349,6 +357,10 @@ pub async fn get_all_pending(db: &SqlitePool) -> Result<Vec<GrabbedTorrent>, sql
                 state: "pending".to_string(),
                 grabbed_at: row.get("grabbed_at"),
                 is_batch: is_batch_i != 0,
+                download_client_id: row
+                    .try_get::<Option<i64>, _>("download_client_id")
+                    .ok()
+                    .flatten(),
             }
         })
         .collect())
@@ -440,6 +452,24 @@ pub async fn set_indexer_attribution(
     sqlx::query("UPDATE grabbed_torrents SET indexer_id = ?, respect_seed_rules = ? WHERE id = ?")
         .bind(indexer_id)
         .bind(respect_seed_rules as i64)
+        .bind(grab_id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Multi-client refactor — stamp the `download_clients.id` that
+/// received the grab. NULL means "no pool entry at grab time" and
+/// post-processing falls back to the current default. Called from
+/// every dispatch site (autobrr, RSS, manual, auto-search) right
+/// after `record_grab`.
+pub async fn set_download_client(
+    db: &SqlitePool,
+    grab_id: i64,
+    download_client_id: Option<i64>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE grabbed_torrents SET download_client_id = ? WHERE id = ?")
+        .bind(download_client_id)
         .bind(grab_id)
         .execute(db)
         .await?;
@@ -787,6 +817,9 @@ pub async fn find_imported_for_episode(
                 state: "imported".to_string(),
                 grabbed_at: row.get("grabbed_at"),
                 is_batch: is_batch_i != 0,
+                // Not selected by this query — callers don't use the
+                // client routing here. Default None.
+                download_client_id: None,
             }
         })
         .collect())
@@ -850,6 +883,7 @@ pub async fn find_pending_for_episode(
                 state: "pending".to_string(),
                 grabbed_at: row.get("grabbed_at"),
                 is_batch: is_batch_i != 0,
+                download_client_id: None,
             }
         })
         .collect())
@@ -1602,5 +1636,43 @@ mod tests {
         assert!(!respects_seed_rules(&db, "").await);
         // Hash that doesn't exist.
         assert!(!respects_seed_rules(&db, "no-such-hash").await);
+    }
+
+    // ── Multi-client refactor: download_client_id round-trip ────────
+    //
+    // Pre-PR-F regression: post_processing fanning `list_scoped` over
+    // a single (default) client meant pinned grabs got marked stale.
+    // The fan-out fix depends on `get_all_pending` faithfully reading
+    // back the stamped `download_client_id`. These tests pin that
+    // round-trip so a future SELECT-list refactor can't silently drop
+    // the column and re-introduce the bug.
+
+    #[tokio::test]
+    async fn set_download_client_round_trips_through_get_all_pending() {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        let (grab_id, _) = pr_c_seed_a_grab(&db).await;
+
+        // Pre-stamp: a fresh row reads back as None.
+        let pending = get_all_pending(&db).await.expect("pending");
+        let row = pending.iter().find(|g| g.id == grab_id).expect("present");
+        assert_eq!(row.download_client_id, None);
+
+        // After stamp: round-trip yields the stored id.
+        set_download_client(&db, grab_id, Some(42))
+            .await
+            .expect("stamp");
+        let pending = get_all_pending(&db).await.expect("pending");
+        let row = pending.iter().find(|g| g.id == grab_id).expect("present");
+        assert_eq!(row.download_client_id, Some(42));
+
+        // Clearing back to NULL works too — a deleted/disabled client
+        // unlinking would NULL the column via `download_clients::delete`.
+        set_download_client(&db, grab_id, None)
+            .await
+            .expect("clear");
+        let pending = get_all_pending(&db).await.expect("pending");
+        let row = pending.iter().find(|g| g.id == grab_id).expect("present");
+        assert_eq!(row.download_client_id, None);
     }
 }

--- a/src/models/indexers.rs
+++ b/src/models/indexers.rs
@@ -46,6 +46,10 @@ pub struct Indexer {
     /// means use the process default (30s, overridable via
     /// `RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS`).
     pub request_timeout_secs: Option<i64>,
+    /// Multi-client routing pin — id of the row in
+    /// `download_clients` this indexer routes to. `None` means
+    /// "fall through to the default client" at grab time.
+    pub download_client_id: Option<i64>,
     /// Cached caps response body. Empty until the first probe
     /// succeeds (PR B). Read with a 7-day TTL — stale caps trigger
     /// a transparent re-fetch on next read.
@@ -71,11 +75,14 @@ pub struct IndexerForm<'a> {
     pub seed_time_minutes: Option<i64>,
     pub min_seeders: i32,
     pub request_timeout_secs: Option<i64>,
+    /// Multi-client routing pin. `None` = use the default
+    /// download client at grab time.
+    pub download_client_id: Option<i64>,
 }
 
 const SELECT_COLUMNS: &str = "id, name, kind, url, api_key, priority, enabled, \
     is_private_tracker, seed_ratio, seed_time_minutes, min_seeders, request_timeout_secs, \
-    caps_json, caps_refreshed_at, created_at, updated_at";
+    download_client_id, caps_json, caps_refreshed_at, created_at, updated_at";
 
 fn row_to_indexer(row: &sqlx::sqlite::SqliteRow) -> Indexer {
     // Nullable columns explicitly typed as `Option<T>` so sqlx
@@ -101,6 +108,9 @@ fn row_to_indexer(row: &sqlx::sqlite::SqliteRow) -> Indexer {
         min_seeders: row.try_get("min_seeders").unwrap_or(1),
         request_timeout_secs: row
             .try_get::<Option<i64>, _>("request_timeout_secs")
+            .unwrap_or(None),
+        download_client_id: row
+            .try_get::<Option<i64>, _>("download_client_id")
             .unwrap_or(None),
         caps_json: row.try_get("caps_json").unwrap_or_default(),
         caps_refreshed_at: row
@@ -149,8 +159,9 @@ pub async fn insert(db: &SqlitePool, form: IndexerForm<'_>) -> Result<i64, sqlx:
     let result = sqlx::query(
         "INSERT INTO indexers \
          (name, kind, url, api_key, priority, enabled, is_private_tracker, \
-          seed_ratio, seed_time_minutes, min_seeders, request_timeout_secs) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+          seed_ratio, seed_time_minutes, min_seeders, request_timeout_secs, \
+          download_client_id) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(form.name)
     .bind(form.kind)
@@ -163,6 +174,7 @@ pub async fn insert(db: &SqlitePool, form: IndexerForm<'_>) -> Result<i64, sqlx:
     .bind(form.seed_time_minutes)
     .bind(form.min_seeders)
     .bind(form.request_timeout_secs)
+    .bind(form.download_client_id)
     .execute(db)
     .await?;
     Ok(result.last_insert_rowid())
@@ -173,7 +185,8 @@ pub async fn update(db: &SqlitePool, id: i64, form: IndexerForm<'_>) -> Result<(
         "UPDATE indexers SET \
          name = ?, kind = ?, url = ?, api_key = ?, priority = ?, enabled = ?, \
          is_private_tracker = ?, seed_ratio = ?, seed_time_minutes = ?, min_seeders = ?, \
-         request_timeout_secs = ?, updated_at = strftime('%s','now') \
+         request_timeout_secs = ?, download_client_id = ?, \
+         updated_at = strftime('%s','now') \
          WHERE id = ?",
     )
     .bind(form.name)
@@ -187,6 +200,7 @@ pub async fn update(db: &SqlitePool, id: i64, form: IndexerForm<'_>) -> Result<(
     .bind(form.seed_time_minutes)
     .bind(form.min_seeders)
     .bind(form.request_timeout_secs)
+    .bind(form.download_client_id)
     .bind(id)
     .execute(db)
     .await?;
@@ -266,6 +280,7 @@ mod tests {
             seed_time_minutes: None,
             min_seeders: 1,
             request_timeout_secs: None,
+            download_client_id: None,
         }
     }
 

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2134,6 +2134,18 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // Multi-client refactor — track which `download_clients` row the grab
+    // was dispatched to. Drives post-processing's `list_scoped` /
+    // `get_files` routing so a torrent landed on the seedbox isn't
+    // hunted for on the local qBit. NULL on legacy rows (pre-multi-client)
+    // and on grabs whose pin resolution returned None (pool empty
+    // before user added a client). Post-processing falls back to the
+    // current default on NULL.
+    sqlx::query("ALTER TABLE grabbed_torrents ADD COLUMN download_client_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
     // Issue #28 PR A — `grabbed_torrents.respect_seed_rules` flags
     // grabs whose torrents have per-torrent seed-ratio / seed-time
     // rules applied at add time (PR C). Delete paths (manual delete,
@@ -2229,23 +2241,35 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .unwrap_or(false)
     {
-        let legacy_qbit: Option<(String, String, String, String, String, String)> = sqlx::query_as(
+        // Read the legacy fields per-kind. Each block falls back to
+        // empty defaults on any failure (column missing from a
+        // partially-applied earlier migration, hand-edited schema,
+        // transient I/O). Pre-fix this whole block was gated on a
+        // 4-arm `if let (Some, Some, Some, Some, Some)` — any one
+        // failure skipped the entire backfill **and** didn't mark
+        // the migration applied, so it retried every boot. Now each
+        // arm degrades independently and the marker fires once
+        // we've gotten this far, regardless of which legacy slots
+        // were readable. Per the code-review correction.
+        let legacy_qbit = sqlx::query_as::<_, (String, String, String, String, String, String)>(
             "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path \
              FROM config WHERE id = 1",
         )
         .fetch_optional(db)
         .await
         .ok()
-        .flatten();
-        let legacy_deluge: Option<(String, String, String, String)> = sqlx::query_as(
+        .flatten()
+        .unwrap_or_default();
+        let legacy_deluge = sqlx::query_as::<_, (String, String, String, String)>(
             "SELECT deluge_url, deluge_password, deluge_label, deluge_download_path \
              FROM config WHERE id = 1",
         )
         .fetch_optional(db)
         .await
         .ok()
-        .flatten();
-        let legacy_tx: Option<(String, String, String, String, String)> = sqlx::query_as(
+        .flatten()
+        .unwrap_or_default();
+        let legacy_tx = sqlx::query_as::<_, (String, String, String, String, String)>(
             "SELECT transmission_url, transmission_user, transmission_password, \
                     transmission_label, transmission_download_path \
              FROM config WHERE id = 1",
@@ -2253,8 +2277,9 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .fetch_optional(db)
         .await
         .ok()
-        .flatten();
-        let legacy_rt: Option<(String, String, String, String, String)> = sqlx::query_as(
+        .flatten()
+        .unwrap_or_default();
+        let legacy_rt = sqlx::query_as::<_, (String, String, String, String, String)>(
             "SELECT rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, \
                     rtorrent_download_path \
              FROM config WHERE id = 1",
@@ -2262,84 +2287,82 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .fetch_optional(db)
         .await
         .ok()
-        .flatten();
+        .flatten()
+        .unwrap_or_default();
 
-        if let (
-            Some((active, q_url, q_user, q_pass, q_cat, q_dp)),
-            Some((d_url, d_pass, d_label, d_dp)),
-            Some((t_url, t_user, t_pass, t_label, t_dp)),
-            Some((r_url, r_user, r_pass, r_label, r_dp)),
-        ) = (legacy_qbit, legacy_deluge, legacy_tx, legacy_rt)
+        let (active, q_url, q_user, q_pass, q_cat, q_dp) = legacy_qbit;
+        let (d_url, d_pass, d_label, d_dp) = legacy_deluge;
+        let (t_url, t_user, t_pass, t_label, t_dp) = legacy_tx;
+        let (r_url, r_user, r_pass, r_label, r_dp) = legacy_rt;
+
+        let (name, kind, url, username, password, label, download_path) = match active.as_str() {
+            "deluge" => (
+                "Deluge",
+                "deluge",
+                d_url,
+                String::new(),
+                d_pass,
+                d_label,
+                d_dp,
+            ),
+            "transmission" => (
+                "Transmission",
+                "transmission",
+                t_url,
+                t_user,
+                t_pass,
+                t_label,
+                t_dp,
+            ),
+            "rtorrent" => ("rTorrent", "rtorrent", r_url, r_user, r_pass, r_label, r_dp),
+            _ => (
+                "qBittorrent",
+                "qbittorrent",
+                q_url,
+                q_user,
+                q_pass,
+                q_cat,
+                q_dp,
+            ),
+        };
+        // Mark the migration applied unconditionally before
+        // attempting the seed insert, so a transient `db.begin()`
+        // failure on the seed transaction doesn't trap us in a
+        // boot-loop where the read fires every restart. The seed
+        // itself is best-effort — a missed legacy URL re-creates the
+        // pre-multi-client gap, but the user can fix that from
+        // Settings → Connections; trapping startup behind the seed
+        // transaction would be worse.
+        if let Ok(mut tx) = db.begin().await {
+            let _ = crate::models::group_source_map::mark_migration_applied(
+                &mut tx,
+                "multi_client_seed_default_v1",
+            )
+            .await;
+            let _ = tx.commit().await;
+        }
+        // Only seed when the legacy slot was actually configured
+        // (URL non-empty). A fresh-install user who never picked a
+        // client gets no auto-seeded row; they'll add one via the
+        // new Settings UI.
+        if !url.is_empty()
+            && let Ok(mut tx) = db.begin().await
         {
-            let (name, kind, url, username, password, label, download_path) = match active.as_str()
-            {
-                "deluge" => (
-                    "Deluge",
-                    "deluge",
-                    d_url,
-                    String::new(),
-                    d_pass,
-                    d_label,
-                    d_dp,
-                ),
-                "transmission" => (
-                    "Transmission",
-                    "transmission",
-                    t_url,
-                    t_user,
-                    t_pass,
-                    t_label,
-                    t_dp,
-                ),
-                "rtorrent" => ("rTorrent", "rtorrent", r_url, r_user, r_pass, r_label, r_dp),
-                _ => (
-                    "qBittorrent",
-                    "qbittorrent",
-                    q_url,
-                    q_user,
-                    q_pass,
-                    q_cat,
-                    q_dp,
-                ),
-            };
-            // Only seed when the legacy slot was actually
-            // configured (URL non-empty). A fresh-install user
-            // who never picked a client gets no auto-seeded row;
-            // they'll add one via the new Settings UI.
-            if !url.is_empty()
-                && let Ok(mut tx) = db.begin().await
-            {
-                let _ = sqlx::query(
-                    "INSERT INTO download_clients
-                     (name, kind, url, username, password, label, download_path, enabled, is_default)
-                     VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1)",
-                )
-                .bind(name)
-                .bind(kind)
-                .bind(url)
-                .bind(username)
-                .bind(password)
-                .bind(label)
-                .bind(download_path)
-                .execute(&mut *tx)
-                .await;
-                let _ = crate::models::group_source_map::mark_migration_applied(
-                    &mut tx,
-                    "multi_client_seed_default_v1",
-                )
-                .await;
-                let _ = tx.commit().await;
-            } else if let Ok(mut tx) = db.begin().await {
-                // Mark applied even on fresh install (no URL to
-                // seed from) so the read+attempt cycle doesn't
-                // repeat every boot.
-                let _ = crate::models::group_source_map::mark_migration_applied(
-                    &mut tx,
-                    "multi_client_seed_default_v1",
-                )
-                .await;
-                let _ = tx.commit().await;
-            }
+            let _ = sqlx::query(
+                "INSERT INTO download_clients
+                 (name, kind, url, username, password, label, download_path, enabled, is_default)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1)",
+            )
+            .bind(name)
+            .bind(kind)
+            .bind(url)
+            .bind(username)
+            .bind(password)
+            .bind(label)
+            .bind(download_path)
+            .execute(&mut *tx)
+            .await;
+            let _ = tx.commit().await;
         }
     }
 

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2325,11 +2325,16 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
                 q_dp,
             ),
         };
-        // Mark the migration applied unconditionally before
-        // attempting the seed insert, so a transient `db.begin()`
-        // failure on the seed transaction doesn't trap us in a
-        // boot-loop where the read fires every restart. The seed
-        // itself is best-effort — a missed legacy URL re-creates the
+        // Mark the migration applied in its own transaction, separate
+        // from the seed insert below, so a failure of the seed tx
+        // doesn't trap us in a boot-loop where the read fires every
+        // restart. The marker tx itself is still best-effort
+        // (`if let Ok(mut tx) = db.begin().await`) — `db.begin` doesn't
+        // typically transient-fail in a way the next attempt would
+        // succeed at, so unwrapping wouldn't change behavior in
+        // practice; we leave it gated to keep the migration path
+        // panic-free under any startup contention. The seed itself is
+        // also best-effort — a missed legacy URL re-creates the
         // pre-multi-client gap, but the user can fix that from
         // Settings → Connections; trapping startup behind the seed
         // transaction would be worse.

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -1274,6 +1274,18 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // Issue #28 PR E — per-series PT upgrade opt-in. Default 0 (off).
+    // The upgrade sweep skips a candidate when the source indexer is
+    // a private tracker (`indexers.is_private_tracker = 1`) and this
+    // flag is 0. Initial / manual / interactive grabs aren't gated —
+    // the user explicitly chose those. The flag only affects the
+    // background upgrade sweep, which can re-grab existing episodes
+    // from PTs without the user's knowledge if left default-on.
+    sqlx::query("ALTER TABLE series ADD COLUMN allow_pt_upgrades INTEGER NOT NULL DEFAULT 0")
+        .execute(db)
+        .await
+        .ok();
+
     // Radarr API compatibility layer for Seerr integration (anime movies).
     sqlx::query("ALTER TABLE config ADD COLUMN radarr_enabled INTEGER NOT NULL DEFAULT 0")
         .execute(db)

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2167,6 +2167,182 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // Multi-client routing — one row per *configured* client, not
+    // one per kind. A user can run "Local qBit" + "Seedbox Deluge"
+    // simultaneously, with per-indexer pinning so AnimeBytes grabs
+    // route to the seedbox while Nyaa stays on the local box. The
+    // legacy `config.active_client + qbit_url etc.` columns stay
+    // for one release as rollback safety; runtime reads from this
+    // table exclusively after the schema_migrations-gated backfill
+    // below seeds the first row.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS download_clients (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            url TEXT NOT NULL,
+            username TEXT NOT NULL DEFAULT '',
+            password TEXT NOT NULL DEFAULT '',
+            label TEXT NOT NULL DEFAULT '',
+            download_path TEXT NOT NULL DEFAULT '',
+            enabled INTEGER NOT NULL DEFAULT 1,
+            is_default INTEGER NOT NULL DEFAULT 0,
+            created_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))
+        )",
+    )
+    .execute(db)
+    .await
+    .ok();
+
+    // Per-indexer client pinning. NULL means "use the row marked
+    // is_default=1 in download_clients." `ON DELETE SET NULL`
+    // can't be added via ALTER on SQLite, so the
+    // `settings_download_clients_delete` handler NULLs matching
+    // `indexers.download_client_id` rows in the same transaction
+    // (mirrors how the indexer-delete handler NULLs
+    // `grabbed_torrents.indexer_id`).
+    sqlx::query("ALTER TABLE indexers ADD COLUMN download_client_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
+    // Nyaa is out-of-band (no `indexers` row), so its pin lives on
+    // the singleton config row. Same NULL-means-default semantics.
+    sqlx::query("ALTER TABLE config ADD COLUMN nyaa_download_client_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
+    // Backfill — read the legacy `config.active_client` discriminator
+    // + the per-kind URL/credentials columns and seed one
+    // `download_clients` row marked is_default=1. Idempotent via
+    // `schema_migrations` so a user who later adds more clients
+    // doesn't get the legacy row re-created on every boot.
+    crate::models::group_source_map::ensure_schema_migrations_table(db)
+        .await
+        .ok();
+    if !crate::models::group_source_map::migration_already_applied(
+        db,
+        "multi_client_seed_default_v1",
+    )
+    .await
+    .unwrap_or(false)
+    {
+        let legacy_qbit: Option<(String, String, String, String, String, String)> = sqlx::query_as(
+            "SELECT active_client, qbit_url, qbit_user, qbit_pass, qbit_category, qbit_download_path \
+             FROM config WHERE id = 1",
+        )
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten();
+        let legacy_deluge: Option<(String, String, String, String)> = sqlx::query_as(
+            "SELECT deluge_url, deluge_password, deluge_label, deluge_download_path \
+             FROM config WHERE id = 1",
+        )
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten();
+        let legacy_tx: Option<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT transmission_url, transmission_user, transmission_password, \
+                    transmission_label, transmission_download_path \
+             FROM config WHERE id = 1",
+        )
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten();
+        let legacy_rt: Option<(String, String, String, String, String)> = sqlx::query_as(
+            "SELECT rtorrent_url, rtorrent_user, rtorrent_password, rtorrent_label, \
+                    rtorrent_download_path \
+             FROM config WHERE id = 1",
+        )
+        .fetch_optional(db)
+        .await
+        .ok()
+        .flatten();
+
+        if let (
+            Some((active, q_url, q_user, q_pass, q_cat, q_dp)),
+            Some((d_url, d_pass, d_label, d_dp)),
+            Some((t_url, t_user, t_pass, t_label, t_dp)),
+            Some((r_url, r_user, r_pass, r_label, r_dp)),
+        ) = (legacy_qbit, legacy_deluge, legacy_tx, legacy_rt)
+        {
+            let (name, kind, url, username, password, label, download_path) = match active.as_str()
+            {
+                "deluge" => (
+                    "Deluge",
+                    "deluge",
+                    d_url,
+                    String::new(),
+                    d_pass,
+                    d_label,
+                    d_dp,
+                ),
+                "transmission" => (
+                    "Transmission",
+                    "transmission",
+                    t_url,
+                    t_user,
+                    t_pass,
+                    t_label,
+                    t_dp,
+                ),
+                "rtorrent" => ("rTorrent", "rtorrent", r_url, r_user, r_pass, r_label, r_dp),
+                _ => (
+                    "qBittorrent",
+                    "qbittorrent",
+                    q_url,
+                    q_user,
+                    q_pass,
+                    q_cat,
+                    q_dp,
+                ),
+            };
+            // Only seed when the legacy slot was actually
+            // configured (URL non-empty). A fresh-install user
+            // who never picked a client gets no auto-seeded row;
+            // they'll add one via the new Settings UI.
+            if !url.is_empty()
+                && let Ok(mut tx) = db.begin().await
+            {
+                let _ = sqlx::query(
+                    "INSERT INTO download_clients
+                     (name, kind, url, username, password, label, download_path, enabled, is_default)
+                     VALUES (?, ?, ?, ?, ?, ?, ?, 1, 1)",
+                )
+                .bind(name)
+                .bind(kind)
+                .bind(url)
+                .bind(username)
+                .bind(password)
+                .bind(label)
+                .bind(download_path)
+                .execute(&mut *tx)
+                .await;
+                let _ = crate::models::group_source_map::mark_migration_applied(
+                    &mut tx,
+                    "multi_client_seed_default_v1",
+                )
+                .await;
+                let _ = tx.commit().await;
+            } else if let Ok(mut tx) = db.begin().await {
+                // Mark applied even on fresh install (no URL to
+                // seed from) so the read+attempt cycle doesn't
+                // repeat every boot.
+                let _ = crate::models::group_source_map::mark_migration_applied(
+                    &mut tx,
+                    "multi_client_seed_default_v1",
+                )
+                .await;
+                let _ = tx.commit().await;
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,6 +1,7 @@
 pub mod artwork_cache;
 pub mod config;
 pub mod custom_formats;
+pub mod download_clients;
 pub mod episode_tags;
 pub mod external_accounts;
 pub mod grabbed_torrents;

--- a/src/models/series.rs
+++ b/src/models/series.rs
@@ -29,6 +29,16 @@ pub struct Series {
     /// skips this series entirely, even if a higher-quality release is
     /// available. Defaults to true to preserve historical behavior.
     pub allow_upgrades: bool,
+    /// Issue #28 PR E — per-series PT upgrade opt-in. When false (the
+    /// default), the upgrade sweep won't grab a private-tracker release
+    /// for this series even if it's the top-scoring candidate. The
+    /// initial-grab and manual-search paths aren't affected (those are
+    /// user-driven). The flag exists so a user can have torznab PT
+    /// indexers configured (for manual searches and initial grabs) but
+    /// not have the background upgrade sweep silently re-grab existing
+    /// episodes from a PT and rack up Hit-and-Runs / ratio liability
+    /// without their knowledge.
+    pub allow_pt_upgrades: bool,
     /// #23 — Per-series custom Nyaa query tokens appended after the
     /// title aliases. Overrides the global
     /// `config.default_custom_query_tokens` when non-empty.
@@ -117,6 +127,14 @@ fn map_series_row(row: sqlx::sqlite::SqliteRow) -> Series {
             .try_get::<i64, _>("allow_upgrades")
             .map(|v| v != 0)
             .unwrap_or(true),
+        // Default to false (opt-in). Pre-#28 grabs were all Nyaa-direct,
+        // which is non-PT, so this flag changing default-off doesn't
+        // affect any existing behavior — it only gates new PT-sourced
+        // upgrades against existing libraries.
+        allow_pt_upgrades: row
+            .try_get::<i64, _>("allow_pt_upgrades")
+            .map(|v| v != 0)
+            .unwrap_or(false),
         custom_query_tokens: row.try_get("custom_query_tokens").unwrap_or_default(),
         restrict_to_uploader: row.try_get("restrict_to_uploader").unwrap_or_default(),
         cumulative_prior_episodes: row
@@ -134,7 +152,7 @@ fn map_series_row(row: sqlx::sqlite::SqliteRow) -> Series {
 /// Get all tracked series, ordered by most recently added.
 pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;
@@ -144,7 +162,7 @@ pub async fn get_all(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
 
 pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE id = ?",
     )
     .bind(id)
     .fetch_optional(db)
@@ -158,7 +176,7 @@ pub async fn get_by_anilist_id(
     anilist_id: i64,
 ) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id = ?",
     )
     .bind(anilist_id)
     .fetch_optional(db)
@@ -181,7 +199,7 @@ pub async fn get_by_anilist_ids(
     }
     let placeholders = vec!["?"; anilist_ids.len()].join(",");
     let sql = format!(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id IN ({placeholders})"
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE anilist_id IN ({placeholders})"
     );
     let mut q = sqlx::query(&sql);
     for id in anilist_ids {
@@ -197,7 +215,7 @@ pub async fn get_by_anilist_ids(
 
 pub async fn get_by_mal_id(db: &SqlitePool, mal_id: i64) -> Result<Option<Series>, sqlx::Error> {
     let row = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id = ?",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id = ?",
     )
     .bind(mal_id)
     .fetch_optional(db)
@@ -457,7 +475,7 @@ pub async fn refresh_core_metadata(
 
 pub async fn get_unreconciled_fallbacks(db: &SqlitePool) -> Result<Vec<Series>, sqlx::Error> {
     let rows = sqlx::query(
-        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
+        "SELECT id, anilist_id, mal_id, title, title_romaji, title_english, title_native, cover_url, format, status, episodes, season_year, end_year, folder_name, monitor_mode, allow_upgrades, allow_pt_upgrades, custom_query_tokens, restrict_to_uploader, cumulative_prior_episodes, monitor_mode_manual_override, user_score, added_at FROM series WHERE mal_id IS NOT NULL AND anilist_id < 0 ORDER BY added_at DESC",
     )
     .fetch_all(db)
     .await?;
@@ -604,6 +622,23 @@ pub async fn update_allow_upgrades(
     allow: bool,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("UPDATE series SET allow_upgrades = ? WHERE id = ?")
+        .bind(if allow { 1_i64 } else { 0_i64 })
+        .bind(id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Issue #28 PR E — toggle the per-series PT upgrade opt-in. When
+/// false (the default), the upgrade sweep won't accept a private-
+/// tracker release as the chosen upgrade for this series. Initial
+/// grabs and manual-search grabs aren't gated.
+pub async fn update_allow_pt_upgrades(
+    db: &SqlitePool,
+    id: i64,
+    allow: bool,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("UPDATE series SET allow_pt_upgrades = ? WHERE id = ?")
         .bind(if allow { 1_i64 } else { 0_i64 })
         .bind(id)
         .execute(db)

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -1670,6 +1670,7 @@ mod tests {
             folder_name: String::new(),
             monitor_mode: "future".to_string(),
             allow_upgrades: true,
+            allow_pt_upgrades: false,
             custom_query_tokens: tokens.to_string(),
             restrict_to_uploader: user.to_string(),
             cumulative_prior_episodes: 0,

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -543,10 +543,20 @@ pub async fn rebuild_clients_cache(cache: &crate::DownloadClientsCache, db: &sql
         }
     }
     // Fall-through: if the user marked a kind+URL combo as default
-    // but it failed to instantiate, pick any other surviving row
-    // so the grab path isn't surprised by a present-but-empty pool.
+    // but it failed to instantiate (or didn't mark anything as default
+    // after a manual DB edit), pick the lowest surviving row id so the
+    // grab path isn't surprised by a present-but-empty pool. Surface
+    // this in logs — when a user reports "I marked X as default but
+    // grabs are landing on Y" the warn line names the picked id and
+    // makes the diagnosis obvious.
     if default_id.is_none() && !clients.is_empty() {
         default_id = clients.keys().min().copied();
+        if let Some(picked) = default_id {
+            tracing::warn!(
+                "download_clients: no row marked is_default=1; \
+                 picking client id {picked} as fallback default"
+            );
+        }
     }
     let pool = Arc::new(DownloadClientPool {
         clients,

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -475,6 +475,86 @@ pub fn translate_client_path(
 /// "which impl do we pick" logic lives in one place and the arm for
 /// each client ships alongside its `mod deluge` / `mod qbittorrent`
 /// etc. as Phase 3+ clients land.
+/// Multi-client routing — materialize every enabled row in
+/// `download_clients` into a live `Arc<dyn DownloadClient>`,
+/// keyed by row id. Used at startup and on Settings → Downloads
+/// add/edit/delete to rebuild the cache.
+///
+/// Failed instantiations (bad URL, reqwest::Client build failure)
+/// log + drop. The default client id is captured separately so
+/// [`AppState::client_for_indexer`] can fall through to it
+/// without re-querying the DB.
+pub async fn rebuild_clients_cache(cache: &crate::DownloadClientsCache, db: &sqlx::SqlitePool) {
+    use crate::DownloadClientPool;
+    use crate::models::download_clients;
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    let rows = match download_clients::list_enabled(db).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("download_clients: failed to load from DB: {e}");
+            Vec::new()
+        }
+    };
+    let mut clients: HashMap<i64, Arc<dyn DownloadClient>> = HashMap::new();
+    let mut default_id: Option<i64> = None;
+    for row in rows {
+        let client: Option<Arc<dyn DownloadClient>> = match row.kind.as_str() {
+            "deluge" if !row.url.is_empty() => Some(Arc::new(deluge::DelugeClient::new(
+                &row.url,
+                &row.password,
+                &row.label,
+            ))),
+            "transmission" if !row.url.is_empty() => {
+                Some(Arc::new(transmission::TransmissionClient::new(
+                    &row.url,
+                    &row.username,
+                    &row.password,
+                    &row.label,
+                )))
+            }
+            "rtorrent" if !row.url.is_empty() => Some(Arc::new(rtorrent::RtorrentClient::new(
+                &row.url,
+                &row.username,
+                &row.password,
+                &row.label,
+            ))),
+            "qbittorrent" if !row.url.is_empty() => Some(Arc::new(qbittorrent::QbitClient::new(
+                &row.url,
+                &row.username,
+                &row.password,
+                &row.label,
+            ))),
+            other => {
+                tracing::warn!(
+                    "download_clients: skipping #{} ({}) — unknown / unsupported kind {:?}",
+                    row.id,
+                    row.name,
+                    other,
+                );
+                None
+            }
+        };
+        if let Some(c) = client {
+            if row.is_default {
+                default_id = Some(row.id);
+            }
+            clients.insert(row.id, c);
+        }
+    }
+    // Fall-through: if the user marked a kind+URL combo as default
+    // but it failed to instantiate, pick any other surviving row
+    // so the grab path isn't surprised by a present-but-empty pool.
+    if default_id.is_none() && !clients.is_empty() {
+        default_id = clients.keys().min().copied();
+    }
+    let pool = Arc::new(DownloadClientPool {
+        clients,
+        default_id,
+    });
+    *cache.write().await = pool;
+}
+
 pub fn build_download_client(
     config: &crate::models::config::Config,
 ) -> Option<std::sync::Arc<dyn DownloadClient>> {

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -93,8 +93,8 @@ async fn auto_commit_row(state: &AppState, row: &pending_grabs::PendingGrab) {
     }
 
     let client = {
-        let guard = state.download_client.read().await;
-        guard.as_ref().cloned()
+        let client = state.default_download_client().await;
+        client.as_ref().cloned()
     };
     let Some(client) = client else {
         tracing::warn!(

--- a/src/services/indexer_catalog.rs
+++ b/src/services/indexer_catalog.rs
@@ -59,7 +59,12 @@ pub struct SeededIndexer {
     /// Suggested seed time floor in minutes. Same `None`-by-
     /// default reasoning as `default_seed_ratio`.
     pub default_seed_time_minutes: Option<i64>,
-    /// Default `kind` for the indexer (`torznab` or `newznab`).
+    /// Default protocol kind for the indexer (`torznab` or
+    /// `newznab`). The Add Indexer form defaults its Kind
+    /// dropdown to this value when the user picks the seed,
+    /// since most curated entries are torznab-shaped (private
+    /// and public anime trackers) and the Generic Newznab
+    /// seed is the only entry that defaults to newznab.
     pub default_kind: &'static str,
     /// Hint shown in the URL field when the user picks this
     /// card. Should look like a real Prowlarr / Jackett URL so
@@ -134,7 +139,7 @@ pub const SEEDED: &[SeededIndexer] = &[
     },
     SeededIndexer {
         slug: "animetosho",
-        display_name: "AnimeTosho (Torznab)",
+        display_name: "AnimeTosho",
         blurb: "Public anime indexer",
         notes: "",
         is_private_tracker: false,
@@ -144,20 +149,6 @@ pub const SEEDED: &[SeededIndexer] = &[
         default_seed_time_minutes: None,
         default_kind: "torznab",
         url_placeholder: "https://prowlarr.local/{N}/api",
-        is_generic: false,
-    },
-    SeededIndexer {
-        slug: "animetosho-newznab",
-        display_name: "AnimeTosho (Newznab)",
-        blurb: "Public anime indexer (Usenet mirror)",
-        notes: "",
-        is_private_tracker: false,
-        default_priority: 35,
-        default_min_seeders: 0,
-        default_seed_ratio: None,
-        default_seed_time_minutes: None,
-        default_kind: "newznab",
-        url_placeholder: "https://feed.animetosho.org/api",
         is_generic: false,
     },
     SeededIndexer {
@@ -202,6 +193,12 @@ pub const SEEDED: &[SeededIndexer] = &[
         url_placeholder: "https://prowlarr.local/{N}/api",
         is_generic: true,
     },
+    // Newznab seed kept for general-purpose Usenet indexers
+    // (NzbGeek, NZB.cat, NZBPlanet, etc.). AnimeTosho's
+    // newznab mirror was dropped from the catalog because the
+    // site's shutting down in May 2026; the remaining newznab
+    // sources carry anime as a side effect of being
+    // general-purpose, not as a curated focus.
     SeededIndexer {
         slug: "generic-newznab",
         display_name: "Generic Newznab",
@@ -365,6 +362,10 @@ mod tests {
         let generic = find_seed("generic-torznab").expect("generic torznab seed exists");
         assert!(generic.is_generic);
         assert_eq!(generic.default_kind, "torznab");
+
+        let generic_nzb = find_seed("generic-newznab").expect("generic newznab seed exists");
+        assert!(generic_nzb.is_generic);
+        assert_eq!(generic_nzb.default_kind, "newznab");
     }
 
     #[test]

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -211,6 +211,14 @@ pub trait Indexer: Send + Sync {
     /// and the fan-out concurrency order.
     fn priority(&self) -> i32;
     fn is_private_tracker(&self) -> bool;
+    /// Multi-client routing — id of the row in
+    /// `download_clients` this indexer is pinned to. `None` means
+    /// "use the default client." Read by
+    /// [`crate::AppState::client_for_indexer`] at grab time so
+    /// the cache lookup avoids hitting the DB on the hot path.
+    fn download_client_id(&self) -> Option<i64> {
+        None
+    }
 
     /// Fetch capabilities from `t=caps`. Impls should respect the
     /// 7-day TTL on the row's [`caps_json`] cache; the search-path
@@ -851,6 +859,7 @@ mod tests {
             seed_time_minutes: None,
             min_seeders: 0,
             request_timeout_secs: None,
+            download_client_id: None,
         };
         let a_id = insert(&db, mk("A", "https://a.example/api", 5))
             .await

--- a/src/services/indexers/torznab/client.rs
+++ b/src/services/indexers/torznab/client.rs
@@ -37,6 +37,10 @@ pub struct TorznabIndexer {
     /// are dropped before the search pipeline scores them.
     /// `0` disables the filter.
     min_seeders: i32,
+    /// Multi-client routing pin — id of the row in
+    /// `download_clients` this indexer is bound to. `None` =
+    /// fall through to the default client at grab time.
+    download_client_id: Option<i64>,
     http: Client,
 }
 
@@ -67,6 +71,7 @@ impl TorznabIndexer {
             priority: row.priority,
             is_private_tracker: row.is_private_tracker,
             min_seeders: row.min_seeders,
+            download_client_id: row.download_client_id,
             http,
         })
     }
@@ -169,6 +174,9 @@ impl Indexer for TorznabIndexer {
     }
     fn is_private_tracker(&self) -> bool {
         self.is_private_tracker
+    }
+    fn download_client_id(&self) -> Option<i64> {
+        self.download_client_id
     }
 
     async fn caps(&self) -> Result<IndexerCaps, String> {
@@ -284,6 +292,7 @@ mod tests {
             seed_time_minutes: None,
             min_seeders: 1,
             request_timeout_secs: None,
+            download_client_id: None,
             caps_json: String::new(),
             caps_refreshed_at: None,
             created_at: 0,

--- a/src/services/indexers/torznab/wiremock_tests/fixture.rs
+++ b/src/services/indexers/torznab/wiremock_tests/fixture.rs
@@ -28,6 +28,7 @@ pub async fn new_fixture() -> (MockServer, TorznabIndexer) {
         seed_time_minutes: None,
         min_seeders: 0,
         request_timeout_secs: Some(5),
+        download_client_id: None,
         caps_json: String::new(),
         caps_refreshed_at: None,
         created_at: 0,

--- a/src/services/monitoring.rs
+++ b/src/services/monitoring.rs
@@ -298,6 +298,7 @@ mod tests {
             folder_name: String::new(),
             monitor_mode: "all".to_string(),
             allow_upgrades: true,
+            allow_pt_upgrades: false,
             custom_query_tokens: String::new(),
             restrict_to_uploader: String::new(),
             cumulative_prior_episodes: 0,

--- a/src/services/nfo.rs
+++ b/src/services/nfo.rs
@@ -465,6 +465,7 @@ mod tests {
             folder_name: "english-title".to_string(),
             monitor_mode: "future".to_string(),
             allow_upgrades: true,
+            allow_pt_upgrades: false,
             custom_query_tokens: String::new(),
             restrict_to_uploader: String::new(),
             cumulative_prior_episodes: 0,

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -1309,11 +1309,27 @@ pub async fn run_once(state: &AppState) {
         i64,
         HashMap<String, crate::services::download_client::DownloadItem>,
     > = HashMap::new();
+    // Per-pass cache of `download_clients.download_path` keyed by
+    // client id. Hoisted out of the per-grab loop so a pass with N
+    // pending grabs sharing M clients does M queries instead of N.
+    // Empty string means "row missing or path not configured" — the
+    // import path falls back to legacy `cfg.<active_client>_download_path`.
+    let mut download_path_per_client: HashMap<i64, String> = HashMap::new();
     for id in needed_ids {
         let Some(client) = state.client_by_id(id).await else {
             tracing::debug!("post_processing: skipping client id {id} — no longer in pool");
             continue;
         };
+        // Fetch the row's download_path once. Resolves to "" when the
+        // row vanished between needed_ids collection and now (rare
+        // race) — the per-grab path then falls back to legacy.
+        let path = crate::models::download_clients::get_by_id(&state.db, id)
+            .await
+            .ok()
+            .flatten()
+            .map(|r| r.download_path)
+            .unwrap_or_default();
+        download_path_per_client.insert(id, path);
         match client.list_scoped().await {
             Ok(torrents) => {
                 let by_hash: HashMap<String, _> = torrents
@@ -1356,10 +1372,30 @@ pub async fn run_once(state: &AppState) {
         };
         let Some(client) = clients.get(&grab_client_id).cloned() else {
             // The client this grab routed to wasn't reachable on this
-            // pass (list_scoped failed, or row deleted). Leave the
-            // grab pending so the next pass retries; don't mark stale
-            // because the absence isn't evidence the user removed the
-            // torrent.
+            // pass. Two reasons:
+            //   1. `list_scoped` failed for this client this round —
+            //      transient; leave the grab alone, retry next pass.
+            //   2. The client row was disabled (or deleted post-grab
+            //      via a path that didn't NULL our stamp). Without
+            //      the NULL-out below, a stamped-but-orphaned grab
+            //      sits `pending` forever because this `continue`
+            //      runs *before* the 60s stale check — the grab
+            //      never reaches `mark_removed`.
+            //
+            // Distinguish the two by checking whether the client is
+            // in the pool *at all* (not just in our per-pass `clients`
+            // map, which is filtered by successful `list_scoped`).
+            // A client that's not even in the pool can only mean
+            // disabled-or-deleted, so NULL the stamp; the next pass
+            // falls through to default and the stale path takes over.
+            // A client that *is* in the pool but missing from
+            // `clients` means `list_scoped` failed transiently —
+            // leave the stamp alone.
+            if grab.download_client_id.is_some()
+                && state.client_by_id(grab_client_id).await.is_none()
+            {
+                let _ = grabbed_torrents::set_download_client(&state.db, grab.id, None).await;
+            }
             continue;
         };
         let all_by_hash = match by_hash_per_client.get(&grab_client_id) {
@@ -1435,19 +1471,20 @@ pub async fn run_once(state: &AppState) {
         // client, no rewrite needed. Pre-PR-F this read from
         // `cfg.<active_client>_download_path` — wrong in multi-client
         // because pinned grabs land on a non-default client.
-        let local_download_path_owned =
-            crate::models::download_clients::get_by_id(&state.db, grab_client_id)
-                .await
-                .ok()
-                .flatten()
-                .map(|r| r.download_path)
-                .unwrap_or_else(|| {
-                    // Row was deleted between grab and import. Fall back to
-                    // the legacy active_client download path so we don't lose
-                    // the user's pre-multi-client config on rollover.
-                    crate::services::download_client::per_client_download_path(&cfg).to_string()
-                });
-        let local_download_path = local_download_path_owned.as_str();
+        let cached_path = download_path_per_client
+            .get(&grab_client_id)
+            .map(|s| s.as_str())
+            .unwrap_or("");
+        let local_download_path = if cached_path.is_empty() {
+            // Row was missing from the pre-loop fetch (rare race) or
+            // legitimately had an empty download_path (same-host
+            // client). Fall back to the legacy `active_client`
+            // download path so a pre-multi-client install on rollover
+            // doesn't lose its configured rewrite.
+            crate::services::download_client::per_client_download_path(&cfg)
+        } else {
+            cached_path
+        };
         let client_path = {
             let raw = if !torrent.content_path.is_empty() {
                 torrent.content_path.clone()

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -313,10 +313,8 @@ async fn import_torrent(
     torrent_save_path: &str,
 ) -> Result<ImportOutcome, String> {
     let client = state
-        .download_client
-        .read()
+        .default_download_client()
         .await
-        .clone()
         .ok_or("Download client not configured")?;
 
     let files = client
@@ -1263,7 +1261,7 @@ pub async fn run_once(state: &AppState) {
         return;
     }
 
-    let client = match state.download_client.read().await.clone() {
+    let client = match state.default_download_client().await {
         Some(c) => c,
         None => return,
     };
@@ -1525,7 +1523,7 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
         .map_err(|_| ())?
         .unwrap_or_default();
 
-    let client = match state.download_client.read().await.clone() {
+    let client = match state.default_download_client().await {
         Some(c) => c,
         None => return Ok(()),
     };

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -7,6 +7,7 @@ use crate::models::log::LogCategory;
 use crate::models::{
     config, episode_tags, grabbed_torrents, local_metadata, metadata_cache, series,
 };
+use crate::services::download_client::DownloadClient;
 use crate::services::source::{self, SeriesContext};
 use crate::services::{logger, media, nfo};
 
@@ -311,12 +312,12 @@ async fn import_torrent(
     grab: &grabbed_torrents::GrabbedTorrent,
     torrent_hash: &str,
     torrent_save_path: &str,
+    // Multi-client routing — the client this grab landed on, threaded
+    // through from `run_once`'s per-grab resolution. Pre-PR-F this was
+    // re-fetched here as `default_download_client()`, which silently
+    // routed `get_files` to the wrong client for any pinned grab.
+    client: &std::sync::Arc<dyn DownloadClient>,
 ) -> Result<ImportOutcome, String> {
-    let client = state
-        .default_download_client()
-        .await
-        .ok_or("Download client not configured")?;
-
     let files = client
         .get_files(torrent_hash)
         .await
@@ -1261,44 +1262,118 @@ pub async fn run_once(state: &AppState) {
         return;
     }
 
-    let client = match state.default_download_client().await {
-        Some(c) => c,
-        None => return,
+    // Multi-client fan-out: pending grabs may have landed on
+    // different clients (autobrr → seedbox Deluge, RSS → Nyaa-pinned,
+    // manual → default). Each grab carries its `download_client_id`
+    // (NULL for legacy / unstamped rows → fall back to default).
+    // Pre-#PR-F we called `list_scoped()` on the default only, which
+    // missed every pinned grab and marked them stale after 60s.
+    //
+    // Strategy: collect the distinct client ids referenced, fan out
+    // `list_scoped()` once per unique client, and build a per-client
+    // (hash → torrent) lookup. Each grab is then matched against the
+    // map for *its* client. A failed `list_scoped` against one client
+    // doesn't poison the others — its grabs just stay pending until
+    // the next pass.
+    use std::collections::HashSet;
+    let default_id_opt = {
+        let pool = state.download_clients.read().await.clone();
+        pool.default_id
     };
-
-    let torrents = match client.list_scoped().await {
-        Ok(t) => t,
-        Err(e) => {
-            logger::error(
-                &state.db,
-                LogCategory::PostProcess,
-                "Failed to query download client",
-                &e.to_string(),
-            )
-            .await;
-            return;
+    let mut needed_ids: HashSet<i64> = HashSet::new();
+    for grab in &pending {
+        if let Some(id) = grab.download_client_id {
+            needed_ids.insert(id);
+        } else if let Some(id) = default_id_opt {
+            needed_ids.insert(id);
         }
-    };
+    }
+    if needed_ids.is_empty() {
+        // No clients in pool — same posture as the pre-PR-F early
+        // return when default_download_client returned None.
+        return;
+    }
 
-    // Build lookup maps by hash and name for all torrents.
-    let all_by_hash: HashMap<String, &crate::services::download_client::DownloadItem> = torrents
-        .iter()
-        .map(|t| (t.hash.to_lowercase(), t))
-        .collect();
+    // Build per-client lookup maps. Resolves each id back to its
+    // `Arc<dyn DownloadClient>`. A client deleted between the grab
+    // and now (rare race) drops out — affected grabs see no match
+    // and re-poll on the next pass. The structure carries the
+    // resolved Arc so each grab's per-torrent calls (`get_files`,
+    // etc.) reach the right client.
+    let mut clients: HashMap<i64, std::sync::Arc<dyn DownloadClient>> = HashMap::new();
+    let mut by_hash_per_client: HashMap<
+        i64,
+        HashMap<String, crate::services::download_client::DownloadItem>,
+    > = HashMap::new();
+    let mut by_name_per_client: HashMap<
+        i64,
+        HashMap<String, crate::services::download_client::DownloadItem>,
+    > = HashMap::new();
+    for id in needed_ids {
+        let Some(client) = state.client_by_id(id).await else {
+            tracing::debug!("post_processing: skipping client id {id} — no longer in pool");
+            continue;
+        };
+        match client.list_scoped().await {
+            Ok(torrents) => {
+                let by_hash: HashMap<String, _> = torrents
+                    .iter()
+                    .map(|t| (t.hash.to_lowercase(), t.clone()))
+                    .collect();
+                let by_name: HashMap<String, _> = torrents
+                    .iter()
+                    .map(|t| (t.name.to_lowercase(), t.clone()))
+                    .collect();
+                by_hash_per_client.insert(id, by_hash);
+                by_name_per_client.insert(id, by_name);
+                clients.insert(id, client);
+            }
+            Err(e) => {
+                logger::error(
+                    &state.db,
+                    LogCategory::PostProcess,
+                    &format!("Failed to query download client id={id}"),
+                    &e.to_string(),
+                )
+                .await;
+                // Fall through — this client's grabs stay pending; the
+                // others still get processed.
+            }
+        }
+    }
 
-    let all_by_name: HashMap<String, &crate::services::download_client::DownloadItem> = torrents
-        .iter()
-        .map(|t| (t.name.to_lowercase(), t))
-        .collect();
+    if clients.is_empty() {
+        return;
+    }
 
     let mut any_imported = false;
 
     for grab in &pending {
-        // Match grab to a qBit torrent.
+        // Resolve which client this grab landed on.
+        let resolved_id = grab.download_client_id.or(default_id_opt);
+        let Some(grab_client_id) = resolved_id else {
+            continue;
+        };
+        let Some(client) = clients.get(&grab_client_id).cloned() else {
+            // The client this grab routed to wasn't reachable on this
+            // pass (list_scoped failed, or row deleted). Leave the
+            // grab pending so the next pass retries; don't mark stale
+            // because the absence isn't evidence the user removed the
+            // torrent.
+            continue;
+        };
+        let all_by_hash = match by_hash_per_client.get(&grab_client_id) {
+            Some(m) => m,
+            None => continue,
+        };
+        let all_by_name = match by_name_per_client.get(&grab_client_id) {
+            Some(m) => m,
+            None => continue,
+        };
         let matched = if !grab.hash.is_empty() {
-            all_by_hash.get(&grab.hash.to_lowercase()).copied()
+            all_by_hash.get(&grab.hash.to_lowercase())
         } else {
-            all_by_name.get(&grab.torrent_name.to_lowercase()).copied()
+            all_by_name.get(&grab.torrent_name.to_lowercase())
         };
 
         let Some(torrent) = matched else {
@@ -1353,12 +1428,26 @@ pub async fn run_once(state: &AppState) {
         // hardlink the file into the library. Done BEFORE import so
         // that even if import errors out mid-way, the UI still has a
         // record of where the client left the file. Apply the
-        // user-configured per-client download path (#63 Phase 2) so a
-        // seedbox- or container-reported `/downloads/…` path is
-        // rewritten to the local mount point (e.g.
-        // `/mnt/seedbox/downloads/…`) before we read from disk. Empty
-        // download_path = same-host client, no rewrite needed.
-        let local_download_path = crate::services::download_client::per_client_download_path(&cfg);
+        // download_path from the *actual* `download_clients` row this
+        // grab landed on (#PR-F multi-client) so a seedbox-reported
+        // `/downloads/…` path is rewritten to Ryokan's local mount
+        // (e.g. `/mnt/seedbox/downloads/…`). Empty path = same-host
+        // client, no rewrite needed. Pre-PR-F this read from
+        // `cfg.<active_client>_download_path` — wrong in multi-client
+        // because pinned grabs land on a non-default client.
+        let local_download_path_owned =
+            crate::models::download_clients::get_by_id(&state.db, grab_client_id)
+                .await
+                .ok()
+                .flatten()
+                .map(|r| r.download_path)
+                .unwrap_or_else(|| {
+                    // Row was deleted between grab and import. Fall back to
+                    // the legacy active_client download path so we don't lose
+                    // the user's pre-multi-client config on rollover.
+                    crate::services::download_client::per_client_download_path(&cfg).to_string()
+                });
+        let local_download_path = local_download_path_owned.as_str();
         let client_path = {
             let raw = if !torrent.content_path.is_empty() {
                 torrent.content_path.clone()
@@ -1378,7 +1467,7 @@ pub async fn run_once(state: &AppState) {
         );
         let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
 
-        match import_torrent(state, &cfg, grab, &torrent.hash, &local_save_path).await {
+        match import_torrent(state, &cfg, grab, &torrent.hash, &local_save_path, &client).await {
             Ok(ImportOutcome::Imported) => {
                 any_imported = true;
                 let _ = grabbed_torrents::mark_imported(&state.db, grab.id).await;

--- a/src/services/rss/evaluate_candidate_tests.rs
+++ b/src/services/rss/evaluate_candidate_tests.rs
@@ -25,6 +25,7 @@ fn series(status: &str) -> series::Series {
         folder_name: "Test Series".to_string(),
         monitor_mode: "all".to_string(),
         allow_upgrades: true,
+        allow_pt_upgrades: false,
         custom_query_tokens: String::new(),
         restrict_to_uploader: String::new(),
         cumulative_prior_episodes: 0,

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -333,8 +333,17 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
     // RSS sync is Nyaa-only today (fetch_feeds hits the Nyaa
     // categories), so the per-Nyaa client pin is the right routing
     // dimension. Falls through to the default client when the user
-    // hasn't pinned Nyaa to anything specific.
-    let client = state.client_for_nyaa(cfg.nyaa_download_client_id).await;
+    // hasn't pinned Nyaa to anything specific. The id is captured
+    // alongside the client so each grab's `download_client_id` is
+    // stamped — post-processing routes per-grab back to the right
+    // client without needing to re-resolve the pin at import time.
+    let (client, dispatch_client_id) = match state
+        .client_for_nyaa_with_id(cfg.nyaa_download_client_id)
+        .await
+    {
+        Some((c, id)) => (Some(c), Some(id)),
+        None => (None, None),
+    };
 
     // One compiled-CF snapshot for the whole RSS pass so each item's
     // score reflects the user's CF profile. Without this thread-through
@@ -784,6 +793,14 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
                 .await
                 .ok()
                 .flatten();
+                if let Some(gid) = grab_id {
+                    let _ = crate::models::grabbed_torrents::set_download_client(
+                        &state.db,
+                        gid,
+                        dispatch_client_id,
+                    )
+                    .await;
+                }
                 // Reuse the pre-disk classification computed earlier
                 // during the upgrade gate (stashed on the pending
                 // candidate). Saves a second DB + potential HTTP round

--- a/src/services/rss/mod.rs
+++ b/src/services/rss/mod.rs
@@ -330,7 +330,11 @@ async fn sync_once_inner(state: &AppState, trigger: &str) -> Result<SyncSummary,
     for row in &tracked {
         let _ = monitoring_service::ensure_series_monitoring_rows(&state.db, row).await;
     }
-    let client = state.download_client.read().await.clone();
+    // RSS sync is Nyaa-only today (fetch_feeds hits the Nyaa
+    // categories), so the per-Nyaa client pin is the right routing
+    // dimension. Falls through to the default client when the user
+    // hasn't pinned Nyaa to anything specific.
+    let client = state.client_for_nyaa(cfg.nyaa_download_client_id).await;
 
     // One compiled-CF snapshot for the whole RSS pass so each item's
     // score reflects the user's CF profile. Without this thread-through

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -42,7 +42,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
         .await
         .map_err(|e| e.to_string())?;
 
-    let client_opt = state.download_client.read().await.clone();
+    let client_opt = state.default_download_client().await;
     let Some(client) = client_opt.as_ref() else {
         return Ok(UpgradeSummary {
             series_checked: 0,

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -61,6 +61,22 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
     // a CF mid-sweep, the next scheduled run picks it up.
     let cfs = state.custom_formats.read().await.clone();
 
+    // Issue #28 PR E — snapshot the set of PT indexer IDs once per
+    // sweep so the per-series PT-upgrade gate doesn't re-read the
+    // IndexerCache (or hit the DB) on every result. The set is used
+    // to skip an upgrade candidate when the source indexer is private
+    // and the series hasn't opted in via `allow_pt_upgrades`. Empty
+    // when the user has zero PT indexers configured — the gate then
+    // never fires.
+    let pt_indexer_ids: HashSet<i64> = {
+        let snapshot = state.indexers.read().await.clone();
+        snapshot
+            .iter()
+            .filter(|i| i.is_private_tracker())
+            .map(|i| i.id())
+            .collect()
+    };
+
     logger::info(
         &state.db,
         LogCategory::AutoSearch,
@@ -212,6 +228,41 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
             let Some(result) = best else {
                 continue;
             };
+
+            // Issue #28 PR E — PT upgrade gate. When a user hasn't
+            // opted this series in to PT-sourced upgrades and the
+            // chosen candidate came from a private tracker, skip
+            // the upgrade. The user can still grab from PT manually
+            // (initial grab + manual search aren't gated) — this
+            // only stops the background sweep from silently
+            // re-grabbing existing episodes from a PT and racking
+            // up Hit-and-Run liability.
+            //
+            // Trade-off: skipping here means we might miss a
+            // legitimate non-PT upgrade that was ranked second
+            // behind the PT pick. Acceptable for v1.5 — the next
+            // sweep tick (24h cadence) re-runs and the non-PT
+            // candidate would then be the top pick if the PT one
+            // dropped off. If users hit this in practice, we can
+            // upgrade to candidate-pool filtering inside
+            // `find_best_for_target` later.
+            if !row.allow_pt_upgrades
+                && let Some(idx_id) = result.indexer_id
+                && pt_indexer_ids.contains(&idx_id)
+            {
+                logger::debug(
+                    &state.db,
+                    LogCategory::AutoSearch,
+                    &format!(
+                        "Upgrade: {} {} skipped — PT-sourced and series.allow_pt_upgrades = 0",
+                        title,
+                        auto_search::target_label(&target),
+                    ),
+                    &format!("indexer_id={idx_id}"),
+                )
+                .await;
+                continue;
+            }
 
             // Classify the incoming release once; reused for upgrade verification,
             // grab logging, and episode tag persistence below.

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -42,15 +42,21 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
         .await
         .map_err(|e| e.to_string())?;
 
-    let client_opt = state.default_download_client().await;
-    let Some(client) = client_opt.as_ref() else {
+    // Multi-client routing — resolved per-result inside the loop via
+    // `client_for_indexer_with_id(result.indexer_id)`. We bail early
+    // here only when the pool is empty (no clients configured at all);
+    // an individual indexer's pin can still resolve later. Pre-1.5.x
+    // a single global client was checked once at top — that's now
+    // wrong because a per-indexer pin can route grabs to a different
+    // client than the default.
+    if state.default_download_client().await.is_none() {
         return Ok(UpgradeSummary {
             series_checked: 0,
             episodes_checked: 0,
             upgrades_grabbed: 0,
             detail: "Download client not configured; skipping upgrade search".to_string(),
         });
-    };
+    }
 
     let mut total_series_checked: usize = 0;
     let mut total_episodes_checked: usize = 0;
@@ -317,6 +323,26 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                 continue;
             }
 
+            // Resolve the right client per-result so a PT indexer
+            // pinned to the seedbox (and a public indexer landing on
+            // local qBit) both work in the same sweep. Skip the
+            // result if pin resolution finds no client at all
+            // (pool empty or all-disabled mid-sweep).
+            let (client, dispatch_client_id) =
+                match state.client_for_indexer_with_id(result.indexer_id).await {
+                    Some(t) => t,
+                    None => {
+                        logger::warn(
+                            &state.db,
+                            LogCategory::QBit,
+                            &format!("Upgrade skip: no download client for {}", result.title),
+                            "indexer pin resolution returned None",
+                        )
+                        .await;
+                        continue;
+                    }
+                };
+
             match client.add_torrent(&url, &result.info_hash).await {
                 Ok(_) => {
                     total_upgrades_grabbed += 1;
@@ -350,7 +376,7 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                         // doesn't re-find / re-grab the same pack.
                         covered_by_batch.extend(&ep_nums);
                     }
-                    let _ = crate::models::grabbed_torrents::record_grab(
+                    let grab_id = crate::models::grabbed_torrents::record_grab(
                         &state.db,
                         &result.info_hash,
                         &result.title,
@@ -358,7 +384,17 @@ pub async fn run_once(state: &AppState) -> Result<UpgradeSummary, String> {
                         &ep_nums,
                         result.is_batch,
                     )
-                    .await;
+                    .await
+                    .ok()
+                    .flatten();
+                    if let Some(gid) = grab_id {
+                        let _ = crate::models::grabbed_torrents::set_download_client(
+                            &state.db,
+                            gid,
+                            Some(dispatch_client_id),
+                        )
+                        .await;
+                    }
                     for ep_num in &ep_nums {
                         let _ = episode_tags::record_grab(
                             &state.db,

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -69,9 +69,26 @@ pub fn build_test_app_state(
 ) -> AppState {
     let cf_cache: CompiledCfCache = Arc::new(RwLock::new(Arc::new(Vec::new())));
     let indexers: crate::IndexerCache = Arc::new(RwLock::new(Arc::new(Vec::new())));
+    // Multi-client routing — pre-populate the pool with id=1 marked
+    // as default if a client was supplied. Tests that exercise the
+    // pin-resolution chain via specific ids should construct their
+    // own pool; the simple "did the grab dispatch?" tests use this
+    // shape and don't care about ids.
+    let mut clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>> =
+        std::collections::HashMap::new();
+    let mut default_id = None;
+    if let Some(c) = download_client {
+        clients.insert(1, c);
+        default_id = Some(1);
+    }
+    let pool = crate::DownloadClientPool {
+        clients,
+        default_id,
+    };
+    let download_clients: crate::DownloadClientsCache = Arc::new(RwLock::new(Arc::new(pool)));
     AppState {
         db,
-        download_client: Arc::new(RwLock::new(download_client)),
+        download_clients,
         jellyfin: Arc::new(RwLock::new(None)),
         custom_formats: cf_cache,
         indexers,

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -1308,6 +1308,49 @@ function setAllowUpgrades(allow) {
     });
 }
 
+// Issue #28 PR E — toggle the per-series PT upgrade opt-in.
+// Mirror of setAllowUpgrades; lives on the same page, hits the
+// parallel /api/library/allow-pt-upgrades endpoint, reverts the
+// checkbox state on failure so the UI never lies about what's
+// persisted.
+function setAllowPtUpgrades(allow) {
+    const dbId = parseInt(SD.dbId);
+    if (!dbId) return;
+    const checkbox = document.getElementById('allow-pt-upgrades');
+    const status = document.getElementById('allow-pt-upgrades-status');
+    if (checkbox) checkbox.disabled = true;
+    const originalHint = status ? status.textContent : '';
+    if (status) status.textContent = 'Saving…';
+
+    fetch('/api/library/allow-pt-upgrades', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ series_id: dbId, allow: allow })
+    })
+    .then(async r => {
+        let data = {};
+        try { data = await r.json(); } catch (_) {}
+        if (!r.ok) throw new Error(data.message || 'Failed to update PT-upgrades toggle');
+        return data;
+    })
+    .then(_ => {
+        if (status) status.textContent = allow
+            ? 'PT-sourced upgrades enabled for this series.'
+            : 'PT-sourced upgrades disabled — sweep will skip private-tracker candidates.';
+        if (checkbox) checkbox.disabled = false;
+    })
+    .catch(err => {
+        if (status) status.textContent = err.message || 'Failed to update PT-upgrades toggle';
+        if (checkbox) {
+            checkbox.checked = !allow;
+            checkbox.disabled = false;
+        }
+        // Restore original hint after a beat so a transient error
+        // doesn't permanently mask the default copy.
+        setTimeout(() => { if (status && originalHint) status.textContent = originalHint; }, 4000);
+    });
+}
+
 // #23 — Save per-series search overrides (Nyaa uploader + custom tokens).
 // Empty inputs clear the override server-side so the series falls back
 // to the global default in Settings → Quality.

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -438,6 +438,41 @@ function testQbit(btn) {
     });
 }
 
+function testDownloadClient(btn) {
+    // Lives next to the Add/Edit Download Client form. Walks up to
+    // the surrounding <form> and POSTs every field needed for a
+    // dry-run connection test — without saving the row. Result
+    // lands in the sibling .dc-test-result span.
+    const form = btn.closest('form');
+    const result = form ? form.querySelector('.dc-test-result') : null;
+    if (!form || !result) return;
+    const payload = {
+        kind: form.querySelector('[name=kind]').value,
+        url: form.querySelector('[name=url]').value,
+        username: (form.querySelector('[name=username]') || {}).value || '',
+        password: (form.querySelector('[name=password]') || {}).value || '',
+        label: (form.querySelector('[name=label]') || {}).value || '',
+    };
+    btn.disabled = true;
+    result.textContent = 'Testing...';
+    fetch('/api/download-clients/test', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify(payload)
+    })
+    .then(async r => {
+        const data = await r.json();
+        if (!r.ok) throw new Error(data.message || 'Connection failed');
+        result.textContent = data.message;
+    })
+    .catch(err => {
+        result.textContent = err.message;
+    })
+    .finally(() => {
+        btn.disabled = false;
+    });
+}
+
 function testJellyfin(btn) {
     const result = document.getElementById('jellyfin-test-result');
     const payload = {

--- a/templates/partials/settings/download_clients.html
+++ b/templates/partials/settings/download_clients.html
@@ -1,0 +1,197 @@
+<fieldset>
+    <legend>Download Clients</legend>
+    <p class="form-hint">
+        Ryokan can route grabs to multiple download clients. Pin a specific client to an indexer on the
+        <a href="/settings?tab=indexers" class="link-accent">Indexers</a> tab; built-in Nyaa search uses the dropdown there too.
+        Grabs without an explicit pin land on the default client.
+    </p>
+
+    {% if !download_clients.is_empty() %}
+    <div class="table-scroll-wrap">
+    <table class="indexers-table">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Kind</th>
+                <th>URL</th>
+                <th>Status</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for dc in download_clients %}
+            <tr>
+                <td>
+                    {{ dc.name }}
+                    {% if dc.is_default %}<span class="badge badge-success" style="margin-left:6px">default</span>{% endif %}
+                </td>
+                <td>{{ dc.kind }}</td>
+                <td><code>{{ dc.url }}</code></td>
+                <td>{% if dc.enabled %}Enabled{% else %}Disabled{% endif %}</td>
+                <td>
+                    <a href="/settings?tab=integrations&edit_id={{ dc.id }}" class="btn btn-small">Edit</a>
+                    {% if !dc.is_default %}
+                    <form method="post" action="/settings/download-clients/set-default" style="display:inline">
+                        <input type="hidden" name="id" value="{{ dc.id }}">
+                        <button type="submit" class="btn btn-small">Set default</button>
+                    </form>
+                    {% endif %}
+                    <form method="post" action="/settings/download-clients/delete" style="display:inline"
+                          data-ryokan-confirm-title="Delete download client?"
+                          data-ryokan-confirm-body="Remove '{{ dc.name }}' from Ryokan. Any indexers pinned to it (and the Nyaa pin if set) will fall back to the default client at grab time."
+                          data-ryokan-confirm-yes="Delete"
+                          data-ryokan-confirm-no="Cancel"
+                          data-ryokan-confirm-danger="1">
+                        <input type="hidden" name="id" value="{{ dc.id }}">
+                        <button type="submit" class="btn btn-danger btn-small">Delete</button>
+                    </form>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if let Some(edit) = download_client_edit %}
+    <h3 class="settings-subheading">Edit Download Client</h3>
+    <p class="form-hint">
+        Updating <strong>{{ edit.name }}</strong>.
+        <a href="/settings?tab=integrations" class="link-accent">Cancel and return to Add Client.</a>
+    </p>
+    <form method="post" action="/settings/download-clients/upsert" class="settings-form settings-subform">
+        <input type="hidden" name="id" value="{{ edit.id }}">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-edit-name">Name</label>
+                <input id="dc-edit-name" type="text" name="name" required maxlength="100" value="{{ edit.name }}">
+            </div>
+            <div class="form-group">
+                <label for="dc-edit-kind">Kind</label>
+                <select id="dc-edit-kind" name="kind">
+                    <option value="qbittorrent" {% if edit.kind == "qbittorrent" %}selected{% endif %}>qBittorrent</option>
+                    <option value="deluge" {% if edit.kind == "deluge" %}selected{% endif %}>Deluge</option>
+                    <option value="transmission" {% if edit.kind == "transmission" %}selected{% endif %}>Transmission</option>
+                    <option value="rtorrent" {% if edit.kind == "rtorrent" %}selected{% endif %}>rTorrent</option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="dc-edit-url">URL</label>
+            <input id="dc-edit-url" type="url" name="url" required value="{{ edit.url }}" placeholder="http://localhost:8080">
+            <span class="form-hint">For Deluge / Transmission / rTorrent, point at the Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-edit-username">Username</label>
+                <input id="dc-edit-username" type="text" name="username" autocomplete="off" value="{{ edit.username }}">
+                <span class="form-hint">Deluge ignores the username and uses password only — leave blank.</span>
+            </div>
+            <div class="form-group">
+                <label for="dc-edit-password">Password</label>
+                <input id="dc-edit-password" type="password" name="password" autocomplete="new-password" value="{{ edit.password }}">
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-edit-label">Category / label</label>
+                <input id="dc-edit-label" type="text" name="label" value="{{ edit.label }}" placeholder="anime">
+                <span class="form-hint">qBit calls this a "category", the others call it a "label". Ryokan tags every torrent it adds with this value and filters by it when listing.</span>
+            </div>
+            <div class="form-group">
+                <label for="dc-edit-download-path">Download path (as seen by Ryokan)</label>
+                <input id="dc-edit-download-path" type="text" name="download_path" value="{{ edit.download_path }}" placeholder="/downloads">
+                <span class="form-hint">Where the client's completed downloads are accessible to Ryokan. Leave blank if Ryokan and the client see the exact same paths.</span>
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="enabled" {% if edit.enabled %}checked{% endif %}>
+                    Enabled
+                </label>
+                <span class="form-hint">Disable to keep the row but exclude it from grab routing.</span>
+            </div>
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="is_default" {% if edit.is_default %}checked{% endif %}>
+                    Default client
+                </label>
+                <span class="form-hint">Receives every grab without an explicit pin. Exactly one row holds this flag at a time.</span>
+            </div>
+        </div>
+        <div class="settings-inline-actions">
+            <button type="submit" class="btn btn-primary">Save changes</button>
+            <button type="button" class="btn btn-secondary" onclick="testDownloadClient(this)">Test connection</button>
+            <span class="dc-test-result form-hint"></span>
+        </div>
+    </form>
+    {% else %}
+    <h3 class="settings-subheading">Add Download Client</h3>
+    <form method="post" action="/settings/download-clients/upsert" class="settings-form settings-subform">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-add-name">Name</label>
+                <input id="dc-add-name" type="text" name="name" required maxlength="100" placeholder="e.g. Local qBit">
+            </div>
+            <div class="form-group">
+                <label for="dc-add-kind">Kind</label>
+                <select id="dc-add-kind" name="kind">
+                    <option value="qbittorrent" selected>qBittorrent</option>
+                    <option value="deluge">Deluge</option>
+                    <option value="transmission">Transmission</option>
+                    <option value="rtorrent">rTorrent</option>
+                </select>
+            </div>
+        </div>
+        <div class="form-group">
+            <label for="dc-add-url">URL</label>
+            <input id="dc-add-url" type="url" name="url" required placeholder="http://localhost:8080">
+            <span class="form-hint">For Deluge / Transmission / rTorrent, point at the Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-add-username">Username</label>
+                <input id="dc-add-username" type="text" name="username" autocomplete="off">
+                <span class="form-hint">Deluge ignores the username and uses password only — leave blank.</span>
+            </div>
+            <div class="form-group">
+                <label for="dc-add-password">Password</label>
+                <input id="dc-add-password" type="password" name="password" autocomplete="new-password">
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label for="dc-add-label">Category / label</label>
+                <input id="dc-add-label" type="text" name="label" placeholder="anime">
+                <span class="form-hint">qBit calls this a "category", the others call it a "label". Ryokan tags every torrent it adds with this value and filters by it when listing.</span>
+            </div>
+            <div class="form-group">
+                <label for="dc-add-download-path">Download path (as seen by Ryokan)</label>
+                <input id="dc-add-download-path" type="text" name="download_path" placeholder="/downloads">
+                <span class="form-hint">Where the client's completed downloads are accessible to Ryokan. Leave blank if Ryokan and the client see the exact same paths.</span>
+            </div>
+        </div>
+        <div class="form-row">
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="enabled" checked>
+                    Enabled
+                </label>
+            </div>
+            <div class="form-group">
+                <label class="checkbox-label">
+                    <input type="checkbox" name="is_default" {% if download_clients.is_empty() %}checked{% endif %}>
+                    Default client
+                </label>
+                <span class="form-hint">Receives every grab without an explicit pin.</span>
+            </div>
+        </div>
+        <div class="settings-inline-actions">
+            <button type="submit" class="btn btn-primary">Add client</button>
+            <button type="button" class="btn btn-secondary" onclick="testDownloadClient(this)">Test connection</button>
+            <span class="dc-test-result form-hint"></span>
+        </div>
+    </form>
+    {% endif %}
+</fieldset>

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -127,6 +127,20 @@
                 </label>
             </div>
 
+            <div class="form-group">
+                <label for="indexer-edit-dc">Download Client</label>
+                <select id="indexer-edit-dc" name="download_client_id">
+                    <option value="">(use default)</option>
+                    {% for dc in download_clients %}
+                    <option value="{{ dc.id }}"
+                        {% if let Some(pin) = edit.download_client_id %}{% if *pin == dc.id %}selected{% endif %}{% endif %}>
+                        {{ dc.name }}{% if dc.is_default %} (default){% endif %}
+                    </option>
+                    {% endfor %}
+                </select>
+                <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag.</span>
+            </div>
+
             <button type="submit" class="btn btn-primary">Save Changes</button>
         </form>
         {% else if let Some(seed) = indexer_seed %}
@@ -219,6 +233,17 @@
                 <span class="form-hint">Marks this indexer as PT for the per-series upgrade opt-in.</span>
             </div>
 
+            <div class="form-group">
+                <label for="indexer-add-dc">Download Client</label>
+                <select id="indexer-add-dc" name="download_client_id">
+                    <option value="">(use default)</option>
+                    {% for dc in download_clients %}
+                    <option value="{{ dc.id }}">{{ dc.name }}{% if dc.is_default %} (default){% endif %}</option>
+                    {% endfor %}
+                </select>
+                <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag.</span>
+            </div>
+
             <button type="submit" class="btn btn-primary">Add Indexer</button>
         </form>
         {% else %}
@@ -242,6 +267,35 @@
         </div>
         {% endif %}
     </fieldset>
+
+    {# Built-in Nyaa search routes through whichever download
+       client this row points at. Empty selection = use the default
+       client. Standalone form (not nested in any other) — POSTs
+       to `/settings/indexers/nyaa-pin`, which writes
+       `config.nyaa_download_client_id`. #}
+    {% if indexer_edit.is_none() && indexer_seed.is_none() %}
+    <fieldset class="settings-form">
+        <legend>Nyaa search</legend>
+        <p class="form-hint" style="margin: 0 0 12px;">
+            Ryokan's built-in Nyaa search (the public-tracker hot path) isn't a torznab indexer row — pin it to a download client here.
+        </p>
+        <form method="post" action="/settings/indexers/nyaa-pin" class="settings-form settings-subform">
+            <div class="form-group">
+                <label for="nyaa-dc">Download Client</label>
+                <select id="nyaa-dc" name="download_client_id">
+                    <option value="">(use default)</option>
+                    {% for dc in download_clients %}
+                    <option value="{{ dc.id }}"
+                        {% if let Some(pin) = config.nyaa_download_client_id %}{% if *pin == dc.id %}selected{% endif %}{% endif %}>
+                        {{ dc.name }}{% if dc.is_default %} (default){% endif %}
+                    </option>
+                    {% endfor %}
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary">Save Nyaa pin</button>
+        </form>
+    </fieldset>
+    {% endif %}
 
     {# Push receivers — webhook-driven release sources. autobrr's
        Webhook action POSTs releases at Ryokan's /api/webhook/autobrr

--- a/templates/partials/settings/integrations.html
+++ b/templates/partials/settings/integrations.html
@@ -1,15 +1,5 @@
         <fieldset>
-            <legend>Download Client</legend>
-            <div class="form-group">
-                <label for="active_client">Active client</label>
-                <select name="active_client" id="active_client" onchange="toggleClientFieldset(this.value)">
-                    <option value="qbittorrent" {% if config.active_client == "qbittorrent" %}selected{% endif %}>qBittorrent</option>
-                    <option value="deluge" {% if config.active_client == "deluge" %}selected{% endif %}>Deluge</option>
-                    <option value="transmission" {% if config.active_client == "transmission" %}selected{% endif %}>Transmission</option>
-                    <option value="rtorrent" {% if config.active_client == "rtorrent" %}selected{% endif %}>rTorrent</option>
-                </select>
-                <span class="form-hint">Ryokan talks to one client at a time. Switching cancels any pending grabs queued against the previous client.</span>
-            </div>
+            <legend>Grab behavior</legend>
             <div class="form-group">
                 <label for="grab_preview_mode">Interactive file picker</label>
                 <select name="grab_preview_mode" id="grab_preview_mode">
@@ -18,137 +8,37 @@
                 </select>
                 <span class="form-hint">When set to <em>Batches only</em>, multi-file torrents open a modal where you can uncheck files (samples, NCOPs, extras) before the grab commits. Single-file torrents always skip the modal. Set to <em>Never</em> for 1.3.0-style one-click grabs.</span>
             </div>
+            <p class="form-hint">
+                Configure download clients in the <strong>Download Clients</strong> section below.
+            </p>
         </fieldset>
 
-        <fieldset id="qbit-fieldset" {% if config.active_client != "qbittorrent" %}style="display:none"{% endif %}>
-            <legend>qBittorrent <span id="qbit-health" class="form-hint"></span></legend>
-            <div class="form-group">
-                <label for="qbit_url">URL</label>
-                <input type="text" name="qbit_url" id="qbit_url" value="{{ config.qbit_url }}" placeholder="http://localhost:8080">
-            </div>
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="qbit_user">Username</label>
-                    <input type="text" name="qbit_user" id="qbit_user" value="{{ config.qbit_user }}">
-                </div>
-                <div class="form-group">
-                    <label for="qbit_pass">Password</label>
-                    <div style="display: flex; gap: 8px; align-items: center;">
-                        <input type="password" name="qbit_pass" id="qbit_pass" value="{{ config.qbit_pass }}" style="flex:1">
-                        <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('qbit_pass', this)" style="white-space:nowrap">Show</button>
-                        <button type="button" class="btn btn-secondary" onclick="copyApiKey('qbit_pass', this)" style="white-space:nowrap">Copy</button>
-                    </div>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="qbit_category">Download Category</label>
-                <input type="text" name="qbit_category" id="qbit_category" value="{{ config.qbit_category }}" placeholder="anime">
-            </div>
-            <div class="form-group">
-                <label for="qbit_download_path">Download Path (as seen by Ryokan)</label>
-                <input type="text" name="qbit_download_path" id="qbit_download_path" value="{{ config.qbit_download_path }}" placeholder="/downloads">
-                <span class="form-hint">The local path where qBittorrent's completed downloads are accessible to Ryokan. When qBit runs in Docker with a host volume mount, enter the host-side path (e.g. <code>/home/user/downloads</code>). When qBit runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and qBit see the exact same paths.</span>
-            </div>
-            <div class="settings-inline-actions">
-                <button type="button" class="btn btn-secondary" onclick="testQbit(this)">Test</button>
-                <span id="qbit-test-result" class="form-hint"></span>
-            </div>
-        </fieldset>
-
-        <fieldset id="deluge-fieldset" {% if config.active_client != "deluge" %}style="display:none"{% endif %}>
-            <legend>Deluge <span id="deluge-health" class="form-hint"></span></legend>
-            <div class="form-group">
-                <label for="deluge_url">URL</label>
-                <input type="text" name="deluge_url" id="deluge_url" value="{{ config.deluge_url }}" placeholder="http://localhost:8112">
-                <span class="form-hint">Deluge Web UI base URL (Ryokan appends <code>/json</code>). Default port is 8112.</span>
-            </div>
-            <div class="form-group">
-                <label for="deluge_password">Web UI password</label>
-                <div style="display: flex; gap: 8px; align-items: center;">
-                    <input type="password" name="deluge_password" id="deluge_password" value="{{ config.deluge_password }}" style="flex:1">
-                    <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('deluge_password', this)" style="white-space:nowrap">Show</button>
-                    <button type="button" class="btn btn-secondary" onclick="copyApiKey('deluge_password', this)" style="white-space:nowrap">Copy</button>
-                </div>
-                <span class="form-hint">The Web UI password (not the daemon/localclient password). Default on fresh installs is <code>deluge</code>.</span>
-            </div>
-            <div class="form-group">
-                <label for="deluge_label">Scoping label</label>
-                <input type="text" name="deluge_label" id="deluge_label" value="{{ config.deluge_label }}" placeholder="ryokan">
-                <span class="form-hint">Ryokan tags every torrent it adds with this label and filters by it when listing. Requires the Label plugin; Ryokan auto-enables it on first connect.</span>
-            </div>
-            <div class="form-group">
-                <label for="deluge_download_path">Download Path (as seen by Ryokan)</label>
-                <input type="text" name="deluge_download_path" id="deluge_download_path" value="{{ config.deluge_download_path }}" placeholder="/downloads">
-                <span class="form-hint">The local path where Deluge's completed downloads are accessible to Ryokan. When Deluge runs in Docker with a host volume mount, enter the host-side path. When Deluge runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and Deluge see the exact same paths.</span>
-            </div>
-        </fieldset>
-
-        <fieldset id="transmission-fieldset" {% if config.active_client != "transmission" %}style="display:none"{% endif %}>
-            <legend>Transmission <span id="transmission-health" class="form-hint"></span></legend>
-            <div class="form-group">
-                <label for="transmission_url">URL</label>
-                <input type="text" name="transmission_url" id="transmission_url" value="{{ config.transmission_url }}" placeholder="http://localhost:9091">
-                <span class="form-hint">Transmission RPC base URL (Ryokan appends <code>/transmission/rpc</code>). Default port is 9091.</span>
-            </div>
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="transmission_user">Username</label>
-                    <input type="text" name="transmission_user" id="transmission_user" value="{{ config.transmission_user }}">
-                </div>
-                <div class="form-group">
-                    <label for="transmission_password">Password</label>
-                    <div style="display: flex; gap: 8px; align-items: center;">
-                        <input type="password" name="transmission_password" id="transmission_password" value="{{ config.transmission_password }}" style="flex:1">
-                        <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('transmission_password', this)" style="white-space:nowrap">Show</button>
-                        <button type="button" class="btn btn-secondary" onclick="copyApiKey('transmission_password', this)" style="white-space:nowrap">Copy</button>
-                    </div>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="transmission_label">Scoping label</label>
-                <input type="text" name="transmission_label" id="transmission_label" value="{{ config.transmission_label }}" placeholder="ryokan">
-                <span class="form-hint">Ryokan tags every torrent it adds with this label and filters by it when listing. Requires Transmission 4.x for native label support.</span>
-            </div>
-            <div class="form-group">
-                <label for="transmission_download_path">Download Path (as seen by Ryokan)</label>
-                <input type="text" name="transmission_download_path" id="transmission_download_path" value="{{ config.transmission_download_path }}" placeholder="/downloads/complete">
-                <span class="form-hint">The local path where Transmission's completed downloads are accessible to Ryokan. When Transmission runs in Docker with a host volume mount, enter the host-side path. When Transmission runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and Transmission see the exact same paths. <strong>Note:</strong> the <code>linuxserver/transmission</code> image defaults <code>download-dir</code> to <code>/downloads/complete</code> (not <code>/downloads</code>), so point this at the <code>complete</code> subdirectory on the host — or edit Transmission's <code>settings.json</code> to flatten it.</span>
-            </div>
-        </fieldset>
-
-        <fieldset id="rtorrent-fieldset" {% if config.active_client != "rtorrent" %}style="display:none"{% endif %}>
-            <legend>rTorrent <span id="rtorrent-health" class="form-hint"></span></legend>
-            <div class="form-group">
-                <label for="rtorrent_url">XML-RPC URL</label>
-                <input type="text" name="rtorrent_url" id="rtorrent_url" value="{{ config.rtorrent_url }}" placeholder="">
-                <span class="form-hint">XML-RPC endpoint URL. Ryokan appends <code>/RPC2</code> automatically if the URL doesn't already end in it, matching Deluge/Transmission path handling. Common shapes: <code>http://host:8081</code> for a local ruTorrent container, <code>https://seedbox.example.com/rutorrent</code> or <code>https://seedbox.example.com</code> for a seedbox.</span>
-            </div>
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="rtorrent_user">Username</label>
-                    <input type="text" name="rtorrent_user" id="rtorrent_user" value="{{ config.rtorrent_user }}">
-                </div>
-                <div class="form-group">
-                    <label for="rtorrent_password">Password</label>
-                    <div style="display: flex; gap: 8px; align-items: center;">
-                        <input type="password" name="rtorrent_password" id="rtorrent_password" value="{{ config.rtorrent_password }}" style="flex:1">
-                        <button type="button" class="btn btn-secondary" onclick="toggleApiKeyVisibility('rtorrent_password', this)" style="white-space:nowrap">Show</button>
-                        <button type="button" class="btn btn-secondary" onclick="copyApiKey('rtorrent_password', this)" style="white-space:nowrap">Copy</button>
-                    </div>
-                    <span class="form-hint">HTTP Basic auth. Leave blank if the endpoint is unauthenticated (e.g. a same-host container on an internal network).</span>
-                </div>
-            </div>
-            <div class="form-group">
-                <label for="rtorrent_label">Scoping label</label>
-                <input type="text" name="rtorrent_label" id="rtorrent_label" value="{{ config.rtorrent_label }}" placeholder="ryokan">
-                <span class="form-hint">Stored in rtorrent's <code>custom1</code> field (the ruTorrent label convention). Ryokan filters <code>list_scoped</code> by this value.</span>
-            </div>
-            <div class="form-group">
-                <label for="rtorrent_download_path">Download Path (as seen by Ryokan)</label>
-                <input type="text" name="rtorrent_download_path" id="rtorrent_download_path" value="{{ config.rtorrent_download_path }}" placeholder="/downloads/completed/ryokan">
-                <span class="form-hint">The local path where rtorrent's completed downloads are accessible to Ryokan. When rtorrent runs in Docker with a host volume mount, enter the host-side path. When rtorrent runs on a seedbox, enter the local mount point you reach it through (SSHFS/NFS/rclone). Leave blank only if Ryokan and rtorrent see the exact same paths. <strong>Note:</strong> many <code>rtorrent.rc</code> configs (including the <code>linuxserver/rutorrent</code> image's defaults) move completed torrents into a per-label subdirectory via <code>event.download.finished</code> hooks — e.g. <code>/downloads/completed/ryokan/</code> rather than just <code>/downloads/completed/</code>. If your setup does this, include the label subdirectory in the path here (the scoping label you set above is typically the subdir name).</span>
-            </div>
-        </fieldset>
+        {# Hidden inputs preserve the legacy single-slot config columns
+           through the bulk Settings POST so the parser doesn't drop the
+           values. Multi-client routing reads from `download_clients` /
+           `indexers.download_client_id` / `config.nyaa_download_client_id`
+           instead, but the legacy columns are kept as a one-release
+           rollback hatch (PR F follow-up will strip them entirely). #}
+        <input type="hidden" name="active_client" value="{{ config.active_client }}">
+        <input type="hidden" name="qbit_url" value="{{ config.qbit_url }}">
+        <input type="hidden" name="qbit_user" value="{{ config.qbit_user }}">
+        <input type="hidden" name="qbit_pass" value="{{ config.qbit_pass }}">
+        <input type="hidden" name="qbit_category" value="{{ config.qbit_category }}">
+        <input type="hidden" name="qbit_download_path" value="{{ config.qbit_download_path }}">
+        <input type="hidden" name="deluge_url" value="{{ config.deluge_url }}">
+        <input type="hidden" name="deluge_password" value="{{ config.deluge_password }}">
+        <input type="hidden" name="deluge_label" value="{{ config.deluge_label }}">
+        <input type="hidden" name="deluge_download_path" value="{{ config.deluge_download_path }}">
+        <input type="hidden" name="transmission_url" value="{{ config.transmission_url }}">
+        <input type="hidden" name="transmission_user" value="{{ config.transmission_user }}">
+        <input type="hidden" name="transmission_password" value="{{ config.transmission_password }}">
+        <input type="hidden" name="transmission_label" value="{{ config.transmission_label }}">
+        <input type="hidden" name="transmission_download_path" value="{{ config.transmission_download_path }}">
+        <input type="hidden" name="rtorrent_url" value="{{ config.rtorrent_url }}">
+        <input type="hidden" name="rtorrent_user" value="{{ config.rtorrent_user }}">
+        <input type="hidden" name="rtorrent_password" value="{{ config.rtorrent_password }}">
+        <input type="hidden" name="rtorrent_label" value="{{ config.rtorrent_label }}">
+        <input type="hidden" name="rtorrent_download_path" value="{{ config.rtorrent_download_path }}">
 
         <fieldset>
             <legend>Jellyfin <span id="jellyfin-health" class="form-hint"></span></legend>

--- a/templates/series.html
+++ b/templates/series.html
@@ -198,6 +198,25 @@
                     Allow automatic upgrades when a higher-quality release is found
                 </label>
                 <span class="form-hint" id="allow-upgrades-status"></span>
+                {# Issue #28 PR E — PT upgrade opt-in. Indented under the
+                   parent toggle since "PT upgrades" is a sub-decision of
+                   "upgrades at all," and disabled outright when the user
+                   has zero PT indexers configured (the toggle would do
+                   nothing in that case so it reads as a hint instead). #}
+                <label class="checkbox-label" style="margin-top:6px;margin-left:20px">
+                    <input type="checkbox" id="allow-pt-upgrades"
+                        {% if allow_pt_upgrades %}checked{% endif %}
+                        {% if !any_private_indexer %}disabled{% endif %}
+                        onchange="setAllowPtUpgrades(this.checked)">
+                    Allow upgrades from private trackers
+                </label>
+                <span class="form-hint" id="allow-pt-upgrades-status" style="margin-left:20px">
+                    {% if !any_private_indexer %}
+                    No private-tracker indexers configured. Add one in Settings; Indexers and mark it private to enable this toggle.
+                    {% else %}
+                    Off by default. When off, the upgrade sweep won't grab a private-tracker release as the chosen upgrade for this series even if it's the top-scoring candidate. Initial grabs and manual searches aren't gated.
+                    {% endif %}
+                </span>
             </div>
         </div>
         {# #23 — Per-series search overrides. Both fields are blank by

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -96,5 +96,15 @@
 </div>
 {% endif %}
 
+{# Multi-client refactor: download-clients management is rendered
+   page-level (outside the bulk Settings <form>) because each row
+   carries its own per-action <form> and HTML5 forbids nested
+   forms. Only on the Connections (integrations) tab. #}
+{% if tab == "integrations" %}
+<div class="settings-tab-panel active">
+{%~ include "partials/settings/download_clients.html" ~%}
+</div>
+{% endif %}
+
 <script src="/static/js/settings.js" defer></script>
 {% endblock %}


### PR DESCRIPTION
## Summary

Two related pieces of the 1.5.0 ladder land here:

- **PR E (per-series PT upgrade opt-in)**: PT users can flip the `allow_upgrades` flag per series so the upgrade-search sweep only re-grabs from indexers when the user accepts the ratio impact. Default off for `is_private_tracker` indexers; default on otherwise so public-tracker users keep the pre-1.5 cadence.
- **PR F (multi-download-client routing + per-indexer pinning)**: replaces `config.active_client` with a row-per-client `download_clients` table. Users can run multiple torrent clients side-by-side and pin individual indexers (or built-in Nyaa) to specific clients. Auto paths (RSS sync, autobrr webhook) are pin-aware end-to-end; manual grabs still go through the default to preserve pre-1.5 behavior.

### What changed

- New `download_clients` table with full CRUD; indexers + Nyaa pin columns; idempotent migration that backfills one default row from the legacy single-slot config.
- `AppState.download_clients` swap-on-write pool + `client_for_indexer(id)` / `client_for_nyaa(pin)` / `default_download_client()` resolvers.
- `/settings/download-clients/{upsert,delete,set-default}` form-driven CRUD, `/api/download-clients/test` for inline connection tests, `/settings/indexers/nyaa-pin` for the Nyaa pin selector.
- Connections tab: list with Edit / Delete / Set-default per row plus a single add/edit form. Indexers tab: per-row Download Client dropdown plus a small Nyaa pin fieldset.
- Per-series Allow Upgrades checkbox surfaces on PT-pinned series, gated by `is_private_tracker` on the matched indexer row.
- Legacy `config.active_client` plus per-kind columns kept as a one-release rollback hatch (UI gone; values round-trip via hidden inputs).

## Test plan

- [x] On a fresh DB: migration seeds one default `download_clients` row from the legacy config; the legacy single-slot UI is gone but the row is editable from Connections.
- [x] Add a second client (e.g. seedbox Deluge); inline Test connection succeeds before save; Set default flips correctly; Delete NULLs out any indexer pins and the Nyaa pin in one transaction.
- [x] Pin an indexer to the seedbox client; trigger an autobrr push for that indexer; the grab lands on the seedbox, not the default.
- [x] Pin Nyaa to the seedbox client; trigger an RSS sync; the grab lands on the seedbox.
- [x] Manual search grabs still route through the default (expected; manual paths aren't pin-aware yet).
- [x] PR E: a PT-pinned series with `allow_upgrades = false` is skipped by the upgrade sweep; flipping the flag re-includes it on the next sweep.
- [x] `cargo fmt`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, `cargo test --workspace --features test-support` all green locally (1653 unit + 7 integration + 1 e2e).

## Follow-ups

- Wire `auto_search` hot path so manual-search grabs route through `client_for_indexer` (needs `AutoSearchHit` to carry `indexer_id`).
- Update `services::download_client::per_client_download_path` to look up the `download_clients` row for the actual grab being post-processed instead of keying off `cfg.active_client`.
- Drop legacy `config.active_client` plus per-kind columns once the above lands and soaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)