### PR TITLE
fix(grab): pin-aware manual-search dispatch (PR F follow-up)

### DIFF
--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -62,6 +62,13 @@ pub struct GrabPreviewForm {
     /// GET preview endpoint.
     #[serde(default)]
     pub release_metadata: serde_json::Value,
+    /// Multi-client routing — id of the indexer that surfaced this
+    /// release. `None` for Nyaa-direct (routes via Nyaa pin), `Some`
+    /// for torznab/newznab fan-out (routes via per-indexer pin). The
+    /// resolved `download_clients.id` is stamped on the pending row
+    /// so confirm/cancel hit the same client.
+    #[serde(default)]
+    pub indexer_id: Option<i64>,
 }
 
 /// POST `/api/grab/preview` response.
@@ -286,7 +293,28 @@ pub async fn grab_preview(
         }));
     }
 
-    let client = require_download_client(&state).await?;
+    // Multi-client routing — preview locks the dispatch client at
+    // add-time. Confirm + cancel read `download_client_id` back from
+    // the pending row so resume / set_file_wanted / delete hit the
+    // same client (a torrent paused on the seedbox can't be resumed
+    // via the local qBit). Pin chain: indexer_id (torznab/newznab
+    // fan-out hits) > Nyaa pin (Nyaa-direct) > default.
+    let resolved = if form.indexer_id.is_some() {
+        state.client_for_indexer_with_id(form.indexer_id).await
+    } else {
+        let cfg = crate::models::config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        state
+            .client_for_nyaa_with_id(cfg.nyaa_download_client_id)
+            .await
+    };
+    let (client, dispatch_client_id) = resolved.ok_or((
+        StatusCode::BAD_REQUEST,
+        "Download client not configured".to_string(),
+    ))?;
     let client_kind = client.sonarr_impl_name().to_string();
     let metadata_json = form.release_metadata.to_string();
 
@@ -310,10 +338,11 @@ pub async fn grab_preview(
         &preview_id,
         &info_hash,
         &client_kind,
-        None,
+        form.indexer_id,
         form.series_id,
         &metadata_json,
         we_added,
+        Some(dispatch_client_id),
     )
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
@@ -577,7 +606,29 @@ pub async fn grab_confirm(
     })?;
     let total = files.len();
 
-    let client = require_download_client(&state).await?;
+    // Multi-client routing — resume + set_file_wanted must hit the
+    // same client `add_torrent_paused` landed on at preview time.
+    // Falls back to default for legacy rows (NULL stamp).
+    let client = match row.download_client_id {
+        Some(id) => match state.client_by_id(id).await {
+            Some(c) => c,
+            None => {
+                // Client got deleted or disabled mid-modal. Pre-fix
+                // this would silently fall through to the wrong
+                // default; instead surface 503 so the modal shows the
+                // error and the user can re-grab. The pending row
+                // stays for the TTL sweep — manual cleanup via cancel
+                // is the user's escape hatch.
+                return Err((
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    format!(
+                        "download client #{id} is no longer available; the torrent is still in your client but Ryokan can't manage it from this preview"
+                    ),
+                ));
+            }
+        },
+        None => require_download_client(&state).await?,
+    };
 
     // Compute the wanted / unwanted partitions. Any index outside
     // [0, total) in `wanted_indices` is silently ignored — the modal
@@ -693,7 +744,18 @@ pub async fn grab_cancel(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?
         .ok_or((StatusCode::NOT_FOUND, "preview not found".to_string()))?;
 
-    let client = require_download_client(&state).await?;
+    // Same multi-client lookup as confirm — cancel must hit the same
+    // client the preview added the torrent to. Legacy NULL stamp →
+    // fall back to default. A vanished client (deleted/disabled mid-
+    // modal) skips the destructive delete but still drops the
+    // pending row so the modal state doesn't linger; the torrent
+    // either stays orphaned in the unreachable client (rare) or
+    // gets cleaned up on a subsequent rebuild_clients_cache.
+    let client_opt: Option<std::sync::Arc<dyn crate::services::download_client::DownloadClient>> =
+        match row.download_client_id {
+            Some(id) => state.client_by_id(id).await,
+            None => state.default_download_client().await,
+        };
 
     // Only delete the torrent if THIS preview added it fresh. If the
     // torrent was already in the client at add time (AlreadyPresent),
@@ -703,6 +765,7 @@ pub async fn grab_cancel(
     // The pending_grabs row is still dropped either way so the modal-
     // state doesn't linger.
     if row.we_added_torrent
+        && let Some(client) = client_opt
         && let Err(e) = client.delete(&row.info_hash, true).await
     {
         tracing::warn!(
@@ -813,6 +876,7 @@ mod tests {
             None,
             "{\"title\":\"t\"}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -844,9 +908,19 @@ mod tests {
     #[tokio::test]
     async fn heartbeat_200_when_present_404_when_gone() {
         let db = in_memory_pool().await;
-        pending_grabs::create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        pending_grabs::create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
 
         let state = build_test_app_state(db.clone(), None);
         let ok = grab_heartbeat(State(state.clone()), Path("pid-1".to_string())).await;
@@ -892,9 +966,19 @@ mod tests {
     #[tokio::test]
     async fn confirm_400_when_file_list_empty() {
         let db = in_memory_pool().await;
-        pending_grabs::create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        pending_grabs::create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         let state = build_test_app_state(db, None);
         let res = grab_confirm(
             State(state),
@@ -919,6 +1003,7 @@ mod tests {
                 info_hash: "abc".into(),
                 series_id: None,
                 release_metadata: serde_json::Value::Null,
+                indexer_id: None,
             }),
         )
         .await;
@@ -931,6 +1016,7 @@ mod tests {
                 info_hash: "".into(),
                 series_id: None,
                 release_metadata: serde_json::Value::Null,
+                indexer_id: None,
             }),
         )
         .await;
@@ -948,6 +1034,7 @@ mod tests {
                 info_hash: VALID_HASH.into(),
                 series_id: Some(42),
                 release_metadata: serde_json::json!({"title": "test"}),
+                indexer_id: None,
             }),
         )
         .await;
@@ -975,6 +1062,7 @@ mod tests {
                 info_hash: too_long,
                 series_id: None,
                 release_metadata: serde_json::Value::Null,
+                indexer_id: None,
             }),
         )
         .await;
@@ -989,6 +1077,7 @@ mod tests {
                 info_hash: bad_chars,
                 series_id: None,
                 release_metadata: serde_json::Value::Null,
+                indexer_id: None,
             }),
         )
         .await;
@@ -1014,6 +1103,7 @@ mod tests {
             None,
             "{\"title\":\"tab-1 snapshot\"}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1025,6 +1115,7 @@ mod tests {
                 info_hash: VALID_HASH.into(),
                 series_id: None,
                 release_metadata: serde_json::json!({"title": "tab-2 request"}),
+                indexer_id: None,
             }),
         )
         .await
@@ -1061,6 +1152,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1075,6 +1167,7 @@ mod tests {
                 info_hash: VALID_HASH.into(),
                 series_id: None,
                 release_metadata: serde_json::Value::Null,
+                indexer_id: None,
             }),
         )
         .await;
@@ -1179,6 +1272,7 @@ mod tests {
             Some(series_id),
             &release_metadata.to_string(),
             true,
+            None,
         )
         .await
         .unwrap();
@@ -1246,6 +1340,7 @@ mod tests {
             Some(series_id),
             "{\"title\":\"Test Release\"}",
             true,
+            None,
         )
         .await
         .unwrap();

--- a/src/handlers/grab.rs
+++ b/src/handlers/grab.rs
@@ -749,8 +749,11 @@ pub async fn grab_cancel(
     // fall back to default. A vanished client (deleted/disabled mid-
     // modal) skips the destructive delete but still drops the
     // pending row so the modal state doesn't linger; the torrent
-    // either stays orphaned in the unreachable client (rare) or
-    // gets cleaned up on a subsequent rebuild_clients_cache.
+    // stays orphaned in the unreachable client and the user must
+    // remove it from that client's UI manually (Ryokan has no handle
+    // to it once the row is gone from `download_clients`, and
+    // `rebuild_clients_cache` only refreshes the in-memory pool — it
+    // doesn't reach into a removed client to clean up).
     let client_opt: Option<std::sync::Arc<dyn crate::services::download_client::DownloadClient>> =
         match row.download_client_id {
             Some(id) => state.client_by_id(id).await,

--- a/src/handlers/library/search/grab.rs
+++ b/src/handlers/library/search/grab.rs
@@ -56,6 +56,11 @@ pub async fn grab_batch_result(
     let resolution = body["resolution"].as_str().unwrap_or("").to_string();
     let info_hash = body["info_hash"].as_str().unwrap_or("").to_string();
     let size_bytes = body["size_bytes"].as_i64().unwrap_or(0);
+    // Multi-client routing — the search-result row carries `indexer_id`
+    // (None for Nyaa-direct, Some for torznab/newznab fan-out). The
+    // frontend round-trips it on grab so the dispatch routes through
+    // the indexer's pin (or Nyaa pin for Nyaa-direct).
+    let indexer_id: Option<i64> = body["indexer_id"].as_i64();
 
     if url.is_empty() {
         return Err((
@@ -64,7 +69,19 @@ pub async fn grab_batch_result(
         ));
     }
 
-    let (qbit, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
+    let resolved_client = if indexer_id.is_some() {
+        state.client_for_indexer_with_id(indexer_id).await
+    } else {
+        let cfg = crate::models::config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        state
+            .client_for_nyaa_with_id(cfg.nyaa_download_client_id)
+            .await
+    };
+    let (qbit, dispatch_client_id) = resolved_client.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -267,6 +284,11 @@ pub async fn grab_interactive_result(
     let resolution = body["resolution"].as_str().unwrap_or("").to_string();
     let info_hash = body["info_hash"].as_str().unwrap_or("").to_string();
     let size_bytes = body["size_bytes"].as_i64().unwrap_or(0);
+    // Multi-client routing — the search-result row carries `indexer_id`
+    // (None for Nyaa-direct, Some for torznab/newznab fan-out). The
+    // frontend round-trips it on grab so the dispatch routes through
+    // the indexer's pin (or Nyaa pin for Nyaa-direct).
+    let indexer_id: Option<i64> = body["indexer_id"].as_i64();
 
     if url.is_empty() {
         return Err((
@@ -275,7 +297,19 @@ pub async fn grab_interactive_result(
         ));
     }
 
-    let (qbit, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
+    let resolved_client = if indexer_id.is_some() {
+        state.client_for_indexer_with_id(indexer_id).await
+    } else {
+        let cfg = crate::models::config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        state
+            .client_for_nyaa_with_id(cfg.nyaa_download_client_id)
+            .await
+    };
+    let (qbit, dispatch_client_id) = resolved_client.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -82,6 +82,13 @@ pub struct GrabForm {
     /// Gates auto_expand at grab time.
     #[serde(default)]
     is_batch: Option<bool>,
+    /// Multi-client routing — id of the indexer that surfaced this
+    /// release. `None` for Nyaa-direct hits (which route via the
+    /// Nyaa pin), `Some(id)` for torznab/newznab fan-out hits (which
+    /// route via the indexer's per-row pin). Frontend reads this
+    /// from `SearchResult.indexer_id` and round-trips it on grab.
+    #[serde(default)]
+    indexer_id: Option<i64>,
 }
 
 /// Helper to build SearchOptions from config.
@@ -279,7 +286,24 @@ pub async fn grab_release(
     State(state): State<AppState>,
     Json(form): Json<GrabForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let (client, dispatch_client_id) = state.default_download_client_with_id().await.ok_or((
+    // Pin chain: indexer_id (when the result came from a torznab/newznab
+    // fan-out) > Nyaa pin (Nyaa-direct results) > default. The manual-
+    // search page only invokes `nyaa::search` today, so any form arriving
+    // here without `indexer_id` is implicitly Nyaa-direct and routes
+    // through the Nyaa pin. Pre-PR-F-followup this always hit the default.
+    let resolved = if form.indexer_id.is_some() {
+        state.client_for_indexer_with_id(form.indexer_id).await
+    } else {
+        let cfg = crate::models::config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .unwrap_or_default();
+        state
+            .client_for_nyaa_with_id(cfg.nyaa_download_client_id)
+            .await
+    };
+    let (client, dispatch_client_id) = resolved.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -813,6 +813,18 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // Multi-client refactor follow-up — capture which `download_clients`
+    // row the preview's `add_torrent_paused` call landed on so the
+    // confirm path resumes against the same client. Pre-fix the
+    // confirm path used `default_download_client()`, which silently
+    // routed selective-narrow + resume to the wrong client when the
+    // preview had been pinned to a non-default. NULL on legacy rows
+    // and on previews where pin resolution returned the default.
+    sqlx::query("ALTER TABLE pending_grabs ADD COLUMN download_client_id INTEGER")
+        .execute(db)
+        .await
+        .ok();
+
     // Issue #62 PR A — external AL/MAL account linkage. One row per
     // linked provider (decision #10 limits this to one row total at
     // any time; the "at most one" invariant is enforced in the

--- a/src/models/pending_grabs.rs
+++ b/src/models/pending_grabs.rs
@@ -79,6 +79,11 @@ pub struct PendingGrab {
     /// the column existed take the conservative "yes, we added it"
     /// path on read without any Rust-side default needed.
     pub we_added_torrent: bool,
+    /// Multi-client refactor — the `download_clients.id` the preview's
+    /// `add_torrent_paused` landed on. Confirm reads this back to
+    /// resume the torrent against the same client. NULL on legacy
+    /// rows; the confirm handler then falls back to default.
+    pub download_client_id: Option<i64>,
 }
 
 /// Insert a new row. `preview_id` is a caller-supplied opaque string
@@ -103,14 +108,15 @@ pub async fn create(
     series_id: Option<i64>,
     release_metadata_json: &str,
     we_added_torrent: bool,
+    download_client_id: Option<i64>,
 ) -> Result<(), String> {
     let now = now_unix();
     sqlx::query(
         "INSERT INTO pending_grabs \
          (preview_id, info_hash, client_kind, indexer_id, series_id, \
           created_at, heartbeat_at, file_list_json, release_metadata_json, \
-          error_message, we_added_torrent) \
-         VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, '', ?)",
+          error_message, we_added_torrent, download_client_id) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, '', ?, '', ?, ?)",
     )
     .bind(preview_id)
     .bind(info_hash)
@@ -121,6 +127,7 @@ pub async fn create(
     .bind(now)
     .bind(release_metadata_json)
     .bind(if we_added_torrent { 1_i64 } else { 0_i64 })
+    .bind(download_client_id)
     .execute(db)
     .await
     .map_err(|e| format!("failed to create pending grab: {}", e))?;
@@ -129,7 +136,7 @@ pub async fn create(
 
 const SELECT_COLUMNS: &str = "preview_id, info_hash, client_kind, indexer_id, series_id, \
      created_at, heartbeat_at, file_list_json, release_metadata_json, \
-     error_message, we_added_torrent";
+     error_message, we_added_torrent, download_client_id";
 
 pub async fn get(db: &SqlitePool, preview_id: &str) -> Result<Option<PendingGrab>, String> {
     sqlx::query_as::<_, PendingGrab>(&format!(
@@ -285,6 +292,7 @@ mod tests {
             Some(42),
             "{\"title\":\"test\"}",
             true,
+            None,
         )
         .await
         .expect("create");
@@ -300,12 +308,72 @@ mod tests {
         assert_eq!(row.created_at, row.heartbeat_at);
     }
 
+    /// Pre-PR-F-followup regression: confirm/cancel used
+    /// `default_download_client` even when preview had landed on a
+    /// pinned client. The schema column `download_client_id` plus
+    /// `create()`'s 9th arg + the handler's read-back together cover
+    /// the fix; this test pins the round-trip so a future SELECT-list
+    /// refactor can't drop the column and silently regress.
+    #[tokio::test]
+    async fn download_client_id_round_trips() {
+        let db = in_memory_pool().await;
+        create(
+            &db,
+            "pid-pinned",
+            "ab",
+            "deluge",
+            Some(7),
+            Some(42),
+            "{}",
+            true,
+            Some(2),
+        )
+        .await
+        .expect("create");
+        let row = get(&db, "pid-pinned")
+            .await
+            .expect("get")
+            .expect("row present");
+        assert_eq!(row.download_client_id, Some(2));
+        assert_eq!(row.indexer_id, Some(7));
+
+        // Legacy (NULL) shape still works.
+        create(
+            &db,
+            "pid-legacy",
+            "cd",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .expect("create");
+        let row = get(&db, "pid-legacy")
+            .await
+            .expect("get")
+            .expect("row present");
+        assert_eq!(row.download_client_id, None);
+    }
+
     #[tokio::test]
     async fn we_added_false_roundtrips() {
         let db = in_memory_pool().await;
-        create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", false)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            false,
+            None,
+        )
+        .await
+        .unwrap();
         let row = get(&db, "pid-1").await.unwrap().unwrap();
         assert!(!row.we_added_torrent);
     }
@@ -313,9 +381,19 @@ mod tests {
     #[tokio::test]
     async fn set_error_flips_column() {
         let db = in_memory_pool().await;
-        create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         assert!(
             get(&db, "pid-1")
                 .await
@@ -336,9 +414,19 @@ mod tests {
     #[tokio::test]
     async fn bump_heartbeat_updates_heartbeat_at() {
         let db = in_memory_pool().await;
-        create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         let before = get(&db, "pid-1").await.unwrap().unwrap().heartbeat_at;
         // Force a clock tick by sleeping 1s — the unix-seconds resolution
         // needs at least one second to move. Cheap enough for a single test.
@@ -373,6 +461,7 @@ mod tests {
             Some(7),
             "{\"title\":\"t\"}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -389,9 +478,19 @@ mod tests {
     #[tokio::test]
     async fn delete_removes_the_row() {
         let db = in_memory_pool().await;
-        create(&db, "pid-1", "abc", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "abc",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         delete(&db, "pid-1").await.unwrap();
         assert!(get(&db, "pid-1").await.unwrap().is_none());
     }
@@ -408,6 +507,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -421,6 +521,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -434,9 +535,19 @@ mod tests {
     #[tokio::test]
     async fn get_by_hash_ignores_empty_hash() {
         let db = in_memory_pool().await;
-        create(&db, "pid-1", "", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         assert!(
             get_by_hash(&db, "").await.unwrap().is_none(),
             "empty hash lookup should never return a row"
@@ -461,6 +572,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -489,6 +601,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -503,6 +616,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -517,13 +631,33 @@ mod tests {
     async fn list_expired_returns_stale_rows_only() {
         let db = in_memory_pool().await;
         // Fresh row — heartbeat just now.
-        create(&db, "fresh", "h1", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "fresh",
+            "h1",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         // Backdate a second row's heartbeat past the TTL.
-        create(&db, "stale", "h2", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "stale",
+            "h2",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         let stale_heartbeat = now_unix() - HEARTBEAT_TTL_SECS - 5;
         sqlx::query("UPDATE pending_grabs SET heartbeat_at = ? WHERE preview_id = 'stale'")
             .bind(stale_heartbeat)
@@ -539,12 +673,32 @@ mod tests {
     async fn count_reflects_creates_and_deletes() {
         let db = in_memory_pool().await;
         assert_eq!(count(&db).await.unwrap(), 0);
-        create(&db, "pid-1", "a", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
-        create(&db, "pid-2", "b", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        create(
+            &db,
+            "pid-1",
+            "a",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        create(
+            &db,
+            "pid-2",
+            "b",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         assert_eq!(count(&db).await.unwrap(), 2);
         delete(&db, "pid-1").await.unwrap();
         assert_eq!(count(&db).await.unwrap(), 1);

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -277,12 +277,32 @@ mod tests {
     #[tokio::test]
     async fn sweep_drops_stale_rows_only() {
         let db = in_memory_pool().await;
-        pending_grabs::create(&db, "fresh", "h1", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
-        pending_grabs::create(&db, "stale", "h2", "qbittorrent", None, None, "{}", true)
-            .await
-            .unwrap();
+        pending_grabs::create(
+            &db,
+            "fresh",
+            "h1",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
+        pending_grabs::create(
+            &db,
+            "stale",
+            "h2",
+            "qbittorrent",
+            None,
+            None,
+            "{}",
+            true,
+            None,
+        )
+        .await
+        .unwrap();
         sqlx::query("UPDATE pending_grabs SET heartbeat_at = ? WHERE preview_id = 'stale'")
             .bind(now_unix() - HEARTBEAT_TTL_SECS - 5)
             .execute(&db)
@@ -316,7 +336,7 @@ mod tests {
         let db = in_memory_pool().await;
         for i in 0..3 {
             let id = format!("stale-{}", i);
-            pending_grabs::create(&db, &id, "h", "qbittorrent", None, None, "{}", true)
+            pending_grabs::create(&db, &id, "h", "qbittorrent", None, None, "{}", true, None)
                 .await
                 .unwrap();
         }
@@ -348,6 +368,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -387,6 +408,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -445,6 +467,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();
@@ -493,6 +516,7 @@ mod tests {
             None,
             "{}",
             true,
+            None,
         )
         .await
         .unwrap();

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -92,16 +92,28 @@ async fn auto_commit_row(state: &AppState, row: &pending_grabs::PendingGrab) {
         return;
     }
 
-    let client = {
-        let client = state.default_download_client().await;
-        client.as_ref().cloned()
+    // Multi-client routing — the auto-commit-on-walkaway path is the
+    // 4th manual dispatch site (alongside the two grab handlers and
+    // the picker confirm/cancel pair) and must hit the same client
+    // the preview's `add_torrent_paused` landed on. Mirroring the
+    // cancel handler's lookup: stamped id → `client_by_id`, NULL →
+    // default. Pre-fix this path always grabbed the default, so a
+    // walkaway on a torrent paused on the seedbox would `set_file_wanted`
+    // + `resume` against local qBit, fail (the torrent isn't there),
+    // log a warn, and the user's torrent stayed paused on the seedbox
+    // forever — no retry because the pending row gets dropped after
+    // this function returns regardless of outcome.
+    let client = match row.download_client_id {
+        Some(id) => state.client_by_id(id).await,
+        None => state.default_download_client().await,
     };
     let Some(client) = client else {
         tracing::warn!(
             target: "ryokan::services::grab_sweep",
             preview_id = %row.preview_id,
             info_hash = %row.info_hash,
-            "download client not configured; can't auto-commit expired pending grab"
+            stamped_client_id = ?row.download_client_id,
+            "download client not available; can't auto-commit expired pending grab"
         );
         return;
     };
@@ -444,6 +456,96 @@ mod tests {
             resumed,
             vec!["hash-happy".to_string()],
             "expected one resume call on the row's info_hash"
+        );
+    }
+
+    /// Multi-client routing regression — the auto-commit-on-walkaway
+    /// path must dispatch to the client the preview added the torrent
+    /// to (per `pending_grabs.download_client_id`), NOT the pool's
+    /// default. Pre-PR-110-review-1 the sweep used
+    /// `default_download_client()` unconditionally; a walkaway on a
+    /// torrent pinned to a non-default client would leave the torrent
+    /// paused on the wrong client forever (no retry).
+    ///
+    /// Pool shape: id=1 default + id=2 second client. Pending row
+    /// stamped with `download_client_id=2`. Assert the
+    /// set_file_wanted+resume call pair lands on the id=2 client, not
+    /// id=1.
+    #[tokio::test]
+    async fn sweep_dispatches_to_pinned_client_not_default() {
+        let db = in_memory_pool().await;
+        pending_grabs::create(
+            &db,
+            "pinned",
+            "hash-pinned",
+            "deluge",
+            None,
+            None,
+            "{}",
+            true,
+            Some(2),
+        )
+        .await
+        .unwrap();
+        pending_grabs::set_file_list(&db, "pinned", "[{\"name\":\"a.mkv\",\"size\":1}]")
+            .await
+            .unwrap();
+        sqlx::query("UPDATE pending_grabs SET heartbeat_at = ?")
+            .bind(now_unix() - HEARTBEAT_TTL_SECS - 5)
+            .execute(&db)
+            .await
+            .unwrap();
+
+        // Build a multi-client pool by hand. `build_test_app_state`
+        // can't do this (it plants the supplied client at id=1 with
+        // `default_id=Some(1)`), so the pool ends up with one entry
+        // and `client_by_id(2)` always misses — an existing bug
+        // would silently fall through to default and the test would
+        // pass even with the regression in place.
+        let default_client = Arc::new(RecordingClient::default());
+        let pinned_client = Arc::new(RecordingClient::default());
+        let mut clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>> =
+            std::collections::HashMap::new();
+        clients.insert(1, default_client.clone());
+        clients.insert(2, pinned_client.clone());
+        let pool = crate::DownloadClientPool {
+            clients,
+            default_id: Some(1),
+        };
+        let state = build_test_app_state(db.clone(), None);
+        // Override the pool — `build_test_app_state` left it empty
+        // since we passed `None`. Direct mutation is fine in tests.
+        *state.download_clients.write().await = Arc::new(pool);
+
+        let count = sweep_once(&state).await.unwrap();
+        assert_eq!(count, 1);
+
+        // The pinned client must have received the calls.
+        let pinned_wanted = pinned_client.set_wanted_calls.lock().unwrap().clone();
+        let pinned_resumed = pinned_client.resume_calls.lock().unwrap().clone();
+        assert_eq!(
+            pinned_wanted,
+            vec![("hash-pinned".to_string(), vec![0], true)],
+            "set_file_wanted must hit the PINNED client (id=2), not the default"
+        );
+        assert_eq!(
+            pinned_resumed,
+            vec!["hash-pinned".to_string()],
+            "resume must hit the PINNED client (id=2), not the default"
+        );
+
+        // The default client must NOT have received any calls — this
+        // is the assertion that catches the regression. Pre-fix this
+        // would fail because every call landed on the default.
+        let default_wanted = default_client.set_wanted_calls.lock().unwrap().clone();
+        let default_resumed = default_client.resume_calls.lock().unwrap().clone();
+        assert!(
+            default_wanted.is_empty(),
+            "default client must not see set_file_wanted; got {default_wanted:?}"
+        );
+        assert!(
+            default_resumed.is_empty(),
+            "default client must not see resume; got {default_resumed:?}"
         );
     }
 

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -123,6 +123,7 @@ function loadMore() {
                 tr.dataset.downloads = r.downloads;
                 tr.dataset.infoHash = r.info_hash || '';
                 tr.dataset.group = r.group || '';
+                if (r.indexer_id != null) tr.dataset.indexerId = r.indexer_id;
                 tr.innerHTML = `
                     <td class="col-score">
                         <details class="score-details" name="score-breakdown">
@@ -154,6 +155,7 @@ function loadMore() {
                     card.dataset.seeders = r.seeders;
                     card.dataset.infoHash = r.info_hash || '';
                     card.dataset.group = r.group || '';
+                    if (r.indexer_id != null) card.dataset.indexerId = r.indexer_id;
                     card.innerHTML = `
                         <div class="result-card-header">
                             <details class="score-details" name="score-breakdown">
@@ -239,6 +241,10 @@ function grabRelease(url, btn) {
         if (row.dataset.name) payload.title = row.dataset.name;
         if (row.dataset.infoHash) payload.info_hash = row.dataset.infoHash;
         payload.is_batch = isBatch;
+        // Multi-client routing — round-trip the result's indexer_id so
+        // the backend can dispatch through the per-indexer pin. Falls
+        // through to the Nyaa pin server-side when absent.
+        if (row.dataset.indexerId) payload.indexer_id = Number(row.dataset.indexerId);
     }
     fetch('/api/grab', {
         method: 'POST',

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -755,7 +755,8 @@ function grabInteractiveResult(epNum, idx, btn) {
             group: result.group,
             resolution: result.resolution,
             info_hash: result.info_hash,
-            size_bytes: result.size_bytes || 0
+            size_bytes: result.size_bytes || 0,
+            indexer_id: result.indexer_id ?? null
         })
     })
     .then(async r => {
@@ -892,7 +893,8 @@ function grabInteractiveBatchResult(idx, btn) {
             group: result.group,
             resolution: result.resolution,
             info_hash: result.info_hash,
-            size_bytes: result.size_bytes || 0
+            size_bytes: result.size_bytes || 0,
+            indexer_id: result.indexer_id ?? null
         })
     })
     .then(async r => {

--- a/templates/search.html
+++ b/templates/search.html
@@ -48,7 +48,7 @@
             </thead>
             <tbody id="results-body">
                 {% for r in results %}
-                <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}" data-score="{{ r.score }}" data-name="{{ r.title }}" data-size="{{ r.size_bytes }}" data-size-human="{{ r.size }}" data-date="{{ r.upload_date }}" data-seeders="{{ r.seeders }}" data-leechers="{{ r.leechers }}" data-downloads="{{ r.downloads }}" data-info-hash="{{ r.info_hash }}" data-group="{{ r.group }}">
+                <tr class="{% if r.is_batch && r.is_trusted %}is-batch is-trusted{% else if r.is_batch %}is-batch{% else if r.is_trusted %}is-trusted{% endif %}" data-score="{{ r.score }}" data-name="{{ r.title }}" data-size="{{ r.size_bytes }}" data-size-human="{{ r.size }}" data-date="{{ r.upload_date }}" data-seeders="{{ r.seeders }}" data-leechers="{{ r.leechers }}" data-downloads="{{ r.downloads }}" data-info-hash="{{ r.info_hash }}" data-group="{{ r.group }}"{% if let Some(idx) = r.indexer_id %} data-indexer-id="{{ idx }}"{% endif %}>
                     <td class="col-score">
                         <details class="score-details" name="score-breakdown">
                             <summary class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}" title="Click to see breakdown">{{ r.score }}</summary>
@@ -103,7 +103,7 @@
            paginated results show up regardless of viewport. #}
         <div class="results-cards" id="results-cards">
             {% for r in results %}
-            <div class="result-card {% if r.is_batch %}is-batch{% endif %} {% if r.is_trusted %}is-trusted{% endif %}" data-name="{{ r.title }}" data-size-human="{{ r.size }}" data-seeders="{{ r.seeders }}" data-info-hash="{{ r.info_hash }}" data-group="{{ r.group }}">
+            <div class="result-card {% if r.is_batch %}is-batch{% endif %} {% if r.is_trusted %}is-trusted{% endif %}" data-name="{{ r.title }}" data-size-human="{{ r.size }}" data-seeders="{{ r.seeders }}" data-info-hash="{{ r.info_hash }}" data-group="{{ r.group }}"{% if let Some(idx) = r.indexer_id %} data-indexer-id="{{ idx }}"{% endif %}>
                 <div class="result-card-header">
                     <span class="score-badge {% if r.score >= 60 %}score-high{% else if r.score >= 30 %}score-mid{% else %}score-low{% endif %}">{{ r.score }}</span>
                     <a class="result-card-title" href="{{ r.link }}" target="_blank" rel="noopener">{{ r.title }}</a>


### PR DESCRIPTION
## Summary

Closes the dangling thread from PR #109's description: manual-search grabs and the interactive file picker now route through the same multi-client pin chain the auto paths (autobrr webhook, RSS sync) already use. Pre-fix a torznab/newznab result from a pinned indexer landed on the local default instead of the seedbox.

Pin chain at every manual dispatch site: **`indexer_id`** (set on torznab/newznab fan-out hits) → **Nyaa pin** (Nyaa-direct hits) → **default**.

## What changed

- `handlers::search::grab_release` reads `indexer_id` from the POST body; routes via `client_for_indexer_with_id` when present, `client_for_nyaa_with_id` otherwise.
- `handlers::library::search::grab::{grab_batch_result, grab_interactive_result}` do the same with the JSON body's `indexer_id`.
- **Interactive picker** (preview → confirm): new `pending_grabs.download_client_id` column (idempotent ALTER) preserves the resolved client across the boundary. Confirm/cancel read it back via `client_by_id` and dispatch resume / `set_file_wanted` / delete to the same client `add_torrent_paused` landed on. Pre-fix the picker silently fell back to default at confirm time.
- Confirm returns `503` (with a clear message) if the client got deleted/disabled mid-modal — pre-fix would silently route to the wrong client or 500.
- Frontend (`search.js` + `series.js` + `templates/search.html`): stamps `data-indexer-id` on result rows/cards; round-trips it on every grab POST.

## Test plan

- [x] On a fresh install with two clients (e.g. local qBit default + seedbox Deluge), pin a torznab indexer to the seedbox; grab a result that came from that indexer via the manual library search; verify the dispatch URL in logs hits the seedbox not the qBit default.
- [x] Same setup but grab a Nyaa-direct result via the global search page; verify it routes through the Nyaa pin (or default if no pin).
- [x] Open the interactive picker on a batch torrent from a pinned indexer; verify confirm dispatches `set_file_wanted` to the pinned client (not default).
- [x] Delete a download client mid-modal; verify confirm returns 503 with a clear message instead of silently routing.
- [x] `cargo fmt --all -- --check`, `cargo clippy --workspace --all-targets --features test-support -- -D warnings`, `cargo test --workspace --features test-support` all green locally (1656 unit + 7 integration + 1 e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)