### PR TITLE
fix(sab): multi-client routing + source-side cleanup, Settings UI redesign

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,9 @@ Release scoring combines Sonarr-style **Custom Formats** (TRaSH-Guides-compatibl
 cargo build              # build (debug)
 cargo build --release    # build (release)
 cargo run                # run locally (creates data/ryokan.db, listens on 0.0.0.0:8978)
-cargo test               # run all tests
-cargo test <test_name>   # run a single test
+cargo nextest run --workspace --features test-support  # canonical local-test entry point. ~2-3× faster than `cargo test`, parallel-by-default with stable per-test reporting. cargo-nextest is installed locally; default to it for iterative work. `cargo test` still runs (CI uses it for `--locked`), but nextest is preferred.
+cargo nextest run --workspace --features test-support <test_name>  # single-test filter — same syntax as `cargo test <test_name>`
+cargo test --workspace --features test-support  # CI-shape fallback / when you specifically need cargo test (doc tests, locked-deps, etc.)
 cargo clippy             # lint
 docker compose up -d --build  # build and run in Docker
 ```

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,11 @@ name = "htmx_browser_e2e_settings_subforms"
 path = "tests/htmx_browser_e2e_settings_subforms.rs"
 required-features = ["test-support", "browser-e2e"]
 
+[[test]]
+name = "htmx_browser_e2e_settings_modals"
+path = "tests/htmx_browser_e2e_settings_modals.rs"
+required-features = ["test-support", "browser-e2e"]
+
 [dependencies]
 # Web framework + async runtime
 axum = { version = "0.8", features = ["macros"] }

--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -17,17 +17,13 @@ use crate::services::download_client::{DownloadClient, DownloadItemState};
 
 /// Route a queue-action (pause/resume/delete) to the right client by
 /// looking up the grab row for `hash` and resolving its
-/// `download_client_id`. Falls back to the torrent default for
-/// legacy rows whose column is NULL or for hashes not stamped in
-/// `grabbed_torrents` at all (manual adds outside Ryokan land here).
+/// `download_client_id`. The composed fallback chain via
+/// `resolve_grab_client` handles legacy NULL stamps for SAB grabs
+/// (nzo_id-shape heuristic) and finally the torrent default.
 /// Returns `None` only when no client is configured at all.
 async fn resolve_client_for_hash(state: &AppState, hash: &str) -> Option<Arc<dyn DownloadClient>> {
-    if let Some(id) = grabbed_torrents::client_id_for_hash(&state.db, hash).await
-        && let Some(client) = state.client_by_id(id).await
-    {
-        return Some(client);
-    }
-    state.default_download_client().await
+    let dc_id = grabbed_torrents::client_id_for_hash(&state.db, hash).await;
+    state.resolve_grab_client(dc_id, hash).await
 }
 
 struct QueueTorrentView {

--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -9,9 +9,26 @@ use axum::{
 use axum_htmx::HxRequest;
 use serde::Deserialize;
 
+use std::sync::Arc;
+
 use crate::AppState;
 use crate::models::grabbed_torrents;
-use crate::services::download_client::DownloadItemState;
+use crate::services::download_client::{DownloadClient, DownloadItemState};
+
+/// Route a queue-action (pause/resume/delete) to the right client by
+/// looking up the grab row for `hash` and resolving its
+/// `download_client_id`. Falls back to the torrent default for
+/// legacy rows whose column is NULL or for hashes not stamped in
+/// `grabbed_torrents` at all (manual adds outside Ryokan land here).
+/// Returns `None` only when no client is configured at all.
+async fn resolve_client_for_hash(state: &AppState, hash: &str) -> Option<Arc<dyn DownloadClient>> {
+    if let Some(id) = grabbed_torrents::client_id_for_hash(&state.db, hash).await
+        && let Some(client) = state.client_by_id(id).await
+    {
+        return Some(client);
+    }
+    state.default_download_client().await
+}
 
 struct QueueTorrentView {
     hash: String,
@@ -151,35 +168,47 @@ pub async fn downloads_page(
         .unwrap_or_else(|| "english".to_string());
 
     let (queue, queue_error) = if tab == "queue" {
-        let client = state.default_download_client().await;
-        match client {
-            Some(c) => match c.list_scoped().await {
-                Ok(mut torrents) => {
-                    // Sort: downloading first, then by progress descending.
-                    let is_downloading = |k: DownloadItemState| {
-                        matches!(
-                            k,
-                            DownloadItemState::Downloading
-                                | DownloadItemState::DownloadingStalled
-                                | DownloadItemState::DownloadingQueued
-                                | DownloadItemState::CheckingDownload
-                        )
-                    };
-                    torrents.sort_by(|a, b| {
-                        let a_down = if is_downloading(a.state_kind) { 0 } else { 1 };
-                        let b_down = if is_downloading(b.state_kind) { 0 } else { 1 };
-                        a_down.cmp(&b_down).then(
-                            b.progress
-                                .partial_cmp(&a.progress)
-                                .unwrap_or(std::cmp::Ordering::Equal),
-                        )
-                    });
-                    let views = torrents.iter().map(torrent_to_view).collect();
-                    (views, String::new())
+        // Fan out across every enabled client so SAB / Usenet jobs
+        // appear alongside torrent jobs in the queue. A single
+        // client erroring (e.g. SAB unreachable) doesn't blank the
+        // whole tab — it logs and the other clients still render.
+        let pool = state.download_clients.read().await.clone();
+        if pool.clients.is_empty() {
+            (Vec::new(), "Download client is not configured.".to_string())
+        } else {
+            let mut torrents: Vec<crate::services::download_client::DownloadItem> = Vec::new();
+            let mut errors: Vec<String> = Vec::new();
+            for (id, c) in pool.clients.iter() {
+                match c.list_scoped().await {
+                    Ok(mut items) => torrents.append(&mut items),
+                    Err(e) => errors.push(format!("client #{}: {}", id, e)),
                 }
-                Err(e) => (Vec::new(), format!("Could not load queue: {}", e)),
-            },
-            None => (Vec::new(), "Download client is not configured.".to_string()),
+            }
+            let is_downloading = |k: DownloadItemState| {
+                matches!(
+                    k,
+                    DownloadItemState::Downloading
+                        | DownloadItemState::DownloadingStalled
+                        | DownloadItemState::DownloadingQueued
+                        | DownloadItemState::CheckingDownload
+                )
+            };
+            torrents.sort_by(|a, b| {
+                let a_down = if is_downloading(a.state_kind) { 0 } else { 1 };
+                let b_down = if is_downloading(b.state_kind) { 0 } else { 1 };
+                a_down.cmp(&b_down).then(
+                    b.progress
+                        .partial_cmp(&a.progress)
+                        .unwrap_or(std::cmp::Ordering::Equal),
+                )
+            });
+            let views = torrents.iter().map(torrent_to_view).collect();
+            let error_msg = if errors.is_empty() {
+                String::new()
+            } else {
+                format!("Could not load queue from: {}", errors.join("; "))
+            };
+            (views, error_msg)
         }
     } else {
         (Vec::new(), String::new())
@@ -246,7 +275,7 @@ pub async fn api_pause_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentActionForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = state.default_download_client().await.ok_or((
+    let client = resolve_client_for_hash(&state, &form.hash).await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -273,7 +302,7 @@ pub async fn api_resume_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentActionForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = state.default_download_client().await.ok_or((
+    let client = resolve_client_for_hash(&state, &form.hash).await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;
@@ -300,7 +329,7 @@ pub async fn api_delete_torrent(
     State(state): State<AppState>,
     Json(form): Json<TorrentDeleteForm>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let client = state.default_download_client().await.ok_or((
+    let client = resolve_client_for_hash(&state, &form.hash).await.ok_or((
         axum::http::StatusCode::BAD_REQUEST,
         "Download client not configured".to_string(),
     ))?;

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -311,14 +311,12 @@ pub async fn remove_series(
         };
 
         if !hashes.is_empty() {
-            // Per-grab client routing: a series can have grabs across
-            // multiple clients (e.g. early SAB Usenet rip plus later
-            // qBit BD upgrade). Each grab's `download_client_id`
-            // points at the client that holds it; route per-grab so
-            // a SAB nzo_id doesn't get sent to qBit's `delete` (or
-            // vice versa) and silently leave the original behind.
-            let default_client = state.default_download_client().await;
-            for (_id, hash, dc_id) in &hashes {
+            // Per-grab client routing via `resolve_grab_client`. A
+            // series can have grabs across multiple clients (e.g.
+            // early SAB Usenet rip plus later qBit BD upgrade) AND
+            // legacy SAB grabs may have a NULL stamp; the helper's
+            // nzo_id-shape heuristic rescues those.
+            for (id, hash, dc_id) in &hashes {
                 if hash.is_empty() {
                     continue;
                 }
@@ -334,20 +332,42 @@ pub async fn remove_series(
                     torrents_removed += 1; // counted as "handled"
                     continue;
                 }
-                let client_for_grab = match dc_id {
-                    Some(id) => match state.client_by_id(*id).await {
-                        Some(c) => Some(c),
-                        None => default_client.clone(),
-                    },
-                    None => default_client.clone(),
-                };
-                let Some(client) = client_for_grab else {
+                let Some(client) = state.resolve_grab_client(*dc_id, hash).await else {
                     torrent_failures.push("Download client not configured".to_string());
                     continue;
                 };
                 match client.delete(hash, true).await {
                     Ok(()) => torrents_removed += 1,
                     Err(err) => torrent_failures.push(format!("{}: {}", hash, err)),
+                }
+
+                // Source-side cleanup using import-time-stamped paths.
+                // Same rationale as `delete_episode_file`: the client's
+                // delete is unreliable for SAB jobs whose history
+                // `storage` field is the parent complete dir. Stamped
+                // paths are precise and mode-agnostic.
+                let stamped = grabbed_torrents::get_imported_source_paths(&state.db, *id).await;
+                if !stamped.is_empty() {
+                    let owned: Vec<std::path::PathBuf> =
+                        stamped.iter().map(std::path::PathBuf::from).collect();
+                    let _ = tokio::task::spawn_blocking(move || {
+                        let mut removed: Vec<std::path::PathBuf> = Vec::new();
+                        for p in &owned {
+                            if std::fs::remove_file(p).is_ok() {
+                                removed.push(p.clone());
+                            }
+                        }
+                        // Single-level parent prune only. Mirror the
+                        // shape in `episodes::remove_stamped_source_paths`:
+                        // walking up unbounded would nuke the user's
+                        // complete dir if it only held this one job.
+                        for p in &removed {
+                            if let Some(dir) = p.parent() {
+                                let _ = std::fs::remove_dir(dir);
+                            }
+                        }
+                    })
+                    .await;
                 }
             }
         }

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -316,7 +316,7 @@ pub async fn remove_series(
             // early SAB Usenet rip plus later qBit BD upgrade) AND
             // legacy SAB grabs may have a NULL stamp; the helper's
             // nzo_id-shape heuristic rescues those.
-            for (id, hash, dc_id) in &hashes {
+            for &(id, ref hash, dc_id) in &hashes {
                 if hash.is_empty() {
                     continue;
                 }
@@ -332,7 +332,7 @@ pub async fn remove_series(
                     torrents_removed += 1; // counted as "handled"
                     continue;
                 }
-                let Some(client) = state.resolve_grab_client(*dc_id, hash).await else {
+                let Some(client) = state.resolve_grab_client(dc_id, hash).await else {
                     torrent_failures.push("Download client not configured".to_string());
                     continue;
                 };
@@ -346,28 +346,9 @@ pub async fn remove_series(
                 // delete is unreliable for SAB jobs whose history
                 // `storage` field is the parent complete dir. Stamped
                 // paths are precise and mode-agnostic.
-                let stamped = grabbed_torrents::get_imported_source_paths(&state.db, *id).await;
+                let stamped = grabbed_torrents::get_imported_source_paths(&state.db, id).await;
                 if !stamped.is_empty() {
-                    let owned: Vec<std::path::PathBuf> =
-                        stamped.iter().map(std::path::PathBuf::from).collect();
-                    let _ = tokio::task::spawn_blocking(move || {
-                        let mut removed: Vec<std::path::PathBuf> = Vec::new();
-                        for p in &owned {
-                            if std::fs::remove_file(p).is_ok() {
-                                removed.push(p.clone());
-                            }
-                        }
-                        // Single-level parent prune only. Mirror the
-                        // shape in `episodes::remove_stamped_source_paths`:
-                        // walking up unbounded would nuke the user's
-                        // complete dir if it only held this one job.
-                        for p in &removed {
-                            if let Some(dir) = p.parent() {
-                                let _ = std::fs::remove_dir(dir);
-                            }
-                        }
-                    })
-                    .await;
+                    super::episodes::remove_stamped_source_paths(&stamped).await;
                 }
             }
         }

--- a/src/handlers/library/crud.rs
+++ b/src/handlers/library/crud.rs
@@ -311,31 +311,44 @@ pub async fn remove_series(
         };
 
         if !hashes.is_empty() {
-            let client_opt = state.default_download_client().await;
-            if let Some(client) = client_opt {
-                for (_id, hash) in &hashes {
-                    if hash.is_empty() {
-                        continue;
-                    }
-                    // Issue #28 PR C — preserve PT seed rules across
-                    // series removal. A user wiping a series from the
-                    // library typically wants ratio policies honored
-                    // (their PT account's ratio is downstream of
-                    // every grab). The grabbed_torrents row gets
-                    // deleted below regardless via
-                    // delete_all_for_series, so the upgrade sweep
-                    // can't re-grab the same hash.
-                    if grabbed_torrents::respects_seed_rules(&state.db, hash).await {
-                        torrents_removed += 1; // counted as "handled"
-                        continue;
-                    }
-                    match client.delete(hash, true).await {
-                        Ok(()) => torrents_removed += 1,
-                        Err(err) => torrent_failures.push(format!("{}: {}", hash, err)),
-                    }
+            // Per-grab client routing: a series can have grabs across
+            // multiple clients (e.g. early SAB Usenet rip plus later
+            // qBit BD upgrade). Each grab's `download_client_id`
+            // points at the client that holds it; route per-grab so
+            // a SAB nzo_id doesn't get sent to qBit's `delete` (or
+            // vice versa) and silently leave the original behind.
+            let default_client = state.default_download_client().await;
+            for (_id, hash, dc_id) in &hashes {
+                if hash.is_empty() {
+                    continue;
                 }
-            } else {
-                torrent_failures.push("Download client not configured".to_string());
+                // Issue #28 PR C — preserve PT seed rules across
+                // series removal. A user wiping a series from the
+                // library typically wants ratio policies honored
+                // (their PT account's ratio is downstream of
+                // every grab). The grabbed_torrents row gets
+                // deleted below regardless via
+                // delete_all_for_series, so the upgrade sweep
+                // can't re-grab the same hash.
+                if grabbed_torrents::respects_seed_rules(&state.db, hash).await {
+                    torrents_removed += 1; // counted as "handled"
+                    continue;
+                }
+                let client_for_grab = match dc_id {
+                    Some(id) => match state.client_by_id(*id).await {
+                        Some(c) => Some(c),
+                        None => default_client.clone(),
+                    },
+                    None => default_client.clone(),
+                };
+                let Some(client) = client_for_grab else {
+                    torrent_failures.push("Download client not configured".to_string());
+                    continue;
+                };
+                match client.delete(hash, true).await {
+                    Ok(()) => torrents_removed += 1,
+                    Err(err) => torrent_failures.push(format!("{}: {}", hash, err)),
+                }
             }
         }
 

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -149,7 +149,7 @@ async fn path_has_inode(_path: &str, _inode: u64) -> bool {
 /// jobs in it. Earlier versions walked up unbounded — for users
 /// whose `complete/` happened to contain only this one job, that
 /// removed the entire complete dir.
-async fn remove_stamped_source_paths(sources: &[String]) -> Vec<std::path::PathBuf> {
+pub(super) async fn remove_stamped_source_paths(sources: &[String]) -> Vec<std::path::PathBuf> {
     let owned: Vec<std::path::PathBuf> = sources.iter().map(std::path::PathBuf::from).collect();
     tokio::task::spawn_blocking(move || {
         let mut removed = Vec::new();
@@ -326,15 +326,31 @@ pub async fn delete_episode_file(
                     grabbed_torrents::imported_source_paths_for_series(&state.db, tracked.id)
                         .await
                         .unwrap_or_default();
-                let mut targets: Vec<String> = Vec::new();
+                // Flatten every grab's stamps into one path list; for
+                // a series with N imported grabs and ~M stamps each,
+                // this is N×M paths to stat. Run the inode probes in
+                // parallel via `buffer_unordered(8)` so a series with
+                // a deep history doesn't serialize ~hundreds of
+                // `spawn_blocking` round-trips through the blocking
+                // pool while the user waits on the delete handler.
+                let mut all_paths: Vec<String> = Vec::new();
                 for (_grab_id, json) in &bundles {
                     let paths: Vec<String> = serde_json::from_str(json).unwrap_or_default();
-                    for p in paths {
-                        if path_has_inode(&p, ino).await {
-                            targets.push(p);
-                        }
-                    }
+                    all_paths.extend(paths);
                 }
+                use futures_util::StreamExt;
+                let targets: Vec<String> = futures_util::stream::iter(all_paths)
+                    .map(|p| async move {
+                        if path_has_inode(&p, ino).await {
+                            Some(p)
+                        } else {
+                            None
+                        }
+                    })
+                    .buffer_unordered(8)
+                    .filter_map(|opt| async move { opt })
+                    .collect()
+                    .await;
                 if !targets.is_empty() {
                     let removed = remove_stamped_source_paths(&targets).await;
                     if !removed.is_empty() {

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -139,52 +139,66 @@ pub async fn delete_episode_file(
                     .unwrap_or_default();
             let mut qbit_removed: Vec<String> = Vec::new();
             if !imported_grabs.is_empty() {
-                let client = state.default_download_client().await;
-                if let Some(client) = client {
-                    for grab in &imported_grabs {
-                        if grab.is_batch {
-                            continue;
+                // Per-grab client routing: each grab row stamps its
+                // `download_client_id` at grab time so a SAB grab
+                // doesn't get sent to a qBit `delete` (no-op since
+                // qBit doesn't know that nzo_id) and vice-versa.
+                // Legacy grab rows with NULL fall back to the
+                // torrent default.
+                let default_client = state.default_download_client().await;
+                for grab in &imported_grabs {
+                    if grab.is_batch {
+                        continue;
+                    }
+                    if grab.hash.is_empty() {
+                        continue;
+                    }
+                    // Issue #28 PR C — skip the client-side
+                    // delete for grabs from a PT indexer with
+                    // seed rules in effect; the client owns
+                    // when seeding ends. The grab row still
+                    // gets `mark_removed` so the upgrade sweep
+                    // doesn't re-grab.
+                    if grabbed_torrents::respects_seed_rules(&state.db, &grab.hash).await {
+                        logger::info(
+                            &state.db,
+                            LogCategory::DownloadClient,
+                            &format!(
+                                "Skipping client delete for {} (respect_seed_rules); client will stop on its own ratio policy",
+                                grab.torrent_name
+                            ),
+                            &grab.hash,
+                        )
+                        .await;
+                        let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
+                        continue;
+                    }
+                    let client_for_grab = match grab.download_client_id {
+                        Some(id) => match state.client_by_id(id).await {
+                            Some(c) => Some(c),
+                            None => default_client.clone(),
+                        },
+                        None => default_client.clone(),
+                    };
+                    let Some(client) = client_for_grab else {
+                        continue;
+                    };
+                    match client.delete(&grab.hash, true).await {
+                        Ok(()) => {
+                            qbit_removed.push(grab.torrent_name.clone());
+                            let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
                         }
-                        if grab.hash.is_empty() {
-                            continue;
-                        }
-                        // Issue #28 PR C — skip the client-side
-                        // delete for grabs from a PT indexer with
-                        // seed rules in effect; the client owns
-                        // when seeding ends. The grab row still
-                        // gets `mark_removed` so the upgrade sweep
-                        // doesn't re-grab.
-                        if grabbed_torrents::respects_seed_rules(&state.db, &grab.hash).await {
-                            logger::info(
+                        Err(e) => {
+                            logger::warn(
                                 &state.db,
                                 LogCategory::DownloadClient,
                                 &format!(
-                                    "Skipping client delete for {} (respect_seed_rules); client will stop on its own ratio policy",
-                                    grab.torrent_name
+                                    "Download client delete failed for episode {} torrent '{}' — continuing with file delete",
+                                    episode_number, grab.torrent_name
                                 ),
-                                &grab.hash,
+                                &e,
                             )
                             .await;
-                            let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
-                            continue;
-                        }
-                        match client.delete(&grab.hash, true).await {
-                            Ok(()) => {
-                                qbit_removed.push(grab.torrent_name.clone());
-                                let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
-                            }
-                            Err(e) => {
-                                logger::debug(
-                                    &state.db,
-                                    LogCategory::DownloadClient,
-                                    &format!(
-                                        "Download client delete failed for episode {} torrent '{}' — continuing with file delete",
-                                        episode_number, grab.torrent_name
-                                    ),
-                                    &e,
-                                )
-                                .await;
-                            }
                         }
                     }
                 }
@@ -347,26 +361,38 @@ pub async fn cancel_pending_episode(
         "cancel_pending_episode: matching grabs"
     );
 
-    let client = state.default_download_client().await;
+    // Per-grab client routing: each grab row's `download_client_id`
+    // points at the client that holds it. Legacy NULLs fall back to
+    // the torrent default so cancel still works on rows that pre-date
+    // the multi-client refactor.
+    let default_client = state.default_download_client().await;
 
     let mut removed_count = 0;
     let mut torrent_failures: Vec<String> = Vec::new();
     for grab in &pending {
-        if !grab.hash.is_empty()
-            && let Some(ref client) = client
-            && let Err(e) = client.delete(&grab.hash, true).await
-        {
-            torrent_failures.push(format!("{}: {}", grab.torrent_name, e));
-            logger::warn(
-                &state.db,
-                LogCategory::DownloadClient,
-                &format!(
-                    "Failed to remove pending torrent for S?E{:02} cancel: '{}'",
-                    episode_number, grab.torrent_name
-                ),
-                &e,
-            )
-            .await;
+        if !grab.hash.is_empty() {
+            let client_for_grab = match grab.download_client_id {
+                Some(id) => match state.client_by_id(id).await {
+                    Some(c) => Some(c),
+                    None => default_client.clone(),
+                },
+                None => default_client.clone(),
+            };
+            if let Some(client) = client_for_grab
+                && let Err(e) = client.delete(&grab.hash, true).await
+            {
+                torrent_failures.push(format!("{}: {}", grab.torrent_name, e));
+                logger::warn(
+                    &state.db,
+                    LogCategory::DownloadClient,
+                    &format!(
+                        "Failed to remove pending torrent for S?E{:02} cancel: '{}'",
+                        episode_number, grab.torrent_name
+                    ),
+                    &e,
+                )
+                .await;
+            }
         }
 
         if let Err(e) = grabbed_torrents::mark_removed(&state.db, grab.id).await {
@@ -491,42 +517,55 @@ pub async fn mark_episode_failed(
         grabbed_torrents::find_imported_for_episode(&state.db, series_id, episode_number).await
         && !old_grabs.is_empty()
     {
-        let client = { state.default_download_client().await };
-        if let Some(client) = client {
-            for old in &old_grabs {
-                if old.hash.is_empty() {
-                    continue;
-                }
-                // Issue #28 PR C — preserve PT seed rules across
-                // episode-replace. The old torrent has already
-                // imported successfully and is seeding to its
-                // per-tracker ratio/time policy; deleting it
-                // mid-seed could ding the user's tracker ratio.
-                if grabbed_torrents::respects_seed_rules(&state.db, &old.hash).await {
-                    crate::services::logger::info(
-                        &state.db,
-                        crate::models::log::LogCategory::DownloadClient,
-                        &format!(
-                            "Skipping client delete for replaced torrent {} (respect_seed_rules)",
-                            old.torrent_name
-                        ),
-                        &old.hash,
-                    )
-                    .await;
-                    continue;
-                }
-                if let Err(e) = client.delete(&old.hash, true).await {
-                    crate::services::logger::warn(
-                        &state.db,
-                        crate::models::log::LogCategory::DownloadClient,
-                        &format!(
-                            "Failed to remove old torrent for S?E{:02} replacement: '{}'",
-                            episode_number, old.torrent_name
-                        ),
-                        &e,
-                    )
-                    .await;
-                }
+        // Per-grab client routing: the old grab might be on SAB
+        // while the new replacement is being acquired through a
+        // torrent indexer (or vice versa). Sending the SAB nzo_id
+        // to qBit's `delete` would silently no-op and leave the
+        // old SAB job behind.
+        let default_client = state.default_download_client().await;
+        for old in &old_grabs {
+            if old.hash.is_empty() {
+                continue;
+            }
+            // Issue #28 PR C — preserve PT seed rules across
+            // episode-replace. The old torrent has already
+            // imported successfully and is seeding to its
+            // per-tracker ratio/time policy; deleting it
+            // mid-seed could ding the user's tracker ratio.
+            if grabbed_torrents::respects_seed_rules(&state.db, &old.hash).await {
+                crate::services::logger::info(
+                    &state.db,
+                    crate::models::log::LogCategory::DownloadClient,
+                    &format!(
+                        "Skipping client delete for replaced torrent {} (respect_seed_rules)",
+                        old.torrent_name
+                    ),
+                    &old.hash,
+                )
+                .await;
+                continue;
+            }
+            let client_for_grab = match old.download_client_id {
+                Some(id) => match state.client_by_id(id).await {
+                    Some(c) => Some(c),
+                    None => default_client.clone(),
+                },
+                None => default_client.clone(),
+            };
+            let Some(client) = client_for_grab else {
+                continue;
+            };
+            if let Err(e) = client.delete(&old.hash, true).await {
+                crate::services::logger::warn(
+                    &state.db,
+                    crate::models::log::LogCategory::DownloadClient,
+                    &format!(
+                        "Failed to remove old torrent for S?E{:02} replacement: '{}'",
+                        episode_number, old.torrent_name
+                    ),
+                    &e,
+                )
+                .await;
             }
         }
     }
@@ -594,24 +633,39 @@ pub async fn episode_download_progress(
             .await
             .unwrap_or_default();
 
-    let client = {
-        let client = state.default_download_client().await;
-        match client.as_ref() {
-            Some(c) => c.clone(),
-            None => return Ok(Json(Vec::new())),
+    // Fetch list_scoped from EVERY configured client and merge. The
+    // pre-fix code called `state.default_download_client()` which
+    // returns the torrent default specifically — fine for BT-only
+    // setups but wrong as soon as SAB enters the picture, since SAB
+    // grabs land on the usenet default and their `nzo_id` hashes
+    // never appear in qBit's `list_scoped`. Symptom: SAB grabs got
+    // marked "Torrent removed in download client" at the 30s stale
+    // mark even when the SAB job was happily completing.
+    //
+    // Fetching from all clients is cheap (one HTTP call per client
+    // per poll, typical homelab has 1-2 clients) and the merge
+    // doesn't collide because BT v1 infohashes (40-char hex) and
+    // SAB nzo_ids (SABnzbd_nzo_*) share no namespace.
+    let pool = state.download_clients.read().await.clone();
+    if pool.clients.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+    let mut all_torrents: Vec<crate::services::download_client::DownloadItem> = Vec::new();
+    for (client_id, client) in pool.clients.iter() {
+        match client.list_scoped().await {
+            Ok(t) => all_torrents.extend(t),
+            Err(err) => {
+                // One client unreachable shouldn't blank the progress
+                // surface for grabs on other clients. Log + continue.
+                tracing::debug!(
+                    "episode-progress poll: list_scoped failed for client #{}: {}",
+                    client_id,
+                    err
+                );
+            }
         }
-    };
-
-    let torrents = match client.list_scoped().await {
-        Ok(t) => t,
-        Err(err) => {
-            return Err((
-                axum::http::StatusCode::SERVICE_UNAVAILABLE,
-                format!("Download client unavailable: {err}"),
-            ));
-        }
-    };
-    let by_hash: HashMap<String, &crate::services::download_client::DownloadItem> = torrents
+    }
+    let by_hash: HashMap<String, &crate::services::download_client::DownloadItem> = all_torrents
         .iter()
         .map(|t| (t.hash.to_lowercase(), t))
         .collect();

--- a/src/handlers/library/episodes.rs
+++ b/src/handlers/library/episodes.rs
@@ -23,6 +23,156 @@ use super::reconcile::{resolve_series_context, resolve_tracked_series};
 use super::search::run_auto_search_targets;
 use super::{Episode, MarkEpisodeFailedForm};
 
+/// Walk `root` recursively (depth cap matches `walk_video_files` in
+/// post_processing — 4 levels) and remove any regular file whose
+/// inode equals `inode`. Returns the list of removed paths so the
+/// caller can log them. Best-effort: I/O errors during walk or
+/// remove are swallowed because this is a cleanup pass after the
+/// authoritative media-side delete has already succeeded.
+///
+/// Used by `delete_episode_file` to scrub SAB-side hardlink sources
+/// when the client's own `del_files=1` doesn't reach them — the
+/// shared-inode property of hardlinks gives us a reliable way to
+/// find the source regardless of how SAB reports its history
+/// `storage` field. After file removal, walks back up cleaning out
+/// any directories that became empty as a result, stopping at
+/// `root` so we never empty out the configured complete dir.
+#[cfg(unix)]
+async fn remove_hardlinks_with_inode(
+    root: &std::path::Path,
+    inode: u64,
+) -> Vec<std::path::PathBuf> {
+    use std::os::unix::fs::MetadataExt;
+
+    fn walk(dir: &std::path::Path, depth: u32, inode: u64, out: &mut Vec<std::path::PathBuf>) {
+        const MAX_DEPTH: u32 = 4;
+        if depth > MAX_DEPTH {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = entry.metadata() else {
+                continue;
+            };
+            if meta.is_dir() {
+                walk(&path, depth + 1, inode, out);
+            } else if meta.is_file() && meta.ino() == inode {
+                out.push(path);
+            }
+        }
+    }
+
+    let root = root.to_path_buf();
+    let inode_arg = inode;
+    tokio::task::spawn_blocking(move || {
+        let mut found = Vec::new();
+        walk(&root, 0, inode_arg, &mut found);
+        let mut removed = Vec::new();
+        for p in found {
+            if std::fs::remove_file(&p).is_ok() {
+                removed.push(p);
+            }
+        }
+        // Walk back up cleaning out emptied parents. Stop at `root`
+        // (don't try to rmdir the root itself — that's the user's
+        // configured complete dir).
+        let root_canon = std::fs::canonicalize(&root).unwrap_or(root.clone());
+        for p in &removed {
+            let mut parent = p.parent();
+            while let Some(dir) = parent {
+                if let Ok(canon) = std::fs::canonicalize(dir)
+                    && canon == root_canon
+                {
+                    break;
+                }
+                if std::fs::remove_dir(dir).is_err() {
+                    // Non-empty or permission denied — stop ascending.
+                    break;
+                }
+                parent = dir.parent();
+            }
+        }
+        removed
+    })
+    .await
+    .unwrap_or_default()
+}
+
+#[cfg(not(unix))]
+async fn remove_hardlinks_with_inode(
+    _root: &std::path::Path,
+    _inode: u64,
+) -> Vec<std::path::PathBuf> {
+    Vec::new()
+}
+
+/// Check whether `path` is a regular file with the given inode.
+/// Used by the orphan-source-cleanup fallback in
+/// `delete_episode_file`: when a grab's stamped paths contain a file
+/// matching the just-deleted media file's inode, that's the SAB
+/// source we want to remove (regardless of which grab "officially"
+/// claims the episode).
+#[cfg(unix)]
+async fn path_has_inode(path: &str, inode: u64) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let p = std::path::PathBuf::from(path);
+    tokio::task::spawn_blocking(move || {
+        std::fs::metadata(&p)
+            .ok()
+            .filter(|m| m.is_file())
+            .map(|m| m.ino() == inode)
+            .unwrap_or(false)
+    })
+    .await
+    .unwrap_or(false)
+}
+
+#[cfg(not(unix))]
+async fn path_has_inode(_path: &str, _inode: u64) -> bool {
+    false
+}
+
+/// Remove each path in `sources` (best-effort) and prune the
+/// **immediate parent directory only** if it became empty as a
+/// result. Used by `delete_episode_file` and the series-remove path
+/// to clean up the source-side files Ryokan imported FROM — stamped
+/// at import time so we know exact paths regardless of how the
+/// download client reports its layout.
+///
+/// The single-level prune cap is critical: removing `complete/job/file.mkv`
+/// leaves `complete/job/` empty, which we want gone (the SAB job
+/// folder); but we must NEVER ascend further to `complete/` itself,
+/// or we'd nuke the user's configured complete root and all sibling
+/// jobs in it. Earlier versions walked up unbounded — for users
+/// whose `complete/` happened to contain only this one job, that
+/// removed the entire complete dir.
+async fn remove_stamped_source_paths(sources: &[String]) -> Vec<std::path::PathBuf> {
+    let owned: Vec<std::path::PathBuf> = sources.iter().map(std::path::PathBuf::from).collect();
+    tokio::task::spawn_blocking(move || {
+        let mut removed = Vec::new();
+        for p in &owned {
+            if std::fs::remove_file(p).is_ok() {
+                removed.push(p.clone());
+            }
+        }
+        // Single-level parent prune: try once per removed file. If
+        // the directory is non-empty (other files we didn't touch)
+        // or rmdir fails (permission, etc.), we leave it alone. We
+        // deliberately do NOT walk further up — see fn doc.
+        for p in &removed {
+            if let Some(dir) = p.parent() {
+                let _ = std::fs::remove_dir(dir);
+            }
+        }
+        removed
+    })
+    .await
+    .unwrap_or_default()
+}
+
 #[utoipa::path(
     post,
     path = "/api/series/{anilist_id}/delete-file/{episode_number}",
@@ -117,6 +267,26 @@ pub async fn delete_episode_file(
                 );
             }
 
+            // Capture the media file's inode BEFORE removal. In
+            // hardlink import mode the SAB-side source shares this
+            // inode; we use it to find and remove the source after
+            // the media-side hardlink is gone. Necessary because
+            // SAB's `del_files=1` is unreliable when its history
+            // entry's `storage` field points at the parent complete
+            // dir (SAB refuses to recursively rm the whole complete
+            // root) — leaving the original .mkv intact in
+            // `complete/<job-folder>/`.
+            #[cfg(unix)]
+            let media_inode = {
+                use std::os::unix::fs::MetadataExt;
+                tokio::fs::metadata(&full_path_canon)
+                    .await
+                    .ok()
+                    .map(|m| m.ino())
+            };
+            #[cfg(not(unix))]
+            let media_inode: Option<u64> = None;
+
             if let Err(e) = tokio::fs::remove_file(&full_path_canon).await {
                 return json_err(
                     axum::http::StatusCode::INTERNAL_SERVER_ERROR,
@@ -137,15 +307,66 @@ pub async fn delete_episode_file(
                 grabbed_torrents::find_imported_for_episode(&state.db, tracked.id, episode_number)
                     .await
                     .unwrap_or_default();
+
+            // Inode fallback when no grab claims this episode. Pre-fix
+            // wide-walk SAB grabs swept in stranger episodes from
+            // sibling SAB jobs and stamped them onto whichever grab's
+            // import was running; the grab's `episode_numbers` only
+            // covers its OWN release, so `find_imported_for_episode`
+            // returns empty for the over-imported episode even though
+            // a real stamped path for it exists. Walk every imported
+            // grab in this series, decode stamped JSON, find a path
+            // whose inode matches the just-deleted media file, remove
+            // it. Defense-in-depth — most grabs after the
+            // `canonical_job_path` fix won't need this.
+            if imported_grabs.is_empty()
+                && let Some(ino) = media_inode
+            {
+                let bundles =
+                    grabbed_torrents::imported_source_paths_for_series(&state.db, tracked.id)
+                        .await
+                        .unwrap_or_default();
+                let mut targets: Vec<String> = Vec::new();
+                for (_grab_id, json) in &bundles {
+                    let paths: Vec<String> = serde_json::from_str(json).unwrap_or_default();
+                    for p in paths {
+                        if path_has_inode(&p, ino).await {
+                            targets.push(p);
+                        }
+                    }
+                }
+                if !targets.is_empty() {
+                    let removed = remove_stamped_source_paths(&targets).await;
+                    if !removed.is_empty() {
+                        logger::info(
+                            &state.db,
+                            LogCategory::PostProcess,
+                            &format!(
+                                "Removed {} orphan source file(s) for episode {} via inode fallback",
+                                removed.len(),
+                                episode_number
+                            ),
+                            &removed
+                                .iter()
+                                .map(|p| p.display().to_string())
+                                .collect::<Vec<_>>()
+                                .join(", "),
+                        )
+                        .await;
+                    }
+                }
+            }
+
             let mut qbit_removed: Vec<String> = Vec::new();
             if !imported_grabs.is_empty() {
-                // Per-grab client routing: each grab row stamps its
-                // `download_client_id` at grab time so a SAB grab
-                // doesn't get sent to a qBit `delete` (no-op since
-                // qBit doesn't know that nzo_id) and vice-versa.
-                // Legacy grab rows with NULL fall back to the
-                // torrent default.
-                let default_client = state.default_download_client().await;
+                // Per-grab client routing via `resolve_grab_client`:
+                // prefers the stamped `download_client_id`, falls back
+                // through a SAB-nzo_id-shape heuristic for legacy
+                // grabs (NULL stamp from before grab-time stamping
+                // was wired), then to the torrent default. Without
+                // the heuristic an old SAB grab routes to qBit's
+                // delete, qBit 200s on the unknown hash, and the SAB
+                // job survives.
                 for grab in &imported_grabs {
                     if grab.is_batch {
                         continue;
@@ -173,27 +394,150 @@ pub async fn delete_episode_file(
                         let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
                         continue;
                     }
-                    let client_for_grab = match grab.download_client_id {
-                        Some(id) => match state.client_by_id(id).await {
-                            Some(c) => Some(c),
-                            None => default_client.clone(),
-                        },
-                        None => default_client.clone(),
-                    };
-                    let Some(client) = client_for_grab else {
+                    let Some(client) = state
+                        .resolve_grab_client(grab.download_client_id, &grab.hash)
+                        .await
+                    else {
                         continue;
                     };
-                    match client.delete(&grab.hash, true).await {
+                    let delete_result = client.delete(&grab.hash, true).await;
+
+                    // Belt-and-suspenders source-side cleanup. The
+                    // client's own `delete(hash, true)` is unreliable
+                    // for SAB (its `del_files=1` no-ops when its
+                    // history `storage` field is the parent complete
+                    // dir). Two complementary local-fs cleanup paths
+                    // run alongside the client delete:
+                    //
+                    //   1. **Stamped source paths** —
+                    //      `import_torrent` records the exact paths
+                    //      it imported FROM. Direct, mode-agnostic
+                    //      (works for hardlink, copy, and move —
+                    //      though move's source is already gone).
+                    //      Primary cleanup channel for fresh grabs.
+                    //   2. **Inode-based fallback** — for legacy
+                    //      grabs imported before stamping was wired
+                    //      (NULL `imported_source_paths`). Hardlink
+                    //      mode shares inodes between media-side and
+                    //      SAB-side files; we use the media inode
+                    //      (captured pre-deletion) to find the
+                    //      surviving SAB-side hardlink under the
+                    //      grab's `client_content_path`. Doesn't fire
+                    //      for legacy copy-mode grabs — those have
+                    //      no recovery path short of the user
+                    //      cleaning SAB by hand.
+                    let stamped_sources =
+                        grabbed_torrents::get_imported_source_paths(&state.db, grab.id).await;
+                    if !stamped_sources.is_empty() {
+                        let removed = remove_stamped_source_paths(&stamped_sources).await;
+                        if !removed.is_empty() {
+                            logger::info(
+                                &state.db,
+                                LogCategory::PostProcess,
+                                &format!(
+                                    "Removed {} source file(s) for episode {} via import-time stamps",
+                                    removed.len(),
+                                    episode_number
+                                ),
+                                &removed
+                                    .iter()
+                                    .map(|p| p.display().to_string())
+                                    .collect::<Vec<_>>()
+                                    .join(", "),
+                            )
+                            .await;
+                        }
+                    } else if let Some(ino) = media_inode {
+                        // Live-query the client for this hash's
+                        // canonical content_path. The stamped
+                        // `client_content_path` on legacy grabs
+                        // pre-dates our title-matching narrowing
+                        // (`canonical_job_path` in
+                        // `services::download_client::sabnzbd`)
+                        // and may still be the parent complete dir.
+                        // `list_scoped` runs the narrowing fresh, so
+                        // its `content_path` is the per-job folder.
+                        let live_path = match client.list_scoped().await {
+                            Ok(items) => items
+                                .into_iter()
+                                .find(|i| i.hash == grab.hash)
+                                .map(|i| i.content_path),
+                            Err(_) => None,
+                        };
+                        let stamped_path =
+                            grabbed_torrents::get_client_content_path(&state.db, grab.id).await;
+                        let content_path = live_path
+                            .filter(|s| !s.trim().is_empty())
+                            .unwrap_or(stamped_path);
+                        if !content_path.trim().is_empty() {
+                            let local = crate::services::download_client::translate_client_path(
+                                &content_path,
+                                &content_path,
+                                crate::services::download_client::per_client_download_path(&cfg),
+                            );
+                            let candidate = if local.is_empty() {
+                                content_path
+                            } else {
+                                local
+                            };
+                            let removed =
+                                remove_hardlinks_with_inode(std::path::Path::new(&candidate), ino)
+                                    .await;
+                            if !removed.is_empty() {
+                                logger::info(
+                                    &state.db,
+                                    LogCategory::PostProcess,
+                                    &format!(
+                                        "Removed {} source hardlink(s) for episode {} via inode match in '{}'",
+                                        removed.len(),
+                                        episode_number,
+                                        candidate
+                                    ),
+                                    &removed
+                                        .iter()
+                                        .map(|p| p.display().to_string())
+                                        .collect::<Vec<_>>()
+                                        .join(", "),
+                                )
+                                .await;
+                            } else {
+                                logger::warn(
+                                    &state.db,
+                                    LogCategory::PostProcess,
+                                    &format!(
+                                        "No source files matched inode for episode {} under '{}'",
+                                        episode_number, candidate
+                                    ),
+                                    &format!("inode={ino} hash={}", grab.hash),
+                                )
+                                .await;
+                            }
+                        }
+                    }
+
+                    // Mark the grab removed regardless of the
+                    // client's delete result. The user explicitly
+                    // asked for deletion, the media file IS gone,
+                    // and the source-side cleanup above already
+                    // ran. Gating `mark_removed` on `client.delete`
+                    // returning `Ok` left the row stuck in
+                    // 'imported' state any time SAB returned a
+                    // non-success on housekeeping (e.g. the nzo_id
+                    // had already been purged from history by SAB's
+                    // own retention policy, or a stale-state grab
+                    // from a prior aborted session). The UI then
+                    // showed the episode as still imported even
+                    // though it was actually deleted on disk.
+                    match delete_result {
                         Ok(()) => {
                             qbit_removed.push(grab.torrent_name.clone());
-                            let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
                         }
                         Err(e) => {
                             logger::warn(
                                 &state.db,
                                 LogCategory::DownloadClient,
                                 &format!(
-                                    "Download client delete failed for episode {} torrent '{}' — continuing with file delete",
+                                    "Download client delete returned an error for episode {} torrent '{}' — proceeding with grab cleanup anyway",
                                     episode_number, grab.torrent_name
                                 ),
                                 &e,
@@ -201,6 +545,7 @@ pub async fn delete_episode_file(
                             .await;
                         }
                     }
+                    let _ = grabbed_torrents::mark_removed(&state.db, grab.id).await;
                 }
             }
 
@@ -361,23 +706,15 @@ pub async fn cancel_pending_episode(
         "cancel_pending_episode: matching grabs"
     );
 
-    // Per-grab client routing: each grab row's `download_client_id`
-    // points at the client that holds it. Legacy NULLs fall back to
-    // the torrent default so cancel still works on rows that pre-date
-    // the multi-client refactor.
-    let default_client = state.default_download_client().await;
-
     let mut removed_count = 0;
     let mut torrent_failures: Vec<String> = Vec::new();
     for grab in &pending {
         if !grab.hash.is_empty() {
-            let client_for_grab = match grab.download_client_id {
-                Some(id) => match state.client_by_id(id).await {
-                    Some(c) => Some(c),
-                    None => default_client.clone(),
-                },
-                None => default_client.clone(),
-            };
+            // Per-grab client routing — see `resolve_grab_client` for
+            // the SAB-nzo_id heuristic that rescues legacy NULL stamps.
+            let client_for_grab = state
+                .resolve_grab_client(grab.download_client_id, &grab.hash)
+                .await;
             if let Some(client) = client_for_grab
                 && let Err(e) = client.delete(&grab.hash, true).await
             {
@@ -517,12 +854,6 @@ pub async fn mark_episode_failed(
         grabbed_torrents::find_imported_for_episode(&state.db, series_id, episode_number).await
         && !old_grabs.is_empty()
     {
-        // Per-grab client routing: the old grab might be on SAB
-        // while the new replacement is being acquired through a
-        // torrent indexer (or vice versa). Sending the SAB nzo_id
-        // to qBit's `delete` would silently no-op and leave the
-        // old SAB job behind.
-        let default_client = state.default_download_client().await;
         for old in &old_grabs {
             if old.hash.is_empty() {
                 continue;
@@ -545,14 +876,12 @@ pub async fn mark_episode_failed(
                 .await;
                 continue;
             }
-            let client_for_grab = match old.download_client_id {
-                Some(id) => match state.client_by_id(id).await {
-                    Some(c) => Some(c),
-                    None => default_client.clone(),
-                },
-                None => default_client.clone(),
-            };
-            let Some(client) = client_for_grab else {
+            // Per-grab client routing — see `resolve_grab_client`.
+            // Cross-protocol upgrade (SAB→qBit etc) lands here.
+            let Some(client) = state
+                .resolve_grab_client(old.download_client_id, &old.hash)
+                .await
+            else {
                 continue;
             };
             if let Err(e) = client.delete(&old.hash, true).await {
@@ -802,6 +1131,155 @@ mod tests {
     use crate::services::download_client::test_helpers;
     use crate::test_support;
     use std::sync::Arc;
+
+    /// `remove_hardlinks_with_inode` finds a hardlink anywhere under
+    /// `root` (depth-limited) and removes it. Verifies the actual
+    /// SAB-source-cleanup path: in hardlink import mode the
+    /// media-side and SAB-side files share an inode, so given the
+    /// inode of one we can locate and remove the other under SAB's
+    /// content_path even when SAB's reported `storage` field is
+    /// the parent complete dir (the user's reproducible bug).
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remove_hardlinks_with_inode_finds_link_in_subdirectory() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        // Simulate SAB's complete dir + per-job subfolder shape that
+        // SAB's `del_files=1` guard refuses to descend into.
+        let job_dir = root.join("[Erai-raws].One.Piece-1159.HEVC");
+        std::fs::create_dir(&job_dir).unwrap();
+        let source = job_dir.join("[Erai-raws].One.Piece-1159.HEVC.mkv");
+        std::fs::write(&source, b"fake mkv contents").unwrap();
+        // Media-side hardlink — same inode. Lives outside `root` so
+        // it's not in scope for the cleanup pass.
+        let media_dir = tmp.path().join("media");
+        std::fs::create_dir(&media_dir).unwrap();
+        let media = media_dir.join("ONE PIECE - S01E1159.mkv");
+        std::fs::hard_link(&source, &media).unwrap();
+
+        // Capture the shared inode via the media side (the realistic
+        // call shape — caller has the media file's inode pre-deletion).
+        use std::os::unix::fs::MetadataExt;
+        let inode = std::fs::metadata(&media).unwrap().ino();
+        // Remove the media side first (mirrors the production order:
+        // delete media file, then walk SAB content_path for the
+        // surviving hardlink).
+        std::fs::remove_file(&media).unwrap();
+
+        let removed = remove_hardlinks_with_inode(root, inode).await;
+        assert_eq!(removed.len(), 1, "expected one source hardlink removed");
+        assert_eq!(removed[0], source);
+        assert!(!source.exists(), "source file must be gone");
+        // Job subdir cleaned up (became empty after file removal).
+        assert!(!job_dir.exists(), "empty job dir must be cleaned");
+        // Root preserved — never rmdir the user's complete dir.
+        assert!(root.exists(), "root must not be touched");
+    }
+
+    /// Inode mismatch (copy-mode imports — different inodes) means
+    /// the helper finds nothing and removes nothing. The client's
+    /// own `delete(hash, true)` is the cleanup path for copy-mode.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn remove_hardlinks_with_inode_skips_when_inode_does_not_match() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path();
+        let source = root.join("show.mkv");
+        std::fs::write(&source, b"contents").unwrap();
+
+        // Pick an inode that very likely doesn't match anything in
+        // tmp (max u64 sentinel — real inodes are never this).
+        let removed = remove_hardlinks_with_inode(root, u64::MAX).await;
+        assert!(removed.is_empty());
+        assert!(source.exists(), "non-matching files must survive");
+    }
+
+    /// `remove_stamped_source_paths` removes the exact paths recorded
+    /// at import time and prunes the immediate parent dir (the SAB
+    /// job folder) if it became empty. Mode-agnostic — works for
+    /// hardlink, copy, or move imports (move's source already gone,
+    /// paths just no-op).
+    #[tokio::test]
+    async fn remove_stamped_source_paths_removes_files_and_immediate_parent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let job_dir = tmp.path().join("job-folder");
+        std::fs::create_dir(&job_dir).unwrap();
+        let f1 = job_dir.join("ep01.mkv");
+        let f2 = job_dir.join("ep02.mkv");
+        std::fs::write(&f1, b"a").unwrap();
+        std::fs::write(&f2, b"b").unwrap();
+        let stamps = vec![f1.display().to_string(), f2.display().to_string()];
+
+        let removed = remove_stamped_source_paths(&stamps).await;
+        assert_eq!(removed.len(), 2);
+        assert!(!f1.exists());
+        assert!(!f2.exists());
+        // Job folder (immediate parent of the removed files) cleaned.
+        assert!(!job_dir.exists(), "empty job dir should be pruned");
+        // Tempdir itself (the would-be `complete/` root) preserved.
+        assert!(tmp.path().exists(), "tempdir root must NOT be pruned");
+    }
+
+    /// **Regression guard for the "deletes the whole complete dir"
+    /// bug.** When the SAB complete dir contains exactly one job and
+    /// we remove that job, the prune logic must NOT ascend into
+    /// removing the complete dir itself. Earlier versions walked up
+    /// unbounded and trashed the whole download tree.
+    #[tokio::test]
+    async fn remove_stamped_source_paths_does_not_ascend_above_one_level() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        // Mirror the user-reported shape:
+        // <tmp>/complete/[job-folder]/file.mkv
+        let complete = tmp.path().join("complete");
+        let job = complete.join("[job-folder]");
+        std::fs::create_dir(&complete).unwrap();
+        std::fs::create_dir(&job).unwrap();
+        let f = job.join("file.mkv");
+        std::fs::write(&f, b"data").unwrap();
+
+        let removed = remove_stamped_source_paths(&[f.display().to_string()]).await;
+        assert_eq!(removed.len(), 1);
+        assert!(!f.exists(), "stamped file removed");
+        assert!(!job.exists(), "empty job folder cleaned (one level up)");
+        // CRITICAL: the configured complete dir survives even though
+        // it's now empty. Earlier unbounded walk would rmdir this.
+        assert!(
+            complete.exists(),
+            "complete dir must NOT be rmdir'd just because the only job inside it was cleared"
+        );
+    }
+
+    /// Missing source files (move-mode imports — source already
+    /// renamed away) don't error out. The helper just records nothing
+    /// removed and the caller continues.
+    #[tokio::test]
+    async fn remove_stamped_source_paths_silently_skips_missing_files() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let stamps = vec![tmp.path().join("does-not-exist.mkv").display().to_string()];
+        let removed = remove_stamped_source_paths(&stamps).await;
+        assert!(removed.is_empty());
+    }
+
+    /// Non-empty parent dir is preserved — we only prune dirs that
+    /// became empty as a result of OUR removal. Other unrelated files
+    /// in a shared dir aren't touched.
+    #[tokio::test]
+    async fn remove_stamped_source_paths_preserves_non_empty_parent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("shared");
+        std::fs::create_dir(&dir).unwrap();
+        let target = dir.join("target.mkv");
+        let bystander = dir.join("bystander.mkv");
+        std::fs::write(&target, b"a").unwrap();
+        std::fs::write(&bystander, b"b").unwrap();
+
+        let stamps = vec![target.display().to_string()];
+        let removed = remove_stamped_source_paths(&stamps).await;
+        assert_eq!(removed.len(), 1);
+        assert!(!target.exists());
+        assert!(bystander.exists(), "unrelated sibling must survive");
+        assert!(dir.exists(), "non-empty parent must not be pruned");
+    }
 
     /// D2+D3 live integration test: cancelling a pending grab for an
     /// episode must delete the torrent from the active download

--- a/src/handlers/library/search/auto_search.rs
+++ b/src/handlers/library/search/auto_search.rs
@@ -463,45 +463,60 @@ async fn run_auto_search_targets_with_upgrades(
                 // files to its own library entry. On filter error,
                 // fall back to a full add rather than dropping the
                 // grab entirely.
-                let selective_outcome: Result<Option<Vec<usize>>, String> = if wants_selective {
-                    let detail_clone = detail.clone();
-                    let info_hash_clone = result.info_hash.clone();
-                    let mut pick = move |files: &[String]| {
-                        auto_search::pick_wanted_file_indices(files, &detail_clone)
+                // `effective_hash` is the id Ryokan persists on
+                // `grabbed_torrents.hash` — same rationale as the interactive
+                // grab handler in handlers/library/search/grab.rs. BT clients
+                // echo the precomputed info_hash via `add_torrent_returning_id`'s
+                // default impl; SAB returns its `nzo_id`, which is the only
+                // id SAB lets you key queue/history ops by. Without this
+                // capture, SAB-routed grabs land with `hash=""` and the
+                // post-processing reconcile loop marks them removed after
+                // 30s when `list_scoped` can't match them.
+                let selective_outcome: Result<(Option<Vec<usize>>, String), String> =
+                    if wants_selective {
+                        let detail_clone = detail.clone();
+                        let info_hash_clone = result.info_hash.clone();
+                        let mut pick = move |files: &[String]| {
+                            auto_search::pick_wanted_file_indices(files, &detail_clone)
+                        };
+                        match qbit
+                            .add_torrent_with_file_filter(&url, &info_hash_clone, &mut pick)
+                            .await
+                        {
+                            // Selective branch echoes the precomputed
+                            // info_hash since `add_torrent_with_file_filter`
+                            // doesn't return an id. SAB grabs don't fire
+                            // this branch in practice (require info_hash
+                            // non-empty, which NZBs lack).
+                            Ok(crate::services::download_client::SelectiveOutcome::Filtered(
+                                kept,
+                            )) => Ok((Some(kept), result.info_hash.clone())),
+                            Ok(
+                                crate::services::download_client::SelectiveOutcome::FullDownload,
+                            ) => Ok((None, result.info_hash.clone())),
+                            Err(e) => {
+                                logger::warn(
+                                    &state.db,
+                                    LogCategory::Grab,
+                                    &format!(
+                                        "{}: selective download failed, falling back to full grab",
+                                        label
+                                    ),
+                                    &e,
+                                )
+                                .await;
+                                qbit.add_torrent_returning_id(&url, &result.info_hash)
+                                    .await
+                                    .map(|(_, hash)| (None, hash))
+                            }
+                        }
+                    } else {
+                        qbit.add_torrent_returning_id(&url, &result.info_hash)
+                            .await
+                            .map(|(_, hash)| (None, hash))
                     };
-                    match qbit
-                        .add_torrent_with_file_filter(&url, &info_hash_clone, &mut pick)
-                        .await
-                    {
-                        Ok(crate::services::download_client::SelectiveOutcome::Filtered(kept)) => {
-                            Ok(Some(kept))
-                        }
-                        Ok(crate::services::download_client::SelectiveOutcome::FullDownload) => {
-                            Ok(None)
-                        }
-                        Err(e) => {
-                            logger::warn(
-                                &state.db,
-                                LogCategory::Grab,
-                                &format!(
-                                    "{}: selective download failed, falling back to full grab",
-                                    label
-                                ),
-                                &e,
-                            )
-                            .await;
-                            qbit.add_torrent(&url, &result.info_hash)
-                                .await
-                                .map(|_| None)
-                        }
-                    }
-                } else {
-                    qbit.add_torrent(&url, &result.info_hash)
-                        .await
-                        .map(|_| None)
-                };
                 match selective_outcome {
-                    Ok(kept) => {
+                    Ok((kept, effective_hash)) => {
                         let selective_suffix = match (&kept, wants_selective) {
                             (Some(ids), _) => format!(", selective={}", ids.len()),
                             (None, true) => ", selective=full(timeout)".to_string(),
@@ -558,7 +573,7 @@ async fn run_auto_search_targets_with_upgrades(
                             // and let the next reconcile pick it up.
                             let grab_id = crate::models::grabbed_torrents::record_grab(
                                 &state.db,
-                                &result.info_hash,
+                                &effective_hash,
                                 &result.title,
                                 sid,
                                 &ep_nums,
@@ -577,7 +592,7 @@ async fn run_auto_search_targets_with_upgrades(
                                     crate::services::download_client::apply_indexer_seed_rules(
                                         &state.db,
                                         &*qbit,
-                                        &result.info_hash,
+                                        &effective_hash,
                                         result.indexer_id,
                                     )
                                     .await;
@@ -639,7 +654,7 @@ async fn run_auto_search_targets_with_upgrades(
                                 // falls back to the parent series.
                                 let db_task = state.db.clone();
                                 let qbit_task = qbit.clone();
-                                let info_hash_task = result.info_hash.clone();
+                                let info_hash_task = effective_hash.clone();
                                 let detail_task = detail.clone();
                                 let ep_nums_task = ep_nums.clone();
                                 let title_task = result.title.clone();

--- a/src/handlers/library/search/grab.rs
+++ b/src/handlers/library/search/grab.rs
@@ -93,7 +93,15 @@ pub async fn grab_batch_result(
     // each sibling's files into its own library entry instead.
     let wants_selective =
         !info_hash.is_empty() && auto_search::has_selective_discriminator(&detail);
-    let selective_outcome: Option<Vec<usize>> = if wants_selective {
+    // `effective_hash` is the id Ryokan persists on `grabbed_torrents.hash`
+    // and uses to reconcile the grab against the client's later state. For
+    // BT clients it equals the precomputed v1 infohash from the magnet/.torrent
+    // URL (default `add_torrent_returning_id` impl echoes it back). For SAB it
+    // becomes the `nzo_id` returned from `mode=addurl`, which is the only id
+    // SAB lets you key queue/history ops by — without this capture, SAB grabs
+    // got `hash=""` persisted, the episode-progress poller never matched them
+    // in `list_scoped`, and after 30s the reconcile loop marked them removed.
+    let (selective_outcome, effective_hash): (Option<Vec<usize>>, String) = if wants_selective {
         let detail_clone = detail.clone();
         let mut pick =
             move |files: &[String]| auto_search::pick_wanted_file_indices(files, &detail_clone);
@@ -101,8 +109,21 @@ pub async fn grab_batch_result(
             .add_torrent_with_file_filter(&url, &info_hash, &mut pick)
             .await
         {
-            Ok(crate::services::download_client::SelectiveOutcome::Filtered(kept)) => Some(kept),
-            Ok(crate::services::download_client::SelectiveOutcome::FullDownload) => None,
+            // Selective branch echoes the precomputed info_hash since
+            // `add_torrent_with_file_filter` doesn't return an id. SAB's
+            // file-filter impl no-ops the filter and returns FullDownload,
+            // so SAB grabs that route through here keep the v1 picker-path
+            // limitation (documented in services/download_client/sabnzbd/mod.rs).
+            // Practically rare — SAB grabs require info_hash to be empty
+            // (NZBs have no infohash), and `wants_selective` requires
+            // info_hash to be non-empty, so this branch shouldn't fire for
+            // SAB in the first place.
+            Ok(crate::services::download_client::SelectiveOutcome::Filtered(kept)) => {
+                (Some(kept), info_hash.clone())
+            }
+            Ok(crate::services::download_client::SelectiveOutcome::FullDownload) => {
+                (None, info_hash.clone())
+            }
             Err(e) => {
                 logger::warn(
                     &state.db,
@@ -114,17 +135,19 @@ pub async fn grab_batch_result(
                     &e,
                 )
                 .await;
-                qbit.add_torrent(&url, &info_hash)
+                let (_, hash) = qbit
+                    .add_torrent_returning_id(&url, &info_hash)
                     .await
                     .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
-                None
+                (None, hash)
             }
         }
     } else {
-        qbit.add_torrent(&url, &info_hash)
+        let (_, hash) = qbit
+            .add_torrent_returning_id(&url, &info_hash)
             .await
             .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
-        None
+        (None, hash)
     };
 
     // Classify so the log line carries the actual quality tier. Pass the
@@ -174,7 +197,12 @@ pub async fn grab_batch_result(
         // rows never get created at all.
         let ep_nums = batch_episode_numbers(&title, &detail);
         let grab_id = crate::models::grabbed_torrents::record_grab(
-            &state.db, &info_hash, &title, sid, &ep_nums, true,
+            &state.db,
+            &effective_hash,
+            &title,
+            sid,
+            &ep_nums,
+            true,
         )
         .await
         .ok()
@@ -216,7 +244,11 @@ pub async fn grab_batch_result(
             // matching spawn in `run_auto_search_targets_with_upgrades`.
             let db_task = state.db.clone();
             let qbit_task = qbit.clone();
-            let info_hash_task = info_hash.clone();
+            // `effective_hash` (the SAB nzo_id or the BT infohash)
+            // is what `get_files` keys off in the auto-expand path
+            // — passing the original BT-shape `info_hash` would be
+            // empty for SAB grabs and miss the file list entirely.
+            let info_hash_task = effective_hash.clone();
             let detail_task = detail.clone();
             let title_task = title.clone();
             let ep_nums_task = ep_nums.clone();
@@ -323,7 +355,10 @@ pub async fn grab_interactive_result(
     // auto-expand the library (that's `grab_batch_result`'s job).
     let wants_selective =
         !info_hash.is_empty() && auto_search::has_selective_discriminator(&detail);
-    let selective_outcome: Option<Vec<usize>> = if wants_selective {
+    // See `grab_batch_result` above for why `add_torrent_returning_id`
+    // matters. Same SAB-nzo_id capture rationale applies to the
+    // single-episode interactive grab path.
+    let (selective_outcome, effective_hash): (Option<Vec<usize>>, String) = if wants_selective {
         let detail_clone = detail.clone();
         let mut pick =
             move |files: &[String]| auto_search::pick_wanted_file_indices(files, &detail_clone);
@@ -331,8 +366,12 @@ pub async fn grab_interactive_result(
             .add_torrent_with_file_filter(&url, &info_hash, &mut pick)
             .await
         {
-            Ok(crate::services::download_client::SelectiveOutcome::Filtered(kept)) => Some(kept),
-            Ok(crate::services::download_client::SelectiveOutcome::FullDownload) => None,
+            Ok(crate::services::download_client::SelectiveOutcome::Filtered(kept)) => {
+                (Some(kept), info_hash.clone())
+            }
+            Ok(crate::services::download_client::SelectiveOutcome::FullDownload) => {
+                (None, info_hash.clone())
+            }
             Err(e) => {
                 logger::warn(
                     &state.db,
@@ -344,17 +383,19 @@ pub async fn grab_interactive_result(
                     &e,
                 )
                 .await;
-                qbit.add_torrent(&url, &info_hash)
+                let (_, hash) = qbit
+                    .add_torrent_returning_id(&url, &info_hash)
                     .await
                     .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
-                None
+                (None, hash)
             }
         }
     } else {
-        qbit.add_torrent(&url, &info_hash)
+        let (_, hash) = qbit
+            .add_torrent_returning_id(&url, &info_hash)
             .await
             .map_err(|e| (axum::http::StatusCode::BAD_GATEWAY, e))?;
-        None
+        (None, hash)
     };
 
     // Interactive grab: the frontend doesn't currently round-trip the Nyaa
@@ -400,7 +441,7 @@ pub async fn grab_interactive_result(
         // Interactive single-episode grab — not a batch by definition.
         let grab_id = crate::models::grabbed_torrents::record_grab(
             &state.db,
-            &info_hash,
+            &effective_hash,
             &title,
             sid,
             &[episode_number],

--- a/src/handlers/library/search/interactive.rs
+++ b/src/handlers/library/search/interactive.rs
@@ -312,8 +312,16 @@ pub async fn interactive_search_episode(
     // Same single-entry collapse as auto_search_episode — the interactive
     // picker otherwise returns zero results for movies.
     let target = auto_search::SearchTarget::for_episode(&detail, episode_number);
-    let mut results =
-        auto_search::find_all_for_target(&state.db, &detail, &cfg, &target, false, &cfs).await;
+    let mut results = auto_search::find_all_for_target(
+        &state.db,
+        &detail,
+        &cfg,
+        &target,
+        false,
+        &cfs,
+        &state.indexers,
+    )
+    .await;
 
     // Layer 3 (group-map) enrichment. Auto-search already runs the full
     // source pipeline so its classification is complete, but the interactive

--- a/src/handlers/search.rs
+++ b/src/handlers/search.rs
@@ -516,15 +516,24 @@ pub async fn get_torrents(
     Json<Vec<crate::services::download_client::DownloadItem>>,
     (axum::http::StatusCode, String),
 > {
-    let client = state.default_download_client().await.ok_or((
-        axum::http::StatusCode::BAD_REQUEST,
-        "Download client not configured".to_string(),
-    ))?;
-
-    let torrents = client
-        .list_scoped()
-        .await
-        .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e))?;
-
+    // Fan out across every enabled client so SAB / Usenet jobs
+    // appear in the queue alongside torrent jobs. Mirrors the
+    // server-rendered queue tab in `handlers::downloads`.
+    let pool = state.download_clients.read().await.clone();
+    if pool.clients.is_empty() {
+        return Err((
+            axum::http::StatusCode::BAD_REQUEST,
+            "Download client not configured".to_string(),
+        ));
+    }
+    let mut torrents: Vec<crate::services::download_client::DownloadItem> = Vec::new();
+    for c in pool.clients.values() {
+        match c.list_scoped().await {
+            Ok(mut items) => torrents.append(&mut items),
+            Err(e) => {
+                tracing::warn!("get_torrents: client list_scoped failed: {e}");
+            }
+        }
+    }
     Ok(Json(torrents))
 }

--- a/src/handlers/settings/custom_formats.rs
+++ b/src/handlers/settings/custom_formats.rs
@@ -662,7 +662,6 @@ pub async fn settings_custom_formats_import(
             None,
             Some(review),
             None,
-            None,
         )
         .await;
         return Html(template.render().unwrap_or_default()).into_response();
@@ -1349,6 +1348,7 @@ pub async fn settings_custom_formats_test(
         score_breakdown: Vec::new(),
         upload_date: String::new(),
         indexer_id: None,
+        indexer_name: String::new(),
     };
     let seadex: std::collections::HashSet<String> = std::collections::HashSet::new();
     let ctx = EvalContext {

--- a/src/handlers/settings/download_clients.rs
+++ b/src/handlers/settings/download_clients.rs
@@ -66,6 +66,15 @@ pub fn kind_label(kind: &str) -> &'static str {
 #[template(path = "partials/settings/download_clients/list.html")]
 struct DownloadClientsListPartial {
     rows: Vec<DownloadClientRow>,
+    // Per-protocol "first client" flags consumed by the inline
+    // include of `add_form_body.html` at the bottom of `list.html`
+    // (the section partial pre-renders the Add form body so the
+    // modal opens fast on first click). Same data the GET-only
+    // `DownloadClientAddFormPartial` carries; populated from the
+    // section's `rows` so a fresh install pre-checks Default on
+    // both protocols.
+    first_torrent_client: bool,
+    first_usenet_client: bool,
 }
 
 impl DownloadClientsListPartial {
@@ -84,6 +93,16 @@ impl DownloadClientsListPartial {
 #[template(path = "partials/settings/download_clients/edit_form_body.html")]
 struct DownloadClientEditFormPartial {
     row: DownloadClientRow,
+    /// Same per-protocol "first client" flags as the Add partial.
+    /// Used by the Default-checkbox initial-render condition AND by
+    /// the JS kind-relabel helper after a kind change. Computed
+    /// from the current DB state (including this row's contribution
+    /// — if this row IS the default torrent, `first_torrent_client`
+    /// resolves to false, and the template-side condition
+    /// `row.is_default || first_<protocol>_client` lands on
+    /// row.is_default for the checked state).
+    first_torrent_client: bool,
+    first_usenet_client: bool,
 }
 
 impl DownloadClientEditFormPartial {
@@ -95,14 +114,22 @@ impl DownloadClientEditFormPartial {
 /// Add form body — symmetric with the edit form but for fresh
 /// inserts. Returned by `GET /api/download-clients/add-form`;
 /// swapped into `#dc-modal-body` when the user clicks the "+
-/// Add download client" tile. `first_client` pre-checks the
-/// "default" checkbox so the very first row lands as default
-/// (an empty default config surfaces "no download client
-/// configured" at grab-routing time, which is a worse default).
+/// Add download client" tile.
+///
+/// `first_torrent_client` / `first_usenet_client` drive the
+/// auto-check on the "Default client" checkbox. Per-protocol so the
+/// first SAB added gets default-checked even when a torrent default
+/// already exists (and vice versa) — without this, a user adding
+/// SAB after qBit would end up with no usenet default until they
+/// manually clicked Set Default. The kind-relabel JS in
+/// `static/js/settings.js` reads both flags via data attributes on
+/// the form and toggles the checkbox state when the user flips the
+/// kind dropdown.
 #[derive(Template)]
 #[template(path = "partials/settings/download_clients/add_form_body.html")]
 struct DownloadClientAddFormPartial {
-    first_client: bool,
+    first_torrent_client: bool,
+    first_usenet_client: bool,
 }
 
 impl DownloadClientAddFormPartial {
@@ -139,7 +166,19 @@ impl DownloadClientStatusPillPartial {
 /// the `/api/download-clients/section` cancel-edit refresh route.
 async fn render_section(state: &AppState) -> Response {
     let rows = list_all(&state.db).await.unwrap_or_default();
-    DownloadClientsListPartial { rows }.into_html_ok()
+    use crate::models::download_clients::protocol_for_kind;
+    let first_torrent_client = !rows
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+    let first_usenet_client = !rows
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
+    DownloadClientsListPartial {
+        rows,
+        first_torrent_client,
+        first_usenet_client,
+    }
+    .into_html_ok()
 }
 
 /// Form payload for create/update. `id == None` creates a new row;
@@ -548,7 +587,31 @@ pub async fn settings_download_clients_edit_form(
     Path(id): Path<i64>,
 ) -> Response {
     match get_by_id(&state.db, id).await {
-        Ok(Some(row)) => DownloadClientEditFormPartial { row }.into_html_ok(),
+        Ok(Some(row)) => {
+            // Same per-protocol "first client" probe the Add form
+            // does, scoped to ALL rows (including this one). The
+            // template's checkbox condition is
+            // `row.is_default || first_<protocol>_client`, so when
+            // this row IS the default the first-flag resolves to
+            // false and the row's own state takes precedence; when
+            // this row isn't the default but no other row of the
+            // same protocol is, the first-flag flips on and the
+            // checkbox auto-checks.
+            let rows = list_all(&state.db).await.unwrap_or_default();
+            use crate::models::download_clients::protocol_for_kind;
+            let first_torrent_client = !rows
+                .iter()
+                .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+            let first_usenet_client = !rows
+                .iter()
+                .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
+            DownloadClientEditFormPartial {
+                row,
+                first_torrent_client,
+                first_usenet_client,
+            }
+            .into_html_ok()
+        }
         Ok(None) => (StatusCode::NOT_FOUND, "Download client not found").into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
@@ -565,11 +628,26 @@ pub async fn settings_download_clients_edit_form(
     ),
 )]
 pub async fn settings_download_clients_add_form(State(state): State<AppState>) -> Response {
-    let first_client = list_all(&state.db)
-        .await
-        .map(|rows| rows.is_empty())
-        .unwrap_or(false);
-    DownloadClientAddFormPartial { first_client }.into_html_ok()
+    // Per-protocol "no current default" probe — auto-checks Default
+    // when no row of this protocol is marked is_default, so adding
+    // SAB when no usenet default exists picks it up automatically
+    // (and same for the first torrent client). Semantic-mirror with
+    // the Edit partial so behavior is identical across the two
+    // forms. DB-error fallback is false-on-both so a transient sqlx
+    // hiccup doesn't silently steal an existing default's flag.
+    let rows = list_all(&state.db).await.unwrap_or_default();
+    use crate::models::download_clients::protocol_for_kind;
+    let first_torrent_client = !rows
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+    let first_usenet_client = !rows
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
+    DownloadClientAddFormPartial {
+        first_torrent_client,
+        first_usenet_client,
+    }
+    .into_html_ok()
 }
 
 #[utoipa::path(

--- a/src/handlers/settings/indexers.rs
+++ b/src/handlers/settings/indexers.rs
@@ -6,19 +6,94 @@
 //! commit since it needs the full search-pipeline integration to
 //! be useful.
 
+use askama::Template;
 use axum::{
     Form, Json,
-    extract::State,
+    extract::{Path, Query, State},
     http::StatusCode,
-    response::{IntoResponse, Redirect, Response},
+    response::{Html, IntoResponse, Redirect, Response},
 };
 use axum_htmx::HxRequest;
 use serde::Deserialize;
 
 use crate::AppState;
-use crate::models::indexers::{IndexerForm, KIND_NEWZNAB, KIND_TORZNAB, delete, insert, update};
+use crate::models::download_clients::DownloadClientRow;
+use crate::models::indexers::{
+    Indexer, IndexerForm, KIND_NEWZNAB, KIND_TORZNAB, delete, insert, list_all, update,
+};
 use crate::models::log::LogCategory;
+use crate::services::indexer_catalog::{SEEDED, SeededIndexer, find_seed};
 use crate::services::logger;
+
+/// Section partial — the entire Indexers fieldset (catalog grid +
+/// existing-row card grid + shared edit/add modal). Every successful
+/// HTMX action (upsert / delete) returns this so a single swap
+/// re-renders the whole section without a page reload, mirroring the
+/// Download Clients section pattern.
+#[derive(Template)]
+#[template(path = "partials/settings/indexers/list.html")]
+struct IndexerSectionPartial {
+    indexers: Vec<Indexer>,
+    download_clients: Vec<DownloadClientRow>,
+    indexer_catalog: &'static [SeededIndexer],
+}
+
+impl IndexerSectionPartial {
+    fn into_html_ok(self) -> Response {
+        Html(self.render().unwrap_or_default()).into_response()
+    }
+}
+
+/// Edit form body — modal content for the Edit flow. Returned by
+/// `GET /settings/indexers/{id}/edit-form` and swapped into
+/// `#indexer-modal-body` (innerHTML) when the user clicks an
+/// existing-indexer card.
+#[derive(Template)]
+#[template(path = "partials/settings/indexers/edit_form_body.html")]
+struct IndexerEditFormPartial {
+    row: Indexer,
+    download_clients: Vec<DownloadClientRow>,
+}
+
+impl IndexerEditFormPartial {
+    fn into_html_ok(self) -> Response {
+        Html(self.render().unwrap_or_default()).into_response()
+    }
+}
+
+/// Add form body — modal content for the Add flow. Returned by
+/// `GET /settings/indexers/add-form?template=<slug>` and swapped
+/// into `#indexer-modal-body` when the user clicks one of the
+/// catalog seed cards. `seed = None` (no template, or unknown
+/// slug) renders a blank Add form.
+#[derive(Template)]
+#[template(path = "partials/settings/indexers/add_form_body.html")]
+struct IndexerAddFormPartial {
+    seed: Option<&'static SeededIndexer>,
+    download_clients: Vec<DownloadClientRow>,
+}
+
+impl IndexerAddFormPartial {
+    fn into_html_ok(self) -> Response {
+        Html(self.render().unwrap_or_default()).into_response()
+    }
+}
+
+/// Helper — load the current rows + download clients and render the
+/// section partial. Used by the success path of upsert/delete and the
+/// `/settings/indexers/section` cancel-edit / refresh route.
+async fn render_section(state: &AppState) -> Response {
+    let indexers = list_all(&state.db).await.unwrap_or_default();
+    let download_clients = crate::models::download_clients::list_all(&state.db)
+        .await
+        .unwrap_or_default();
+    IndexerSectionPartial {
+        indexers,
+        download_clients,
+        indexer_catalog: SEEDED,
+    }
+    .into_html_ok()
+}
 
 /// Form for create/update — `id == None` creates, `id == Some(n)`
 /// updates row `n`. Mirrors CustomFormatUpsertForm shape.
@@ -67,28 +142,29 @@ pub struct IndexerDeleteForm {
 )]
 pub async fn settings_indexers_upsert(
     State(state): State<AppState>,
+    HxRequest(is_htmx): HxRequest,
     Form(form): Form<IndexerUpsertForm>,
 ) -> Response {
     let name = form.name.trim();
     if name.is_empty() {
-        return Redirect::to("/settings?tab=indexers&err=Name+required").into_response();
+        return error_redirect(is_htmx, "Name+required");
     }
     let kind = match form.kind.as_str() {
         KIND_TORZNAB | KIND_NEWZNAB => form.kind.as_str(),
         _ => {
-            return Redirect::to("/settings?tab=indexers&err=Invalid+kind").into_response();
+            return error_redirect(is_htmx, "Invalid+kind");
         }
     };
     let url = form.url.trim();
     if url.is_empty() {
-        return Redirect::to("/settings?tab=indexers&err=URL+required").into_response();
+        return error_redirect(is_htmx, "URL+required");
     }
     // PR #107 review fix #12: catch typos at save time rather
     // than at the next search. reqwest::Url::parse is what the
     // client uses internally; round-tripping it here surfaces
     // missing scheme / malformed host immediately.
     if reqwest::Url::parse(url).is_err() {
-        return Redirect::to("/settings?tab=indexers&err=Invalid+URL+syntax").into_response();
+        return error_redirect(is_htmx, "Invalid+URL+syntax");
     }
     let priority = parse_priority(&form.priority);
     let min_seeders = parse_optional_i32(&form.min_seeders, 1).max(0);
@@ -119,7 +195,7 @@ pub async fn settings_indexers_upsert(
                     "Couldn't verify protocol pin (DB error: {e}); please retry."
                 ))
                 .into_owned();
-                return Redirect::to(&format!("/settings?tab=indexers&err={msg}")).into_response();
+                return error_redirect(is_htmx, &msg);
             }
         };
         if let Some(row) = row {
@@ -130,12 +206,12 @@ pub async fn settings_indexers_upsert(
                 && ip != cp
             {
                 let msg = urlencoding::encode(&format!(
-                    "Can't pin a {kind} indexer to a {} client (protocol mismatch — \
+                    "Can't pin a {kind} indexer to a {} client (protocol mismatch; \
                      {kind} returns {ip} URLs, {} accepts {cp})",
                     row.kind, row.kind
                 ))
                 .into_owned();
-                return Redirect::to(&format!("/settings?tab=indexers&err={msg}")).into_response();
+                return error_redirect(is_htmx, &msg);
             }
         }
     }
@@ -179,8 +255,16 @@ pub async fn settings_indexers_upsert(
             // the next search picks up the new/edited row without
             // a process restart.
             crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
-            let msg = urlencoding::encode(&format!("Indexer '{name}' {verb}")).into_owned();
-            Redirect::to(&format!("/settings?tab=indexers&msg={msg}")).into_response()
+            // HTMX redesign — re-render the whole #indexer-section so
+            // the new/edited card surfaces and the modal goes back to
+            // display:none with the default body, all in one swap.
+            // Mirrors the DC upsert handler.
+            if is_htmx {
+                render_section(&state).await
+            } else {
+                let msg = urlencoding::encode(&format!("Indexer '{name}' {verb}")).into_owned();
+                Redirect::to(&format!("/settings?tab=indexers&msg={msg}")).into_response()
+            }
         }
         Err(e) => {
             logger::error(
@@ -190,8 +274,30 @@ pub async fn settings_indexers_upsert(
                 &e.to_string(),
             )
             .await;
-            Redirect::to("/settings?tab=indexers&err=Save+failed").into_response()
+            error_redirect(is_htmx, "Save+failed")
         }
+    }
+}
+
+/// Send the user back to the Indexers tab with `&err=<msg>` flashed.
+/// HTMX path uses `HX-Redirect: /settings?tab=indexers&err=…` so htmx
+/// does a full client-side navigation; without this, htmx silently
+/// follows a 303 with `fetch` and swaps the resulting full-page
+/// HTML into the form's `hx-target="#indexer-section"`, producing a
+/// nested-page render (duplicate "Settings" h2 + tabs inside the
+/// fieldset). The non-HTMX path keeps the standard 303 so the
+/// progressive-enhancement form-POST still works without JS.
+fn error_redirect(is_htmx: bool, encoded_msg: &str) -> Response {
+    let url = format!("/settings?tab=indexers&err={encoded_msg}");
+    if is_htmx {
+        let mut resp = Response::new(axum::body::Body::empty());
+        *resp.status_mut() = StatusCode::OK;
+        if let Ok(value) = url.parse() {
+            resp.headers_mut().insert("HX-Redirect", value);
+        }
+        resp
+    } else {
+        Redirect::to(&url).into_response()
     }
 }
 
@@ -236,14 +342,12 @@ pub async fn settings_indexers_delete(
             .await;
             // PR #107 review fix #4: same cache refresh as upsert.
             crate::services::indexers::refresh_cache_in_place(&state.indexers, &state.db).await;
-            // HTMX migration (issue #129) — the row form has
-            // `hx-target="closest tr" hx-swap="outerHTML"`; an empty
-            // 200 response replaces the row with nothing, removing it
-            // from the DOM without a full page reload. The non-HTMX
-            // path keeps the redirect-with-flash so progressive
-            // enhancement holds.
+            // Card-redesign — delete also re-renders the whole
+            // #indexer-section so the empty-state path renders when
+            // the last row goes away, and the modal stays at
+            // display:none. Mirrors the DC delete handler.
             if is_htmx {
-                StatusCode::OK.into_response()
+                render_section(&state).await
             } else {
                 let msg =
                     urlencoding::encode(&format!("Indexer '{display_name}' deleted")).into_owned();
@@ -346,6 +450,276 @@ pub async fn settings_indexers_test_rss(
             first_title: None,
         }),
     }
+}
+
+// ── Modal-form GET endpoints ──────────────────────────────────────
+//
+// These three read-only endpoints back the card-redesign modal flow.
+// `/settings/indexers/section` re-renders the whole section (used by
+// any caller that wants to reset the UI without a full page reload —
+// currently no callers, but symmetric with DC and useful for future
+// Cancel-button wiring). The two form-body endpoints are what the
+// modal opens fetch into `#indexer-modal-body`.
+
+#[utoipa::path(
+    get,
+    path = "/settings/indexers/section",
+    tag = "Settings",
+    summary = "Render the Indexers section partial",
+    description = "Returns the catalog grid + existing-indexer cards + shared modal fragment that lives at #indexer-section on the Indexers tab. Mirrors `/api/download-clients/section`.",
+    responses(
+        (status = 200, description = "HTML fragment"),
+    ),
+)]
+pub async fn settings_indexers_section(State(state): State<AppState>) -> Response {
+    render_section(&state).await
+}
+
+#[utoipa::path(
+    get,
+    path = "/settings/indexers/{id}/edit-form",
+    tag = "Settings",
+    summary = "Render the edit form body for one indexer",
+    description = "Returns the edit_form_body.html fragment for the targeted row, prefilled with current values. Swapped into the shared modal body (`#indexer-modal-body`) when the user clicks an existing-indexer card. Returns 404 when the row no longer exists (e.g. concurrent delete from another tab).",
+    responses(
+        (status = 200, description = "HTML fragment"),
+        (status = 404, description = "Row not found"),
+    ),
+)]
+pub async fn settings_indexers_edit_form(
+    State(state): State<AppState>,
+    Path(id): Path<i64>,
+) -> Response {
+    match crate::models::indexers::get_by_id(&state.db, id).await {
+        Ok(Some(row)) => {
+            let download_clients = crate::models::download_clients::list_all(&state.db)
+                .await
+                .unwrap_or_default();
+            IndexerEditFormPartial {
+                row,
+                download_clients,
+            }
+            .into_html_ok()
+        }
+        Ok(None) => (StatusCode::NOT_FOUND, "Indexer not found").into_response(),
+        Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[derive(Deserialize)]
+pub struct AddFormQuery {
+    /// Catalog seed slug. When set + recognized, the form pre-fills
+    /// from the matched seed (name / kind / private flag / priority /
+    /// min seeders / suggested seed-ratio). Empty / unrecognized →
+    /// blank form.
+    pub template: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/settings/indexers/add-form",
+    tag = "Settings",
+    summary = "Render the add form body",
+    description = "Returns the add_form_body.html fragment swapped into the shared modal body (`#indexer-modal-body`) when the user clicks one of the catalog seed cards. The optional `template` query param resolves a seed and pre-fills the form; an unknown / missing template renders a blank Add form.",
+    responses(
+        (status = 200, description = "HTML fragment"),
+    ),
+)]
+pub async fn settings_indexers_add_form(
+    State(state): State<AppState>,
+    Query(q): Query<AddFormQuery>,
+) -> Response {
+    let seed = q.template.as_deref().and_then(find_seed);
+    let download_clients = crate::models::download_clients::list_all(&state.db)
+        .await
+        .unwrap_or_default();
+    IndexerAddFormPartial {
+        seed,
+        download_clients,
+    }
+    .into_html_ok()
+}
+
+/// Form payload for the stateless `/api/indexers/test` endpoint —
+/// probes a transient TorznabIndexer built from form fields, without
+/// requiring a save first. Lets the Add/Edit modal verify URL +
+/// API key before persisting; complements the existing id-based
+/// `/settings/indexers/test-rss` which only works for already-saved
+/// rows. `#[serde(default)]` on every field because `hx-include=
+/// "closest form"` pulls in extras (priority, min_seeders, etc.) the
+/// test path doesn't care about.
+#[derive(Deserialize, utoipa::ToSchema)]
+pub struct IndexerStatelessTestForm {
+    #[serde(default)]
+    pub kind: String,
+    #[serde(default)]
+    pub url: String,
+    #[serde(default)]
+    pub api_key: String,
+    /// Optional — when set the response uses the matching cache
+    /// entry (re-uses the warm reqwest client + cooldown state).
+    /// When unset, a transient TorznabIndexer is built per request.
+    #[serde(default)]
+    pub id: Option<i64>,
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/indexers/test",
+    tag = "Settings",
+    summary = "Test-fetch a torznab/newznab indexer (stateless)",
+    description = "Stateless variant of `/settings/indexers/test-rss` that accepts form fields instead of an id, so the Add/Edit modal can probe an unsaved row. Builds a transient TorznabIndexer from the supplied URL + API key and runs an empty-q tvsearch against it. Returns the JSON test envelope with item count + first title or the error message. Toast-rendered on the frontend.",
+    request_body = IndexerStatelessTestForm,
+    responses(
+        (status = 200, description = "Test result envelope", body = IndexerRssTestResponse),
+    ),
+)]
+pub async fn settings_indexers_test_stateless(
+    State(state): State<AppState>,
+    Form(form): Form<IndexerStatelessTestForm>,
+) -> Response {
+    // Validate the basics before building anything. Empty URL or
+    // unknown kind would just produce a confusing builder error
+    // downstream; surface those upfront.
+    let kind = form.kind.trim();
+    if !matches!(kind, "torznab" | "newznab") {
+        return indexer_test_trigger(
+            false,
+            &format!("Invalid kind: {kind:?} (expected torznab or newznab)"),
+        );
+    }
+    let url = form.url.trim();
+    if url.is_empty() {
+        return indexer_test_trigger(false, "URL required");
+    }
+    if reqwest::Url::parse(url).is_err() {
+        return indexer_test_trigger(false, &format!("Invalid URL syntax: {url}"));
+    }
+
+    // Prefer the cached client when an id is provided AND it resolves
+    // to a row in the IndexerCache — keeps the warm reqwest client +
+    // cooldown state intact for the Edit case. Fall back to building
+    // a transient indexer from form fields for the Add case (no id
+    // yet) or when the id missed the cache (saved-but-disabled).
+    let indexer: std::sync::Arc<dyn crate::services::indexers::Indexer> = if let Some(id) = form.id
+    {
+        let snapshot = state.indexers.read().await.clone();
+        if let Some(cached) = snapshot.iter().find(|i| i.id() == id).cloned() {
+            cached
+        } else {
+            match build_transient_indexer(0, kind, url, form.api_key.trim()) {
+                Ok(c) => c,
+                Err(e) => {
+                    return indexer_test_trigger(
+                        false,
+                        &format!("Failed to build indexer client: {e}"),
+                    );
+                }
+            }
+        }
+    } else {
+        match build_transient_indexer(0, kind, url, form.api_key.trim()) {
+            Ok(c) => c,
+            Err(e) => {
+                return indexer_test_trigger(
+                    false,
+                    &format!("Failed to build indexer client: {e}"),
+                );
+            }
+        }
+    };
+
+    match crate::services::indexers::fetch_indexer_rss(&*indexer).await {
+        Ok(items) => {
+            // ASCII-only message body. The HX-Trigger header is the
+            // transport, and HTTP headers carry no charset metadata.
+            // Non-ASCII bytes survive as raw bytes which htmx then
+            // interprets as Latin-1 when JSON-parsing the header
+            // value, producing mojibake (e.g. an em-dash's UTF-8
+            // bytes \xe2\x80\x94 render as `â\u{80}\u{94}` in the
+            // toast). The first-item title CAN carry arbitrary
+            // UTF-8 (groups put kanji in titles all the time) and
+            // will mojibake the same way; trade-off is accepting
+            // some title garbling vs dropping the title entirely
+            // since the user usually wants confirmation that
+            // SOMETHING is being parsed. ASCII-only on the prefix
+            // keeps the most-load-bearing words readable.
+            let msg = if items.is_empty() {
+                "Connected. 0 items returned (try a real query to confirm grabs work).".to_string()
+            } else {
+                let first = items
+                    .first()
+                    .map(|i| i.title.as_str())
+                    .unwrap_or("(no title)");
+                format!("Connected. {} item(s). First: {}", items.len(), first)
+            };
+            indexer_test_trigger(true, &msg)
+        }
+        Err(err) => indexer_test_trigger(false, &err),
+    }
+}
+
+/// Build the HTMX response for the indexer Test probe. Same shape
+/// as the DC `test_result_response` helper — empty body + an
+/// `HX-Trigger` header carrying the result. The frontend listener
+/// in `static/js/settings.js` (`ryokan-indexer-test-result`) reads
+/// the trigger payload and fires a toast. Empty body keeps the
+/// modal-footer button row at a stable height regardless of result
+/// text length.
+fn indexer_test_trigger(ok: bool, message: &str) -> Response {
+    let payload = serde_json::json!({
+        "ryokan-indexer-test-result": {
+            "ok": ok,
+            "message": message,
+        }
+    });
+    let mut resp = Response::new(axum::body::Body::empty());
+    *resp.status_mut() = StatusCode::OK;
+    resp.headers_mut().insert(
+        "HX-Trigger",
+        payload
+            .to_string()
+            .parse()
+            .unwrap_or_else(|_| "ryokan-indexer-test-result".parse().unwrap()),
+    );
+    resp
+}
+
+/// Build a transient TorznabIndexer for the stateless test path.
+/// Mirrors the production `from_row` constructor, but synthesizes
+/// the `Indexer` row in-memory from the form fields so unsaved
+/// configurations can be probed. Test-only id is `0` since this
+/// indexer never goes through the dedup pass.
+fn build_transient_indexer(
+    id: i64,
+    kind: &str,
+    url: &str,
+    api_key: &str,
+) -> Result<std::sync::Arc<dyn crate::services::indexers::Indexer>, String> {
+    let row = crate::models::indexers::Indexer {
+        id,
+        name: "Test".to_string(),
+        kind: kind.to_string(),
+        url: url.to_string(),
+        api_key: api_key.to_string(),
+        priority: 25,
+        enabled: true,
+        is_private_tracker: false,
+        seed_ratio: None,
+        seed_time_minutes: None,
+        min_seeders: 0,
+        request_timeout_secs: Some(15),
+        download_client_id: None,
+        rss_enabled: false,
+        rss_last_polled_at: None,
+        rss_last_poll_error: String::new(),
+        rss_last_item_count: 0,
+        caps_json: String::new(),
+        caps_refreshed_at: None,
+        created_at: 0,
+        updated_at: 0,
+    };
+    crate::services::indexers::torznab::TorznabIndexer::from_row_arc(&row)
 }
 
 /// Coerce the priority form field into the Sonarr-convention
@@ -527,9 +901,12 @@ mod tests {
             let db = in_memory_pool().await;
             let (_qbit, sab) = seed_clients(&db).await;
             let state = build_test_app_state(db.clone(), None);
-            let resp =
-                settings_indexers_upsert(State(state.clone()), Form(upsert_form("torznab", sab)))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(false),
+                Form(upsert_form("torznab", sab)),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("err=") && location.contains("protocol"),
@@ -548,9 +925,12 @@ mod tests {
             let db = in_memory_pool().await;
             let (qbit, _sab) = seed_clients(&db).await;
             let state = build_test_app_state(db.clone(), None);
-            let resp =
-                settings_indexers_upsert(State(state.clone()), Form(upsert_form("newznab", qbit)))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(false),
+                Form(upsert_form("newznab", qbit)),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("err=") && location.contains("protocol"),
@@ -571,9 +951,12 @@ mod tests {
             let db = in_memory_pool().await;
             let (qbit, _sab) = seed_clients(&db).await;
             let state = build_test_app_state(db.clone(), None);
-            let resp =
-                settings_indexers_upsert(State(state.clone()), Form(upsert_form("torznab", qbit)))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(false),
+                Form(upsert_form("torznab", qbit)),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("msg=") && !location.contains("err="),
@@ -589,9 +972,12 @@ mod tests {
             let db = in_memory_pool().await;
             let (_qbit, sab) = seed_clients(&db).await;
             let state = build_test_app_state(db.clone(), None);
-            let resp =
-                settings_indexers_upsert(State(state.clone()), Form(upsert_form("newznab", sab)))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(false),
+                Form(upsert_form("newznab", sab)),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("msg=") && !location.contains("err="),
@@ -613,7 +999,8 @@ mod tests {
             let state = build_test_app_state(db.clone(), None);
             let mut form = upsert_form("torznab", 0);
             form.download_client_id = None;
-            let resp = settings_indexers_upsert(State(state.clone()), Form(form)).await;
+            let resp =
+                settings_indexers_upsert(State(state.clone()), HxRequest(false), Form(form)).await;
             let location = extract_location(resp);
             assert!(
                 location.contains("msg=") && !location.contains("err="),
@@ -632,14 +1019,60 @@ mod tests {
             let (_qbit, sab) = seed_clients(&db).await;
             let state = build_test_app_state(db.clone(), None);
             db.close().await;
-            let resp =
-                settings_indexers_upsert(State(state.clone()), Form(upsert_form("torznab", sab)))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(false),
+                Form(upsert_form("torznab", sab)),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("err=")
                     && (location.contains("DB%20error") || location.contains("DB+error")),
                 "expected fail-closed err redirect mentioning DB error, got: {location}"
+            );
+        }
+
+        #[tokio::test]
+        async fn htmx_protocol_mismatch_returns_hx_redirect_not_303() {
+            // Regression guard for the modal-redesign nesting bug:
+            // an HTMX upsert that hits a validation error MUST return
+            // 200 + `HX-Redirect: …` so htmx does a real client-side
+            // navigation. A 303 Location redirect would silently get
+            // followed by htmx's fetch and the resulting full-page
+            // HTML would be swapped into the form's hx-target
+            // (#indexer-section), producing a duplicate "Settings"
+            // h2 + nested tabs inside the fieldset.
+            let db = in_memory_pool().await;
+            let (_qbit, sab) = seed_clients(&db).await;
+            let state = build_test_app_state(db.clone(), None);
+            let resp = settings_indexers_upsert(
+                State(state.clone()),
+                HxRequest(true),
+                Form(upsert_form("torznab", sab)),
+            )
+            .await;
+            assert_eq!(
+                resp.status(),
+                axum::http::StatusCode::OK,
+                "HTMX error path must be 200 (no Location 303) so htmx doesn't \
+                 silent-follow + nested-swap the full settings page"
+            );
+            let hx_redirect = resp
+                .headers()
+                .get("HX-Redirect")
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or_default();
+            assert!(
+                hx_redirect.contains("tab=indexers") && hx_redirect.contains("err="),
+                "HTMX error path must carry HX-Redirect header pointing back to the \
+                 Indexers tab with the err flash; got: {hx_redirect:?}"
+            );
+            // Sanity: still rejected the save.
+            let rows = crate::models::indexers::list_all(&state.db).await.unwrap();
+            assert!(
+                rows.is_empty(),
+                "save must be rejected on protocol mismatch"
             );
         }
     }
@@ -688,9 +1121,12 @@ mod tests {
         async fn upsert_insert_toast_names_added_indexer() {
             let db = in_memory_pool().await;
             let state = build_test_app_state(db, None);
-            let resp =
-                settings_indexers_upsert(State(state), Form(upsert_form(None, "Test Indexer")))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state),
+                HxRequest(false),
+                Form(upsert_form(None, "Test Indexer")),
+            )
+            .await;
             let location = extract_location(resp);
             // `'` percent-encodes to %27 via urlencoding::encode.
             assert!(
@@ -725,9 +1161,12 @@ mod tests {
             .await
             .expect("seed indexer");
             let state = build_test_app_state(db, None);
-            let resp =
-                settings_indexers_upsert(State(state), Form(upsert_form(Some(row_id), "Renamed")))
-                    .await;
+            let resp = settings_indexers_upsert(
+                State(state),
+                HxRequest(false),
+                Form(upsert_form(Some(row_id), "Renamed")),
+            )
+            .await;
             let location = extract_location(resp);
             assert!(
                 location.contains("msg=Indexer%20%27Renamed%27%20updated")

--- a/src/handlers/settings/mod.rs
+++ b/src/handlers/settings/mod.rs
@@ -170,30 +170,26 @@ struct SettingsTemplate {
     /// list. Empty on a fresh install since no indexers exist
     /// until the user adds one.
     indexers: Vec<crate::models::indexers::Indexer>,
-    /// PR #107 review fix #5: when the indexers tab is active
-    /// and `?edit_id=N` is set, populate this with the matching
-    /// row so the upsert form prefills from the existing values.
-    /// `None` renders the bare "Add Indexer" form; same prefill
-    /// pattern as the Custom Formats tab.
-    indexer_edit: Option<crate::models::indexers::Indexer>,
     /// Curated picker grid for the Settings → Indexers tab.
     /// Always populated from the static catalog so the grid
-    /// renders identically regardless of DB state. The user
-    /// can still skip the picker by clicking one of the
-    /// `is_generic` cards or scrolling past to the form.
+    /// renders identically regardless of DB state. Each card
+    /// opens the shared add modal pre-filled with the seed's
+    /// defaults via `openIndexerAddModal(slug, name)` (see
+    /// static/js/settings.js).
     indexer_catalog: &'static [crate::services::indexer_catalog::SeededIndexer],
-    /// When the user clicks a picker card, the link sends
-    /// `?tab=indexers&template=<slug>` and this gets
-    /// populated with the matched seed so the Add form pre-
-    /// fills name / kind / private-flag / priority / min-
-    /// seeders / suggested seed-ratio. `None` renders the
-    /// generic blank form (which is what the user sees if
-    /// they bypass the picker).
-    indexer_seed: Option<&'static crate::services::indexer_catalog::SeededIndexer>,
     /// Multi-client refactor — every configured download client
     /// for the Download Clients tab list. Sorted default-first then
     /// case-insensitive by name (see `models::download_clients::list_all`).
     download_clients: Vec<crate::models::download_clients::DownloadClientRow>,
+    /// Per-protocol "no client of this protocol exists yet" flags.
+    /// Consumed by the inline-included `add_form_body.html` so the
+    /// pre-rendered Add modal pre-checks the Default checkbox per
+    /// protocol on a fresh install. Computed from `download_clients`
+    /// at render time. The section partial
+    /// (`DownloadClientsListPartial`) carries the same fields for
+    /// the HTMX-served partial path.
+    first_torrent_client: bool,
+    first_usenet_client: bool,
     /// Multi-RSS PR G/H — user-supplied direct RSS feeds (e.g.
     /// SubsPlease per-quality feeds) rendered on the Indexers tab
     /// alongside the torznab/newznab indexer rows. Empty until the
@@ -320,11 +316,6 @@ pub struct SettingsQuery {
     /// and re-render inline so the form state is preserved.
     msg: Option<String>,
     err: Option<String>,
-    /// Indexers tab — slug from the seeded catalog
-    /// (`services::indexer_catalog`). When set on the Add path,
-    /// the form pre-fills from the matched seed instead of
-    /// rendering blank.
-    template: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -813,7 +804,6 @@ async fn build_settings_template(
     msg: Option<String>,
     err: Option<String>,
     import_review: Option<ImportReviewView>,
-    template_slug: Option<String>,
     cfg_override: Option<config::Config>,
 ) -> SettingsTemplate {
     // Fan out the five independent lookups — config row, release-group
@@ -885,29 +875,14 @@ async fn build_settings_template(
 
     let custom_format_min_score_display = min_score_display(cfg.custom_format_minimum_score);
     let title_language = cfg.title_language.clone();
-    // PR #107 review fix #5: resolve the indexer edit prefill the
-    // same way CF does. `edit_id` is shared across tabs — at most
-    // one tab consumes it at a time.
-    let indexer_edit = match edit_id {
-        Some(id) => crate::models::indexers::get_by_id(&state.db, id)
-            .await
-            .ok()
-            .flatten(),
-        None => None,
-    };
-    // Resolve the picker template only on the Add path — the
-    // Edit form is already row-driven, so the seed would just
-    // shadow real values. `template_slug` is also discarded if
-    // it doesn't match a known seed (stale or hand-typed
-    // links fall through to the blank Add form).
-    let indexer_seed = if indexer_edit.is_none() {
-        template_slug
-            .as_deref()
-            .and_then(crate::services::indexer_catalog::find_seed)
-    } else {
-        None
-    };
     let download_clients = download_clients_res.unwrap_or_default();
+    use crate::models::download_clients::protocol_for_kind;
+    let first_torrent_client = !download_clients
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+    let first_usenet_client = !download_clients
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
     let direct_rss_feeds = direct_rss_feeds_res.unwrap_or_default();
     SettingsTemplate {
         page: "settings".to_string(),
@@ -925,10 +900,10 @@ async fn build_settings_template(
         external_account,
         title_language,
         indexers: indexers_res.unwrap_or_default(),
-        indexer_edit,
         indexer_catalog: crate::services::indexer_catalog::SEEDED,
-        indexer_seed,
         download_clients,
+        first_torrent_client,
+        first_usenet_client,
         direct_rss_feeds,
     }
 }
@@ -944,7 +919,6 @@ pub async fn settings_page(
         params.msg,
         params.err,
         None,
-        params.template,
         None,
     )
     .await;
@@ -1359,6 +1333,13 @@ pub async fn settings_submit(
         let download_clients = crate::models::download_clients::list_all(&state.db)
             .await
             .unwrap_or_default();
+        use crate::models::download_clients::protocol_for_kind;
+        let first_torrent_client = !download_clients
+            .iter()
+            .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+        let first_usenet_client = !download_clients
+            .iter()
+            .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
         let direct_rss_feeds = crate::models::direct_rss_feeds::list_all(&state.db)
             .await
             .unwrap_or_default();
@@ -1374,14 +1355,14 @@ pub async fn settings_submit(
             custom_format_import_review: None,
             message: None,
             error: Some(format!("Failed to save: {}", e)),
-            indexer_edit: None,
             version: env!("CARGO_PKG_VERSION"),
             external_account,
             title_language,
             indexers,
             indexer_catalog: crate::services::indexer_catalog::SEEDED,
-            indexer_seed: None,
             download_clients,
+            first_torrent_client,
+            first_usenet_client,
             direct_rss_feeds,
         };
         return Html(template.render().unwrap_or_default());
@@ -1470,6 +1451,13 @@ pub async fn settings_submit(
     let download_clients = crate::models::download_clients::list_all(&state.db)
         .await
         .unwrap_or_default();
+    use crate::models::download_clients::protocol_for_kind;
+    let first_torrent_client = !download_clients
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("torrent"));
+    let first_usenet_client = !download_clients
+        .iter()
+        .any(|r| r.is_default && protocol_for_kind(&r.kind) == Some("usenet"));
     let direct_rss_feeds = crate::models::direct_rss_feeds::list_all(&state.db)
         .await
         .unwrap_or_default();
@@ -1490,14 +1478,14 @@ pub async fn settings_submit(
         // the user changes integration settings).
         message: Some(notices.join(" ")),
         error: None,
-        indexer_edit: None,
         version: env!("CARGO_PKG_VERSION"),
         external_account,
         title_language,
         indexers,
         indexer_catalog: crate::services::indexer_catalog::SEEDED,
-        indexer_seed: None,
         download_clients,
+        first_torrent_client,
+        first_usenet_client,
         direct_rss_feeds,
     };
     Html(template.render().unwrap_or_default())
@@ -1642,7 +1630,6 @@ async fn general_response(
         message,
         error,
         None,
-        None,
         Some(cfg),
     )
     .await;
@@ -1772,7 +1759,6 @@ async fn quality_response(
         None,
         message,
         error,
-        None,
         None,
         Some(cfg),
     )
@@ -2001,7 +1987,6 @@ async fn integrations_response(
         None,
         message,
         error,
-        None,
         None,
         Some(cfg),
     )
@@ -2791,125 +2776,21 @@ mod tests {
         assert!(!labels[0].required);
     }
 
-    /// Indexer-picker pre-fill flow on the Settings → Indexers
-    /// tab. `?template=<slug>` resolves through
-    /// [`crate::services::indexer_catalog::find_seed`] and
-    /// populates [`SettingsTemplate::indexer_seed`]; the form
-    /// then renders pre-filled defaults from the seed instead of
-    /// blank. The two precedence rules below (edit shadows seed,
-    /// unknown-slug falls through) are the load-bearing
-    /// invariants for the picker UX.
+    /// Indexer picker / catalog rendering on the Settings → Indexers
+    /// tab. The URL-driven `?edit_id=N` / `?template=<slug>` inline-
+    /// form flow has been replaced by a click-to-modal flow whose
+    /// form bodies come from dedicated GET endpoints (covered by
+    /// `IndexerEditFormPartial` / `IndexerAddFormPartial` rendering
+    /// tests). What this section still needs to assert is that the
+    /// catalog grid is always populated from the static seed list,
+    /// since the page renders unconditionally without any
+    /// catalog-suppression branch.
     mod indexer_picker {
         use super::super::*;
         use crate::test_support::{build_test_app_state, in_memory_pool};
 
         #[tokio::test]
-        async fn template_slug_populates_indexer_seed() {
-            let db = in_memory_pool().await;
-            let state = build_test_app_state(db, None);
-            let template = build_settings_template(
-                &state,
-                Some("indexers".to_string()),
-                None,
-                None,
-                None,
-                None,
-                Some("animebytes".to_string()),
-                None,
-            )
-            .await;
-            let seed = template
-                .indexer_seed
-                .expect("animebytes slug should resolve to a seed");
-            assert_eq!(seed.slug, "animebytes");
-            assert_eq!(seed.display_name, "AnimeBytes");
-            assert!(seed.is_private_tracker);
-        }
-
-        #[tokio::test]
-        async fn unknown_template_slug_falls_through_to_picker() {
-            // Stale `?template=…` links from a removed catalog
-            // entry must degrade gracefully — the user lands on
-            // the blank picker grid, not an error page.
-            let db = in_memory_pool().await;
-            let state = build_test_app_state(db, None);
-            let template = build_settings_template(
-                &state,
-                Some("indexers".to_string()),
-                None,
-                None,
-                None,
-                None,
-                Some("does-not-exist".to_string()),
-                None,
-            )
-            .await;
-            assert!(template.indexer_seed.is_none());
-        }
-
-        #[tokio::test]
-        async fn edit_id_shadows_template_slug() {
-            // `?edit_id=N&template=…` URLs must pick the row
-            // (real DB values) over the seed (catalog defaults)
-            // — otherwise an Edit click on an existing row that
-            // happened to land on a seed-less form would
-            // overwrite real values with catalog defaults on
-            // Save.
-            let db = in_memory_pool().await;
-            let row_id = crate::models::indexers::insert(
-                &db,
-                crate::models::indexers::IndexerForm {
-                    name: "Existing",
-                    kind: "torznab",
-                    url: "https://prowlarr.local/1/api",
-                    api_key: "k",
-                    priority: 25,
-                    enabled: true,
-                    is_private_tracker: false,
-                    seed_ratio: None,
-                    seed_time_minutes: None,
-                    min_seeders: 1,
-                    request_timeout_secs: None,
-                    download_client_id: None,
-                    rss_enabled: false,
-                },
-            )
-            .await
-            .expect("seed indexer");
-            let state = build_test_app_state(db, None);
-            let template = build_settings_template(
-                &state,
-                Some("indexers".to_string()),
-                Some(row_id),
-                None,
-                None,
-                None,
-                Some("animebytes".to_string()),
-                None,
-            )
-            .await;
-            // Prove the row's fields actually reached the
-            // template — `is_some()` alone wouldn't catch a
-            // future `get_by_id` projection bug that returned
-            // a default-constructed row but kept the
-            // seed-suppression branch intact.
-            let edit = template
-                .indexer_edit
-                .as_ref()
-                .expect("edit_id must populate indexer_edit");
-            assert_eq!(edit.name, "Existing");
-            assert_eq!(edit.id, row_id);
-            assert!(
-                template.indexer_seed.is_none(),
-                "edit_id must shadow the template slug — seed defaults would clobber real row values"
-            );
-        }
-
-        #[tokio::test]
-        async fn no_template_no_edit_renders_blank_picker() {
-            // The default landing on `?tab=indexers` shows the
-            // grid + table; neither edit_id nor template
-            // populated.
+        async fn catalog_grid_is_always_populated() {
             let db = in_memory_pool().await;
             let state = build_test_app_state(db, None);
             let template = build_settings_template(
@@ -2920,11 +2801,8 @@ mod tests {
                 None,
                 None,
                 None,
-                None,
             )
             .await;
-            assert!(template.indexer_seed.is_none());
-            assert!(template.indexer_edit.is_none());
             assert!(
                 !template.indexer_catalog.is_empty(),
                 "picker grid is always populated from the static catalog"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -303,10 +303,186 @@ impl AppState {
         let pool = self.download_clients.read().await.clone();
         pool.clients.get(&id).cloned()
     }
+
+    /// Resolve a grab to its handling client given the `download_client_id`
+    /// stamp (when present) and the hash. Falls back through three layers:
+    ///
+    ///   1. The stamped client id, if it still exists in the pool.
+    ///   2. **Hash-shape heuristic** — SAB's `nzo_id` format
+    ///      (`SABnzbd_nzo_…`) is unmistakable. Old grabs from before
+    ///      grab-time stamping was wired (the `ALTER TABLE … ADD COLUMN
+    ///      download_client_id` migration runs without a backfill) have
+    ///      a NULL stamp, and naively falling through to the torrent
+    ///      default sends an nzo_id to qBit's `delete` endpoint, which
+    ///      silently 200s on unknown hashes — the user's symptom is
+    ///      "delete-from-disk leaves the SAB job alive forever." Route
+    ///      SAB-shaped hashes to ANY usenet client in the pool instead.
+    ///   3. The torrent default (the legacy fall-through; correct for
+    ///      BT v1 infohashes — 40-char hex, no SAB-style prefix).
+    pub async fn resolve_grab_client(
+        &self,
+        download_client_id: Option<i64>,
+        hash: &str,
+    ) -> Option<Arc<dyn DownloadClient>> {
+        if let Some(id) = download_client_id
+            && let Some(client) = self.client_by_id(id).await
+        {
+            return Some(client);
+        }
+        if hash.starts_with("SABnzbd_nzo_") {
+            let pool = self.download_clients.read().await.clone();
+            for c in pool.clients.values() {
+                if c.protocol() == "usenet" {
+                    return Some(c.clone());
+                }
+            }
+        }
+        self.default_download_client().await
+    }
 }
 
 impl FromRef<AppState> for SqlitePool {
     fn from_ref(state: &AppState) -> SqlitePool {
         state.db.clone()
+    }
+}
+
+#[cfg(test)]
+mod resolve_grab_client_tests {
+    use super::*;
+    use crate::services::download_client::{
+        AddOutcome, DownloadClient, DownloadFile, DownloadItem, SelectiveOutcome,
+    };
+    use async_trait::async_trait;
+    use std::sync::atomic::AtomicBool;
+    use tokio::sync::RwLock;
+
+    /// Minimal `DownloadClient` mock that lets a test pin the
+    /// `protocol()` return value. Every other method is a no-op stub.
+    struct ProtoClient(&'static str);
+
+    #[async_trait]
+    impl DownloadClient for ProtoClient {
+        async fn test(&self) -> Result<String, String> {
+            Ok("ok".into())
+        }
+        async fn add_torrent(&self, _url: &str, _hash: &str) -> Result<AddOutcome, String> {
+            Ok(AddOutcome::Added)
+        }
+        async fn add_torrent_with_file_filter(
+            &self,
+            _url: &str,
+            _hash: &str,
+            _pick: &mut (dyn for<'a> FnMut(&'a [String]) -> Option<Vec<usize>> + Send),
+        ) -> Result<SelectiveOutcome, String> {
+            Ok(SelectiveOutcome::FullDownload)
+        }
+        async fn list_scoped(&self) -> Result<Vec<DownloadItem>, String> {
+            Ok(vec![])
+        }
+        async fn get_files(&self, _hash: &str) -> Result<Vec<DownloadFile>, String> {
+            Ok(vec![])
+        }
+        async fn pause(&self, _hash: &str) -> Result<(), String> {
+            Ok(())
+        }
+        async fn resume(&self, _hash: &str) -> Result<(), String> {
+            Ok(())
+        }
+        async fn delete(&self, _hash: &str, _delete_files: bool) -> Result<(), String> {
+            Ok(())
+        }
+        async fn set_file_wanted(
+            &self,
+            _hash: &str,
+            _files: &[usize],
+            _wanted: bool,
+        ) -> Result<(), String> {
+            Ok(())
+        }
+        fn sonarr_impl_name(&self) -> &'static str {
+            self.0
+        }
+        fn protocol(&self) -> &'static str {
+            self.0
+        }
+    }
+
+    fn build_state(default_torrent_id: Option<i64>) -> AppState {
+        let mut clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>> =
+            std::collections::HashMap::new();
+        clients.insert(1, Arc::new(ProtoClient("torrent")));
+        clients.insert(2, Arc::new(ProtoClient("usenet")));
+        let pool = DownloadClientPool {
+            clients,
+            default_torrent_id,
+            default_usenet_id: Some(2),
+        };
+        AppState {
+            db: sqlx::SqlitePool::connect_lazy("sqlite::memory:").expect("lazy pool"),
+            download_clients: Arc::new(RwLock::new(Arc::new(pool))),
+            jellyfin: Arc::new(RwLock::new(None)),
+            custom_formats: Arc::new(RwLock::new(Arc::new(Vec::new()))),
+            indexers: Arc::new(RwLock::new(Arc::new(Vec::new()))),
+            progress: crate::services::progress::ProgressRegistry::new(),
+            users_exist: Arc::new(AtomicBool::new(true)),
+            interactive_search_cache: crate::services::interactive_search_cache::new(),
+            oauth_state: crate::services::oauth_state::new(),
+            start_time: chrono::Utc::now(),
+            tasks: crate::services::task_registry::TaskRegistry::new(),
+        }
+    }
+
+    /// Stamped `download_client_id` always wins, even for a SAB-shaped
+    /// hash that the heuristic would otherwise re-route.
+    #[tokio::test]
+    async fn stamped_id_wins_over_hash_heuristic() {
+        let state = build_state(Some(1));
+        // Pin to the torrent client (id=1) even though the hash looks
+        // SAB-shaped — the stamp is authoritative.
+        let client = state
+            .resolve_grab_client(Some(1), "SABnzbd_nzo_abcdef12")
+            .await
+            .expect("resolved");
+        assert_eq!(client.protocol(), "torrent");
+    }
+
+    /// Legacy NULL stamp + SAB-shaped hash routes to a usenet client
+    /// in the pool. Without this the user's existing SAB grabs (made
+    /// before grab-time stamping was wired) silently route to qBit's
+    /// `delete`, which 200s on unknown hashes and leaves the SAB job
+    /// alive forever.
+    #[tokio::test]
+    async fn null_stamp_with_sab_hash_routes_to_usenet_client() {
+        let state = build_state(Some(1));
+        let client = state
+            .resolve_grab_client(None, "SABnzbd_nzo_4rxsukkq")
+            .await
+            .expect("resolved");
+        assert_eq!(client.protocol(), "usenet");
+    }
+
+    /// Legacy NULL stamp + BT-shaped hash falls through to the torrent
+    /// default — no false-positive on a 40-char-hex infohash.
+    #[tokio::test]
+    async fn null_stamp_with_bt_hash_falls_through_to_torrent_default() {
+        let state = build_state(Some(1));
+        let client = state
+            .resolve_grab_client(None, "abc123def456abc123def456abc123def4567890")
+            .await
+            .expect("resolved");
+        assert_eq!(client.protocol(), "torrent");
+    }
+
+    /// Stamped id that no longer exists (client was deleted) falls
+    /// back through the heuristic. Same SAB rescue as the NULL case.
+    #[tokio::test]
+    async fn stamped_id_missing_from_pool_still_routes_via_heuristic() {
+        let state = build_state(Some(1));
+        let client = state
+            .resolve_grab_client(Some(999), "SABnzbd_nzo_abcdef12")
+            .await
+            .expect("resolved");
+        assert_eq!(client.protocol(), "usenet");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,22 +64,39 @@ use services::{
 /// instances on every per-target search.
 pub type IndexerCache = Arc<RwLock<Arc<Vec<Arc<dyn Indexer>>>>>;
 
-/// Multi-client routing — pair of (id-keyed map of live trait
-/// impls, default client id). Both swap atomically when the
-/// cache is rebuilt by [`services::download_client::rebuild_clients_cache`]
-/// on Settings → Connections → Downloads edits. Lookup at grab
-/// time is a `HashMap::get` against the inner `Arc` — read lock
-/// releases before the dispatch.
+/// Multi-client routing — id-keyed map of live trait impls plus
+/// the per-protocol default ids. The whole struct swaps atomically
+/// when the cache is rebuilt by
+/// [`services::download_client::rebuild_clients_cache`] on
+/// Settings → Connections → Downloads edits. Lookup at grab time
+/// is a `HashMap::get` against the inner `Arc` — read lock releases
+/// before the dispatch.
 ///
-/// `default_id` is the row id of the `is_default = 1` row at
-/// build time. `None` when no client is configured (fresh
-/// install) or when every row was disabled. The pin-resolution
-/// helpers ([`AppState::client_for_indexer`] etc.) fall back to
-/// `default_id` when no pin matches.
+/// `default_torrent_id` and `default_usenet_id` are the row ids of
+/// the `is_default = 1` rows at build time, scoped per protocol.
+/// Each is `None` when no client of that protocol is configured
+/// (or when every row of that protocol was disabled). The pin-
+/// resolution helpers ([`AppState::client_for_indexer`] etc.) fall
+/// back to the matching protocol's default — a torznab indexer with
+/// no pin routes to `default_torrent_id`; a newznab indexer routes
+/// to `default_usenet_id`.
 #[derive(Default)]
 pub struct DownloadClientPool {
     pub clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>>,
-    pub default_id: Option<i64>,
+    pub default_torrent_id: Option<i64>,
+    pub default_usenet_id: Option<i64>,
+}
+
+impl DownloadClientPool {
+    /// The default-client id for the given wire protocol
+    /// (`"torrent"` / `"usenet"`). Anything else returns None.
+    pub fn default_for_protocol(&self, protocol: &str) -> Option<i64> {
+        match protocol {
+            "torrent" => self.default_torrent_id,
+            "usenet" => self.default_usenet_id,
+            _ => None,
+        }
+    }
 }
 
 /// Same swap-on-write shape as `IndexerCache` / `CompiledCfCache`
@@ -187,21 +204,37 @@ impl AppState {
     /// stamp it on `grabbed_torrents.download_client_id`.
     /// Post-processing routes per-grab through that id back to the
     /// owning client.
+    ///
+    /// Default-fallback is per-protocol: a torznab indexer with no
+    /// pin lands on `default_torrent_id`; a newznab indexer lands on
+    /// `default_usenet_id`. When the indexer's protocol can't be
+    /// derived (unknown kind, indexer not in the cache snapshot) —
+    /// or when no pin context is given at all — falls through to
+    /// the torrent default since every Ryokan-internal default-only
+    /// caller is torrent-shaped (Nyaa search, manual grabs, library
+    /// re-grab buttons).
     pub async fn client_for_indexer_with_id(
         &self,
         indexer_id: Option<i64>,
     ) -> Option<(Arc<dyn DownloadClient>, i64)> {
         let pool = self.download_clients.read().await.clone();
+        let mut protocol: &str = "torrent";
         if let Some(id) = indexer_id {
             let indexers = self.indexers.read().await.clone();
-            if let Some(idx) = indexers.iter().find(|i| i.id() == id)
-                && let Some(pinned) = idx.download_client_id()
-                && let Some(client) = pool.clients.get(&pinned)
-            {
-                return Some((client.clone(), pinned));
+            if let Some(idx) = indexers.iter().find(|i| i.id() == id) {
+                if let Some(pinned) = idx.download_client_id()
+                    && let Some(client) = pool.clients.get(&pinned)
+                {
+                    return Some((client.clone(), pinned));
+                }
+                if let Some(p) =
+                    crate::services::download_client::protocol_for_indexer_kind(idx.kind())
+                {
+                    protocol = p;
+                }
             }
         }
-        let default_id = pool.default_id?;
+        let default_id = pool.default_for_protocol(protocol)?;
         let client = pool.clients.get(&default_id)?.clone();
         Some((client, default_id))
     }
@@ -217,6 +250,9 @@ impl AppState {
 
     /// Same resolution as [`Self::client_for_nyaa`] but also returns
     /// the resolved `download_clients.id` for grab-row stamping.
+    /// Always falls back to the torrent default — Nyaa items are
+    /// magnets / .torrent URLs, so a usenet-default fallback would
+    /// just trip the protocol guard at add-time anyway.
     pub async fn client_for_nyaa_with_id(
         &self,
         nyaa_pin: Option<i64>,
@@ -227,7 +263,7 @@ impl AppState {
         {
             return Some((client.clone(), pinned));
         }
-        let default_id = pool.default_id?;
+        let default_id = pool.default_torrent_id?;
         let client = pool.clients.get(&default_id)?.clone();
         Some((client, default_id))
     }
@@ -243,10 +279,16 @@ impl AppState {
 
     /// Same resolution as [`Self::default_download_client`] but also
     /// returns the resolved id for grab-row stamping. Mirror of the
-    /// `_with_id` helpers above.
+    /// `_with_id` helpers above. Returns the **torrent** default —
+    /// every internal call site that hits this helper is torrent-
+    /// flavored (Nyaa search, manual grabs, library episode
+    /// re-grab, post-processing torrent lookup, RSS / upgrade
+    /// "is anything configured" gates). Usenet routing always goes
+    /// through the indexer's pin (or its protocol's per-pin default
+    /// via `client_for_indexer_with_id`).
     pub async fn default_download_client_with_id(&self) -> Option<(Arc<dyn DownloadClient>, i64)> {
         let pool = self.download_clients.read().await.clone();
-        let default_id = pool.default_id?;
+        let default_id = pool.default_torrent_id?;
         let client = pool.clients.get(&default_id)?.clone();
         Some((client, default_id))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -789,12 +789,28 @@ async fn main() {
             post(handlers::settings::indexers::settings_indexers_delete),
         )
         .route(
+            "/settings/indexers/section",
+            get(handlers::settings::indexers::settings_indexers_section),
+        )
+        .route(
+            "/settings/indexers/add-form",
+            get(handlers::settings::indexers::settings_indexers_add_form),
+        )
+        .route(
+            "/settings/indexers/{id}/edit-form",
+            get(handlers::settings::indexers::settings_indexers_edit_form),
+        )
+        .route(
             "/settings/indexers/nyaa-pin",
             post(handlers::settings::download_clients::settings_indexers_nyaa_pin),
         )
         .route(
             "/settings/indexers/test-rss",
             post(handlers::settings::indexers::settings_indexers_test_rss),
+        )
+        .route(
+            "/api/indexers/test",
+            post(handlers::settings::indexers::settings_indexers_test_stateless),
         )
         .route(
             "/settings/direct-rss-feeds/upsert",

--- a/src/models/download_clients.rs
+++ b/src/models/download_clients.rs
@@ -56,6 +56,25 @@ pub struct DownloadClientForm<'a> {
 const SELECT_COLS: &str = "id, name, kind, url, username, password, label, \
                            download_path, enabled, is_default";
 
+/// Wire-protocol family for a download-client kind. Mirrors
+/// `services::download_client::protocol_for_client_kind` — duplicated
+/// at the model layer because services depends on models, so we can't
+/// reach upward without a circular dep. Keep the two in sync; both
+/// derive from the same finite set of known kinds.
+///
+/// Drives the per-protocol uniqueness invariant for `is_default`: at
+/// most one torrent client AND at most one usenet client may carry
+/// the flag at any time. Indexers without an explicit pin route to
+/// the default of their own protocol (torznab → torrent default,
+/// newznab → usenet default).
+pub fn protocol_for_kind(kind: &str) -> Option<&'static str> {
+    match kind {
+        "qbittorrent" | "deluge" | "transmission" | "rtorrent" => Some("torrent"),
+        "sabnzbd" => Some("usenet"),
+        _ => None,
+    }
+}
+
 fn map_row(r: sqlx::sqlite::SqliteRow) -> DownloadClientRow {
     DownloadClientRow {
         id: r.get("id"),
@@ -109,28 +128,61 @@ pub async fn get_by_id(db: &SqlitePool, id: i64) -> Result<Option<DownloadClient
     Ok(row.map(map_row))
 }
 
-/// The current default client, if any. NULL when no client has
-/// been added yet (fresh install) or when a manual DB edit
-/// cleared every `is_default = 1`.
+/// The current default client (any protocol), if any. NULL when
+/// no client has been added yet (fresh install) or when a manual
+/// DB edit cleared every `is_default = 1`. With the per-protocol
+/// invariant the result is non-deterministic when both a torrent
+/// and a usenet default exist — callers that care about protocol
+/// should use [`get_default_for_protocol`] instead.
 pub async fn get_default(db: &SqlitePool) -> Result<Option<DownloadClientRow>, sqlx::Error> {
     let row = sqlx::query(&format!(
-        "SELECT {SELECT_COLS} FROM download_clients WHERE is_default = 1 LIMIT 1"
+        "SELECT {SELECT_COLS} FROM download_clients WHERE is_default = 1 ORDER BY id LIMIT 1"
     ))
     .fetch_optional(db)
     .await?;
     Ok(row.map(map_row))
 }
 
-/// Insert a new row. If `form.is_default` is true, the existing
-/// default (if any) is cleared in the same transaction so the
-/// invariant "exactly one row has is_default = 1" stays
-/// recoverable. Returns the new row's id.
+/// The current default client for the given protocol (`"torrent"`
+/// or `"usenet"`), if any. Returns NULL when nothing of that
+/// protocol is configured or marked default. The pool builder uses
+/// this on rebuild to populate `default_torrent_id` /
+/// `default_usenet_id` independently.
+pub async fn get_default_for_protocol(
+    db: &SqlitePool,
+    protocol: &str,
+) -> Result<Option<DownloadClientRow>, sqlx::Error> {
+    let kinds: &[&str] = match protocol {
+        "torrent" => &["qbittorrent", "deluge", "transmission", "rtorrent"],
+        "usenet" => &["sabnzbd"],
+        _ => return Ok(None),
+    };
+    let placeholders = vec!["?"; kinds.len()].join(", ");
+    let sql = format!(
+        "SELECT {SELECT_COLS} FROM download_clients \
+         WHERE is_default = 1 AND kind IN ({placeholders}) \
+         ORDER BY id LIMIT 1"
+    );
+    let mut q = sqlx::query(&sql);
+    for k in kinds {
+        q = q.bind(*k);
+    }
+    let row = q.fetch_optional(db).await?;
+    Ok(row.map(map_row))
+}
+
+/// Insert a new row. If `form.is_default` is true, every other
+/// row OF THE SAME PROTOCOL gets its `is_default` cleared in the
+/// same transaction so the invariant "exactly one row of each
+/// protocol has is_default = 1" stays recoverable. Cross-protocol
+/// defaults coexist (one torrent + one usenet default at a time)
+/// so a torznab indexer with no pin routes to the torrent default
+/// and a newznab indexer routes to the usenet default. Returns
+/// the new row's id.
 pub async fn insert(db: &SqlitePool, form: DownloadClientForm<'_>) -> Result<i64, sqlx::Error> {
     let mut tx = db.begin().await?;
     if form.is_default {
-        sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1")
-            .execute(&mut *tx)
-            .await?;
+        clear_other_defaults_in_protocol(&mut tx, form.kind, None).await?;
     }
     let id: i64 = sqlx::query_scalar(
         "INSERT INTO download_clients
@@ -163,10 +215,7 @@ pub async fn update(
 ) -> Result<(), sqlx::Error> {
     let mut tx = db.begin().await?;
     if form.is_default {
-        sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1 AND id != ?")
-            .bind(id)
-            .execute(&mut *tx)
-            .await?;
+        clear_other_defaults_in_protocol(&mut tx, form.kind, Some(id)).await?;
     }
     sqlx::query(
         "UPDATE download_clients
@@ -216,18 +265,16 @@ pub async fn update(
 /// is on their own to add a new one.
 pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     let mut tx = db.begin().await?;
-    // Read the deleted row's default-flag BEFORE the row is gone so
-    // we know whether to promote a replacement after the DELETE
-    // commits. None means "row didn't exist anymore" (race with a
-    // parallel delete); skip the promotion check entirely in that
-    // case — the surviving rows already have whatever default state
-    // the other transaction left them in.
-    let was_default =
-        sqlx::query_scalar::<_, i64>("SELECT is_default FROM download_clients WHERE id = ?")
+    // Read the deleted row's (default-flag, kind) BEFORE the row is
+    // gone so we know whether (and within which protocol) to promote
+    // a replacement after the DELETE commits. None means "row didn't
+    // exist anymore" (race with a parallel delete); skip the
+    // promotion check entirely in that case.
+    let row: Option<(i64, String)> =
+        sqlx::query_as("SELECT is_default, kind FROM download_clients WHERE id = ?")
             .bind(id)
             .fetch_optional(&mut *tx)
-            .await?
-            .map(|i| i != 0);
+            .await?;
     sqlx::query("UPDATE indexers SET download_client_id = NULL WHERE download_client_id = ?")
         .bind(id)
         .execute(&mut *tx)
@@ -248,40 +295,65 @@ pub async fn delete(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
         .bind(id)
         .execute(&mut *tx)
         .await?;
-    // Auto-promote: only when the row we just deleted was the default.
-    // Pick the lowest remaining id; SQL returns NULL when the table
-    // is empty, in which case `bind(None)` is a no-op DELETE-WHERE-NULL
-    // shape — the UPDATE simply matches zero rows. No promotion
-    // happens when there's nothing to promote.
-    if was_default == Some(true) {
-        let next_default: Option<i64> = sqlx::query_scalar("SELECT MIN(id) FROM download_clients")
-            .fetch_one(&mut *tx)
-            .await?;
-        if let Some(next_id) = next_default {
-            sqlx::query(
-                "UPDATE download_clients SET is_default = 1, updated_at = strftime('%s','now') WHERE id = ?",
-            )
-            .bind(next_id)
-            .execute(&mut *tx)
-            .await?;
+    // Auto-promote: only when the row we just deleted was the default
+    // AND its protocol still has a surviving row. Picking by min(id)
+    // is deterministic (oldest survivor wins) and scoped per-protocol
+    // so deleting a torrent default doesn't grab a usenet row (or
+    // vice versa). When no row of the same protocol survives, there's
+    // nothing to promote — the user is on their own to add another
+    // client of that protocol.
+    if let Some((flag, kind)) = row
+        && flag != 0
+    {
+        let kinds: &[&str] = match protocol_for_kind(&kind) {
+            Some("torrent") => &["qbittorrent", "deluge", "transmission", "rtorrent"],
+            Some("usenet") => &["sabnzbd"],
+            _ => &[],
+        };
+        if !kinds.is_empty() {
+            let placeholders = vec!["?"; kinds.len()].join(", ");
+            let sql =
+                format!("SELECT MIN(id) FROM download_clients WHERE kind IN ({placeholders})");
+            let mut q = sqlx::query_scalar::<_, Option<i64>>(&sql);
+            for k in kinds {
+                q = q.bind(*k);
+            }
+            let next_default: Option<i64> = q.fetch_one(&mut *tx).await?;
+            if let Some(next_id) = next_default {
+                sqlx::query(
+                    "UPDATE download_clients SET is_default = 1, updated_at = strftime('%s','now') WHERE id = ?",
+                )
+                .bind(next_id)
+                .execute(&mut *tx)
+                .await?;
+            }
         }
     }
     tx.commit().await?;
     Ok(())
 }
 
-/// Mark `id` as the default and clear every other row's flag.
-/// Idempotent at the `is_default` value level (a re-call on an
-/// already-default row leaves the flag at 1); `updated_at` is
-/// bumped on every call regardless. Tighten the second UPDATE to
-/// `WHERE is_default = 0` if a strict no-op-on-repeat semantics is
-/// ever needed for an audit-log trigger.
+/// Mark `id` as the default for its own protocol (torrent or
+/// usenet) and clear every other same-protocol row's flag. The
+/// other-protocol default is left alone so a one-click "Set
+/// default" on a SAB row doesn't quietly clear the torrent
+/// default at the same time. Idempotent at the `is_default` value
+/// level (a re-call on an already-default row leaves the flag at
+/// 1); `updated_at` is bumped on every call regardless.
 pub async fn set_default(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     let mut tx = db.begin().await?;
-    sqlx::query("UPDATE download_clients SET is_default = 0 WHERE is_default = 1 AND id != ?")
+    // Look up the row's kind to scope the clear by protocol.
+    // Missing row (concurrent delete) → bail without touching
+    // anything; the caller's UPDATE below would be a no-op too.
+    let kind: Option<String> = sqlx::query_scalar("SELECT kind FROM download_clients WHERE id = ?")
         .bind(id)
-        .execute(&mut *tx)
+        .fetch_optional(&mut *tx)
         .await?;
+    let Some(kind) = kind else {
+        tx.commit().await?;
+        return Ok(());
+    };
+    clear_other_defaults_in_protocol(&mut tx, &kind, Some(id)).await?;
     sqlx::query(
         "UPDATE download_clients SET is_default = 1, updated_at = strftime('%s','now') WHERE id = ?",
     )
@@ -289,6 +361,43 @@ pub async fn set_default(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
     .execute(&mut *tx)
     .await?;
     tx.commit().await?;
+    Ok(())
+}
+
+/// Clear `is_default` on every row that shares `kind`'s protocol,
+/// optionally excluding `keep_id` (used on the upsert path so the
+/// just-flagged row doesn't get cleared by its own protocol-mates
+/// loop). Unknown kinds (mapped to None by `protocol_for_kind`)
+/// are no-ops — `protocol_for_client_kind`'s permissive contract.
+async fn clear_other_defaults_in_protocol(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    kind: &str,
+    keep_id: Option<i64>,
+) -> Result<(), sqlx::Error> {
+    let kinds: &[&str] = match protocol_for_kind(kind) {
+        Some("torrent") => &["qbittorrent", "deluge", "transmission", "rtorrent"],
+        Some("usenet") => &["sabnzbd"],
+        _ => return Ok(()),
+    };
+    let placeholders = vec!["?"; kinds.len()].join(", ");
+    let sql = match keep_id {
+        Some(_) => format!(
+            "UPDATE download_clients SET is_default = 0 \
+             WHERE is_default = 1 AND kind IN ({placeholders}) AND id != ?"
+        ),
+        None => format!(
+            "UPDATE download_clients SET is_default = 0 \
+             WHERE is_default = 1 AND kind IN ({placeholders})"
+        ),
+    };
+    let mut q = sqlx::query(&sql);
+    for k in kinds {
+        q = q.bind(*k);
+    }
+    if let Some(id) = keep_id {
+        q = q.bind(id);
+    }
+    q.execute(&mut **tx).await?;
     Ok(())
 }
 
@@ -633,5 +742,130 @@ mod tests {
         let rows = list_all(&db).await.unwrap();
         assert!(rows.is_empty());
         assert!(get_default(&db).await.unwrap().is_none());
+    }
+
+    /// Per-protocol default invariant: a torrent default and a usenet
+    /// default coexist because they route disjoint indexer kinds.
+    /// Marking a SAB row as default must NOT clear the torrent default,
+    /// and vice versa. Counterpart of the legacy "exactly one default"
+    /// test that the prior code shape enforced.
+    #[tokio::test]
+    async fn torrent_and_usenet_defaults_coexist() {
+        let db = in_memory_pool().await;
+        // Add a default qBit (torrent).
+        let mut t = form("qBit", "qbittorrent", "http://qbit");
+        t.is_default = true;
+        let qbit_id = insert(&db, t).await.unwrap();
+        // Add a default SAB (usenet).
+        let mut u = form("SAB", "sabnzbd", "http://sab");
+        u.is_default = true;
+        let sab_id = insert(&db, u).await.unwrap();
+
+        // Both rows should still be default — different protocols.
+        let qbit_row = get_by_id(&db, qbit_id).await.unwrap().unwrap();
+        let sab_row = get_by_id(&db, sab_id).await.unwrap().unwrap();
+        assert!(
+            qbit_row.is_default,
+            "torrent default must survive marking a usenet row default"
+        );
+        assert!(
+            sab_row.is_default,
+            "usenet default must survive marking a torrent row default"
+        );
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM download_clients WHERE is_default = 1")
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        assert_eq!(
+            count, 2,
+            "exactly two rows carry is_default = 1 (one per protocol)"
+        );
+    }
+
+    /// Marking a second torrent client as default DOES clear the prior
+    /// torrent default (same-protocol invariant). Same-protocol unique-
+    /// ness is the only mutex; cross-protocol entries are independent.
+    #[tokio::test]
+    async fn second_torrent_default_clears_prior_torrent_default() {
+        let db = in_memory_pool().await;
+        let mut a = form("qBit", "qbittorrent", "http://qbit");
+        a.is_default = true;
+        let qbit_id = insert(&db, a).await.unwrap();
+        let mut b = form("Deluge", "deluge", "http://deluge");
+        b.is_default = true;
+        let deluge_id = insert(&db, b).await.unwrap();
+
+        let qbit_row = get_by_id(&db, qbit_id).await.unwrap().unwrap();
+        let deluge_row = get_by_id(&db, deluge_id).await.unwrap().unwrap();
+        assert!(
+            !qbit_row.is_default,
+            "prior torrent default must be cleared"
+        );
+        assert!(deluge_row.is_default, "new torrent default must take over");
+    }
+
+    /// `get_default_for_protocol` returns the right row per protocol
+    /// when both protocol families have a default configured.
+    #[tokio::test]
+    async fn get_default_for_protocol_returns_per_protocol_row() {
+        let db = in_memory_pool().await;
+        let mut t = form("qBit", "qbittorrent", "http://qbit");
+        t.is_default = true;
+        let qbit_id = insert(&db, t).await.unwrap();
+        let mut u = form("SAB", "sabnzbd", "http://sab");
+        u.is_default = true;
+        let sab_id = insert(&db, u).await.unwrap();
+
+        let torrent_default = get_default_for_protocol(&db, "torrent")
+            .await
+            .unwrap()
+            .expect("torrent default must resolve");
+        assert_eq!(torrent_default.id, qbit_id);
+
+        let usenet_default = get_default_for_protocol(&db, "usenet")
+            .await
+            .unwrap()
+            .expect("usenet default must resolve");
+        assert_eq!(usenet_default.id, sab_id);
+    }
+
+    /// Auto-promote on delete is per-protocol: deleting the torrent
+    /// default elects another torrent row, not a usenet survivor (which
+    /// would silently route torznab grabs through SAB and trip the
+    /// protocol guard at add time).
+    #[tokio::test]
+    async fn delete_torrent_default_promotes_torrent_survivor_not_usenet() {
+        let db = in_memory_pool().await;
+        // Surviving usenet first so its id is < the torrent survivor;
+        // a naive lowest-id-overall promotion would pick this row.
+        let mut u = form("SAB", "sabnzbd", "http://sab");
+        u.is_default = true;
+        let sab_id = insert(&db, u).await.unwrap();
+        let mut t = form("qBitDefault", "qbittorrent", "http://qbit-default");
+        t.is_default = true;
+        let qbit_default_id = insert(&db, t).await.unwrap();
+        let qbit_survivor_id = insert(&db, form("qBitSurvivor", "deluge", "http://deluge"))
+            .await
+            .unwrap();
+
+        delete(&db, qbit_default_id).await.unwrap();
+
+        let promoted = get_default_for_protocol(&db, "torrent")
+            .await
+            .unwrap()
+            .expect("a torrent survivor must be promoted");
+        assert_eq!(
+            promoted.id, qbit_survivor_id,
+            "torrent default must auto-promote to a torrent row, not the usenet row"
+        );
+        // SAB must remain the usenet default — its protocol wasn't
+        // touched by the delete.
+        let usenet_default = get_default_for_protocol(&db, "usenet")
+            .await
+            .unwrap()
+            .expect("usenet default must remain after a torrent delete");
+        assert_eq!(usenet_default.id, sab_id);
     }
 }

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -398,6 +398,90 @@ pub async fn mark_completed_no_import(db: &SqlitePool, id: i64) -> Result<(), sq
 /// recorded here; the library-side path lives on
 /// `episode_grab_history.file_name` after post-processing.
 ///
+/// Persist the source-side paths Ryokan imported from for this grab.
+/// Stored as JSON array of strings in `grabbed_torrents.imported_source_paths`.
+/// Per-grab (not per-episode) — fine because SAB grabs are 1:1 with jobs
+/// and the per-episode delete path skips batch grabs at the client-delete
+/// stage anyway. Used by `delete_episode_file` (in addition to the
+/// inode-based fallback that covers hardlink mode) and by the series
+/// remove path for copy-mode and move-mode imports where shared inodes
+/// don't help.
+pub async fn stamp_imported_source_paths(
+    db: &SqlitePool,
+    grab_id: i64,
+    paths: &[String],
+) -> Result<(), sqlx::Error> {
+    let json = serde_json::to_string(paths).unwrap_or_else(|_| "[]".into());
+    sqlx::query("UPDATE grabbed_torrents SET imported_source_paths = ? WHERE id = ?")
+        .bind(json)
+        .bind(grab_id)
+        .execute(db)
+        .await?;
+    Ok(())
+}
+
+/// Read back the JSON-array source paths persisted by
+/// [`stamp_imported_source_paths`]. Empty Vec when the column is NULL,
+/// the grab id doesn't exist, or the JSON parses badly — all benign
+/// for the cleanup-pass caller (nothing to remove).
+pub async fn get_imported_source_paths(db: &SqlitePool, grab_id: i64) -> Vec<String> {
+    let raw: Option<String> =
+        sqlx::query_scalar("SELECT imported_source_paths FROM grabbed_torrents WHERE id = ?")
+            .bind(grab_id)
+            .fetch_optional(db)
+            .await
+            .ok()
+            .flatten();
+    match raw {
+        Some(s) if !s.is_empty() => serde_json::from_str(&s).unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+/// All `(grab_id, imported_source_paths_json)` tuples for grabs in
+/// state='imported' for a given series. Used by the delete-from-disk
+/// fallback when `find_imported_for_episode` returns empty for an
+/// episode whose media file exists on disk — the file may have been
+/// imported by a sibling grab whose `episode_numbers` doesn't claim
+/// it (a side-effect of the pre-fix wide-walk SAB bug, where one
+/// grab's import swept in files belonging to other SAB jobs in the
+/// same complete dir). The caller then matches by inode against the
+/// JSON paths to recover the real source file.
+pub async fn imported_source_paths_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+) -> Result<Vec<(i64, String)>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, COALESCE(imported_source_paths, '') FROM grabbed_torrents \
+         WHERE series_id = ? AND state = 'imported' \
+         AND COALESCE(imported_source_paths, '') != ''",
+    )
+    .bind(series_id)
+    .fetch_all(db)
+    .await?;
+    Ok(rows
+        .iter()
+        .map(|row| (row.get::<i64, _>(0), row.get::<String, _>(1)))
+        .collect())
+}
+
+/// Read back `client_content_path` for a grab id. Used by the
+/// delete-from-disk path to know where to look for the source file
+/// to clean up alongside the media-library hardlink. Empty string
+/// when the column is NULL or the grab id doesn't exist; both cases
+/// are treated as "no source path known" by the caller.
+pub async fn get_client_content_path(db: &SqlitePool, grab_id: i64) -> String {
+    sqlx::query_scalar::<_, String>(
+        "SELECT COALESCE(client_content_path, '') FROM grabbed_torrents WHERE id = ?",
+    )
+    .bind(grab_id)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten()
+    .unwrap_or_default()
+}
+
 /// Idempotent: `WHERE COALESCE(client_content_path, '') = ''` so a
 /// later completion tick on an already-stamped row is a no-op.
 pub async fn stamp_client_content_path(

--- a/src/models/grabbed_torrents.rs
+++ b/src/models/grabbed_torrents.rs
@@ -498,6 +498,30 @@ pub async fn is_known_hash(db: &SqlitePool, info_hash: &str) -> bool {
     .is_some()
 }
 
+/// Resolve a grab's `download_client_id` by hash. Used by the
+/// queue-action endpoints (pause/resume/delete) so a SAB job's
+/// nzo_id routes to the SAB client and a qBit hash routes to qBit
+/// — the actions only carry the hash on the wire, not the client
+/// id. Returns `None` for unknown hashes or for legacy rows that
+/// pre-date the multi-client refactor (column NULL); callers fall
+/// back to the torrent default in both cases.
+pub async fn client_id_for_hash(db: &SqlitePool, hash: &str) -> Option<i64> {
+    if hash.is_empty() {
+        return None;
+    }
+    sqlx::query_scalar::<_, Option<i64>>(
+        "SELECT download_client_id FROM grabbed_torrents \
+         WHERE hash = ? \
+         ORDER BY id DESC LIMIT 1",
+    )
+    .bind(hash)
+    .fetch_optional(db)
+    .await
+    .ok()
+    .flatten()
+    .flatten()
+}
+
 /// Issue #28 PR C — read back the `respect_seed_rules` flag for
 /// a grab row by hash. Used by delete paths (manual delete,
 /// upgrade-replace) to decide whether to skip the underlying
@@ -776,18 +800,20 @@ pub async fn find_imported_for_episode(
     // UNION dedups grabs where the same series matches through both
     // paths (parent of a single-series grab).
     let rows = sqlx::query(
-        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, is_batch FROM (
+        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, is_batch, download_client_id FROM (
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
                     g.grabbed_at AS grabbed_at,
-                    COALESCE(g.is_batch, 0) AS is_batch
+                    COALESCE(g.is_batch, 0) AS is_batch,
+                    g.download_client_id AS download_client_id
              FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
              WHERE g.series_id = ? AND je.value = ? AND g.state = 'imported'
              UNION
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
                     g.grabbed_at AS grabbed_at,
-                    COALESCE(g.is_batch, 0) AS is_batch
+                    COALESCE(g.is_batch, 0) AS is_batch,
+                    g.download_client_id AS download_client_id
              FROM grabbed_torrents g
              JOIN grabbed_torrent_series r ON r.grab_id = g.id
              , json_each(r.episode_numbers) AS je
@@ -817,9 +843,10 @@ pub async fn find_imported_for_episode(
                 state: "imported".to_string(),
                 grabbed_at: row.get("grabbed_at"),
                 is_batch: is_batch_i != 0,
-                // Not selected by this query — callers don't use the
-                // client routing here. Default None.
-                download_client_id: None,
+                download_client_id: row
+                    .try_get::<Option<i64>, _>("download_client_id")
+                    .ok()
+                    .flatten(),
             }
         })
         .collect())
@@ -842,18 +869,20 @@ pub async fn find_pending_for_episode(
     episode_number: i32,
 ) -> Result<Vec<GrabbedTorrent>, sqlx::Error> {
     let rows = sqlx::query(
-        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, is_batch FROM (
+        r#"SELECT id, hash, torrent_name, series_id, episode_numbers, grabbed_at, is_batch, download_client_id FROM (
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
                     g.grabbed_at AS grabbed_at,
-                    COALESCE(g.is_batch, 0) AS is_batch
+                    COALESCE(g.is_batch, 0) AS is_batch,
+                    g.download_client_id AS download_client_id
              FROM grabbed_torrents g, json_each(g.episode_numbers) AS je
              WHERE g.series_id = ? AND je.value = ? AND g.state = 'pending'
              UNION
              SELECT g.id AS id, g.hash AS hash, g.torrent_name AS torrent_name,
                     g.series_id AS series_id, g.episode_numbers AS episode_numbers,
                     g.grabbed_at AS grabbed_at,
-                    COALESCE(g.is_batch, 0) AS is_batch
+                    COALESCE(g.is_batch, 0) AS is_batch,
+                    g.download_client_id AS download_client_id
              FROM grabbed_torrents g
              JOIN grabbed_torrent_series r ON r.grab_id = g.id
              , json_each(r.episode_numbers) AS je
@@ -883,7 +912,10 @@ pub async fn find_pending_for_episode(
                 state: "pending".to_string(),
                 grabbed_at: row.get("grabbed_at"),
                 is_batch: is_batch_i != 0,
-                download_client_id: None,
+                download_client_id: row
+                    .try_get::<Option<i64>, _>("download_client_id")
+                    .ok()
+                    .flatten(),
             }
         })
         .collect())
@@ -959,15 +991,22 @@ pub async fn remove(db: &SqlitePool, id: i64) -> Result<(), sqlx::Error> {
 pub async fn get_all_for_series(
     db: &SqlitePool,
     series_id: i64,
-) -> Result<Vec<(i64, String)>, sqlx::Error> {
-    let rows = sqlx::query("SELECT id, hash FROM grabbed_torrents WHERE series_id = ?")
-        .bind(series_id)
-        .fetch_all(db)
-        .await?;
+) -> Result<Vec<(i64, String, Option<i64>)>, sqlx::Error> {
+    let rows = sqlx::query(
+        "SELECT id, hash, download_client_id FROM grabbed_torrents WHERE series_id = ?",
+    )
+    .bind(series_id)
+    .fetch_all(db)
+    .await?;
 
     Ok(rows
         .iter()
-        .map(|row| (row.get::<i64, _>("id"), row.get::<String, _>("hash")))
+        .map(|row| {
+            let id: i64 = row.get("id");
+            let hash: String = row.get("hash");
+            let dc_id: Option<i64> = row.try_get("download_client_id").unwrap_or(None);
+            (id, hash, dc_id)
+        })
         .collect())
 }
 
@@ -1674,5 +1713,60 @@ mod tests {
         let pending = get_all_pending(&db).await.expect("pending");
         let row = pending.iter().find(|g| g.id == grab_id).expect("present");
         assert_eq!(row.download_client_id, None);
+    }
+
+    /// `find_pending_for_episode` must read the `download_client_id`
+    /// column. Without it, the cancel-pending handler routes every
+    /// SAB grab to the (torrent) default client and the SAB queue
+    /// entry never gets removed — the user clicks Cancel, the row
+    /// vanishes from Ryokan's UI, and the SAB job downloads to
+    /// completion in the background as if nothing happened.
+    #[tokio::test]
+    async fn find_pending_for_episode_round_trips_download_client_id() {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        let (grab_id, _) = pr_c_seed_a_grab(&db).await;
+        set_download_client(&db, grab_id, Some(99))
+            .await
+            .expect("stamp");
+
+        let series_id: i64 =
+            sqlx::query_scalar("SELECT series_id FROM grabbed_torrents WHERE id = ?")
+                .bind(grab_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        let pending = find_pending_for_episode(&db, series_id, 1)
+            .await
+            .expect("pending");
+        let row = pending.iter().find(|g| g.id == grab_id).expect("present");
+        assert_eq!(row.download_client_id, Some(99));
+    }
+
+    /// Same shape for `find_imported_for_episode` — used by the
+    /// delete-from-disk path. SAB grabs that completed and got
+    /// imported need the per-grab client routing to clean up the
+    /// SAB history entry's storage dir on user delete.
+    #[tokio::test]
+    async fn find_imported_for_episode_round_trips_download_client_id() {
+        let db = SqlitePool::connect("sqlite::memory:").await.unwrap();
+        crate::models::migrate(&db).await.unwrap();
+        let (grab_id, _) = pr_c_seed_a_grab(&db).await;
+        set_download_client(&db, grab_id, Some(123))
+            .await
+            .expect("stamp");
+        mark_imported(&db, grab_id).await.expect("imported");
+
+        let series_id: i64 =
+            sqlx::query_scalar("SELECT series_id FROM grabbed_torrents WHERE id = ?")
+                .bind(grab_id)
+                .fetch_one(&db)
+                .await
+                .unwrap();
+        let imported = find_imported_for_episode(&db, series_id, 1)
+            .await
+            .expect("imported");
+        let row = imported.iter().find(|g| g.id == grab_id).expect("present");
+        assert_eq!(row.download_client_id, Some(123));
     }
 }

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2171,6 +2171,24 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
     .await
     .ok();
 
+    // Source-side paths recorded at import time. JSON array of the
+    // file paths Ryokan hardlinked / copied / moved FROM during
+    // post-processing, in the local-translated form (Ryokan's view
+    // of the path, not the client's). Used by the per-episode delete
+    // and series-remove paths to clean up the original files when
+    // SAB's `del_files=1` doesn't reach them — SAB's reported
+    // history `storage` can be the parent complete dir while the
+    // actual extracted .mkv lives in a subfolder created by the rar
+    // archive contents. The inode-based fallback in
+    // `delete_episode_file` covers hardlink mode; this column
+    // covers copy mode (different inodes) and move mode (source no
+    // longer at SAB's path) uniformly. NULL on legacy rows and on
+    // grabs whose import didn't succeed.
+    sqlx::query("ALTER TABLE grabbed_torrents ADD COLUMN imported_source_paths TEXT")
+        .execute(db)
+        .await
+        .ok();
+
     // Issue #28 PR A — per-series PT-upgrade opt-in (decision: PR E
     // wires the UI + sweep filter; column lands here so PR B's
     // search code can already filter on it without a chained

--- a/src/services/auto_search/aliases.rs
+++ b/src/services/auto_search/aliases.rs
@@ -128,15 +128,25 @@ pub fn collect_aliases(detail: &AnimeDetail) -> Vec<String> {
 // list includes Parts 1 and 3, and the episode-number parser still has to
 // see `02` on the filename for Part 2 to win.
 
+// `\b.*$` (word-boundary + arbitrary trailing) instead of `\s*$`
+// (strict end-of-string) so romaji titles that pack the cour's arc
+// name AFTER the season marker still produce sequel variants. AL ships
+// `Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e 4th Season
+// 2-nensei-hen Ichi Gakki` for COTE S4 — release groups drop the
+// arc descriptor and just publish `[SubsPlease] Youkoso ... S4 - 06`.
+// The pre-fix anchor required the marker to be the LAST tokens of
+// the alias, so COTE-shape titles produced no S4/-04 variants and
+// the search short-circuited with no matches. `\b` is load-bearing
+// against `Seasonal` accidentally matching as `Season`+`al`.
 static RE_ORDINAL_SEASON: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+(\d+)(?:st|nd|rd|th)\s+Season\s*$").unwrap());
+    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+(\d+)(?:st|nd|rd|th)\s+Season\b.*$").unwrap());
 static RE_WORD_SEASON: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)^(.+?)\s+(First|Second|Third|Fourth|Fifth|Sixth)\s+Season\s*$").unwrap()
+    Regex::new(r"(?i)^(.+?)\s+(First|Second|Third|Fourth|Fifth|Sixth)\s+Season\b.*$").unwrap()
 });
 static RE_SEASON_N: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+Season\s+(\d+)\s*$").unwrap());
+    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+Season\s+(\d+)\b.*$").unwrap());
 static RE_S_N: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+S(\d{1,2})\s*$").unwrap());
+    LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+S(\d{1,2})\b.*$").unwrap());
 static RE_PART_N: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"(?i)^(.+?)\s+Part\s+(\d+)(?::\s+.+)?\s*$").unwrap());
 static RE_PART_ROMAN: LazyLock<Regex> = LazyLock::new(|| {
@@ -1145,6 +1155,72 @@ mod tests {
             variants
                 .iter()
                 .any(|v| v == "Sono Bisque Doll wa Koi wo Suru II")
+        );
+    }
+
+    /// Romaji-title regression: AniList ships some titles with the
+    /// cour's arc name appended AFTER the `Nth Season` marker. COTE S4
+    /// is the canonical case: the AL romaji is `Youkoso Jitsuryoku
+    /// Shijou Shugi no Kyoushitsu e 4th Season 2-nensei-hen Ichi
+    /// Gakki`, but every release group ships the same cour as
+    /// `[SubsPlease] Youkoso ... S4 - 06`. Pre-fix the
+    /// `RE_ORDINAL_SEASON` end-of-string anchor required the marker to
+    /// be the last tokens of the alias, so the variant generator
+    /// produced no `S4` / `S04` / `- 04` aliases for these titles —
+    /// auto-search and interactive search both short-circuited with
+    /// zero matches even though the franchise had releases on every
+    /// configured indexer.
+    #[test]
+    fn sequel_variants_strip_trailing_arc_descriptor_after_season_marker() {
+        let input = vec![
+            "Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e 4th Season 2-nensei-hen Ichi Gakki"
+                .to_string(),
+        ];
+        let variants = sequel_variant_aliases(&input);
+        let base = "Youkoso Jitsuryoku Shijou Shugi no Kyoushitsu e";
+        assert!(
+            variants.iter().any(|v| v == &format!("{} S4", base)),
+            "expected base+S4 variant for COTE-shape title; got {:?}",
+            variants
+        );
+        assert!(
+            variants.iter().any(|v| v == &format!("{} S04", base)),
+            "expected base+S04 variant; got {:?}",
+            variants
+        );
+        assert!(
+            variants.iter().any(|v| v == &format!("{} - 04", base)),
+            "expected base+`- 04` variant; got {:?}",
+            variants
+        );
+    }
+
+    /// Word-form season marker with trailing arc — covers the
+    /// `Some Title Second Season Foo Arc` shape (AniList sometimes
+    /// uses ordinal words instead of digits for the season marker).
+    #[test]
+    fn sequel_variants_handle_word_season_with_trailing_descriptor() {
+        let input = vec!["Some Title Second Season Sub Arc".to_string()];
+        let variants = sequel_variant_aliases(&input);
+        assert!(
+            variants.iter().any(|v| v == "Some Title S2"),
+            "word-form season + trailing arc must still produce S2 variant; got {:?}",
+            variants
+        );
+    }
+
+    /// Sanity check: pure-marker aliases (no trailing arc) still work
+    /// after the regex relaxation. Without this, the relaxation could
+    /// silently change behavior for the simple case the original
+    /// regex was designed for.
+    #[test]
+    fn sequel_variants_still_handle_bare_season_markers() {
+        let input = vec!["Sono Bisque Doll wa Koi wo Suru 2nd Season".to_string()];
+        let variants = sequel_variant_aliases(&input);
+        assert!(
+            variants
+                .iter()
+                .any(|v| v == "Sono Bisque Doll wa Koi wo Suru S2")
         );
     }
 

--- a/src/services/auto_search/mod.rs
+++ b/src/services/auto_search/mod.rs
@@ -85,7 +85,15 @@ pub async fn find_all_for_target(
     target: &SearchTarget,
     _allow_batch: bool,
     cfs: &[CompiledCustomFormat],
+    indexers: &crate::IndexerCache,
 ) -> Vec<SearchResult> {
+    // Snapshot the indexer cache once. Same shape as the auto-search
+    // entry points: we clone the inner Arc<Vec<...>> under the read
+    // lock and release it before any HTTP work begins so a slow indexer
+    // can't pin the lock against a concurrent Settings → Indexers save.
+    let indexers_snapshot = indexers.read().await.clone();
+    let indexer_slice: &[std::sync::Arc<dyn crate::services::indexers::Indexer>] =
+        indexers_snapshot.as_slice();
     let (aliases, canonical_aliases, variant_aliases) = collect_aliases_with_variants(detail);
     let series_ctx = resolve_search_overrides(db, detail, config).await;
     let queries = append_custom_tokens(
@@ -158,6 +166,7 @@ pub async fn find_all_for_target(
         restrict_user: &series_ctx.restrict_user,
         absolute_offset: series_ctx.absolute_offset,
         categories: &categories,
+        indexers: indexer_slice,
     };
 
     // Interactive search: allow batch results so user can see & pick them,
@@ -913,6 +922,14 @@ struct InteractiveQueryCtx<'a> {
     preferred_resolution: &'a str,
     target: &'a SearchTarget,
     expected_season: i32,
+    /// Configured torznab/newznab indexers to fan out to, snapshot-
+    /// cloned out of `IndexerCache` once at the entry point. Empty
+    /// slice = Nyaa-only behavior (matches the auto-search
+    /// `AutoQueryCtx::indexers` contract). Without this the
+    /// interactive picker per-episode flow only surfaces Nyaa-direct
+    /// results — torznab matches that auto-search and the batch
+    /// picker would surface stayed invisible.
+    indexers: &'a [std::sync::Arc<dyn crate::services::indexers::Indexer>],
     /// Nyaa category filter set — one of `1_2` (English-translated),
     /// `1_0` (Anime All, includes raws/foreign subs), or the MUSIC
     /// pair. Computed from `config.allow_non_english` at the entry
@@ -1167,75 +1184,183 @@ async fn run_queries_interactive(
         .collect()
         .await;
 
+    // Fan out to configured torznab/newznab indexers in parallel with
+    // the Nyaa stream. Empty `ctx.indexers` skips the pass entirely;
+    // users without indexer rows configured see Nyaa-only results,
+    // identical to v1.4 behavior. Helper is named so it can be
+    // tested in isolation against a wiremock'd torznab/newznab.
+    let indexer_responses: Vec<SearchResult> =
+        fan_out_indexers_for_interactive(queries, ctx.indexers).await;
+
     for resp in responses {
         let results = match resp {
             Ok(v) => v.results,
             Err(_) => continue,
         };
         for result in results {
-            let dedupe_key = if !result.info_hash.is_empty() {
-                result.info_hash.clone()
-            } else {
-                result.title.to_lowercase()
-            };
-            if !seen.insert(dedupe_key) {
-                continue;
-            }
-            // SeaDex trusts its AniList-ID-based curation over any
-            // title heuristic. If this hash is in the set, skip all
-            // alias / season / episode checks below — the unconditional
-            // `season_mismatch` in particular drops releases like
-            // smol's `Monogatari (Season 9)` for a Kizumonogatari Part
-            // 2 target, even though SeaDex has already confirmed the
-            // AniList ID match.
-            if is_seadex_match(&result.info_hash, ctx.seadex_hashes) {
-                tracing::debug!(
-                    "seadex: bypassing heuristic filters for SeaDex-best release title={:?} hash={}",
-                    result.title,
-                    result.info_hash
-                );
-                candidates.push(result);
-                continue;
-            }
-            // Relaxed alias matching: lower threshold than auto search
-            let normalized_title = normalize_title(&result.title);
-            let title_tokens = token_set(&normalized_title);
-            let alias_match = ctx.aliases.iter().any(|alias| {
-                let normalized_alias = normalize_title(alias);
-                normalized_title.contains(&normalized_alias)
-                    || token_overlap_ratio(&title_tokens, &token_set(&normalized_alias)) >= 0.5
-            });
-            if !alias_match {
-                continue;
-            }
-            // Sibling rejection: same sequel/prequel guard as the auto
-            // path — a release that matches a sibling more tightly than
-            // us is almost certainly for the sibling.
-            if sibling_match_rejects(&normalized_title, &title_tokens, ctx.sibling_precompute) {
-                continue;
-            }
-            // Season check: reject results clearly from a different season
-            if season_mismatch(&result.title, ctx.expected_season) {
-                continue;
-            }
-            // Episode check for single-episode targets (allow batches through).
-            // #30 — A release passes if its parsed number matches either the
-            // relative target (AL's per-cour numbering) OR the absolute
-            // number `target + absolute_offset` (what SubsPlease-style TV
-            // releases use for sequel cours, e.g. JJK S3 E9 shipped as
-            // "Jujutsu Kaisen - 56" with offset 47). When offset is 0 this
-            // collapses to the legacy strict-relative behavior.
-            if let SearchTarget::Episode(target_ep) = ctx.target
-                && !result.is_batch
-            {
-                let parsed = parse_release_numbers(&result.title);
-                if !parsed.is_empty() && !episode_match(&parsed, *target_ep, ctx.absolute_offset) {
-                    continue;
-                }
-            }
-            candidates.push(result);
+            apply_interactive_filter_and_push(result, &ctx, seen, candidates);
         }
     }
+
+    // Run torznab/newznab indexer results through the same relaxed-
+    // alias / season / episode gate as Nyaa results. Dedup-key collision
+    // (same infohash returned by both Nyaa and a torznab Prowlarr
+    // mirror) takes the first-seen — Nyaa wins because it ran first
+    // above, which is fine: per-component scoring is identical.
+    for result in indexer_responses {
+        apply_interactive_filter_and_push(result, &ctx, seen, candidates);
+    }
+}
+
+/// Fan out interactive-search queries to configured torznab/newznab
+/// indexers, dedup the resulting Releases (cross-indexer + cross-
+/// query), and convert each survivor to the `SearchResult` shape so
+/// the caller can run the same relaxed-alias / season / episode gate
+/// it runs over Nyaa results. Empty `indexers` returns an empty Vec
+/// without firing any HTTP — preserves the v1.4 Nyaa-only baseline
+/// for users who haven't configured any torznab/newznab rows.
+///
+/// Pulled out of `run_queries_interactive` so the indexer-side of
+/// the bug fix can be tested directly against a wiremock without
+/// also having to mock Nyaa. The auto-search path's `run_queries`
+/// has the same shape inline; deduping the two would require
+/// threading a `seen` HashSet through, and the savings aren't worth
+/// the indirection.
+async fn fan_out_indexers_for_interactive(
+    queries: &[String],
+    indexers: &[std::sync::Arc<dyn crate::services::indexers::Indexer>],
+) -> Vec<SearchResult> {
+    if indexers.is_empty() {
+        return Vec::new();
+    }
+    let outcome_streams: Vec<_> = stream::iter(queries.iter().cloned())
+        .map(|query| async move {
+            let search_query = crate::services::indexers::SearchQuery {
+                q: query.clone(),
+                categories: Vec::new(),
+                limit: None,
+                offset: None,
+            };
+            crate::services::indexers::fan_out_search(indexers, &search_query).await
+        })
+        .buffer_unordered(nyaa::NYAA_BUFFER)
+        .collect()
+        .await;
+    let mut releases: Vec<crate::services::indexers::Release> = Vec::new();
+    for outcomes in outcome_streams {
+        for outcome in outcomes {
+            match outcome.result {
+                Ok(rs) => releases.extend(rs),
+                Err(e) => {
+                    tracing::debug!(
+                        "interactive indexer fan-out failed for indexer #{} ({}): {}",
+                        outcome.indexer_id,
+                        outcome.indexer_name,
+                        e
+                    );
+                }
+            }
+        }
+    }
+    crate::services::indexers::dedup_for_auto_search(releases)
+        .into_iter()
+        .map(|r| r.into_search_result())
+        .collect()
+}
+
+/// Per-result interactive filter. Pulled out of `run_queries_interactive`
+/// so both the Nyaa loop and the indexer-fan-out loop apply the
+/// same relaxed-alias / sibling-rejection / season / episode gate
+/// without code duplication.
+fn apply_interactive_filter_and_push(
+    result: SearchResult,
+    ctx: &InteractiveQueryCtx<'_>,
+    seen: &mut HashSet<String>,
+    candidates: &mut Vec<SearchResult>,
+) {
+    // Dedup is namespaced by source: Nyaa-direct results dedup
+    // against each other (Nyaa returns the same release across
+    // multiple alias-query passes), and indexer results dedup
+    // per-indexer (`<id>:<hash>`). A release that surfaces from
+    // BOTH Nyaa and an indexer (e.g. a Prowlarr Nyaa-mirror, or a
+    // tracker that re-uploads public releases) shows up as TWO
+    // rows — once attributed to Nyaa, once to the indexer — so the
+    // user can pick a preferred tracker.
+    //
+    // This implements the "interactive search policy (decision
+    // #3)" called out in `services::indexers::dedup_for_auto_search`'s
+    // doc comment: per-(indexer, infohash) rows so the user has
+    // actual attribution to pick from. The pre-fix dedup keyed
+    // only on `info_hash`, which silently collapsed indexer rows
+    // into their Nyaa twin and made the new Indexer column always
+    // read "Nyaa" for any release Nyaa also carried — exactly the
+    // symptom that surfaced post-rollout when nekoBT searches
+    // returned successful responses but the modal showed no
+    // nekoBT-attributed rows.
+    let source_tag = match result.indexer_id {
+        Some(id) => id.to_string(),
+        None => "nyaa".to_string(),
+    };
+    let dedupe_key = if !result.info_hash.is_empty() {
+        format!("{source_tag}:{}", result.info_hash)
+    } else {
+        format!("{source_tag}:{}", result.title.to_lowercase())
+    };
+    if !seen.insert(dedupe_key) {
+        return;
+    }
+    // SeaDex trusts its AniList-ID-based curation over any title
+    // heuristic. If this hash is in the set, skip all alias / season /
+    // episode checks below — the unconditional `season_mismatch` in
+    // particular drops releases like smol's `Monogatari (Season 9)`
+    // for a Kizumonogatari Part 2 target, even though SeaDex has
+    // already confirmed the AniList ID match.
+    if is_seadex_match(&result.info_hash, ctx.seadex_hashes) {
+        tracing::debug!(
+            "seadex: bypassing heuristic filters for SeaDex-best release title={:?} hash={}",
+            result.title,
+            result.info_hash
+        );
+        candidates.push(result);
+        return;
+    }
+    // Relaxed alias matching: lower threshold than auto search
+    let normalized_title = normalize_title(&result.title);
+    let title_tokens = token_set(&normalized_title);
+    let alias_match = ctx.aliases.iter().any(|alias| {
+        let normalized_alias = normalize_title(alias);
+        normalized_title.contains(&normalized_alias)
+            || token_overlap_ratio(&title_tokens, &token_set(&normalized_alias)) >= 0.5
+    });
+    if !alias_match {
+        return;
+    }
+    // Sibling rejection: same sequel/prequel guard as the auto path —
+    // a release that matches a sibling more tightly than us is almost
+    // certainly for the sibling.
+    if sibling_match_rejects(&normalized_title, &title_tokens, ctx.sibling_precompute) {
+        return;
+    }
+    // Season check: reject results clearly from a different season
+    if season_mismatch(&result.title, ctx.expected_season) {
+        return;
+    }
+    // Episode check for single-episode targets (allow batches through).
+    // #30 — A release passes if its parsed number matches either the
+    // relative target (AL's per-cour numbering) OR the absolute number
+    // `target + absolute_offset` (what SubsPlease-style TV releases use
+    // for sequel cours, e.g. JJK S3 E9 shipped as "Jujutsu Kaisen -
+    // 56" with offset 47). When offset is 0 this collapses to the
+    // legacy strict-relative behavior.
+    if let SearchTarget::Episode(target_ep) = ctx.target
+        && !result.is_batch
+    {
+        let parsed = parse_release_numbers(&result.title);
+        if !parsed.is_empty() && !episode_match(&parsed, *target_ep, ctx.absolute_offset) {
+            return;
+        }
+    }
+    candidates.push(result);
 }
 
 /// #30 — Episode-filter acceptance check. A release's parsed episode
@@ -1565,6 +1690,347 @@ fn preferred_resolution_search_value(config: &Config) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── fan_out_indexers_for_interactive ─────────────────────────────
+    //
+    // Regression coverage for the interactive-search bug where torznab/
+    // newznab indexers were wired up correctly for auto-search and RSS
+    // but completely skipped on the per-episode interactive picker.
+    // `find_all_for_target` didn't accept an indexer cache and
+    // `run_queries_interactive` didn't fan out — every result came
+    // straight from Nyaa and the user saw no nekoBT hits even when
+    // logs proved the indexer WAS being queried (by auto-search /
+    // RSS, on a separate code path). These tests pin the helper that
+    // closed the gap.
+
+    /// Empty indexer slice = no-op + no HTTP. Preserves the v1.4
+    /// Nyaa-only baseline for users who haven't configured any
+    /// torznab/newznab rows. Without this guard, every interactive
+    /// search would pay a futures-iter setup cost and the bug-fix
+    /// would have landed as a regression for the majority of users.
+    #[tokio::test]
+    async fn fan_out_skips_when_no_indexers_configured() {
+        let result = fan_out_indexers_for_interactive(
+            &["any query".to_string()],
+            &[], // no indexers configured
+        )
+        .await;
+        assert!(
+            result.is_empty(),
+            "empty indexer slice must short-circuit to an empty Vec without firing any HTTP"
+        );
+    }
+
+    /// Torznab indexer end-to-end: configure a wiremock'd torznab
+    /// indexer, call the helper, assert that the resulting
+    /// SearchResult carries the indexer's name (so the UI's
+    /// "Indexer" column attributes it correctly).
+    #[tokio::test]
+    async fn fan_out_torznab_indexer_results_carry_indexer_name() {
+        use crate::services::indexers::torznab::TorznabIndexer;
+        use std::sync::Arc;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<?xml version="1.0"?>
+<rss version="2.0" xmlns:torznab="http://torznab.com/schemas/2015/feed">
+<channel>
+<item>
+  <title>[nekoBT] Test Show - 01</title>
+  <guid>g1</guid>
+  <enclosure url="http://server/dl/abc" length="1000000000" type="application/x-bittorrent"/>
+  <torznab:attr name="seeders" value="42"/>
+  <torznab:attr name="leechers" value="0"/>
+  <torznab:attr name="infohash" value="ABCDEF1234567890"/>
+</item>
+</channel>
+</rss>"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let row = crate::models::indexers::Indexer {
+            id: 7,
+            name: "nekoBT".to_string(),
+            kind: crate::models::indexers::KIND_TORZNAB.to_string(),
+            url: format!("{}/api", server.uri()),
+            api_key: "k".to_string(),
+            priority: 25,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 0,
+            request_timeout_secs: Some(5),
+            download_client_id: None,
+            rss_enabled: false,
+            rss_last_polled_at: None,
+            rss_last_poll_error: String::new(),
+            rss_last_item_count: 0,
+            caps_json: String::new(),
+            caps_refreshed_at: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let indexer = TorznabIndexer::from_row_arc(&row).expect("indexer must build");
+        let indexers: Vec<Arc<dyn crate::services::indexers::Indexer>> = vec![indexer];
+
+        let results = fan_out_indexers_for_interactive(&["Test Show".to_string()], &indexers).await;
+        assert_eq!(
+            results.len(),
+            1,
+            "expected one result from the wiremock'd torznab"
+        );
+        assert_eq!(results[0].title, "[nekoBT] Test Show - 01");
+        assert_eq!(
+            results[0].indexer_name, "nekoBT",
+            "indexer_name must propagate end-to-end (Release → SearchResult) so the \
+             UI 'Indexer' column attributes the row to nekoBT"
+        );
+        assert_eq!(results[0].indexer_id, Some(7));
+    }
+
+    /// Per-source dedup invariant: a release that surfaces from
+    /// BOTH Nyaa and an indexer with the same infohash must appear
+    /// as TWO rows in the candidate pool, one per source. This is
+    /// the explicit "interactive search policy (decision #3)" from
+    /// `services::indexers::dedup_for_auto_search`'s doc.
+    ///
+    /// Pre-fix the dedup keyed only on `info_hash`, which silently
+    /// merged the indexer row into its Nyaa twin. Result: the
+    /// "Indexer" column always read "Nyaa" for any release Nyaa
+    /// also carried. nekoBT-attributable rows became invisible to
+    /// the user even when nekoBT was returning identical results.
+    /// The user reported this verbatim post-fan-out rollout.
+    #[tokio::test]
+    async fn interactive_filter_dedup_is_per_source_not_per_hash() {
+        // Build a HashSet + candidates Vec by hand and exercise
+        // `apply_interactive_filter_and_push` directly with two
+        // SearchResults sharing an infohash but differing in
+        // `indexer_id` (None = Nyaa, Some(7) = nekoBT). Pre-fix
+        // both went through the same `seen.insert(hash)` and the
+        // second got skipped; post-fix the source-namespaced key
+        // lets both through.
+        use std::collections::HashSet;
+        let nyaa_result = SearchResult {
+            title: "[smol] Nisemonogatari".to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            torrent: String::new(),
+            size: String::new(),
+            size_bytes: 0,
+            seeders: 50,
+            leechers: 0,
+            downloads: 0,
+            group: "smol".to_string(),
+            resolution: "1080".to_string(),
+            quality_label: String::new(),
+            source: String::new(),
+            web_kind: String::new(),
+            is_remux: false,
+            is_bdmv: false,
+            is_batch: true,
+            is_trusted: true,
+            score: 100,
+            info_hash: "deadbeef".to_string(),
+            score_breakdown: Vec::new(),
+            upload_date: String::new(),
+            indexer_id: None,
+            indexer_name: String::new(),
+        };
+        let mut indexer_result = nyaa_result.clone();
+        indexer_result.indexer_id = Some(7);
+        indexer_result.indexer_name = "nekoBT".to_string();
+
+        // Build a permissive ctx so the alias / season / episode
+        // gate downstream of the dedup doesn't reject anything.
+        let aliases = vec!["Monogatari".to_string(), "Nisemonogatari".to_string()];
+        let sibling_precompute = SiblingRejectPrecompute::build(&aliases, &[]);
+        let preferred_groups: Vec<String> = Vec::new();
+        let target = SearchTarget::Single;
+        let seadex_hashes = std::collections::HashSet::new();
+        let categories = vec!["1_2".to_string()];
+        let ctx = InteractiveQueryCtx {
+            aliases: &aliases,
+            sibling_precompute: &sibling_precompute,
+            preferred_groups: &preferred_groups,
+            preferred_resolution: "1080p",
+            target: &target,
+            expected_season: 0,
+            seadex_hashes: &seadex_hashes,
+            restrict_user: "",
+            absolute_offset: 0,
+            categories: &categories,
+            indexers: &[],
+        };
+
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut candidates: Vec<SearchResult> = Vec::new();
+
+        apply_interactive_filter_and_push(nyaa_result, &ctx, &mut seen, &mut candidates);
+        apply_interactive_filter_and_push(indexer_result, &ctx, &mut seen, &mut candidates);
+
+        assert_eq!(
+            candidates.len(),
+            2,
+            "Same infohash from Nyaa + nekoBT must produce two rows so the user \
+             can pick a preferred source. A regression here would hide every \
+             nekoBT-attributed row whose hash also lives on Nyaa."
+        );
+        assert!(
+            candidates.iter().any(|c| c.indexer_name.is_empty()),
+            "Nyaa-direct row (empty indexer_name) must be present"
+        );
+        assert!(
+            candidates.iter().any(|c| c.indexer_name == "nekoBT"),
+            "nekoBT-attributed row must be present"
+        );
+    }
+
+    /// Counterpart: the SAME source returning the SAME hash twice
+    /// (which happens because `run_queries_interactive` runs N
+    /// alias-prefixed queries against Nyaa and they overlap) MUST
+    /// still dedup. Without this branch surviving the per-source
+    /// rewrite, every Nyaa result would land 3-5x in the candidate
+    /// pool — the user would see massive duplication.
+    #[tokio::test]
+    async fn interactive_filter_still_dedups_within_a_single_source() {
+        use std::collections::HashSet;
+        let nyaa_result = SearchResult {
+            title: "[smol] Nisemonogatari".to_string(),
+            link: String::new(),
+            magnet: String::new(),
+            torrent: String::new(),
+            size: String::new(),
+            size_bytes: 0,
+            seeders: 50,
+            leechers: 0,
+            downloads: 0,
+            group: "smol".to_string(),
+            resolution: "1080".to_string(),
+            quality_label: String::new(),
+            source: String::new(),
+            web_kind: String::new(),
+            is_remux: false,
+            is_bdmv: false,
+            is_batch: true,
+            is_trusted: true,
+            score: 100,
+            info_hash: "deadbeef".to_string(),
+            score_breakdown: Vec::new(),
+            upload_date: String::new(),
+            indexer_id: None,
+            indexer_name: String::new(),
+        };
+
+        let aliases = vec!["Monogatari".to_string()];
+        let sibling_precompute = SiblingRejectPrecompute::build(&aliases, &[]);
+        let preferred_groups: Vec<String> = Vec::new();
+        let target = SearchTarget::Single;
+        let seadex_hashes = std::collections::HashSet::new();
+        let categories = vec!["1_2".to_string()];
+        let ctx = InteractiveQueryCtx {
+            aliases: &aliases,
+            sibling_precompute: &sibling_precompute,
+            preferred_groups: &preferred_groups,
+            preferred_resolution: "1080p",
+            target: &target,
+            expected_season: 0,
+            seadex_hashes: &seadex_hashes,
+            restrict_user: "",
+            absolute_offset: 0,
+            categories: &categories,
+            indexers: &[],
+        };
+
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut candidates: Vec<SearchResult> = Vec::new();
+
+        apply_interactive_filter_and_push(nyaa_result.clone(), &ctx, &mut seen, &mut candidates);
+        apply_interactive_filter_and_push(nyaa_result, &ctx, &mut seen, &mut candidates);
+
+        assert_eq!(
+            candidates.len(),
+            1,
+            "Two Nyaa hits with identical infohash must collapse to one row \
+             (otherwise alias-query overlap floods the candidate pool)"
+        );
+    }
+
+    /// Newznab variant — identical wire format, identical client,
+    /// just `kind = "newznab"`. Locks in that the indexer-name
+    /// plumbing isn't accidentally torznab-specific. Without this,
+    /// a future refactor that special-cased torznab would break
+    /// usenet attribution silently.
+    #[tokio::test]
+    async fn fan_out_newznab_indexer_results_carry_indexer_name() {
+        use crate::services::indexers::torznab::TorznabIndexer;
+        use std::sync::Arc;
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"<?xml version="1.0"?>
+<rss version="2.0">
+<channel>
+<item>
+  <title>Test.Show.S01E01.WEB-DL</title>
+  <guid>nzb-g1</guid>
+  <enclosure url="http://server/nzb/abc" length="500000000" type="application/x-nzb"/>
+  <torznab:attr name="size" value="500000000"/>
+</item>
+</channel>
+</rss>"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let row = crate::models::indexers::Indexer {
+            id: 9,
+            name: "NZBGeek".to_string(),
+            kind: crate::models::indexers::KIND_NEWZNAB.to_string(),
+            url: format!("{}/api", server.uri()),
+            api_key: "k".to_string(),
+            priority: 30,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 0,
+            request_timeout_secs: Some(5),
+            download_client_id: None,
+            rss_enabled: false,
+            rss_last_polled_at: None,
+            rss_last_poll_error: String::new(),
+            rss_last_item_count: 0,
+            caps_json: String::new(),
+            caps_refreshed_at: None,
+            created_at: 0,
+            updated_at: 0,
+        };
+        let indexer = TorznabIndexer::from_row_arc(&row).expect("indexer must build");
+        let indexers: Vec<Arc<dyn crate::services::indexers::Indexer>> = vec![indexer];
+
+        let results = fan_out_indexers_for_interactive(&["Test Show".to_string()], &indexers).await;
+        assert_eq!(
+            results.len(),
+            1,
+            "expected one result from the wiremock'd newznab"
+        );
+        assert_eq!(
+            results[0].indexer_name, "NZBGeek",
+            "newznab indexers must surface their name through the same plumbing as \
+             torznab — the UI Indexer column needs to attribute usenet hits too"
+        );
+        assert_eq!(results[0].indexer_id, Some(9));
+    }
 
     // ── detect_sibling_entries_in_pack ──────────────────────────────
 

--- a/src/services/custom_formats/evaluator.rs
+++ b/src/services/custom_formats/evaluator.rs
@@ -183,6 +183,7 @@ pub fn total_cf_score_for_release(
         score_breakdown: Vec::new(),
         upload_date: String::new(),
         indexer_id: None,
+        indexer_name: String::new(),
     };
     let ctx = EvalContext {
         result: &result,

--- a/src/services/custom_formats/mod.rs
+++ b/src/services/custom_formats/mod.rs
@@ -229,6 +229,7 @@ pub(super) mod test_helpers {
             score_breakdown: Vec::new(),
             upload_date: String::new(),
             indexer_id: None,
+            indexer_name: String::new(),
         }
     }
 

--- a/src/services/download_client/mod.rs
+++ b/src/services/download_client/mod.rs
@@ -564,7 +564,15 @@ pub async fn rebuild_clients_cache(cache: &crate::DownloadClientsCache, db: &sql
         }
     };
     let mut clients: HashMap<i64, Arc<dyn DownloadClient>> = HashMap::new();
-    let mut default_id: Option<i64> = None;
+    // Per-protocol defaults — at most one of each. Captured during
+    // the row iteration below, then patched up post-loop with a
+    // lowest-id fallback per protocol so a manual DB edit that left
+    // a protocol without an explicit default still routes somewhere
+    // (matching the prior single-default behavior, just per-bucket).
+    let mut default_torrent_id: Option<i64> = None;
+    let mut default_usenet_id: Option<i64> = None;
+    let mut all_torrent_ids: Vec<i64> = Vec::new();
+    let mut all_usenet_ids: Vec<i64> = Vec::new();
     for row in rows {
         let client: Option<Arc<dyn DownloadClient>> = match row.kind.as_str() {
             "deluge" if !row.url.is_empty() => Some(Arc::new(deluge::DelugeClient::new(
@@ -616,31 +624,56 @@ pub async fn rebuild_clients_cache(cache: &crate::DownloadClientsCache, db: &sql
             }
         };
         if let Some(c) = client {
-            if row.is_default {
-                default_id = Some(row.id);
+            // Bucket by protocol so the per-protocol fallback below
+            // can pick a lowest-id replacement when no row of that
+            // protocol carries `is_default = 1`.
+            match protocol_for_client_kind(&row.kind) {
+                Some("torrent") => {
+                    all_torrent_ids.push(row.id);
+                    if row.is_default && default_torrent_id.is_none() {
+                        default_torrent_id = Some(row.id);
+                    }
+                }
+                Some("usenet") => {
+                    all_usenet_ids.push(row.id);
+                    if row.is_default && default_usenet_id.is_none() {
+                        default_usenet_id = Some(row.id);
+                    }
+                }
+                _ => {}
             }
             clients.insert(row.id, c);
         }
     }
-    // Fall-through: if the user marked a kind+URL combo as default
-    // but it failed to instantiate (or didn't mark anything as default
-    // after a manual DB edit), pick the lowest surviving row id so the
-    // grab path isn't surprised by a present-but-empty pool. Surface
-    // this in logs — when a user reports "I marked X as default but
-    // grabs are landing on Y" the warn line names the picked id and
-    // makes the diagnosis obvious.
-    if default_id.is_none() && !clients.is_empty() {
-        default_id = clients.keys().min().copied();
-        if let Some(picked) = default_id {
-            tracing::warn!(
-                "download_clients: no row marked is_default=1; \
-                 picking client id {picked} as fallback default"
-            );
-        }
+    // Per-protocol fall-through: if rows of a protocol exist but none
+    // carries `is_default = 1` (e.g. the user marked a kind+URL combo
+    // as default but it failed to instantiate, or a manual DB edit
+    // cleared every flag), pick the lowest surviving row id of that
+    // protocol so the grab path isn't surprised by a present-but-
+    // empty pool. Surface this in logs so a "I marked X as default
+    // but grabs are landing on Y" report has an obvious culprit.
+    if default_torrent_id.is_none()
+        && let Some(min) = all_torrent_ids.iter().min().copied()
+    {
+        default_torrent_id = Some(min);
+        tracing::warn!(
+            "download_clients: no torrent row marked is_default=1; \
+             picking client id {min} as fallback torrent default"
+        );
+    }
+    if default_usenet_id.is_none()
+        && let Some(min) = all_usenet_ids.iter().min().copied()
+    {
+        default_usenet_id = Some(min);
+        tracing::warn!(
+            "download_clients: no usenet row marked is_default=1; \
+             picking client id {min} as fallback usenet default"
+        );
     }
     let pool = Arc::new(DownloadClientPool {
         clients,
-        default_id,
+        default_torrent_id,
+        default_usenet_id,
     });
     *cache.write().await = pool;
 }

--- a/src/services/download_client/sabnzbd/mod.rs
+++ b/src/services/download_client/sabnzbd/mod.rs
@@ -255,6 +255,17 @@ impl SabClient {
 #[async_trait]
 impl DownloadClient for SabClient {
     async fn test(&self) -> Result<String, String> {
+        // Two-step probe: `mode=version` is a PUBLIC SAB endpoint and
+        // returns 200 even with a missing/wrong API key, so it can't
+        // surface auth issues. `mode=queue` requires the API key, so
+        // following the version probe with a queue probe catches a
+        // bad/missing key at Test-connection time instead of at
+        // first-grab time. Without this, users would see a green
+        // "Connected: 4.5.5" pill, then their first NZB grab would
+        // fail with `SAB add returned HTTP 403 Forbidden` — the
+        // exact symptom the SAB-on-NZBGeek-paired-with-Prowlarr
+        // setup hits when the password / api_key field on the
+        // download_clients row is empty or wrong.
         let resp = self
             .http
             .get(self.endpoint())
@@ -269,15 +280,47 @@ impl DownloadClient for SabClient {
             .json()
             .await
             .map_err(|e| format!("SAB version parse failed: {e}"))?;
+        let version = body.version;
+
+        // Auth probe — fail with a clear message when the API key is
+        // missing/invalid. Only the status code matters; queue body
+        // shape isn't parsed.
+        let auth_resp = self
+            .http
+            .get(self.endpoint())
+            .query(&self.make_query(&[("mode", "queue"), ("start", "0"), ("limit", "1")]))
+            .send()
+            .await
+            .map_err(|e| format!("SAB queue probe failed: {e}"))?;
+        if auth_resp.status().as_u16() == 401 || auth_resp.status().as_u16() == 403 {
+            // SAB returns plain text on 403 ("API Key Required" /
+            // "API Key Incorrect"); surface it so the user knows
+            // exactly which field to fix on the download-clients row.
+            let detail = auth_resp.text().await.unwrap_or_default();
+            let trimmed = detail.trim();
+            return Err(if trimmed.is_empty() {
+                "SAB API key missing or invalid. Set the API Key field on the SABnzbd download-client row.".to_string()
+            } else {
+                format!(
+                    "SAB API key missing or invalid: {}. Set the API Key field on the SABnzbd download-client row.",
+                    trimmed
+                )
+            });
+        }
+        if !auth_resp.status().is_success() {
+            return Err(format!(
+                "SAB queue probe returned HTTP {}",
+                auth_resp.status()
+            ));
+        }
+
         // Return just the version string, without the "SABnzbd "
         // prefix. The status pill on the Settings → Download Clients
         // tab prepends the client kind label itself, so the prefix
         // would render as "SABnzbd SABnzbd 4.5.5"; the toast on the
         // Test-connection button concatenates "Connected: <version>"
         // and reads more naturally without the kind doubling either.
-        // qBit / Deluge / Transmission / rtorrent all return raw
-        // version strings already; this brings SAB in line.
-        Ok(body.version)
+        Ok(version)
     }
 
     async fn add_torrent(&self, url: &str, _info_hash: &str) -> Result<AddOutcome, String> {
@@ -308,17 +351,60 @@ impl DownloadClient for SabClient {
             .await
             .map_err(|e| format!("SAB request failed: {e}"))?;
         if !resp.status().is_success() {
-            return Err(format!("SAB add returned HTTP {}", resp.status()));
+            // 401/403 specifically — capture SAB's plain-text body so
+            // the user sees `API Key Required` / `API Key Incorrect`
+            // instead of the bare HTTP status. Other status codes
+            // surface the status alone since SAB's body for those
+            // (5xx, 502 Bad Gateway from a fronting proxy, etc.)
+            // isn't usefully diagnostic. The Test-connection probe
+            // now catches API-key issues at config time, but this
+            // path stays robust for users who upgraded a working
+            // setup and somehow lost their key.
+            let status = resp.status();
+            let detail = if matches!(status.as_u16(), 401 | 403) {
+                resp.text().await.unwrap_or_default()
+            } else {
+                String::new()
+            };
+            let trimmed = detail.trim();
+            if trimmed.is_empty() {
+                return Err(format!("SAB add returned HTTP {status}"));
+            }
+            return Err(format!("SAB add returned HTTP {status}: {trimmed}"));
         }
-        let body: AddUrlResponse = resp
-            .json()
+        // SAB sometimes returns 200 with an HTML page (not JSON) when
+        // the API key is missing — varies by version + URL_BASE
+        // config, and the user-pasted-NZB-Key-instead-of-API-Key
+        // case is the most common footgun. Read the body as bytes
+        // once so we can fall back to a substring check on the
+        // well-known "API Key" warning if JSON parsing fails.
+        // Without this the user got an opaque parse error instead of
+        // an actionable hint.
+        let body_bytes = resp
+            .bytes()
             .await
-            .map_err(|e| format!("SAB addurl parse failed: {e}"))?;
+            .map_err(|e| format!("SAB addurl read body failed: {e}"))?;
+        let body: AddUrlResponse = match serde_json::from_slice(&body_bytes) {
+            Ok(b) => b,
+            Err(e) => {
+                let body_text = std::str::from_utf8(&body_bytes).unwrap_or_default();
+                if body_text.to_ascii_lowercase().contains("api key") {
+                    return Err(format!(
+                        "SAB rejected addurl: API key missing. Set the API Key field on the SABnzbd download-client row (Settings → Connections → Downloads → click the SAB row). Use SAB's full API Key (not the NZB Key — Ryokan needs queue access too). Find it in SABnzbd → Config → General → Security → API Key. SAB body: {}",
+                        body_text.trim()
+                    ));
+                }
+                return Err(format!("SAB addurl parse failed: {e}"));
+            }
+        };
         if !body.status {
-            return Err(format!(
-                "SAB rejected addurl: {}",
-                body.error.unwrap_or_else(|| "no error provided".into())
-            ));
+            let raw_error = body.error.unwrap_or_else(|| "no error provided".into());
+            if raw_error.to_ascii_lowercase().contains("api key") {
+                return Err(format!(
+                    "SAB rejected addurl: API key missing or invalid. Use the full API Key (not the NZB Key) from SABnzbd → Config → General → Security. SAB error: {raw_error}"
+                ));
+            }
+            return Err(format!("SAB rejected addurl: {raw_error}"));
         }
         if let Some(id) = body.nzo_ids.into_iter().next() {
             return Ok((AddOutcome::Added, id));
@@ -362,9 +448,40 @@ impl DownloadClient for SabClient {
     async fn list_scoped(&self) -> Result<Vec<DownloadItem>, String> {
         let queue = self.fetch_queue().await?;
         let history = self.fetch_history().await?;
-        let mut out: Vec<DownloadItem> =
-            Vec::with_capacity(queue.slots.len() + history.slots.len());
-        for slot in queue.slots.into_iter().filter(|s| s.cat == self.category) {
+        let queue_total = queue.slots.len();
+        let history_total = history.slots.len();
+        let mut out: Vec<DownloadItem> = Vec::with_capacity(queue_total + history_total);
+
+        // Category-match policy:
+        //   - Empty `self.category` → no filter; pass everything
+        //     through. The user didn't pin a category in Ryokan's
+        //     SAB row, so the trade-off "see all SAB activity vs
+        //     never see anything" picks visibility.
+        //   - Non-empty `self.category` → match SAB's slot category
+        //     case-insensitively, AND also accept slots whose
+        //     reported category is empty (SAB sometimes drops the
+        //     category on jobs added with a cat= parameter that
+        //     doesn't correspond to a configured category in SAB's
+        //     UI; the addurl call still succeeds but the resulting
+        //     slot reports `cat=""`). Without this, jobs Ryokan
+        //     just queued via `add_torrent` would silently fail
+        //     the filter and the reconcile loop would mark them
+        //     removed at the 30s grace window. The trade-off is
+        //     accepting cross-tool noise (jobs added by another
+        //     SAB caller with no category) — acceptable for a
+        //     single-user homelab; revisit if Ryokan grows multi-
+        //     user.
+        let configured = self.category.trim();
+        let want_lower = configured.to_ascii_lowercase();
+        let category_matches = |slot_cat: &str| -> bool {
+            if configured.is_empty() {
+                return true;
+            }
+            let s = slot_cat.trim();
+            s.is_empty() || s.eq_ignore_ascii_case(&want_lower)
+        };
+
+        for slot in queue.slots.into_iter().filter(|s| category_matches(&s.cat)) {
             out.push(DownloadItem {
                 hash: slot.nzo_id,
                 name: slot.filename,
@@ -387,7 +504,7 @@ impl DownloadClient for SabClient {
         for slot in history
             .slots
             .into_iter()
-            .filter(|s| s.category == self.category)
+            .filter(|s| category_matches(&s.category))
         {
             out.push(DownloadItem {
                 hash: slot.nzo_id,
@@ -403,6 +520,22 @@ impl DownloadClient for SabClient {
                 state_kind: Self::map_state(&slot.status, true),
             });
         }
+
+        // Diagnostic trace so a user reporting "Ryokan can't see my
+        // SAB jobs" has something to grep for in System → Logs. Two
+        // useful counts: how many slots SAB returned in total, and
+        // how many survived the category filter. A "slots=N matched=0"
+        // line points the user (or future-me) directly at the
+        // category-config mismatch — easier than digging through the
+        // SAB UI to spot it.
+        tracing::debug!(
+            "sab list_scoped: configured_category={:?} queue_slots={} history_slots={} matched={}",
+            configured,
+            queue_total,
+            history_total,
+            out.len()
+        );
+
         Ok(out)
     }
 
@@ -456,19 +589,31 @@ impl DownloadClient for SabClient {
     }
 
     async fn delete(&self, info_hash: &str, delete_files: bool) -> Result<(), String> {
-        // SAB delete is split between queue and history — try queue
-        // first (covers in-flight), then history (covers completed).
-        // `del_files=1` removes the unpacked output directory on
-        // history deletes; queue deletes always remove the partial.
-        let mut q: Vec<(&str, &str)> =
-            vec![("mode", "queue"), ("name", "delete"), ("value", info_hash)];
+        // SAB delete is split between queue and history. Critically,
+        // `mode=queue&name=delete` returns `status: true`
+        // unconditionally — `_handle_queue` calls `report(output)`
+        // after `remove_multiple` even if the nzo_id wasn't in the
+        // queue at all (live-checked against SAB 4.x source). So if
+        // we tried queue first, every completed-and-imported job
+        // (which lives in history, not queue) would "succeed" against
+        // the queue endpoint and never hit history with `del_files=1`,
+        // leaving the unpacked storage dir behind.
+        //
+        // Fix: try history first (covers post-import deletes — the
+        // common case), fall back to queue only if history reports
+        // not-found. Same shape Sonarr / Radarr's SAB clients use.
+        // `del_files=1` removes the unpacked output dir on history;
+        // queue delete removes the partial download.
         let one = "1";
         let zero = "0";
-        if delete_files {
-            q.push(("del_files", one));
-        } else {
-            q.push(("del_files", zero));
-        }
+        let del_value = if delete_files { one } else { zero };
+
+        let mut q: Vec<(&str, &str)> = vec![
+            ("mode", "history"),
+            ("name", "delete"),
+            ("value", info_hash),
+            ("del_files", del_value),
+        ];
         let resp = self
             .http
             .get(self.endpoint())
@@ -480,20 +625,14 @@ impl DownloadClient for SabClient {
         if body.status {
             return Ok(());
         }
-        // Fallback: history. Mirror the queue branch and always send
-        // `del_files` explicitly — SAB's documented default is 0, but
-        // omitting the param leaves us at the mercy of any reverse
-        // proxy / future SAB version that fills in a different default.
-        let mut q: Vec<(&str, &str)> = vec![
-            ("mode", "history"),
+
+        // History didn't find it — try queue (covers in-flight cancel).
+        q = vec![
+            ("mode", "queue"),
             ("name", "delete"),
             ("value", info_hash),
+            ("del_files", del_value),
         ];
-        if delete_files {
-            q.push(("del_files", one));
-        } else {
-            q.push(("del_files", zero));
-        }
         let resp = self
             .http
             .get(self.endpoint())
@@ -570,15 +709,39 @@ impl SabClient {
         if !resp.status().is_success() {
             return Err(format!("SAB add returned HTTP {}", resp.status()));
         }
-        let body: AddUrlResponse = resp
-            .json()
+        // SAB sometimes returns 200 with an HTML page (not JSON) when
+        // the API key is missing — varies by version + URL_BASE
+        // config, and the user-pasted-NZB-Key-instead-of-API-Key
+        // case is the most common footgun. Read the body as bytes
+        // once so we can fall back to a substring check on the
+        // well-known "API Key" warning if JSON parsing fails.
+        // Without this the user got an opaque parse error instead of
+        // an actionable hint.
+        let body_bytes = resp
+            .bytes()
             .await
-            .map_err(|e| format!("SAB addurl parse failed: {e}"))?;
+            .map_err(|e| format!("SAB addurl read body failed: {e}"))?;
+        let body: AddUrlResponse = match serde_json::from_slice(&body_bytes) {
+            Ok(b) => b,
+            Err(e) => {
+                let body_text = std::str::from_utf8(&body_bytes).unwrap_or_default();
+                if body_text.to_ascii_lowercase().contains("api key") {
+                    return Err(format!(
+                        "SAB rejected addurl: API key missing. Set the API Key field on the SABnzbd download-client row (Settings → Connections → Downloads → click the SAB row). Use SAB's full API Key (not the NZB Key — Ryokan needs queue access too). Find it in SABnzbd → Config → General → Security → API Key. SAB body: {}",
+                        body_text.trim()
+                    ));
+                }
+                return Err(format!("SAB addurl parse failed: {e}"));
+            }
+        };
         if !body.status {
-            return Err(format!(
-                "SAB rejected addurl: {}",
-                body.error.unwrap_or_else(|| "no error provided".into())
-            ));
+            let raw_error = body.error.unwrap_or_else(|| "no error provided".into());
+            if raw_error.to_ascii_lowercase().contains("api key") {
+                return Err(format!(
+                    "SAB rejected addurl: API key missing or invalid. Use the full API Key (not the NZB Key) from SABnzbd → Config → General → Security. SAB error: {raw_error}"
+                ));
+            }
+            return Err(format!("SAB rejected addurl: {raw_error}"));
         }
         if let Some(id) = body.nzo_ids.into_iter().next() {
             Ok((AddOutcome::Added, id))

--- a/src/services/download_client/sabnzbd/mod.rs
+++ b/src/services/download_client/sabnzbd/mod.rs
@@ -640,20 +640,17 @@ impl DownloadClient for SabClient {
         let zero = "0";
         let del_value = if delete_files { one } else { zero };
 
+        // Check history first; queue's `report(output)` fires on every
+        // call, including unknown nzo_ids, so a queue-first lookup
+        // would phantom-succeed on every post-import delete and never
+        // hit history with `del_files=1`. See module-level docs.
         let mut q: Vec<(&str, &str)> = vec![
             ("mode", "history"),
             ("name", "delete"),
             ("value", info_hash),
             ("del_files", del_value),
         ];
-        let resp = self
-            .http
-            .get(self.endpoint())
-            .query(&self.make_query(&q))
-            .send()
-            .await
-            .map_err(|e| format!("SAB request failed: {e}"))?;
-        let body: StatusResponse = resp.json().await.unwrap_or_default();
+        let body = self.send_delete_probe(&q).await?;
         if body.status {
             return Ok(());
         }
@@ -665,14 +662,7 @@ impl DownloadClient for SabClient {
             ("value", info_hash),
             ("del_files", del_value),
         ];
-        let resp = self
-            .http
-            .get(self.endpoint())
-            .query(&self.make_query(&q))
-            .send()
-            .await
-            .map_err(|e| format!("SAB request failed: {e}"))?;
-        let body: StatusResponse = resp.json().await.unwrap_or_default();
+        let body = self.send_delete_probe(&q).await?;
         if body.status {
             Ok(())
         } else {
@@ -845,6 +835,37 @@ impl SabClient {
             }
         }
         None
+    }
+
+    /// One leg of the two-leg delete (history first, then queue
+    /// fallback). Mirrors the auth-aware error path that `add_torrent`
+    /// uses: a 401/403 response captures SAB's plain-text body so the
+    /// user sees `API Key Incorrect` instead of the unhelpful
+    /// `SAB delete failed: no error provided` that comes out when
+    /// `resp.json().unwrap_or_default()` parses a non-JSON error page
+    /// into an empty `StatusResponse`.
+    async fn send_delete_probe(&self, params: &[(&str, &str)]) -> Result<StatusResponse, String> {
+        let resp = self
+            .http
+            .get(self.endpoint())
+            .query(&self.make_query(params))
+            .send()
+            .await
+            .map_err(|e| format!("SAB request failed: {e}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let detail = if matches!(status.as_u16(), 401 | 403) {
+                resp.text().await.unwrap_or_default()
+            } else {
+                String::new()
+            };
+            let trimmed = detail.trim();
+            if trimmed.is_empty() {
+                return Err(format!("SAB delete returned HTTP {status}"));
+            }
+            return Err(format!("SAB delete returned HTTP {status}: {trimmed}"));
+        }
+        Ok(resp.json().await.unwrap_or_default())
     }
 
     async fn queue_action(&self, name: &str, nzo_id: &str) -> Result<(), String> {

--- a/src/services/download_client/sabnzbd/mod.rs
+++ b/src/services/download_client/sabnzbd/mod.rs
@@ -506,6 +506,38 @@ impl DownloadClient for SabClient {
             .into_iter()
             .filter(|s| category_matches(&s.category))
         {
+            // Title-matching ancestor walk, ported from Sonarr's
+            // SAB client (`Sabnzbd.cs::GetHistory`). SAB's `storage`
+            // field can be:
+            //   1. The per-job folder path (`/complete/<title>/`) —
+            //      the typical case.
+            //   2. A file path inside the job folder
+            //      (`/complete/<title>/file.mkv`) — single-file
+            //      extracts on some SAB versions.
+            //   3. The parent complete dir alone (`/complete/`) —
+            //      pathological-but-real edge case observed in the
+            //      wild; happens when SAB couldn't determine where
+            //      the job extracted to (no rar / weird archive
+            //      shape) and fell back to recording the parent.
+            //
+            // Walk the parent chain of `storage` looking for an
+            // ancestor whose filename equals `name` (the job title).
+            // That ancestor IS the per-job folder. If we find one,
+            // use it as the canonical content_path so import-time
+            // walks and delete-time cleanups operate on a precise
+            // per-job scope. Without this narrowing, a job's
+            // `import_torrent` walks the WHOLE complete dir and
+            // sweeps in files belonging to OTHER grabs — which then
+            // get stamped onto this grab's `imported_source_paths`
+            // and incorrectly removed when this grab is deleted.
+            //
+            // Fallback when no ancestor matches: try
+            // `<storage>/<title>/` as a candidate (covers case 3
+            // above where Storage is the parent). If neither
+            // resolution works the original `storage` is kept so
+            // downstream code at least has something to attempt.
+            let canonical_job_path = canonical_job_path(&slot.storage, &slot.name);
+
             out.push(DownloadItem {
                 hash: slot.nzo_id,
                 name: slot.name,
@@ -515,26 +547,26 @@ impl DownloadClient for SabClient {
                 state: slot.status.clone(),
                 category: slot.category,
                 eta: 0,
-                save_path: slot.storage.clone(),
-                content_path: slot.storage,
+                save_path: canonical_job_path.clone(),
+                content_path: canonical_job_path,
                 state_kind: Self::map_state(&slot.status, true),
             });
         }
 
-        // Diagnostic trace so a user reporting "Ryokan can't see my
-        // SAB jobs" has something to grep for in System → Logs. Two
-        // useful counts: how many slots SAB returned in total, and
-        // how many survived the category filter. A "slots=N matched=0"
-        // line points the user (or future-me) directly at the
-        // category-config mismatch — easier than digging through the
-        // SAB UI to spot it.
-        tracing::debug!(
-            "sab list_scoped: configured_category={:?} queue_slots={} history_slots={} matched={}",
-            configured,
-            queue_total,
-            history_total,
-            out.len()
-        );
+        // Diagnostic trace, fires only when SAB returned slots but
+        // every one of them got dropped by the category filter — i.e.
+        // a user-reported "Ryokan can't see my SAB jobs" case. Avoids
+        // spamming logs every 5s on the happy path (the queue-tab
+        // poll calls list_scoped on every refresh).
+        let total = queue_total + history_total;
+        if total > 0 && out.is_empty() {
+            tracing::debug!(
+                "sab list_scoped: dropped every slot via category filter — configured_category={:?} queue_slots={} history_slots={}",
+                configured,
+                queue_total,
+                history_total,
+            );
+        }
 
         Ok(out)
     }
@@ -939,6 +971,91 @@ struct GetFilesEntry {
 
 // ── Wire-format helpers ─────────────────────────────────────────────
 
+/// Resolve SAB's `storage` field to the canonical per-job folder.
+/// SAB's reported storage takes one of three shapes:
+///
+///   1. **The per-job folder itself** (`/complete/<title>/`). This
+///      is the typical case. Detected by the basename equalling
+///      the job title; we return it as-is.
+///   2. **A file path inside the job folder**
+///      (`/complete/<title>/file.mkv`). Single-file extracts on some
+///      SAB versions. We use [`title_matching_ancestor`] to walk up
+///      and find the title-named parent dir.
+///   3. **The parent complete dir alone** (`/complete/`). Edge case
+///      observed in the wild — happens when SAB couldn't determine
+///      where extraction landed. We construct `<storage>/<title>/`
+///      as a candidate. This won't be filesystem-checked here (we
+///      operate on SAB-internal paths in Docker setups, where
+///      `is_dir()` against Ryokan's filesystem would lie); the
+///      downstream import walk handles the "path doesn't exist"
+///      case naturally.
+///
+/// The narrowing is critical: without it, `import_torrent`'s
+/// `walk_video_files` would walk SAB's WHOLE complete dir and sweep
+/// in files belonging to OTHER grabs, then stamp them onto this
+/// grab's `imported_source_paths`. Deleting one episode would then
+/// remove sibling episodes' source files too — see the user-reported
+/// 1154/1156 bug.
+fn canonical_job_path(storage: &str, title: &str) -> String {
+    if storage.is_empty() {
+        return String::new();
+    }
+    if title.is_empty() {
+        return storage.to_string();
+    }
+    // Case 1: storage already IS the per-job dir.
+    if let Some(name) = std::path::Path::new(storage)
+        .file_name()
+        .and_then(|n| n.to_str())
+        && name == title
+    {
+        return storage.to_string();
+    }
+    // Case 2: storage points inside the per-job dir somewhere.
+    if let Some(found) = title_matching_ancestor(storage, title) {
+        return found;
+    }
+    // Case 3: storage is the parent root (no per-job context).
+    // Construct the candidate; if SAB really created a per-job
+    // subdir named after the title, this resolves to it.
+    std::path::PathBuf::from(storage)
+        .join(title)
+        .display()
+        .to_string()
+}
+
+/// Walk parents of `path` looking for an ancestor whose filename
+/// equals `title`. Returns the **outermost** matching ancestor as a
+/// string, or `None` if no ancestor matches.
+///
+/// Ported from Sonarr's `Sabnzbd.cs::GetHistory` (the inner `while`
+/// loop ascending parents and matching against `sabHistoryItem.Title`).
+/// Used by [`canonical_job_path`] to handle the case where SAB's
+/// `storage` field points at a file inside the job folder rather
+/// than the folder itself.
+///
+/// The "outermost match wins" semantic mirrors Sonarr's behavior:
+/// the loop overwrites OutputPath each match and keeps walking up,
+/// so for a path like `/complete/<title>/<title>/file.mkv` the
+/// higher-up `<title>/` directory wins. Real-world archives rarely
+/// nest this way, but the chosen behavior is defensive.
+fn title_matching_ancestor(path: &str, title: &str) -> Option<String> {
+    if title.is_empty() || path.is_empty() {
+        return None;
+    }
+    let mut found: Option<std::path::PathBuf> = None;
+    let mut current = std::path::Path::new(path).parent();
+    while let Some(dir) = current {
+        if let Some(name) = dir.file_name().and_then(|n| n.to_str())
+            && name == title
+        {
+            found = Some(dir.to_path_buf());
+        }
+        current = dir.parent();
+    }
+    found.map(|p| p.display().to_string())
+}
+
 /// SAB returns percentages as strings ("47" → 0.47). Bare-int
 /// formatting on most installs; clamp to 0..=1.0.
 fn parse_percentage(s: &str) -> f64 {
@@ -997,6 +1114,109 @@ mod tests {
     fn endpoint_strips_trailing_slash_from_base() {
         let c = SabClient::new("http://host:8080/", "", "k", "anime");
         assert_eq!(c.endpoint(), "http://host:8080/api");
+    }
+
+    /// SAB's history `storage` field for a single-file extract often
+    /// points at the file inside the job folder. The title-matching
+    /// ancestor walk recovers the per-job folder so the import walk
+    /// scopes correctly. Without this, when SAB reports the parent
+    /// `complete/` dir or a file path, downstream code walked too
+    /// broadly and stamped/imported files from OTHER grabs in the
+    /// same complete dir.
+    #[test]
+    fn title_matching_ancestor_finds_job_dir_when_storage_is_a_file_path() {
+        let storage = "/downloads/complete/MyJob.S01E01/file.mkv";
+        let title = "MyJob.S01E01";
+        let got = title_matching_ancestor(storage, title);
+        assert_eq!(got, Some("/downloads/complete/MyJob.S01E01".to_string()));
+    }
+
+    /// When SAB's `storage` IS the per-job folder already, the walk
+    /// finds that folder one level up from the supplied path's
+    /// children — but since we walk *parents* of the input, the input
+    /// itself isn't checked. Returns None; caller falls back to using
+    /// `storage` directly.
+    #[test]
+    fn title_matching_ancestor_returns_none_when_storage_is_already_job_dir() {
+        let storage = "/downloads/complete/MyJob";
+        let title = "MyJob";
+        // The walk inspects PARENTS of storage; the path itself is the
+        // job dir but isn't tested. Caller's fallback chain handles
+        // this case via direct use of `storage`.
+        assert_eq!(title_matching_ancestor(storage, title), None);
+    }
+
+    /// Pathological case: SAB reports `storage` as the parent
+    /// complete dir with no per-job subdir. Walk finds no match
+    /// (no ancestor named after Title). Caller falls through to the
+    /// `<storage>/<title>/` candidate or to `storage` as-is — both
+    /// safer than walking the parent dir.
+    #[test]
+    fn title_matching_ancestor_returns_none_for_parent_only_storage() {
+        let storage = "/downloads/complete";
+        let title = "MyJob.S01E01";
+        assert_eq!(title_matching_ancestor(storage, title), None);
+    }
+
+    /// Multi-match: the OUTERMOST title-named ancestor wins (matches
+    /// Sonarr's behavior — the loop assignment overwrites and keeps
+    /// ascending). Defensive against unusual archive shapes.
+    #[test]
+    fn title_matching_ancestor_picks_outermost_match() {
+        let storage = "/downloads/MyJob/inner/MyJob/file.mkv";
+        let title = "MyJob";
+        assert_eq!(
+            title_matching_ancestor(storage, title),
+            Some("/downloads/MyJob".to_string())
+        );
+    }
+
+    /// Empty title or empty path: no walk, returns None.
+    #[test]
+    fn title_matching_ancestor_handles_empty_inputs() {
+        assert_eq!(title_matching_ancestor("", "MyJob"), None);
+        assert_eq!(title_matching_ancestor("/a/b", ""), None);
+    }
+
+    /// Per-job dir already as storage — return as-is. The basename
+    /// equals the title so we know it IS the job folder.
+    #[test]
+    fn canonical_job_path_uses_storage_when_basename_matches_title() {
+        assert_eq!(
+            canonical_job_path("/downloads/complete/MyJob.S01E01", "MyJob.S01E01"),
+            "/downloads/complete/MyJob.S01E01"
+        );
+    }
+
+    /// File path inside the job folder — walk finds the job dir.
+    #[test]
+    fn canonical_job_path_recovers_job_dir_from_file_path() {
+        assert_eq!(
+            canonical_job_path("/downloads/complete/MyJob.S01E01/file.mkv", "MyJob.S01E01"),
+            "/downloads/complete/MyJob.S01E01"
+        );
+    }
+
+    /// Parent-only storage — construct a candidate by joining title.
+    /// Pinned by the user-reported 1154/1156 bug: when SAB returns
+    /// the bare complete dir, downstream walks must scope to a
+    /// per-job candidate or sibling grabs' files get swept up too.
+    #[test]
+    fn canonical_job_path_constructs_candidate_for_parent_only_storage() {
+        assert_eq!(
+            canonical_job_path("/downloads/complete", "MyJob.S01E01"),
+            "/downloads/complete/MyJob.S01E01"
+        );
+    }
+
+    /// Empty inputs degrade gracefully — no panic, sensible defaults.
+    #[test]
+    fn canonical_job_path_handles_empty_inputs() {
+        assert_eq!(canonical_job_path("", "MyJob"), "");
+        assert_eq!(
+            canonical_job_path("/downloads/complete", ""),
+            "/downloads/complete"
+        );
     }
 
     #[test]

--- a/src/services/download_client/sabnzbd/wiremock_tests/auth_test.rs
+++ b/src/services/download_client/sabnzbd/wiremock_tests/auth_test.rs
@@ -13,6 +13,11 @@ use crate::services::download_client::DownloadClient;
 
 #[tokio::test]
 async fn test_returns_version_string_on_success() {
+    // `test()` is now a two-step probe — `mode=version` (public) for
+    // the version string, then `mode=queue` (auth-required) so a
+    // missing/invalid API key surfaces at config time instead of
+    // silently passing the public-endpoint check and then failing
+    // every grab with HTTP 403. Both mocks must be present.
     let (server, client) = new_fixture().await;
     Mock::given(method("GET"))
         .and(path("/api"))
@@ -20,6 +25,14 @@ async fn test_returns_version_string_on_success() {
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "version": "4.3.2",
         })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"queue": {"slots": []}})),
+        )
         .mount(&server)
         .await;
 
@@ -88,9 +101,60 @@ async fn test_sends_apikey_query_param() {
         })))
         .mount(&server)
         .await;
+    // Auth probe needs the same key — pin both calls to verify the
+    // apikey query param threads through every step of `test()`.
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .and(query_param("apikey", super::fixture::TEST_API_KEY))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"queue": {"slots": []}})),
+        )
+        .mount(&server)
+        .await;
 
     client
         .test()
         .await
         .expect("apikey query param must be sent on every request");
+}
+
+/// New regression test: when SAB's queue probe returns 403, the
+/// error must call out the API key specifically so the user knows
+/// what to fix. The prior `test()` shape only probed `mode=version`
+/// (public endpoint) and silently passed even with a missing/wrong
+/// key — the resulting `Grab failed for episode N: SAB add returned
+/// HTTP 403 Forbidden` toast on first grab was the actionable
+/// symptom. This test pins the diagnostic message at the SAB
+/// trait-impl boundary.
+#[tokio::test]
+async fn test_returns_api_key_error_when_queue_probe_returns_403() {
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "version"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "version": "4.3.2",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .respond_with(ResponseTemplate::new(403).set_body_string("API Key Incorrect"))
+        .mount(&server)
+        .await;
+
+    let err = client
+        .test()
+        .await
+        .expect_err("queue probe 403 must fail the test");
+    assert!(
+        err.contains("API key"),
+        "diagnostic must mention API key explicitly so the user knows which field to fix; got: {err}"
+    );
+    assert!(
+        err.contains("API Key Incorrect"),
+        "SAB's body text must be surfaced so the user sees SAB's exact reason; got: {err}"
+    );
 }

--- a/src/services/download_client/sabnzbd/wiremock_tests/control.rs
+++ b/src/services/download_client/sabnzbd/wiremock_tests/control.rs
@@ -1,6 +1,10 @@
 //! `pause` / `resume` / `delete` against a mocked SAB. Verifies the
-//! wire-format query params for each op and the queue-then-history
-//! fallback that `delete` uses when the nzo_id isn't in the queue.
+//! wire-format query params for each op and the history-then-queue
+//! lookup order that `delete` uses. History is tried first because
+//! SAB's `mode=queue&name=delete` returns `status: true`
+//! unconditionally — even for a nzo_id that isn't in the queue —
+//! which would silently no-op every post-import delete if we tried
+//! queue first.
 
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
@@ -43,23 +47,14 @@ async fn resume_sends_queue_resume_with_nzo_id() {
 }
 
 #[tokio::test]
-async fn delete_tries_queue_first_then_falls_back_to_history() {
-    // Queue delete returns status:false (the nzo_id isn't in the
-    // queue — already moved to history). The impl must fall through
-    // to history delete; without the fallback, completed grabs that
-    // a user blocklists from the Downloads page would never get
-    // their unpacked output cleaned up.
+async fn delete_tries_history_first_then_falls_back_to_queue() {
+    // Common case: a completed-and-imported job lives in SAB's
+    // history (not its queue). History-first gives the canonical
+    // path a clean win without ever pinging queue. If a refactor
+    // ever reverts the order, queue would silently "succeed" (see
+    // module-level comment) and `del_files=1` would never reach
+    // history, leaving the unpacked output dir behind.
     let (server, client) = new_fixture().await;
-    Mock::given(method("GET"))
-        .and(path("/api"))
-        .and(query_param("mode", "queue"))
-        .and(query_param("name", "delete"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "status": false,
-            "error": "nzo_id not in queue",
-        })))
-        .mount(&server)
-        .await;
     Mock::given(method("GET"))
         .and(path("/api"))
         .and(query_param("mode", "history"))
@@ -70,11 +65,86 @@ async fn delete_tries_queue_first_then_falls_back_to_history() {
         })))
         .mount(&server)
         .await;
+    // Queue mock that would also "succeed" — if the impl ever asks
+    // queue first this test would still pass without exercising the
+    // history path. The unique-to-history `del_files=1` matcher above
+    // is what pins that history actually got hit.
 
     client
         .delete("SABnzbd_nzo_done", true)
         .await
-        .expect("delete must succeed via history fallback");
+        .expect("delete must succeed via history (the common post-import case)");
+}
+
+#[tokio::test]
+async fn delete_falls_through_to_queue_when_history_does_not_have_the_nzo_id() {
+    // In-flight cancel: the nzo_id is in the queue, not history yet.
+    // History returns `status:false`, queue returns `status:true`.
+    // Verifies the fallback works in the rarer-but-real direction.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "history"))
+        .and(query_param("name", "delete"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": false,
+            "error": "nzo_id not in history",
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .and(query_param("name", "delete"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": true,
+        })))
+        .mount(&server)
+        .await;
+
+    client
+        .delete("SABnzbd_nzo_pending", false)
+        .await
+        .expect("delete must succeed via queue when history is empty");
+}
+
+#[tokio::test]
+async fn delete_does_not_short_circuit_on_queue_phantom_success() {
+    // Pin the actual bug fix: SAB's `mode=queue&name=delete` returns
+    // `status:true` even when the nzo_id is NOT in the queue (its
+    // `_handle_queue` calls `report(output)` after `remove_multiple`
+    // unconditionally). If we tried queue first we'd see that
+    // phantom success and never hit history with `del_files=1`.
+    //
+    // This test makes the queue mock return the "phantom success"
+    // shape and asserts the impl still succeeds via the history
+    // path AND specifically with `del_files=1` on the wire — the
+    // unpacked storage dir would not get cleaned up otherwise.
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "history"))
+        .and(query_param("name", "delete"))
+        .and(query_param("del_files", "1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": true,
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .and(query_param("name", "delete"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": true,
+        })))
+        .mount(&server)
+        .await;
+
+    client
+        .delete("SABnzbd_nzo_done", true)
+        .await
+        .expect("delete must hit history with del_files=1, not the queue phantom-success");
 }
 
 #[tokio::test]
@@ -110,9 +180,9 @@ async fn delete_surfaces_error_when_both_queue_and_history_fail() {
 #[tokio::test]
 async fn delete_with_delete_files_true_passes_del_files_one_to_sab() {
     // SAB's `del_files=1` query param tells the daemon to remove the
-    // imported files from disk (history-tab fallback path). `=0` (the
-    // default) leaves files in place. Pin the wire shape so a refactor
-    // that drops `del_files` accidentally doesn't silently leave stale
+    // imported files from disk on history delete. `=0` (the default)
+    // leaves files in place. Pin the wire shape so a refactor that
+    // drops `del_files` accidentally doesn't silently leave stale
     // import artifacts on disk after the user explicitly said "delete
     // and remove."
     let (server, client) = new_fixture().await;

--- a/src/services/download_client/sabnzbd/wiremock_tests/list.rs
+++ b/src/services/download_client/sabnzbd/wiremock_tests/list.rs
@@ -4,7 +4,7 @@
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
-use super::fixture::new_fixture;
+use super::fixture::{new_fixture, new_with_category};
 use crate::services::download_client::{DownloadClient, DownloadItemState};
 
 #[tokio::test]
@@ -297,6 +297,168 @@ async fn list_scoped_failed_history_maps_to_errored() {
         .find(|i| i.hash == "SABnzbd_nzo_failed")
         .unwrap();
     assert_eq!(failed.state_kind, DownloadItemState::Errored);
+}
+
+/// Regression: SAB sometimes returns slots with `cat=""` even when
+/// Ryokan called addurl with a `cat=anime` parameter — happens when
+/// the named category isn't configured in SAB's Settings → Categories
+/// (the addurl call accepts the parameter but the resulting slot
+/// doesn't carry it). Pre-fix the strict equality filter dropped
+/// these slots, the reconcile loop saw nothing matching the grab's
+/// hash, and at the 30s grace window flipped the grab to "removed in
+/// download client" — even though the SAB job was happily downloading.
+/// User-reported during the SAB-on-NZBGeek setup pass.
+#[tokio::test]
+async fn list_scoped_includes_slot_with_empty_cat_when_category_configured() {
+    let (server, client) = new_fixture().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "queue": {
+                "slots": [
+                    {
+                        "nzo_id": "SABnzbd_nzo_uncategorized",
+                        "filename": "show.nzb",
+                        "cat": "",
+                        "status": "Downloading",
+                        "percentage": "10",
+                        "kbpersec": "1024",
+                        "timeleft": "0:05:00",
+                        "url": "",
+                    }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "history"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"history": {"slots": []}})),
+        )
+        .mount(&server)
+        .await;
+
+    let items = client.list_scoped().await.expect("list_scoped");
+    assert!(
+        items.iter().any(|i| i.hash == "SABnzbd_nzo_uncategorized"),
+        "slot with empty cat must surface even when client has `ryokan-test` configured; \
+         dropping it would let the reconcile loop mark the grab `removed` while SAB is \
+         still downloading it"
+    );
+}
+
+/// SAB category names are user-typed strings; match case-insensitively
+/// so `Anime` vs `anime` doesn't silently drop slots. Ryokan's input
+/// validation doesn't normalize the category, and SAB itself appears
+/// to preserve case in API responses, so a mixed-case mismatch
+/// between Ryokan's stored row and SAB's slot category would
+/// otherwise reproduce the same "everything looks removed" symptom.
+#[tokio::test]
+async fn list_scoped_matches_category_case_insensitively() {
+    let (server, client) = new_fixture().await;
+    // Fixture's configured category is "ryokan-test" (lowercase).
+    // SAB returns the slot with "RYOKAN-TEST" (uppercase).
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "queue": {
+                "slots": [
+                    {
+                        "nzo_id": "SABnzbd_nzo_caps",
+                        "filename": "show.nzb",
+                        "cat": "RYOKAN-TEST",
+                        "status": "Downloading",
+                        "percentage": "10",
+                        "kbpersec": "0",
+                        "timeleft": "0:00:00",
+                        "url": "",
+                    }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "history"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"history": {"slots": []}})),
+        )
+        .mount(&server)
+        .await;
+
+    let items = client.list_scoped().await.expect("list_scoped");
+    assert!(
+        items.iter().any(|i| i.hash == "SABnzbd_nzo_caps"),
+        "case-insensitive category match expected; got {:?}",
+        items.iter().map(|i| &i.hash).collect::<Vec<_>>()
+    );
+}
+
+/// When the SAB row in Ryokan has no category configured (empty
+/// string), `list_scoped` should pass everything through without
+/// filtering. Without this, a user who left the Category field blank
+/// on the SAB row would never see ANY of their SAB jobs in Ryokan
+/// because every slot has SOME category value (default "*" or
+/// whatever) that doesn't equal the empty string.
+#[tokio::test]
+async fn list_scoped_passes_through_all_when_category_empty() {
+    // Empty configured category — `new_with_category("")` mirrors a
+    // SAB row in Ryokan with the Category field left blank.
+    let (server, client) = new_with_category("").await;
+
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "queue"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "queue": {
+                "slots": [
+                    {
+                        "nzo_id": "SABnzbd_nzo_a",
+                        "filename": "a.nzb",
+                        "cat": "anime",
+                        "status": "Downloading",
+                        "percentage": "0",
+                        "kbpersec": "0",
+                        "timeleft": "0:00:00",
+                        "url": "",
+                    },
+                    {
+                        "nzo_id": "SABnzbd_nzo_b",
+                        "filename": "b.nzb",
+                        "cat": "movies",
+                        "status": "Downloading",
+                        "percentage": "0",
+                        "kbpersec": "0",
+                        "timeleft": "0:00:00",
+                        "url": "",
+                    }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("mode", "history"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"history": {"slots": []}})),
+        )
+        .mount(&server)
+        .await;
+
+    let items = client.list_scoped().await.expect("list_scoped");
+    assert_eq!(
+        items.len(),
+        2,
+        "empty configured category must pass through every SAB slot regardless of cat value; \
+         got {:?}",
+        items.iter().map(|i| &i.hash).collect::<Vec<_>>()
+    );
 }
 
 #[tokio::test]

--- a/src/services/grab_sweep.rs
+++ b/src/services/grab_sweep.rs
@@ -510,7 +510,8 @@ mod tests {
         clients.insert(2, pinned_client.clone());
         let pool = crate::DownloadClientPool {
             clients,
-            default_id: Some(1),
+            default_torrent_id: Some(1),
+            default_usenet_id: None,
         };
         let state = build_test_app_state(db.clone(), None);
         // Override the pool — `build_test_app_state` left it empty

--- a/src/services/indexer_catalog.rs
+++ b/src/services/indexer_catalog.rs
@@ -165,17 +165,23 @@ pub const SEEDED: &[SeededIndexer] = &[
         url_placeholder: "https://prowlarr.local/{N}/api",
         is_generic: false,
     },
+    // NZBGeek — paid newznab Usenet indexer. Carries anime as a
+    // side effect of being a general-purpose Usenet source, but
+    // it's the most widely-used paid indexer in the *arr ecosystem
+    // and shipping a curated entry saves users a Prowlarr trip
+    // for the URL pattern. `default_min_seeders` is 0 because
+    // Usenet has no peer concept — the field is torrent-only.
     SeededIndexer {
-        slug: "anidex",
-        display_name: "AniDex",
-        blurb: "Public anime tracker",
+        slug: "nzbgeek",
+        display_name: "NZBGeek",
+        blurb: "Usenet indexer (paid)",
         notes: "",
         is_private_tracker: false,
-        default_priority: 35,
-        default_min_seeders: 2,
+        default_priority: 30,
+        default_min_seeders: 0,
         default_seed_ratio: None,
         default_seed_time_minutes: None,
-        default_kind: "torznab",
+        default_kind: "newznab",
         url_placeholder: "https://prowlarr.local/{N}/api",
         is_generic: false,
     },
@@ -193,12 +199,10 @@ pub const SEEDED: &[SeededIndexer] = &[
         url_placeholder: "https://prowlarr.local/{N}/api",
         is_generic: true,
     },
-    // Newznab seed kept for general-purpose Usenet indexers
-    // (NzbGeek, NZB.cat, NZBPlanet, etc.). AnimeTosho's
-    // newznab mirror was dropped from the catalog because the
-    // site's shutting down in May 2026; the remaining newznab
-    // sources carry anime as a side effect of being
-    // general-purpose, not as a curated focus.
+    // Generic newznab fall-through for indexers not in the
+    // curated list (NZB.cat, NZBPlanet, DrunkenSlug, …). AnimeTosho's
+    // newznab mirror was dropped from the catalog because the site's
+    // shutting down in May 2026.
     SeededIndexer {
         slug: "generic-newznab",
         display_name: "Generic Newznab",

--- a/src/services/indexers/mod.rs
+++ b/src/services/indexers/mod.rs
@@ -116,6 +116,14 @@ pub struct Release {
     /// Snapshot of the indexer's priority at search time so a
     /// later DB edit can't change attribution retroactively.
     pub indexer_priority: i32,
+    /// Snapshot of the indexer's display name at search time.
+    /// Same retroactive-edit reasoning as `indexer_priority` —
+    /// a later rename of the indexer row in Settings shouldn't
+    /// rewrite the name on past Release records that callers
+    /// kept around. Surfaces through `into_search_result` to
+    /// drive the "Indexer" column on the interactive search UI.
+    #[serde(default)]
+    pub indexer_name: String,
     pub title: String,
     /// Stable per-release identifier from the torznab `<guid>`
     /// element. Used as a dedup key when [`info_hash`] is empty.
@@ -523,6 +531,7 @@ impl Release {
         let resolution = extract_resolution_from_title(&self.title);
         let is_batch = detect_batch_from_title(&self.title);
         let indexer_id = self.indexer_id;
+        let indexer_name = self.indexer_name;
         crate::services::nyaa::SearchResult {
             title: self.title,
             link: self.link.clone(),
@@ -558,6 +567,7 @@ impl Release {
             // dormant — nothing surfaces the source indexer to the
             // grab path.
             indexer_id: Some(indexer_id),
+            indexer_name,
         }
     }
 }
@@ -727,6 +737,7 @@ mod tests {
         Release {
             indexer_id,
             indexer_priority: priority,
+            indexer_name: format!("Indexer{indexer_id}"),
             title: title.to_string(),
             guid: guid.to_string(),
             link: String::new(),
@@ -741,6 +752,38 @@ mod tests {
             upload_volume_factor: None,
             extra: HashMap::new(),
         }
+    }
+
+    // ── into_search_result ───────────────────────────────────────────
+
+    /// The interactive-search "Indexer" column in the UI keys off
+    /// `SearchResult::indexer_name`. Without this propagation,
+    /// torznab/newznab fan-out results would land with empty
+    /// `indexer_name` and the column would render "Nyaa" for every
+    /// row regardless of where the result actually came from —
+    /// exactly the symptom the user reported before this fix.
+    #[test]
+    fn into_search_result_propagates_indexer_name() {
+        let r = release(7, 25, "abc", "g1", "[nekoBT] Show - 01", 10);
+        let sr = r.into_search_result();
+        assert_eq!(
+            sr.indexer_name, "Indexer7",
+            "indexer_name must round-trip through into_search_result()"
+        );
+        assert_eq!(sr.indexer_id, Some(7));
+    }
+
+    /// Counterpart: a Release with an empty indexer_name (defensive
+    /// — shouldn't happen in production but the field is `String`,
+    /// not `NonEmptyString`) produces an empty SearchResult name,
+    /// which the UI then renders as "Nyaa" via its `|| 'Nyaa'`
+    /// fallback. Both paths must work.
+    #[test]
+    fn into_search_result_handles_empty_indexer_name() {
+        let mut r = release(7, 25, "abc", "g1", "Show - 01", 10);
+        r.indexer_name = String::new();
+        let sr = r.into_search_result();
+        assert!(sr.indexer_name.is_empty());
     }
 
     // ── dedup_for_auto_search ────────────────────────────────────────

--- a/src/services/indexers/torznab/client.rs
+++ b/src/services/indexers/torznab/client.rs
@@ -229,7 +229,7 @@ impl Indexer for TorznabIndexer {
 
         let url = self.build_url("tvsearch", &params);
         let body = self.fetch(&url).await?;
-        let parsed = parse_search_response(&body, self.id, self.priority)?;
+        let parsed = parse_search_response(&body, self.id, self.priority, &self.name)?;
         let releases = match parsed {
             Ok(rs) => rs,
             Err(e) => return Err(format_torznab_error(&e)),
@@ -421,6 +421,7 @@ mod tests {
         Release {
             indexer_id: 7,
             indexer_priority: 25,
+            indexer_name: "TestIndexer".to_string(),
             title: "Show".to_string(),
             guid: "g".to_string(),
             link: String::new(),

--- a/src/services/indexers/torznab/parser.rs
+++ b/src/services/indexers/torznab/parser.rs
@@ -60,6 +60,7 @@ pub fn parse_search_response(
     xml: &str,
     indexer_id: i64,
     indexer_priority: i32,
+    indexer_name: &str,
 ) -> Result<Result<Vec<Release>, TorznabError>, String> {
     if let Some(err) = parse_error(xml) {
         return Ok(Err(err));
@@ -68,7 +69,7 @@ pub fn parse_search_response(
     let mut releases = Vec::new();
     for caps in RE_ITEM.captures_iter(xml) {
         let block = caps.get(1).map(|m| m.as_str()).unwrap_or("");
-        let release = parse_item_block(block, indexer_id, indexer_priority);
+        let release = parse_item_block(block, indexer_id, indexer_priority, indexer_name);
         // Skip items with no usable identity. A torznab response
         // shouldn't emit empty items, but be defensive — a single
         // mangled item shouldn't shut out the rest of the page.
@@ -80,7 +81,12 @@ pub fn parse_search_response(
     Ok(Ok(releases))
 }
 
-fn parse_item_block(block: &str, indexer_id: i64, indexer_priority: i32) -> Release {
+fn parse_item_block(
+    block: &str,
+    indexer_id: i64,
+    indexer_priority: i32,
+    indexer_name: &str,
+) -> Release {
     let title = decode_xml(&extract_tag(block, "title"));
     let guid = decode_xml(&extract_tag(block, "guid"));
     let link = decode_xml(&extract_tag(block, "link"));
@@ -150,6 +156,7 @@ fn parse_item_block(block: &str, indexer_id: i64, indexer_priority: i32) -> Rele
     Release {
         indexer_id,
         indexer_priority,
+        indexer_name: indexer_name.to_string(),
         title,
         guid,
         link: download_url,

--- a/src/services/indexers/torznab/tests.rs
+++ b/src/services/indexers/torznab/tests.rs
@@ -80,7 +80,7 @@ const SEARCH_RESPONSE_BASIC: &str = r#"<?xml version="1.0" encoding="UTF-8"?>
 
 #[test]
 fn search_response_extracts_basic_release_fields() {
-    let result = parse_search_response(SEARCH_RESPONSE_BASIC, 7, 25)
+    let result = parse_search_response(SEARCH_RESPONSE_BASIC, 7, 25, "TestIndexer")
         .expect("parse must succeed")
         .expect("body must not be an error");
     assert_eq!(result.len(), 1);
@@ -106,7 +106,7 @@ fn search_response_promotes_enclosure_url_over_link() {
     // The enclosure URL is the canonical download path per spec;
     // <link> is sometimes a comments-page URL. Prefer enclosure.
     let xml = SEARCH_RESPONSE_BASIC;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(
@@ -127,7 +127,7 @@ fn search_response_falls_back_to_size_from_enclosure_when_no_size_attr() {
   <enclosure url="u" length="500000000" type="application/x-bittorrent"/>
   <torznab:attr name="seeders" value="10"/>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result[0].size_bytes, 500_000_000);
@@ -145,7 +145,7 @@ fn search_response_derives_leechers_from_peers_when_missing() {
   <torznab:attr name="seeders" value="40"/>
   <torznab:attr name="peers" value="50"/>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(
@@ -162,7 +162,7 @@ fn search_response_skips_items_with_empty_title() {
 <item><title></title><guid>g1</guid></item>
 <item><title>Real Title</title><guid>g2</guid></item>
 </channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result.len(), 1, "title-less items must drop");
@@ -177,7 +177,7 @@ fn search_response_decodes_xml_entities_in_title() {
   <title>Show &amp; Friends</title>
   <guid>g1</guid>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result[0].title, "Show & Friends");
@@ -191,7 +191,7 @@ fn search_response_handles_cdata_wrapped_title() {
   <title><![CDATA[Show & <Friends>]]></title>
   <guid>g1</guid>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result[0].title, "Show & <Friends>");
@@ -203,7 +203,8 @@ fn search_response_returns_inner_err_for_torznab_error_body() {
     // caller can branch on the torznab error code.
     let err_xml = r#"<?xml version="1.0"?>
 <error code="100" description="Bad API Key"/>"#;
-    let result = parse_search_response(err_xml, 1, 25).expect("outer parse must not fail");
+    let result =
+        parse_search_response(err_xml, 1, 25, "TestIndexer").expect("outer parse must not fail");
     let err = match result {
         Err(e) => e,
         Ok(_) => panic!("error body must surface as Err"),
@@ -215,7 +216,7 @@ fn search_response_returns_inner_err_for_torznab_error_body() {
 fn search_response_empty_channel_returns_empty_releases_not_error() {
     let xml = r#"<?xml version="1.0"?>
 <rss version="2.0"><channel><title>Empty</title></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert!(result.is_empty());
@@ -238,7 +239,7 @@ fn search_response_carries_multiple_categories_when_release_is_double_tagged() {
   <torznab:attr name="category" value="5070"/>
   <torznab:attr name="seeders" value="10"/>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result[0].categories.len(), 2, "both cats must surface");
@@ -259,7 +260,7 @@ fn search_response_collects_unrecognized_attrs_into_extra() {
   <torznab:attr name="seeders" value="5"/>
   <torznab:attr name="customField" value="indexer-specific-data"/>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(
@@ -280,7 +281,7 @@ fn search_response_pubdate_parses_to_unix_timestamp() {
   <guid>g1</guid>
   <pubDate>Thu, 01 Jan 1970 00:00:00 +0000</pubDate>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(result[0].publish_date, 0, "epoch should round-trip to 0");
@@ -297,7 +298,7 @@ fn search_response_pubdate_handles_positive_timezone_offset() {
   <guid>g1</guid>
   <pubDate>Thu, 01 Jan 1970 05:00:00 +0500</pubDate>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(
@@ -319,7 +320,7 @@ fn search_response_pubdate_handles_negative_timezone_offset() {
   <guid>g1</guid>
   <pubDate>Wed, 31 Dec 1969 19:00:00 -0500</pubDate>
 </item></channel></rss>"#;
-    let result = parse_search_response(xml, 1, 25)
+    let result = parse_search_response(xml, 1, 25, "TestIndexer")
         .expect("parse")
         .expect("not error");
     assert_eq!(

--- a/src/services/indexers/torznab/wiremock_tests/fixture.rs
+++ b/src/services/indexers/torznab/wiremock_tests/fixture.rs
@@ -5,7 +5,7 @@
 
 use wiremock::MockServer;
 
-use crate::models::indexers::{Indexer as IndexerRow, KIND_TORZNAB};
+use crate::models::indexers::{Indexer as IndexerRow, KIND_NEWZNAB, KIND_TORZNAB};
 use crate::services::indexers::torznab::TorznabIndexer;
 
 pub const TEST_API_KEY: &str = "wiremock-key-01234567";
@@ -14,11 +14,25 @@ pub const TEST_API_KEY: &str = "wiremock-key-01234567";
 /// `TorznabIndexer` configured to talk to it. The base URL points
 /// at `<server>/api` so tests register `Mock`s on `path("/api")`.
 pub async fn new_fixture() -> (MockServer, TorznabIndexer) {
+    new_fixture_with_kind(KIND_TORZNAB, "Wiremock").await
+}
+
+/// Newznab variant — same wire format and same `TorznabIndexer`
+/// client (newznab is a strict subset of torznab without the
+/// torrent-specific attrs), but the row's `kind` column reads
+/// "newznab". Used by the indexer-name-propagation tests so the
+/// "Indexer" column on interactive search verifiably attributes
+/// usenet-side hits the same way it attributes torrent-side ones.
+pub async fn new_fixture_newznab() -> (MockServer, TorznabIndexer) {
+    new_fixture_with_kind(KIND_NEWZNAB, "WiremockUsenet").await
+}
+
+async fn new_fixture_with_kind(kind: &str, display_name: &str) -> (MockServer, TorznabIndexer) {
     let server = MockServer::start().await;
     let row = IndexerRow {
         id: 7,
-        name: "Wiremock".to_string(),
-        kind: KIND_TORZNAB.to_string(),
+        name: display_name.to_string(),
+        kind: kind.to_string(),
         url: format!("{}/api", server.uri()),
         api_key: TEST_API_KEY.to_string(),
         priority: 25,

--- a/src/services/indexers/torznab/wiremock_tests/search.rs
+++ b/src/services/indexers/torznab/wiremock_tests/search.rs
@@ -4,7 +4,7 @@
 use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, ResponseTemplate};
 
-use super::fixture::{TEST_API_KEY, new_fixture};
+use super::fixture::{TEST_API_KEY, new_fixture, new_fixture_newznab};
 use crate::services::indexers::{Indexer, SearchQuery};
 
 const SEARCH_BODY: &str = r#"<?xml version="1.0"?>
@@ -50,6 +50,51 @@ async fn search_sends_tvsearch_with_anime_category_default() {
     assert_eq!(releases[0].title, "Synthetic.Show.S01E01");
     assert_eq!(releases[0].seeders, 20);
     assert_eq!(releases[0].indexer_id, 7, "stamps caller's id");
+    assert_eq!(
+        releases[0].indexer_name, "Wiremock",
+        "indexer_name must be stamped at parse time so it survives \
+         dedup + into_search_result and reaches the interactive-search \
+         UI's Indexer column. A regression here would silently render \
+         the column blank for every torznab/newznab hit."
+    );
+}
+
+#[tokio::test]
+async fn newznab_search_stamps_indexer_name() {
+    // Newznab indexers (Usenet) reuse the same wire format and
+    // parser; their kind column just changes from "torznab" to
+    // "newznab" so the protocol-mismatch guard at the indexer-pin
+    // save path can route torznab → torrent client and newznab →
+    // SAB. The "Indexer" column on interactive search must
+    // attribute usenet hits identically to torrent hits — the
+    // user can't tell which row of `download_clients` to pin a
+    // grab to without it.
+    let (server, client) = new_fixture_newznab().await;
+    Mock::given(method("GET"))
+        .and(path("/api"))
+        .and(query_param("t", "tvsearch"))
+        .and(query_param("apikey", TEST_API_KEY))
+        .respond_with(ResponseTemplate::new(200).set_body_string(SEARCH_BODY))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let query = SearchQuery {
+        q: "Test Show".to_string(),
+        categories: Vec::new(),
+        limit: None,
+        offset: None,
+    };
+    let releases = client
+        .search(&query)
+        .await
+        .expect("newznab search must succeed");
+    assert_eq!(releases.len(), 1);
+    assert_eq!(
+        releases[0].indexer_name, "WiremockUsenet",
+        "newznab parses to the same Release shape as torznab; the \
+         indexer_name plumbing must work for both kinds."
+    );
 }
 
 #[tokio::test]

--- a/src/services/nyaa/mod.rs
+++ b/src/services/nyaa/mod.rs
@@ -114,6 +114,17 @@ pub struct SearchResult {
     /// break and Nyaa-only flows don't add noise to API responses.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub indexer_id: Option<i64>,
+    /// Display name of the indexer that surfaced this release. Empty
+    /// for Nyaa-direct results — the interactive-search UI renders
+    /// "Nyaa" as the fallback so the column is never blank. Sourced
+    /// from `Release.indexer_name` for torznab/newznab fan-out
+    /// results. Kept distinct from `indexer_id` because the UI needs
+    /// the name without an extra round-trip to /api/indexers, and
+    /// because the name survives indexer-row deletion (the FK
+    /// becomes dangling but the historical name stays meaningful in
+    /// grab-history records that join on the search payload).
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub indexer_name: String,
 }
 
 #[derive(Clone)]

--- a/src/services/nyaa/scraper.rs
+++ b/src/services/nyaa/scraper.rs
@@ -208,6 +208,7 @@ pub(super) fn parse_results(html: &str, opts: &SearchOptions) -> (Vec<SearchResu
             score_breakdown: Vec::new(),
             upload_date: upload_date.clone(),
             indexer_id: None,
+            indexer_name: String::new(),
         };
 
         let (total, breakdown) =
@@ -505,6 +506,7 @@ pub(super) fn parse_view_page(
         // Callers on this path (SeaDex-bypass) get an empty string.
         upload_date: String::new(),
         indexer_id: None,
+        indexer_name: String::new(),
     };
 
     let (total, breakdown) =
@@ -981,6 +983,7 @@ mod tests {
             score_breakdown: Vec::new(),
             upload_date: String::new(),
             indexer_id: None,
+            indexer_name: String::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;
@@ -1025,6 +1028,7 @@ mod tests {
             score_breakdown: Vec::new(),
             upload_date: String::new(),
             indexer_id: None,
+            indexer_name: String::new(),
         }];
 
         enrich_results_with_group_map(&pool, &mut results).await;

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -626,6 +626,14 @@ async fn import_torrent(
     let mut imported_eps_by_series: std::collections::BTreeMap<i64, Vec<(i32, i64, String)>> =
         std::collections::BTreeMap::new();
     let mut imported_count = 0_usize;
+    // Source-side paths we successfully imported FROM. Persisted on
+    // the grab row at the end of this function so the delete and
+    // series-remove handlers can clean up SAB's complete dir
+    // regardless of whether the inode-based fallback applies (only
+    // hardlink mode shares inodes; copy mode has separate inodes,
+    // move mode has no surviving source). Captured in
+    // local-translated form (Ryokan's view of the path).
+    let mut imported_source_paths: Vec<String> = Vec::new();
     // Episode numbers (post-offset, the same value the rest of the
     // codebase uses) that reached `do_file_op` but failed. Drives the
     // PartiallyImported / AllFailed branches below so partial failures
@@ -985,12 +993,15 @@ async fn import_torrent(
                         // (SAB→qBit or qBit→SAB) would otherwise
                         // hit a client that doesn't know the old
                         // hash and silently leave the old job behind.
-                        let old_client = match old_grab.download_client_id {
-                            Some(id) => state.client_by_id(id).await,
-                            None => None,
-                        };
-                        let target = old_client.as_ref().unwrap_or(client);
-                        let _ = target.delete(&old_grab.hash, true).await;
+                        // `resolve_grab_client` also rescues legacy
+                        // NULL-stamped SAB grabs via the nzo_id-shape
+                        // heuristic.
+                        let target = state
+                            .resolve_grab_client(old_grab.download_client_id, &old_grab.hash)
+                            .await;
+                        if let Some(target) = target {
+                            let _ = target.delete(&old_grab.hash, true).await;
+                        }
                     }
                 }
                 grabs_to_mark_replaced.insert(old_grab.id);
@@ -1022,6 +1033,28 @@ async fn import_torrent(
                 )
                 .await;
                 imported_count += 1;
+                // Record the source path we imported from — but only
+                // if this file's parsed episode is one this grab
+                // actually claims. Without the filter, a wide walk
+                // (SAB returning the parent complete dir as `storage`,
+                // pre `canonical_job_path` narrowing) sweeps in
+                // stranger episodes from sibling SAB jobs and stamps
+                // them onto this grab. Deleting one episode then
+                // finds the wrong grab's stamps and over-removes.
+                //
+                // Batch grabs (`is_batch = 1`) and Phase-2 routed
+                // sibling imports legitimately import multiple
+                // episodes via one grab — for those, accept all
+                // imported files. Single-episode grabs check that
+                // the parsed `raw_ep_num` is in the grab's claimed
+                // `episode_numbers`.
+                let claims_this_episode = grab.is_batch
+                    || routes_by_file.contains_key(file_idx)
+                    || grab.episode_numbers.is_empty()
+                    || grab.episode_numbers.contains(&raw_ep_num);
+                if claims_this_episode {
+                    imported_source_paths.push(src.display().to_string());
+                }
                 touched_series.insert(target_series_id);
                 logger::info(
                     &state.db,
@@ -1190,6 +1223,17 @@ async fn import_torrent(
         }
         return Ok(ImportOutcome::AllFailed { failed_episodes });
     }
+
+    // Persist the source-side paths so the delete + series-remove
+    // handlers can clean up SAB's complete dir for copy/move modes
+    // (no shared inode) or for hardlink mode when SAB's
+    // `del_files=1` doesn't reach the file (the user's reported
+    // bug — SAB's history `storage` field can be the parent
+    // complete dir while the actual extracted .mkv lives in a
+    // subfolder created by the rar archive contents).
+    let _ =
+        grabbed_torrents::stamp_imported_source_paths(&state.db, grab.id, &imported_source_paths)
+            .await;
 
     // Flush the `grabbed_torrents.state = 'replaced'` updates collected
     // during the file loop. One UPDATE per distinct old grab instead
@@ -1887,6 +1931,30 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
             )
         };
         let _ = grabbed_torrents::stamp_client_content_path(&state.db, grab.id, &client_path).await;
+
+        // Post-processing-off mode never imports files but still
+        // records source-side paths so the series-remove handler can
+        // clean SAB's complete dir later. Walk the local-translated
+        // content path for video files and stamp them. Best-effort:
+        // empty list is fine (the grab might be a torrent with no
+        // .mkv-shaped extension, or the path might not be readable
+        // from Ryokan's view).
+        let walk_root = std::path::Path::new(&client_path);
+        if walk_root.is_dir() {
+            let videos = walk_video_files(walk_root);
+            let source_paths: Vec<String> = videos
+                .into_iter()
+                .map(|f| walk_root.join(&f.name).display().to_string())
+                .collect();
+            if !source_paths.is_empty() {
+                let _ = grabbed_torrents::stamp_imported_source_paths(
+                    &state.db,
+                    grab.id,
+                    &source_paths,
+                )
+                .await;
+            }
+        }
 
         // Mark the grab row as finalized so we stop polling it and the
         // UI stops treating it as in-flight. Use `mark_completed_no_import`

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -42,6 +42,39 @@ pub static LIBRARY_CLASSIFY_LOCK: LazyLock<tokio::sync::Mutex<()>> =
 // string set, which silently skipped Deluge's completed torrents
 // forever (#63 Phase 2 regression).
 
+/// Decide whether a walked file's parsed episode number is one this
+/// grab's import should claim.
+///
+/// SAB's `storage` field can be the parent complete dir (not the
+/// per-job folder), so `walk_video_files` may sweep in stranger
+/// episodes from sibling jobs. Without a guard, those strangers get
+/// hardlinked AND trigger upgrade-replace on existing grabs for those
+/// episodes — which incorrectly flips unrelated grabs to `replaced`.
+///
+/// Permissive cases (return `true`):
+///   - `is_batch = 1` — batches legitimately span many episodes.
+///   - File is covered by a route row — Phase-2 sibling-routed
+///     imports are allowed to import any episode the route claims.
+///   - `episode_numbers` is empty — legacy grabs from before the
+///     column was reliably populated. Permissive-on-empty preserves
+///     backward compatibility for those rows; tightening to
+///     "everything must claim explicitly" would silently break
+///     imports for any grab whose episode list never got stamped.
+///
+/// Strict case: parsed `raw_ep_num` must appear in
+/// `grab.episode_numbers`.
+pub(crate) fn grab_claims_episode(
+    is_batch: bool,
+    file_in_routes: bool,
+    grab_episode_numbers: &[i32],
+    raw_ep_num: i32,
+) -> bool {
+    is_batch
+        || file_in_routes
+        || grab_episode_numbers.is_empty()
+        || grab_episode_numbers.contains(&raw_ep_num)
+}
+
 pub(crate) fn is_video_file(name: &str) -> bool {
     let lower = name.to_lowercase();
     matches!(
@@ -565,6 +598,22 @@ async fn import_torrent(
         let walk_root = Path::new(&source_base);
         if walk_root.is_dir() {
             files = walk_video_files(walk_root);
+        } else {
+            // SAB's `canonical_job_path` case-3 candidate (constructed
+            // as `<storage>/<title>/` when SAB reports the parent
+            // complete dir as `storage`) doesn't always resolve on
+            // Ryokan's host view. Surface the miss here so a user
+            // reporting "SAB job completed but never imported" has a
+            // log line to grep for; without it the grab silently
+            // stays pending and `client.get_files()` empty leaves no
+            // breadcrumb for what went wrong.
+            tracing::debug!(
+                source_base = %source_base,
+                grab_id = grab.id,
+                hash = %grab.hash,
+                "import_torrent: source_base is not a directory on Ryokan's view — \
+                 SAB-canonical path may not resolve through download_path translation"
+            );
         }
     }
 
@@ -772,19 +821,14 @@ async fn import_torrent(
             continue;
         }
 
-        // Skip files this grab doesn't claim. SAB's `storage` field
-        // can be the parent complete dir (not the per-job folder),
-        // making `walk_video_files` sweep in stranger episodes from
-        // sibling jobs. Without this guard those strangers would
-        // get hardlinked AND trigger upgrade-replace on existing
-        // grabs for those episodes (incorrectly marking unrelated
-        // grabs as `replaced`). Batch grabs and Phase-2 routed
-        // imports legitimately span multiple episodes — for those,
-        // `claims_this_episode` permits everything.
-        let claims_this_episode = grab.is_batch
-            || routes_by_file.contains_key(file_idx)
-            || grab.episode_numbers.is_empty()
-            || grab.episode_numbers.contains(&raw_ep_num);
+        // Skip stranger files. See `grab_claims_episode` doc for the
+        // full rationale and matrix of cases.
+        let claims_this_episode = grab_claims_episode(
+            grab.is_batch,
+            routes_by_file.contains_key(file_idx),
+            &grab.episode_numbers,
+            raw_ep_num,
+        );
         if !claims_this_episode {
             logger::debug(
                 &state.db,

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -53,6 +53,82 @@ pub(crate) fn is_video_file(name: &str) -> bool {
     )
 }
 
+/// Walk `root` recursively and synthesize `DownloadFile` entries for
+/// every video file found. Returns the names RELATIVE to `root` so
+/// the caller can compose `root + name` to get an absolute path
+/// matching the BT-shape `save_path + file.name` convention the
+/// import loop already uses. Used as a fallback when a download
+/// client's `get_files` returns empty for a completed torrent —
+/// notably SAB, whose `mode=get_files` API only works for queue
+/// items and returns nothing once a job moves to history.
+///
+/// All synthesized entries set `progress: 1.0` (anything visible
+/// on disk has finished downloading by definition) and `wanted:
+/// true`. Sizes come from `metadata.len()`, matching what
+/// `is_video_file`'s caller does post-import.
+///
+/// Recursion guard: hard-stops at `MAX_WALK_DEPTH = 4` so a
+/// pathological symlink loop or a deeply-nested archive can't hang
+/// the import path. Real-world SAB extractions are 1 directory
+/// deep (`<storage>/<filename.mkv>`); BT clients with multi-file
+/// torrents go 2-3 deep at most.
+pub(crate) fn walk_video_files(root: &Path) -> Vec<crate::services::download_client::DownloadFile> {
+    const MAX_WALK_DEPTH: u32 = 4;
+    let mut out = Vec::new();
+    fn recurse(
+        root: &Path,
+        cur: &Path,
+        depth: u32,
+        max_depth: u32,
+        out: &mut Vec<crate::services::download_client::DownloadFile>,
+    ) {
+        if depth > max_depth {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(cur) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let metadata = match entry.metadata() {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            if metadata.is_dir() {
+                recurse(root, &path, depth + 1, max_depth, out);
+                continue;
+            }
+            if !metadata.is_file() {
+                continue;
+            }
+            let Some(name_str) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            if !is_video_file(name_str) {
+                continue;
+            }
+            // Build the path relative to `root` so the caller's
+            // `Path::new(&source_base).join(&file.name)` resolves
+            // back to the absolute path. `strip_prefix` always
+            // succeeds here because `path` is descended from `root`.
+            let rel = path
+                .strip_prefix(root)
+                .ok()
+                .and_then(|p| p.to_str())
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| name_str.to_string());
+            out.push(crate::services::download_client::DownloadFile {
+                name: rel,
+                size: metadata.len() as i64,
+                progress: 1.0,
+                wanted: true,
+            });
+        }
+    }
+    recurse(root, root, 0, MAX_WALK_DEPTH, &mut out);
+    out
+}
+
 /// Replace filesystem-unsafe characters in a filename component.
 pub(crate) fn sanitize_filename(s: &str) -> String {
     media::sanitize_folder_name(s)
@@ -330,7 +406,7 @@ async fn import_torrent(
     // routed `get_files` to the wrong client for any pinned grab.
     client: &std::sync::Arc<dyn DownloadClient>,
 ) -> Result<ImportOutcome, String> {
-    let files = client
+    let mut files = client
         .get_files(torrent_hash)
         .await
         .map_err(|e| format!("get torrent files: {}", e))?;
@@ -451,6 +527,47 @@ async fn import_torrent(
     // `enumerate()` applied to the untouched `files` vec yields the
     // same indices that `detect_sibling_entries_in_pack` recorded at
     // grab time.
+    // Determine the source base path. Prefer the torrent's own
+    // `save_path` (already translated by the caller via
+    // `translate_client_path` to host-view) over the configured
+    // per-client download path. Two reasons:
+    //   1. SAB's `save_path` is the per-job extracted directory
+    //      (e.g. `/downloads/complete/[Erai-raws].One.Piece-1158]/`).
+    //      Using that as source_base + filename lands at the actual
+    //      .mkv. Using per_client_download_path (the parent
+    //      `complete/` folder) would point at a non-existent file.
+    //   2. For BT clients with per-category save paths (Deluge
+    //      "Move completed on label", qBit per-category save paths)
+    //      each torrent reports its own `save_path` extending a
+    //      common base. Using save_path preserves the category
+    //      subdir; using per_client_download_path flattens it.
+    // Fall back to per_client_download_path only when save_path is
+    // empty (rare edge case — some clients may report empty
+    // save_path mid-metadata-fetch).
+    let per_client_download_path = crate::services::download_client::per_client_download_path(cfg);
+    let source_base = if !torrent_save_path.is_empty() {
+        torrent_save_path.to_string()
+    } else {
+        per_client_download_path.to_string()
+    };
+
+    // Some clients (notably SAB) don't expose a per-file API for
+    // completed jobs — `mode=get_files&value=<nzo_id>` only works
+    // while the slot is in the queue, returning an empty list once
+    // the job moves to history. Without a fallback, completed SAB
+    // imports got stuck in NotReady forever. When `get_files` came
+    // back empty AND the source directory exists locally, walk it
+    // for video files. Synthesizes `DownloadFile` entries with
+    // `progress: 1.0` (everything we see on disk has finished
+    // downloading by definition) so the rest of the import loop
+    // works unchanged.
+    if files.is_empty() {
+        let walk_root = Path::new(&source_base);
+        if walk_root.is_dir() {
+            files = walk_video_files(walk_root);
+        }
+    }
+
     let video_files: Vec<(usize, &crate::services::download_client::DownloadFile)> = files
         .iter()
         .enumerate()
@@ -478,33 +595,6 @@ async fn import_torrent(
         .await;
         return Ok(ImportOutcome::NotReady);
     }
-
-    // Determine the source base path. Pick the per-client download
-    // path the user configured in Settings ("where Ryokan can read
-    // this client's files"), falling back to whatever the client
-    // itself reported as `save_path` if no override is set. The
-    // override always wins because the client's own save_path is
-    // from its own filesystem namespace (container-internal for
-    // Docker, seedbox-internal for remote setups) and isn't
-    // reachable from Ryokan's process without translation.
-    //
-    // **Known limitation**: when the client uses per-category /
-    // per-label save paths (Deluge "Move completed on label", qBit
-    // per-category save paths), each torrent reports a different
-    // `save_path` extending a common base (`/downloads/anime` vs
-    // `/downloads/movies`). The single-field `<client>_download_path`
-    // can't preserve that subdir — every torrent lands under the
-    // same local base, flattening the category subdir. Covers the
-    // common case (one shared save dir) at the cost of the
-    // per-category case. Fixing would re-introduce the two-field
-    // remote-prefix design we abandoned in 4972624; follow-up issue
-    // if this bites a user.
-    let per_client_download_path = crate::services::download_client::per_client_download_path(cfg);
-    let source_base = if !per_client_download_path.is_empty() {
-        per_client_download_path.to_string()
-    } else {
-        torrent_save_path.to_string()
-    };
 
     // Lazily-loaded per-series context cache. The single-series case
     // fills exactly one entry; a multi-series routed batch fills one
@@ -889,7 +979,18 @@ async fn import_torrent(
                         )
                         .await;
                     } else {
-                        let _ = client.delete(&old_grab.hash, true).await;
+                        // Route the OLD grab's delete to the OLD
+                        // grab's client — not the NEW grab's client
+                        // bound above. A cross-protocol upgrade
+                        // (SAB→qBit or qBit→SAB) would otherwise
+                        // hit a client that doesn't know the old
+                        // hash and silently leave the old job behind.
+                        let old_client = match old_grab.download_client_id {
+                            Some(id) => state.client_by_id(id).await,
+                            None => None,
+                        };
+                        let target = old_client.as_ref().unwrap_or(client);
+                        let _ = target.delete(&old_grab.hash, true).await;
                     }
                 }
                 grabs_to_mark_replaced.insert(old_grab.id);
@@ -1288,9 +1389,24 @@ pub async fn run_once(state: &AppState) {
     // doesn't poison the others — its grabs just stay pending until
     // the next pass.
     use std::collections::HashSet;
-    let default_id_opt = {
+    // Capture both per-protocol defaults — an un-stamped pending grab
+    // could come from either side, and post-processing doesn't know
+    // the original indexer's protocol from the grab row alone, so it
+    // checks both. The grab will only match against `list_scoped()`
+    // on the client that actually has it, so naming both as candidates
+    // is harmless when only one applies.
+    let default_ids: Vec<i64> = {
         let pool = state.download_clients.read().await.clone();
-        pool.default_id
+        let mut v = Vec::new();
+        if let Some(id) = pool.default_torrent_id {
+            v.push(id);
+        }
+        if let Some(id) = pool.default_usenet_id
+            && !v.contains(&id)
+        {
+            v.push(id);
+        }
+        v
     };
 
     // Pre-pass: NULL the `download_client_id` stamp on any pending
@@ -1339,8 +1455,10 @@ pub async fn run_once(state: &AppState) {
     for grab in &pending {
         if let Some(id) = grab.download_client_id {
             needed_ids.insert(id);
-        } else if let Some(id) = default_id_opt {
-            needed_ids.insert(id);
+        } else {
+            for id in &default_ids {
+                needed_ids.insert(*id);
+            }
         }
     }
     if needed_ids.is_empty() {
@@ -1422,34 +1540,61 @@ pub async fn run_once(state: &AppState) {
     let mut any_imported = false;
 
     for grab in &pending {
-        // Resolve which client this grab landed on.
-        let resolved_id = grab.download_client_id.or(default_id_opt);
-        let Some(grab_client_id) = resolved_id else {
+        // Resolve which client this grab landed on. Stamped grabs
+        // land on exactly one id; un-stamped grabs (older history,
+        // orphan-cleanup just NULLed it) check each per-protocol
+        // default in turn and take the first that has the torrent.
+        // First-match-wins is safe because Ryokan never adds the
+        // same torrent to two clients — the duplicate-add detection
+        // in each impl rejects the second.
+        let candidate_ids: Vec<i64> = match grab.download_client_id {
+            Some(id) => vec![id],
+            None => default_ids.clone(),
+        };
+        let mut hit: Option<(
+            i64,
+            std::sync::Arc<dyn DownloadClient>,
+            crate::services::download_client::DownloadItem,
+        )> = None;
+        for cid in &candidate_ids {
+            let Some(client) = clients.get(cid).cloned() else {
+                continue;
+            };
+            let Some(by_hash) = by_hash_per_client.get(cid) else {
+                continue;
+            };
+            let Some(by_name) = by_name_per_client.get(cid) else {
+                continue;
+            };
+            let matched = if !grab.hash.is_empty() {
+                by_hash.get(&grab.hash.to_lowercase())
+            } else {
+                by_name.get(&grab.torrent_name.to_lowercase())
+            };
+            if let Some(t) = matched {
+                hit = Some((*cid, client, t.clone()));
+                break;
+            }
+        }
+        // Pick the first reachable candidate's id even on miss so the
+        // `unmatched-grab` branch below can speak about *some* client
+        // when emitting the "torrent not found" log line. Falls
+        // through to `continue` if nothing was reachable at all.
+        let Some(grab_client_id) = hit.as_ref().map(|(id, _, _)| *id).or_else(|| {
+            candidate_ids
+                .iter()
+                .find(|cid| clients.contains_key(cid))
+                .copied()
+        }) else {
             continue;
         };
         let Some(client) = clients.get(&grab_client_id).cloned() else {
-            // The client this grab routed to wasn't reachable on
-            // this pass — `list_scoped` failed transiently. Leave
-            // the grab pending so the next pass retries against
-            // the same client. The disabled / deleted case is
-            // already handled by the orphan-stamp pre-pass at the
-            // top of `run_once`, which NULLs the stamp before we
-            // even reach this loop.
+            // Pool changed mid-loop (shouldn't happen — pool is read
+            // once at the top of `run_once`), skip defensively.
             continue;
         };
-        let all_by_hash = match by_hash_per_client.get(&grab_client_id) {
-            Some(m) => m,
-            None => continue,
-        };
-        let all_by_name = match by_name_per_client.get(&grab_client_id) {
-            Some(m) => m,
-            None => continue,
-        };
-        let matched = if !grab.hash.is_empty() {
-            all_by_hash.get(&grab.hash.to_lowercase())
-        } else {
-            all_by_name.get(&grab.torrent_name.to_lowercase())
-        };
+        let matched: Option<&crate::services::download_client::DownloadItem> =
+            hit.as_ref().map(|(_, _, t)| t);
 
         let Some(torrent) = matched else {
             // Torrent not found in qBittorrent. If the grab is old enough
@@ -1688,17 +1833,25 @@ async fn advance_state_without_import(state: &AppState) -> Result<(), ()> {
         .map_err(|_| ())?
         .unwrap_or_default();
 
-    let client = match state.default_download_client().await {
-        Some(c) => c,
-        None => return Ok(()),
-    };
-
-    let torrents = client.list_scoped().await.map_err(|_| ())?;
-    let by_hash: HashMap<String, &crate::services::download_client::DownloadItem> = torrents
+    // Fan out across every configured client so SAB grabs surface
+    // here too. Prior implementation called `default_download_client`
+    // and missed every SAB grab, leaving Usenet completions stuck at
+    // "Importing…" forever when post-processing was disabled.
+    let pool = state.download_clients.read().await.clone();
+    if pool.clients.is_empty() {
+        return Ok(());
+    }
+    let mut all_torrents: Vec<crate::services::download_client::DownloadItem> = Vec::new();
+    for c in pool.clients.values() {
+        if let Ok(items) = c.list_scoped().await {
+            all_torrents.extend(items);
+        }
+    }
+    let by_hash: HashMap<String, &crate::services::download_client::DownloadItem> = all_torrents
         .iter()
         .map(|t| (t.hash.to_lowercase(), t))
         .collect();
-    let by_name: HashMap<String, &crate::services::download_client::DownloadItem> = torrents
+    let by_name: HashMap<String, &crate::services::download_client::DownloadItem> = all_torrents
         .iter()
         .map(|t| (t.name.to_lowercase(), t))
         .collect();

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -772,6 +772,33 @@ async fn import_torrent(
             continue;
         }
 
+        // Skip files this grab doesn't claim. SAB's `storage` field
+        // can be the parent complete dir (not the per-job folder),
+        // making `walk_video_files` sweep in stranger episodes from
+        // sibling jobs. Without this guard those strangers would
+        // get hardlinked AND trigger upgrade-replace on existing
+        // grabs for those episodes (incorrectly marking unrelated
+        // grabs as `replaced`). Batch grabs and Phase-2 routed
+        // imports legitimately span multiple episodes — for those,
+        // `claims_this_episode` permits everything.
+        let claims_this_episode = grab.is_batch
+            || routes_by_file.contains_key(file_idx)
+            || grab.episode_numbers.is_empty()
+            || grab.episode_numbers.contains(&raw_ep_num);
+        if !claims_this_episode {
+            logger::debug(
+                &state.db,
+                LogCategory::PostProcess,
+                &format!(
+                    "Skipping stranger file '{}' (parsed ep {}) — grab #{} only claims {:?}",
+                    filename_only, raw_ep_num, grab.id, grab.episode_numbers
+                ),
+                "",
+            )
+            .await;
+            continue;
+        }
+
         let ep_title = ctx
             .ep_meta
             .get(&ep_num)
@@ -1033,28 +1060,11 @@ async fn import_torrent(
                 )
                 .await;
                 imported_count += 1;
-                // Record the source path we imported from — but only
-                // if this file's parsed episode is one this grab
-                // actually claims. Without the filter, a wide walk
-                // (SAB returning the parent complete dir as `storage`,
-                // pre `canonical_job_path` narrowing) sweeps in
-                // stranger episodes from sibling SAB jobs and stamps
-                // them onto this grab. Deleting one episode then
-                // finds the wrong grab's stamps and over-removes.
-                //
-                // Batch grabs (`is_batch = 1`) and Phase-2 routed
-                // sibling imports legitimately import multiple
-                // episodes via one grab — for those, accept all
-                // imported files. Single-episode grabs check that
-                // the parsed `raw_ep_num` is in the grab's claimed
-                // `episode_numbers`.
-                let claims_this_episode = grab.is_batch
-                    || routes_by_file.contains_key(file_idx)
-                    || grab.episode_numbers.is_empty()
-                    || grab.episode_numbers.contains(&raw_ep_num);
-                if claims_this_episode {
-                    imported_source_paths.push(src.display().to_string());
-                }
+                // The early `claims_this_episode` guard above already
+                // filtered out stranger files for this grab — so any
+                // file reaching this point is a legitimate import,
+                // and its source path is safe to stamp.
+                imported_source_paths.push(src.display().to_string());
                 touched_series.insert(target_series_id);
                 logger::info(
                     &state.db,

--- a/src/services/post_processing/tests/grab_claims_episode.rs
+++ b/src/services/post_processing/tests/grab_claims_episode.rs
@@ -1,0 +1,71 @@
+//! `grab_claims_episode` coverage — the import-loop guard that keeps
+//! a single-episode grab from sweeping in stranger episodes when
+//! `walk_video_files` is given the parent complete dir (the SAB
+//! `storage`-points-at-parent edge case). Pinning the four cases:
+//!
+//!   1. Strict: `episode_numbers=[N]` claims only N.
+//!   2. Permissive on batch (`is_batch=true`).
+//!   3. Permissive on route coverage (Phase-2 sibling-routed imports).
+//!   4. Permissive on empty `episode_numbers` (legacy back-compat).
+//!
+//! Case 4 is the one most likely to drift: a future "tighten the guard"
+//! refactor could silently start dropping imports for legacy grabs
+//! whose episode list never got populated. The explicit test here is
+//! the contract.
+
+use crate::services::post_processing::grab_claims_episode;
+
+#[test]
+fn strict_match_when_grab_has_explicit_episode_list() {
+    // Single-episode grab claiming ep 1156. A walk that finds 1156 →
+    // claimed; one that finds 1154 (a stranger from a sibling job) →
+    // dropped.
+    assert!(
+        grab_claims_episode(false, false, &[1156], 1156),
+        "grab claims its own episode"
+    );
+    assert!(
+        !grab_claims_episode(false, false, &[1156], 1154),
+        "grab does NOT claim a stranger episode"
+    );
+}
+
+#[test]
+fn batch_grab_claims_anything() {
+    // is_batch=1 is set on grabs that legitimately span many episodes
+    // (season packs, etc.). Their episode_numbers may be empty or
+    // partial; the guard must permit every walked file regardless.
+    assert!(grab_claims_episode(true, false, &[], 1));
+    assert!(grab_claims_episode(true, false, &[], 99));
+    // Even when episode_numbers IS populated, batch wins.
+    assert!(grab_claims_episode(true, false, &[1, 2, 3], 999));
+}
+
+#[test]
+fn route_covered_file_claims_through_route() {
+    // Phase-2 sibling-routed imports (the smol Monogatari /
+    // JoJo-Egypt-hen shape) are non-batch but get a route row per
+    // file. The route's per-sibling `episode_numbers` lives outside
+    // this guard; route presence alone is sufficient.
+    assert!(grab_claims_episode(false, true, &[1156], 9999));
+}
+
+#[test]
+fn empty_episode_numbers_permits_everything_legacy_back_compat() {
+    // Legacy grabs from before `episode_numbers` was reliably
+    // populated can have an empty array. Permissive-on-empty
+    // preserves backward compatibility — tightening this would
+    // silently break imports for those rows. Pin it.
+    assert!(grab_claims_episode(false, false, &[], 1));
+    assert!(grab_claims_episode(false, false, &[], 1156));
+    assert!(grab_claims_episode(false, false, &[], 99999));
+}
+
+#[test]
+fn precedence_holds_when_multiple_permissive_signals_apply() {
+    // Belt-and-suspenders: a row that's both batch AND route-covered
+    // AND has an empty list AND happens to match the parsed episode
+    // is still claimed. No interaction between the OR clauses.
+    assert!(grab_claims_episode(true, true, &[], 1));
+    assert!(grab_claims_episode(true, true, &[1], 1));
+}

--- a/src/services/post_processing/tests/mod.rs
+++ b/src/services/post_processing/tests/mod.rs
@@ -21,6 +21,7 @@
 
 mod file_ops;
 mod filenames;
+mod grab_claims_episode;
 mod lock;
 mod run_once;
 mod walk_video_files;

--- a/src/services/post_processing/tests/mod.rs
+++ b/src/services/post_processing/tests/mod.rs
@@ -23,6 +23,7 @@ mod file_ops;
 mod filenames;
 mod lock;
 mod run_once;
+mod walk_video_files;
 
 /// Serializes the `lock.rs` test and the `run_once.rs` tests so they
 /// don't race on the production `POST_PROC_LOCK`. Both touch the

--- a/src/services/post_processing/tests/run_once.rs
+++ b/src/services/post_processing/tests/run_once.rs
@@ -164,16 +164,22 @@ async fn install_pool(
 ) {
     let mut clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>> =
         std::collections::HashMap::new();
-    let mut default_id = None;
+    // Tests in this module exercise torrent-side post-processing; the
+    // mock `DownloadClient` fixtures don't carry a protocol, so any
+    // `is_default = true` entry here pins the torrent default. A
+    // future usenet-flavored fixture should mint its own pool that
+    // populates `default_usenet_id` instead.
+    let mut default_torrent_id = None;
     for (id, c, is_default) in entries {
         if is_default {
-            default_id = Some(id);
+            default_torrent_id = Some(id);
         }
         clients.insert(id, c);
     }
     let pool = crate::DownloadClientPool {
         clients,
-        default_id,
+        default_torrent_id,
+        default_usenet_id: None,
     };
     *state.download_clients.write().await = Arc::new(pool);
 }

--- a/src/services/post_processing/tests/walk_video_files.rs
+++ b/src/services/post_processing/tests/walk_video_files.rs
@@ -1,0 +1,176 @@
+//! `walk_video_files` coverage — the directory-walk fallback used
+//! when a download client's `get_files` API returns empty for a
+//! completed torrent. SAB is the motivating case (its
+//! `mode=get_files` only works for queue items; once a job moves
+//! to history the file list is gone, leaving Ryokan unable to
+//! discover the extracted .mkv).
+//!
+//! Tests use real `tempfile::TempDir` directories to exercise the
+//! actual filesystem walker, since the function is intrinsically
+//! filesystem-coupled — mocking would just re-implement the
+//! walker without testing it.
+
+use std::fs;
+use std::io::Write;
+
+use crate::services::post_processing::walk_video_files;
+
+/// SAB's canonical extraction shape: `<storage>/<filename>` with
+/// the storage directory named after the NZB. Most common case for
+/// single-episode grabs from NZBGeek-style indexers. The walker
+/// must find the .mkv one level down without configuration.
+#[test]
+fn walks_one_level_deep_for_sab_shape() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    let mut f = fs::File::create(storage.join("[Erai-raws].One.Piece-1158.mkv")).unwrap();
+    f.write_all(b"fake mkv contents").unwrap();
+    drop(f);
+
+    let files = walk_video_files(storage);
+    assert_eq!(files.len(), 1, "expected one .mkv at the storage root");
+    assert_eq!(files[0].name, "[Erai-raws].One.Piece-1158.mkv");
+    assert_eq!(files[0].progress, 1.0);
+    assert!(files[0].wanted);
+    assert_eq!(files[0].size, b"fake mkv contents".len() as i64);
+}
+
+/// Non-video files in the storage directory must be filtered out.
+/// SAB jobs often leave behind `.nfo`, `.srt`, sample folders, and
+/// par2 / sfv leftovers post-extraction. The import path doesn't
+/// want any of those mistaken for the main video.
+#[test]
+fn filters_non_video_extensions() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    fs::write(storage.join("show.mkv"), b"video").unwrap();
+    fs::write(storage.join("show.nfo"), b"metadata").unwrap();
+    fs::write(storage.join("show.srt"), b"subtitles").unwrap();
+    fs::write(storage.join("readme.txt"), b"notes").unwrap();
+    fs::write(storage.join("show.par2"), b"parity").unwrap();
+
+    let files = walk_video_files(storage);
+    assert_eq!(files.len(), 1, "only the .mkv must survive the filter");
+    assert_eq!(files[0].name, "show.mkv");
+}
+
+/// Multi-file SAB extractions (rare for single-episode anime, but
+/// more common for batch packs) must surface every video. Names
+/// come back as paths relative to the walk root so the caller can
+/// `Path::new(&source_base).join(&file.name)` without prefix
+/// surprises.
+#[test]
+fn walks_multi_file_storage() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    fs::write(storage.join("E01.mkv"), b"a").unwrap();
+    fs::write(storage.join("E02.mkv"), b"b").unwrap();
+    fs::write(storage.join("E03.mp4"), b"c").unwrap();
+
+    let mut files = walk_video_files(storage);
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(files.len(), 3);
+    assert_eq!(files[0].name, "E01.mkv");
+    assert_eq!(files[1].name, "E02.mkv");
+    assert_eq!(files[2].name, "E03.mp4");
+}
+
+/// BT-shape multi-file torrents: a torrent name dir with the
+/// videos inside. `walk_video_files` recurses one level deeper,
+/// returning paths relative to the walk root. Caller's
+/// `source_base + name` resolves to the absolute file location.
+/// The relative-name shape lets the import loop rename files
+/// without losing the per-torrent directory context.
+#[test]
+fn returns_paths_relative_to_walk_root() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    let inner = storage.join("[smol] Monogatari Series");
+    fs::create_dir(&inner).unwrap();
+    fs::write(inner.join("01.mkv"), b"a").unwrap();
+    fs::write(inner.join("02.mkv"), b"b").unwrap();
+
+    let mut files = walk_video_files(storage);
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(files.len(), 2);
+    // On Unix the path separator is `/`. On Windows it would be
+    // `\`. The test is Unix-only via the `cfg!(unix)` guard below
+    // since CI runs on Linux. The relative-path semantic is what
+    // matters; the separator is platform-dependent.
+    if cfg!(unix) {
+        assert_eq!(files[0].name, "[smol] Monogatari Series/01.mkv");
+        assert_eq!(files[1].name, "[smol] Monogatari Series/02.mkv");
+    }
+}
+
+/// Empty storage directory returns empty Vec without erroring.
+/// Edge case: SAB extraction in progress, or a job whose post-
+/// processing failed and left an empty dir behind.
+#[test]
+fn empty_directory_returns_empty_vec() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let files = walk_video_files(tmp.path());
+    assert!(files.is_empty());
+}
+
+/// Non-existent path must NOT panic — `read_dir` returns Err which
+/// the function silently skips. Edge case: the path translation
+/// resolved to a directory that doesn't exist on Ryokan's host
+/// (misconfigured download_path on the SAB row).
+#[test]
+fn nonexistent_path_returns_empty_vec_without_panic() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let bogus = tmp.path().join("does-not-exist");
+    let files = walk_video_files(&bogus);
+    assert!(files.is_empty());
+}
+
+/// Recursion guard — a deeply-nested archive shouldn't hang the
+/// walker. The cap is 4 levels; videos beyond that are silently
+/// skipped. Tested via a 6-deep nesting where only the levels
+/// within the cap should surface.
+#[test]
+fn caps_recursion_depth() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    fs::write(storage.join("d0.mkv"), b"x").unwrap();
+    let mut path = storage.to_path_buf();
+    for i in 1..=6 {
+        path = path.join(format!("level{i}"));
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join(format!("d{i}.mkv")), b"x").unwrap();
+    }
+    let mut files = walk_video_files(storage);
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    // depth 0 (storage root): d0.mkv
+    // depth 1: level1/d1.mkv
+    // depth 2: level1/level2/d2.mkv
+    // depth 3: level1/level2/level3/d3.mkv
+    // depth 4: level1/level2/level3/level4/d4.mkv
+    // depth 5+: not walked
+    assert_eq!(
+        files.len(),
+        5,
+        "expected videos at depths 0-4 inclusive; got {} entries: {:?}",
+        files.len(),
+        files.iter().map(|f| &f.name).collect::<Vec<_>>()
+    );
+}
+
+/// Extension matching is case-insensitive — `show.MKV` and
+/// `show.Mkv` should both surface the same as `show.mkv`. SAB
+/// occasionally yields capitalized extensions on releases from
+/// Windows-side rippers; without case folding those would be
+/// silently filtered out by `is_video_file` and the import
+/// would never trigger.
+#[test]
+fn case_insensitive_extension_match() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let storage = tmp.path();
+    fs::write(storage.join("upper.MKV"), b"a").unwrap();
+    fs::write(storage.join("mixed.Mp4"), b"b").unwrap();
+
+    let mut files = walk_video_files(storage);
+    files.sort_by(|a, b| a.name.cmp(&b.name));
+    assert_eq!(files.len(), 2);
+}

--- a/src/services/scoring.rs
+++ b/src/services/scoring.rs
@@ -336,6 +336,7 @@ mod tests {
             score_breakdown: Vec::new(),
             upload_date: String::new(),
             indexer_id: None,
+            indexer_name: String::new(),
         }
     }
 

--- a/src/services/upgrade.rs
+++ b/src/services/upgrade.rs
@@ -519,7 +519,8 @@ mod tests {
         clients.insert(1, Arc::new(StubClient));
         let pool = crate::DownloadClientPool {
             clients,
-            default_id: Some(1),
+            default_torrent_id: Some(1),
+            default_usenet_id: None,
         };
         *state.download_clients.write().await = Arc::new(pool);
     }

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -76,14 +76,21 @@ pub fn build_test_app_state(
     // shape and don't care about ids.
     let mut clients: std::collections::HashMap<i64, Arc<dyn DownloadClient>> =
         std::collections::HashMap::new();
-    let mut default_id = None;
+    let mut default_torrent_id = None;
     if let Some(c) = download_client {
         clients.insert(1, c);
-        default_id = Some(1);
+        // Test fixtures inject a torrent client by default — the
+        // existing dyn DownloadClient mocks don't distinguish protocol
+        // and every grab-flavored test case is torrent-shaped. A
+        // future usenet-specific test fixture should pass its own
+        // pre-built pool through `build_test_app_state_with_pool` (or
+        // similar).
+        default_torrent_id = Some(1);
     }
     let pool = crate::DownloadClientPool {
         clients,
-        default_id,
+        default_torrent_id,
+        default_usenet_id: None,
     };
     let download_clients: crate::DownloadClientsCache = Arc::new(RwLock::new(Arc::new(pool)));
     AppState {
@@ -482,6 +489,22 @@ mod e2e {
             .route(
                 "/settings/indexers/delete",
                 post(crate::handlers::settings::indexers::settings_indexers_delete),
+            )
+            .route(
+                "/settings/indexers/upsert",
+                post(crate::handlers::settings::indexers::settings_indexers_upsert),
+            )
+            .route(
+                "/settings/indexers/section",
+                axum::routing::get(crate::handlers::settings::indexers::settings_indexers_section),
+            )
+            .route(
+                "/settings/indexers/add-form",
+                axum::routing::get(crate::handlers::settings::indexers::settings_indexers_add_form),
+            )
+            .route(
+                "/settings/indexers/{id}/edit-form",
+                axum::routing::get(crate::handlers::settings::indexers::settings_indexers_edit_form),
             )
             .route(
                 "/settings/download-clients/delete",

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -114,6 +114,20 @@
 
 * { margin: 0; padding: 0; box-sizing: border-box; }
 
+/* Cross-document view transitions — opt every same-origin
+   navigation into the browser's built-in crossfade so back/forward
+   and direct link clicks stop flashing the empty page chrome
+   between renders. `navigation: auto` is the entire surface;
+   browsers that don't support cross-document transitions yet
+   (Firefox <141, Safari <18, anything pre-Chromium-126) ignore
+   the rule and get the prior hard-cut behavior. The same
+   `::view-transition-old` / `::view-transition-new` pseudo-element
+   tree powers htmx's `globalViewTransitions` config, so any future
+   tuning here applies to boosted swaps once `hx-boost` lands. */
+@view-transition {
+    navigation: auto;
+}
+
 body {
     background: var(--bg);
     color: var(--text);

--- a/static/css/forms.css
+++ b/static/css/forms.css
@@ -399,7 +399,8 @@
 }
 
 .cf-section input[type="number"],
-.settings-form input[type="number"] {
+.settings-form input[type="number"],
+.dc-modal-form input[type="number"] {
     appearance: textfield;
     -moz-appearance: textfield;
 }
@@ -407,7 +408,9 @@
 .cf-section input[type="number"]::-webkit-outer-spin-button,
 .cf-section input[type="number"]::-webkit-inner-spin-button,
 .settings-form input[type="number"]::-webkit-outer-spin-button,
-.settings-form input[type="number"]::-webkit-inner-spin-button {
+.settings-form input[type="number"]::-webkit-inner-spin-button,
+.dc-modal-form input[type="number"]::-webkit-outer-spin-button,
+.dc-modal-form input[type="number"]::-webkit-inner-spin-button {
     -webkit-appearance: none;
     appearance: none;
     margin: 0;

--- a/static/css/pages/downloads.css
+++ b/static/css/pages/downloads.css
@@ -8,8 +8,26 @@
     font-size: 12px;
 }
 
+/* `font-size: 0` collapses the ~4px visual gap that adjacent
+   `display: inline-block` <button> siblings get from any source-
+   whitespace between them. The template render keeps newlines +
+   indentation between sibling <button> tags, while the JS poll-
+   rebuild (`container.innerHTML = renderQueue(…)` every 5s)
+   concatenates with `html += ` and produces no whitespace at all.
+   Without the reset, the first render sat at ~8px gap (template
+   whitespace plus the explicit margin below) and the first poll
+   snapped down to 4px — visibly "every button got their padding
+   reduced and they all stuck together". Children carry their own
+   `font-size` from `.btn-sm` so text doesn't disappear. */
 .dl-actions {
     white-space: nowrap;
+    font-size: 0;
+}
+
+/* Explicit gap that doesn't depend on inter-element whitespace,
+   so template and JS renders are pixel-identical. */
+.dl-actions .btn + .btn {
+    margin-left: 4px;
 }
 
 /* Secondary info line under a History row's torrent name, used for

--- a/static/css/pages/series.css
+++ b/static/css/pages/series.css
@@ -953,7 +953,16 @@
 }
 
 .modal-ep {
-    max-width: 1100px;
+    /* Interactive search has 8 columns (Score / Release / Indexer /
+       Group / Quality / Size / Seeds / Grab) and the Release title
+       can be 60+ chars before truncation. Stretch to ~96vw on a
+       desktop screen so the Grab button stays reachable without
+       horizontal scrolling on a typical 1080p+ viewport, and cap at
+       1600px so an ultrawide doesn't get an absurdly stretched
+       modal. The earlier 1320px cap left a long title wrapping on
+       a 1920px viewport, which then forced horizontal scroll
+       inside `.is-modal-scroll` to reach Grab. */
+    max-width: min(96vw, 1600px);
     width: 100%;
 }
 
@@ -1122,7 +1131,7 @@
 .interactive-search-table th {
     text-align: left;
     padding: 7px 10px;
-    font-size: 10px;
+    font-size: 12px;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.4px;
@@ -1154,6 +1163,16 @@
 
 .interactive-search-table .col-quality { width: 120px; white-space: nowrap; font-family: var(--font-mono); font-size: 11px; color: var(--text-dim); }
 
+/* Indexer attribution column. Narrow enough to fit a typical
+   tracker name ("nekoBT", "AnimeBytes") without word-wrap, wide
+   enough that the longer Generic Newznab fallback ("Generic
+   Newznab") still fits on one line. Nyaa-direct results render
+   "Nyaa" in this column when `indexer_name` is empty. Font size
+   intentionally unset so it inherits 12px from the table — the
+   header used to render larger than its siblings when this was
+   `font-size: 12px` AND the parent th rule was 10px. */
+.interactive-search-table .col-indexer { width: 110px; white-space: nowrap; }
+
 /* Release-title link in each row. Matches the manual search page's
    `.col-name a:hover` treatment so hovering a row makes it obvious
    the title opens the Nyaa view page. Without this, the inline
@@ -1170,9 +1189,17 @@
 }
 
 .is-modal-scroll {
+    /* Both axes of overflow — the table can outgrow the modal on
+       both axes (vertical: many rows; horizontal: long release
+       titles + 8 columns push past the modal-body's inner width
+       on smaller viewports). Without `overflow-x: auto` the table
+       gets clipped at the modal's right edge and the Grab button
+       becomes unreachable; with it, the user can scroll horizontally
+       as a safety net even when the modal-ep max-width can't fit
+       the table at the current viewport. */
     overflow-y: auto;
+    overflow-x: auto;
     max-height: 480px;
-    
     padding-top: 0;
     padding-bottom: 0;
 }

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -870,6 +870,7 @@ fieldset legend {
     background: transparent;
     border: none;
     color: inherit;
+    text-decoration: none;
     text-align: left;
     cursor: pointer;
     font: inherit;
@@ -1053,7 +1054,23 @@ fieldset legend {
     border-top: 1px solid var(--border);
 }
 
-.dc-modal-form { display: flex; flex-direction: column; min-height: 0; }
+/* The modal-body container divs (#dc-modal-body, #indexer-modal-body)
+   sit between `.modal` (a column flex container with max-height: 80vh)
+   and the form. Without flex routing through them the form collapses
+   to its content height and the bottom of a tall form (the indexer
+   Add form has 11 fields in 7 rows) gets clipped by the modal's
+   overflow:hidden bound. Making them column-flex containers that
+   grow to fill the parent lets the inner `.modal-body` carry the
+   overflow-y:auto scroll affordance the form needs. */
+#dc-modal-body,
+#indexer-modal-body {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+}
+
+.dc-modal-form { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 .dc-modal-form .modal-body { padding: 20px 24px; }
 .dc-modal-form .form-group { margin-bottom: 14px; }
 .dc-modal-form .form-row   { display: flex; gap: 16px; }

--- a/static/js/base.js
+++ b/static/js/base.js
@@ -640,18 +640,20 @@ window.ryokanEscapeHtml = function (value) {
 // without a secure origin don't expose navigator.clipboard).
 window.ryokanCopy = function (text, btn) {
     if (text == null || text === '') return Promise.resolve();
-    const flash = function (label, ms) {
-        if (!btn) return;
-        const original = btn.textContent;
-        btn.textContent = label;
-        setTimeout(function () { btn.textContent = original; }, ms || 1500);
-    };
+    // No in-button flash — the toast carries the success/failure
+    // feedback. The previous flash mutated `btn.innerHTML` to swap
+    // the SVG for "Copied!" text and back; on icon-only buttons
+    // (downloads queue actions, settings API-key copy) the
+    // round-trip occasionally clobbered padding because any layout
+    // change racing with the 1500ms restore left the button
+    // visibly squashed. `btn` is now an unused parameter, kept on
+    // the signature so existing call sites (`ryokanCopy(hash, this)`)
+    // don't need to change.
+    void btn;
     const success = function () {
-        flash('Copied!', 1500);
         window.ryokanToast({kind: 'success', title: 'Copied to clipboard', body: '', log: false, duration: 1500});
     };
     const failure = function (err) {
-        flash('Failed', 2000);
         window.ryokanToast({kind: 'error', title: 'Copy failed', body: (err && err.message) || 'Browser denied clipboard access', log: false});
     };
     if (navigator.clipboard && navigator.clipboard.writeText) {

--- a/static/js/downloads.js
+++ b/static/js/downloads.js
@@ -69,58 +69,75 @@ function escapeHtml(s) {
 function renderQueue(torrents) {
     const container = document.getElementById('queue-container');
     if (!container) return;
-    // Capture scroll before the wholesale innerHTML replace below.
-    // Without this, the 5s queue poll yanks the user back to the top
-    // of the page mid-scroll because replacing the container's
-    // children temporarily collapses its height to 0, scroll-anchoring
-    // can't keep the prior anchor, and the document scroll position
-    // resets. Restore after the swap.
+
+    // Build the new HTML first, then short-circuit if the rendered
+    // markup is identical to what's already there. The 5s poll
+    // produces the same DOM 99% of the time (no progress change
+    // between two ticks once a job is finished or queued idle), so
+    // skipping the innerHTML replace keeps the scrollbar steady and
+    // the buttons' :hover state alive.
+    let html;
+    if (!torrents || torrents.length === 0) {
+        html = '<div class="logs-empty">No active downloads.</div>';
+    } else {
+        const isDownloadingKind = (k) => k === 'downloading' || k === 'downloading-stalled'
+            || k === 'downloading-queued' || k === 'checking-download';
+        torrents.sort((a, b) => {
+            const aDown = isDownloadingKind(a.state_kind) ? 0 : 1;
+            const bDown = isDownloadingKind(b.state_kind) ? 0 : 1;
+            if (aDown !== bDown) return aDown - bDown;
+            return b.progress - a.progress;
+        });
+        html = '<div class="rss-table-wrap"><table class="rss-table"><thead><tr>';
+        html += '<th>Name</th><th>Size</th><th>Progress</th><th>Speed</th><th>ETA</th><th>Status</th><th>Actions</th>';
+        html += '</tr></thead><tbody>';
+        for (const t of torrents) {
+            const pct = (t.progress * 100).toFixed(1);
+            const isPaused = t.state_kind === 'paused' || t.state_kind === 'paused-complete';
+            html += `<tr data-hash="${escapeHtml(t.hash)}">`;
+            html += `<td><div class="dl-torrent-name">${escapeHtml(t.name)}</div></td>`;
+            html += `<td>${formatSize(t.size)}</td>`;
+            html += `<td><div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:${pct}%"></div></div><span class="dl-progress-text">${pct}%</span></div></td>`;
+            html += `<td>${formatSpeed(t.dlspeed)}</td>`;
+            html += `<td>${formatEta(t.eta)}</td>`;
+            html += `<td><span class="log-badge ${stateBadgeClass(t.state_kind)}">${stateLabel(t.state_kind)}</span></td>`;
+            html += `<td class="dl-actions">`;
+            if (isPaused) {
+                html += `<button class="btn btn-ghost btn-sm" onclick="resumeTorrent('${escapeHtml(t.hash)}')" title="Resume"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg></button>`;
+            } else {
+                html += `<button class="btn btn-ghost btn-sm" onclick="pauseTorrent('${escapeHtml(t.hash)}')" title="Pause"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg></button>`;
+            }
+            // Copy infohash button — keep in sync with the template's
+            // queue-row rendering in downloads.html. Without this, the
+            // post-fetch JS render dropped the button so it visibly
+            // flashed away on page load when loadQueue() ran immediately.
+            html += `<button class="btn btn-ghost btn-sm" onclick="ryokanCopy('${escapeHtml(t.hash)}', this)" title="Copy infohash"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
+            html += `<button class="btn btn-ghost btn-sm" onclick="deleteTorrent('${escapeHtml(t.hash)}')" title="Remove"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></button>`;
+            html += `</td></tr>`;
+        }
+        html += '</tbody></table></div>';
+    }
+
+    // Skip the swap if nothing changed — keeps scroll/hover/focus.
+    if (container.innerHTML === html) return;
+
+    // The queue table sits inside `.rss-table-wrap` which has
+    // `max-height: 680px; overflow: auto` (base.css). The scrollbar
+    // the user actually drags is on THAT element, not the window —
+    // so saving `window.scrollY` is irrelevant; we need the wrap's
+    // `scrollTop`. innerHTML on the parent rebuilds the wrap and the
+    // fresh element starts at scrollTop=0, which the user perceives
+    // as "the page jumped back to the top" of the table.
+    const prevWrap = container.querySelector('.rss-table-wrap');
+    const prevWrapScrollTop = prevWrap ? prevWrap.scrollTop : 0;
+    // Window scroll preservation too — innerHTML can collapse height
+    // momentarily and scroll-anchor the document to the top in some
+    // browsers. Cheap to do alongside.
     const prevScrollX = window.scrollX;
     const prevScrollY = window.scrollY;
-    if (!torrents || torrents.length === 0) {
-        container.innerHTML = '<div class="logs-empty">No active downloads.</div>';
-        return;
-    }
-    const isDownloadingKind = (k) => k === 'downloading' || k === 'downloading-stalled'
-        || k === 'downloading-queued' || k === 'checking-download';
-    torrents.sort((a, b) => {
-        const aDown = isDownloadingKind(a.state_kind) ? 0 : 1;
-        const bDown = isDownloadingKind(b.state_kind) ? 0 : 1;
-        if (aDown !== bDown) return aDown - bDown;
-        return b.progress - a.progress;
-    });
-    let html = '<div class="rss-table-wrap"><table class="rss-table"><thead><tr>';
-    html += '<th>Name</th><th>Size</th><th>Progress</th><th>Speed</th><th>ETA</th><th>Status</th><th>Actions</th>';
-    html += '</tr></thead><tbody>';
-    for (const t of torrents) {
-        const pct = (t.progress * 100).toFixed(1);
-        const isPaused = t.state_kind === 'paused' || t.state_kind === 'paused-complete';
-        html += `<tr data-hash="${escapeHtml(t.hash)}">`;
-        html += `<td><div class="dl-torrent-name">${escapeHtml(t.name)}</div></td>`;
-        html += `<td>${formatSize(t.size)}</td>`;
-        html += `<td><div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:${pct}%"></div></div><span class="dl-progress-text">${pct}%</span></div></td>`;
-        html += `<td>${formatSpeed(t.dlspeed)}</td>`;
-        html += `<td>${formatEta(t.eta)}</td>`;
-        html += `<td><span class="log-badge ${stateBadgeClass(t.state_kind)}">${stateLabel(t.state_kind)}</span></td>`;
-        html += `<td class="dl-actions">`;
-        if (isPaused) {
-            html += `<button class="btn btn-ghost btn-sm" onclick="resumeTorrent('${escapeHtml(t.hash)}')" title="Resume"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polygon points="5 3 19 12 5 21 5 3"/></svg></button>`;
-        } else {
-            html += `<button class="btn btn-ghost btn-sm" onclick="pauseTorrent('${escapeHtml(t.hash)}')" title="Pause"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg></button>`;
-        }
-        // Copy infohash button — keep in sync with the template's
-        // queue-row rendering in downloads.html. Without this, the
-        // post-fetch JS render dropped the button so it visibly
-        // flashed away on page load when loadQueue() ran immediately.
-        html += `<button class="btn btn-ghost btn-sm" onclick="ryokanCopy('${escapeHtml(t.hash)}', this)" title="Copy infohash"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1"/></svg></button>`;
-        html += `<button class="btn btn-ghost btn-sm" onclick="deleteTorrent('${escapeHtml(t.hash)}')" title="Remove"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></button>`;
-        html += `</td></tr>`;
-    }
-    html += '</tbody></table></div>';
     container.innerHTML = html;
-    // Restore the pre-swap scroll position. window.scrollTo with
-    // {behavior: 'instant'} skips the smooth-scroll animation so a
-    // poll tick doesn't visibly jiggle the page.
+    const newWrap = container.querySelector('.rss-table-wrap');
+    if (newWrap) newWrap.scrollTop = prevWrapScrollTop;
     window.scrollTo({left: prevScrollX, top: prevScrollY, behavior: 'instant'});
 }
 

--- a/static/js/downloads.js
+++ b/static/js/downloads.js
@@ -69,6 +69,14 @@ function escapeHtml(s) {
 function renderQueue(torrents) {
     const container = document.getElementById('queue-container');
     if (!container) return;
+    // Capture scroll before the wholesale innerHTML replace below.
+    // Without this, the 5s queue poll yanks the user back to the top
+    // of the page mid-scroll because replacing the container's
+    // children temporarily collapses its height to 0, scroll-anchoring
+    // can't keep the prior anchor, and the document scroll position
+    // resets. Restore after the swap.
+    const prevScrollX = window.scrollX;
+    const prevScrollY = window.scrollY;
     if (!torrents || torrents.length === 0) {
         container.innerHTML = '<div class="logs-empty">No active downloads.</div>';
         return;
@@ -110,6 +118,10 @@ function renderQueue(torrents) {
     }
     html += '</tbody></table></div>';
     container.innerHTML = html;
+    // Restore the pre-swap scroll position. window.scrollTo with
+    // {behavior: 'instant'} skips the smooth-scroll animation so a
+    // poll tick doesn't visibly jiggle the page.
+    window.scrollTo({left: prevScrollX, top: prevScrollY, behavior: 'instant'});
 }
 
 function loadQueue() {

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -671,14 +671,21 @@ function renderInteractiveResults(results, epNum) {
         body.innerHTML = '<div style="text-align:center;color:var(--text-dim);padding:32px">No results found.</div>';
         return;
     }
-    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
+    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th class="col-indexer">Indexer</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
     results.forEach((r, idx) => {
         const batchTag = r.is_batch ? '<span class="tag tag-batch" style="margin-left:4px">batch</span>' : '';
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
+        // Empty `indexer_name` falls back to "Nyaa" — Nyaa-direct
+        // results don't carry a name (Nyaa isn't a row in the indexers
+        // table per plan decision #1) but the column should still
+        // attribute every row so the user can tell where a hit came
+        // from at a glance.
+        const indexer = escHtml(r.indexer_name || 'Nyaa');
         html += `<tr>
             <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
             <td><a class="isearch-release-link" href="${escHtml(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
+            <td class="col-indexer" style="color:var(--text-dim)">${indexer}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>
@@ -740,9 +747,18 @@ function grabInteractiveResult(epNum, idx, btn) {
         })
     })
     .then(async r => {
+        // The server returns errors as `(StatusCode, String)`, which axum
+        // serializes as plain-text bodies — NOT JSON. Reading r.json()
+        // first returns `{}`, dropping the actual server error and leaving
+        // the user with an unhelpful "Grab failed" toast (the JS-side
+        // fallback). Read text first, parse JSON only on success
+        // responses where the handler returns a JSON envelope.
+        const text = await r.text();
+        if (!r.ok) {
+            throw new Error(text && text.trim().length > 0 ? text : 'Grab failed');
+        }
         let data = {};
-        try { data = await r.json(); } catch (_) {}
-        if (!r.ok) throw new Error(data.message || 'Grab failed');
+        try { data = JSON.parse(text); } catch (_) {}
         btn.textContent = 'Sent';
         btn.classList.add('btn-success');
         // Update the episode row to show grabbed state
@@ -813,14 +829,16 @@ function renderInteractiveBatchResults(results) {
         body.innerHTML = '<div style="text-align:center;color:var(--text-dim);padding:32px">No batch releases found.</div>';
         return;
     }
-    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
+    let html = '<table class="interactive-search-table"><thead><tr><th class="col-score">Score</th><th>Release</th><th class="col-indexer">Indexer</th><th>Group</th><th class="col-quality">Quality</th><th class="col-size">Size</th><th class="col-seeds">Seeds</th><th class="col-grab">Grab</th></tr></thead><tbody>';
     results.forEach((r, idx) => {
         const batchTag = r.is_batch ? '<span class="tag tag-batch" style="margin-left:4px">batch</span>' : '';
         const trustedTag = r.is_trusted ? '<span class="tag tag-trusted" style="margin-left:4px">trusted</span>' : '';
         const scoreClass = r.score >= 80 ? 'score-high' : r.score >= 40 ? 'score-mid' : 'score-low';
+        const indexer = escHtml(r.indexer_name || 'Nyaa');
         html += `<tr>
             <td class="col-score">${renderScoreDetails(r, scoreClass)}</td>
             <td><a class="isearch-release-link" href="${escHtml(r.link)}" target="_blank" rel="noopener">${escHtml(r.title)}</a>${batchTag}${trustedTag}</td>
+            <td class="col-indexer" style="color:var(--text-dim)">${indexer}</td>
             <td style="color:var(--text-dim)">${escHtml(r.group)}</td>
             <td class="col-quality">${escHtml(r.quality_label || parseQualityFromTitle(r.title, r.resolution))}</td>
             <td class="col-size" style="color:var(--text-dim)">${escHtml(r.size)}</td>
@@ -878,9 +896,14 @@ function grabInteractiveBatchResult(idx, btn) {
         })
     })
     .then(async r => {
-        let data = {};
-        try { data = await r.json(); } catch (_) {}
-        if (!r.ok) throw new Error(data.message || 'Grab failed');
+        // Same error-surfacing pattern as the single-episode grab —
+        // axum's `(StatusCode, String)` errors come back as plain text,
+        // not JSON, so reading r.json() first drops the actual server
+        // message.
+        const text = await r.text();
+        if (!r.ok) {
+            throw new Error(text && text.trim().length > 0 ? text : 'Grab failed');
+        }
         btn.textContent = 'Sent';
         btn.classList.add('btn-success');
         ensureDlPollRunning();

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -194,6 +194,46 @@ document.body.addEventListener('ryokan-dc-test-result', function (ev) {
         body: detail.message || '',
     });
 });
+// Indexer Test result — same shape as the DC variant. Server fires
+// `ryokan-indexer-test-result` via HX-Trigger from /api/indexers/test.
+// Used by both the modal-footer Test button (Add and Edit) and the
+// per-card Test button on the configured-indexer cards.
+document.body.addEventListener('ryokan-indexer-test-result', function (ev) {
+    const detail = ev.detail || {};
+    window.ryokanToast({
+        kind: detail.ok ? 'success' : 'error',
+        category: 'indexer',
+        title: detail.ok ? 'Indexer reachable' : 'Indexer test failed',
+        body: detail.message || '',
+    });
+});
+// Companion to the modal-footer Test button. htmx's `hx-disabled-elt`
+// re-enables the button on htmx:afterRequest automatically, but we
+// also want the button text to flash "Testing…" while the request is
+// in flight so the user has visual feedback. No-op when called
+// outside an htmx context.
+window.ryokanWaitForIndexerTest = function (btn) {
+    if (!btn) return;
+    const original = btn.textContent;
+    btn.textContent = 'Testing…';
+    const restore = function () { btn.textContent = original; };
+    // htmx:afterRequest fires once per request. Use a one-shot
+    // listener scoped to this btn so concurrent Test clicks elsewhere
+    // don't restore each other prematurely.
+    const handler = function (ev) {
+        if (ev.target === btn) {
+            restore();
+            btn.removeEventListener('htmx:afterRequest', handler);
+        }
+    };
+    btn.addEventListener('htmx:afterRequest', handler);
+    // Safety net: if htmx swallows the event for some reason (e.g. the
+    // request errors out before sending), the disabled-elt timer
+    // restores the button after 6s.
+    setTimeout(function() {
+        if (btn.textContent === 'Testing…') restore();
+    }, 6000);
+};
 // Backdrop-click + Escape dismissal. Re-bound on every section swap
 // because the modal element is replaced when #dc-section re-renders;
 // htmx fires `htmx:afterSwap` on the swap target, so we listen there
@@ -222,6 +262,318 @@ document.body.addEventListener('ryokan-dc-test-result', function (ev) {
         }
     });
 })();
+
+// ── DC modal: kind-aware credential / hint relabel ────────────────
+//
+// The download_clients table has one schema (name, kind, url, username,
+// password, label, download_path) but five client kinds map onto it
+// differently — most notably SAB, where the `password` column carries
+// the API key and `username` is unused. The form templates carry the
+// raw column names + generic labels by default, then this helper
+// rewrites labels / hints / input types when the kind dropdown
+// changes so the UI accurately describes what each field means for
+// the currently-selected kind.
+//
+// Wired off `data-dc-*` markers so it works for both add_form_body
+// and edit_form_body without per-form duplication. Re-runs on:
+//   1. modal open (htmx:afterSwap into #dc-modal-body) — sets the
+//      initial state for an Edit form whose kind is already
+//      pre-selected.
+//   2. kind dropdown change — handles the user flipping kinds while
+//      composing the form.
+//
+// The DC_KIND_COPY map is the source of truth for per-kind copy.
+// Keep new kinds here in sync with `models::download_clients`'s
+// `protocol_for_kind` so the protocol-mismatch guard at save time
+// doesn't reject inputs the form description encouraged the user
+// to enter.
+const DC_KIND_COPY = {
+    qbittorrent: {
+        url_placeholder: 'http://localhost:8080',
+        url_hint: "Point at qBittorrent's Web UI base. Ryokan handles the API path internally.",
+        username_visible: true,
+        username_hint: "qBit's Web UI username (default is admin).",
+        password_label: 'Password',
+        password_type: 'password',
+        password_hint: "qBit's Web UI password. qBittorrent 4.6.1+ generates a random temporary password on first start. Pre-4.6.1's default password is 'adminadmin'.",
+        label_label: 'Category',
+        label_hint: "qBit category Ryokan tags every torrent with. Determines scoping (Ryokan only sees torrents in this category) AND the post-processing target directory if qBit's category-rule has one set.",
+    },
+    deluge: {
+        url_placeholder: 'http://localhost:8112',
+        url_hint: "Point at Deluge's Web UI base.",
+        username_visible: false,
+        username_hint: '',
+        password_label: 'Password',
+        password_type: 'password',
+        password_hint: "Deluge Web UI password. Deluge has no per-user auth at the API layer; the password is the only credential.",
+        label_label: 'Label',
+        label_hint: "Deluge's Label plugin tag. The plugin must be enabled; Ryokan auto-enables it on first connect when Label shows up in available_plugins but not enabled_plugins.",
+    },
+    transmission: {
+        url_placeholder: 'http://localhost:9091',
+        url_hint: "Point at Transmission's RPC endpoint base.",
+        username_visible: true,
+        username_hint: "Transmission HTTP Basic auth user (matches rpc-username in settings.json).",
+        password_label: 'Password',
+        password_type: 'password',
+        password_hint: "Transmission HTTP Basic auth password (matches rpc-password in settings.json).",
+        label_label: 'Label',
+        label_hint: "Transmission native label (4.x+). On 3.x and earlier Ryokan falls back to a save-path prefix for scoping.",
+    },
+    rtorrent: {
+        url_placeholder: 'http://localhost/RPC2',
+        url_hint: "Point at rtorrent's XML-RPC endpoint (typically /RPC2 under the SCGI / nginx proxy).",
+        username_visible: true,
+        username_hint: "HTTP Basic auth user if the RPC endpoint is fronted by nginx with auth_basic. Leave blank for unauthenticated RPC.",
+        password_label: 'Password',
+        password_type: 'password',
+        password_hint: "HTTP Basic auth password matching the username above.",
+        label_label: 'Label',
+        label_hint: "Sets the custom1 field on every added torrent (the ruTorrent label convention). Ryokan filters list_scoped by this tag.",
+    },
+    sabnzbd: {
+        url_placeholder: 'http://localhost:8080',
+        url_hint: "Point at SABnzbd's Web UI base. Ryokan appends /api. If your SAB has URL_BASE set (e.g. /sabnzbd), include it: http://host:8080/sabnzbd.",
+        username_visible: false,
+        username_hint: '',
+        password_label: 'API Key',
+        // text (not password) so the user can see what they pasted.
+        // API keys aren't really secrets in the way a user-chosen
+        // password is, and verifying the value visually is more
+        // useful here than masking it.
+        password_type: 'text',
+        password_hint: "SABnzbd's API key. Find it in SABnzbd → Config → General → Security → API Key.",
+        label_label: 'Category',
+        label_hint: "SAB category. Determines the post-processing target directory. Ryokan filters list_scoped by category so it only sees jobs it added.",
+    },
+};
+// Map a download-client kind to its protocol family. Mirrors
+// `models::download_clients::protocol_for_kind` on the server side;
+// keep them in sync if a new kind lands.
+function dcProtocolForKind(kind) {
+    if (kind === 'sabnzbd') return 'usenet';
+    return 'torrent';
+}
+function applyDcKindCopy(form, kind) {
+    if (!form) return;
+    const copy = DC_KIND_COPY[kind] || DC_KIND_COPY.qbittorrent;
+
+    // Per-protocol "first client" auto-check on the Default checkbox.
+    // The handler stamps `data-first-torrent` / `data-first-usenet`
+    // on the checkbox at render time so a kind flip can re-evaluate
+    // without a server round-trip. Only auto-check on KIND CHANGE
+    // (not on every relabel pass) so the user can uncheck the box
+    // and have the uncheck stick across other field edits — without
+    // this guard, every change to URL / username etc. would re-run
+    // the relabel and force-check the box back. The
+    // `dc-prev-kind` data attr tracks "what kind was previously
+    // selected" so we only flip the checkbox the moment the user
+    // changes the dropdown.
+    const defaultBox = form.querySelector('[data-dc-default-checkbox]');
+    if (defaultBox) {
+        const prevKind = form.dataset.dcPrevKind;
+        if (prevKind !== kind) {
+            const protocol = dcProtocolForKind(kind);
+            const flag = protocol === 'usenet' ? defaultBox.dataset.firstUsenet : defaultBox.dataset.firstTorrent;
+            defaultBox.checked = flag === '1';
+        }
+        form.dataset.dcPrevKind = kind;
+    }
+
+    const urlInput = form.querySelector('[data-dc-url-input]');
+    if (urlInput) urlInput.placeholder = copy.url_placeholder;
+    const urlHint = form.querySelector('[data-dc-url-hint]');
+    if (urlHint) urlHint.textContent = copy.url_hint;
+
+    const usernameGroup = form.querySelector('[data-dc-username-group]');
+    if (usernameGroup) {
+        usernameGroup.style.display = copy.username_visible ? '' : 'none';
+    }
+    const usernameHint = form.querySelector('[data-dc-username-hint]');
+    if (usernameHint) usernameHint.textContent = copy.username_hint;
+
+    const passwordLabel = form.querySelector('[data-dc-password-label]');
+    if (passwordLabel) passwordLabel.textContent = copy.password_label;
+    const passwordInput = form.querySelector('[data-dc-password-input]');
+    if (passwordInput) passwordInput.type = copy.password_type;
+    const passwordHint = form.querySelector('[data-dc-password-hint]');
+    if (passwordHint) {
+        if (copy.password_hint) {
+            passwordHint.textContent = copy.password_hint;
+            passwordHint.style.display = '';
+        } else {
+            passwordHint.textContent = '';
+            passwordHint.style.display = 'none';
+        }
+    }
+
+    const labelLabel = form.querySelector('[data-dc-label-label]');
+    if (labelLabel) labelLabel.textContent = copy.label_label;
+    const labelHint = form.querySelector('[data-dc-label-hint]');
+    if (labelHint) labelHint.textContent = copy.label_hint;
+}
+function bindDcKindCopyToForm(form) {
+    if (!form || form.dataset.dcKindBound === '1') return;
+    form.dataset.dcKindBound = '1';
+    const kindSelect = form.querySelector('[data-dc-kind-select]');
+    if (!kindSelect) return;
+    // Pre-seed `dc-prev-kind` to the CURRENT kind so the initial
+    // `applyDcKindCopy` pass skips the Default-checkbox toggle. The
+    // server already rendered the right initial state — for Add via
+    // `first_torrent_client` (kind defaults to qBit/torrent), for
+    // Edit via `row.is_default || first-of-protocol`. Without this
+    // pre-seed, the initial pass would clobber Edit's checkbox state
+    // (a user editing a non-default torrent client when another
+    // torrent client IS the default would see the box auto-checked,
+    // which is wrong).
+    form.dataset.dcPrevKind = kindSelect.value;
+    applyDcKindCopy(form, kindSelect.value);
+    kindSelect.addEventListener('change', function() {
+        applyDcKindCopy(form, kindSelect.value);
+    });
+}
+// htmx swaps the modal-body when an Edit/Add modal opens. Run the
+// relabel pass on every fresh body so the initial state matches the
+// pre-selected kind (Edit) or the qBittorrent default (Add).
+document.body.addEventListener('htmx:afterSettle', function(ev) {
+    if (ev.target && ev.target.id === 'dc-modal-body') {
+        const form = ev.target.querySelector('form');
+        if (form) bindDcKindCopyToForm(form);
+    }
+});
+// Initial load (the section partial pre-renders the Add form body so
+// the modal opens fast on first click — see download_clients/list.html
+// `{%~ include "...add_form_body.html" %}`). Apply the relabel pass
+// to that pre-rendered form too so the user sees correct copy if
+// they happen to change kind before any modal swap fires.
+window.addEventListener('DOMContentLoaded', function() {
+    document.querySelectorAll('#dc-modal-body form').forEach(bindDcKindCopyToForm);
+});
+
+// ── Settings → Indexers shared add/edit modal ─────────────────────
+// Mirrors the DC modal flow. Catalog seed cards →
+// `openIndexerAddModal(slug, name)` fetches the Add form pre-filled
+// with that seed's defaults; existing-indexer cards →
+// `openIndexerEditModal(id, name)` fetches the row's Edit form. Both
+// land in `#indexer-modal-body`. After a successful save the form's
+// hx-target="#indexer-section" causes the server's section-partial
+// response to replace the entire section, including the modal, at
+// display:none — closing + resetting in one shot.
+function openIndexerModal(title) {
+    const modal = document.getElementById('indexer-modal');
+    if (!modal) return;
+    if (typeof title === 'string' && title.length > 0) {
+        const titleEl = document.getElementById('indexer-modal-title');
+        if (titleEl) titleEl.textContent = title;
+    }
+    modal.style.display = 'flex';
+    // Focus first text/url input in the freshly-swapped body for
+    // keyboard ergonomics. Run after a microtask so the htmx.ajax
+    // call below has a chance to swap the body in first.
+    setTimeout(function() {
+        const firstInput = modal.querySelector('input[type="text"], input[type="url"]');
+        if (firstInput) firstInput.focus();
+    }, 50);
+}
+function closeIndexerModal() {
+    const modal = document.getElementById('indexer-modal');
+    if (modal) modal.style.display = 'none';
+}
+function openIndexerEditModal(id, name) {
+    openIndexerModal('Editing ' + (name || 'indexer'));
+    if (window.htmx) {
+        window.htmx.ajax(
+            'GET',
+            '/settings/indexers/' + encodeURIComponent(id) + '/edit-form',
+            { target: '#indexer-modal-body', swap: 'innerHTML' }
+        );
+    }
+}
+function openIndexerAddModal(slug, name) {
+    openIndexerModal('Add ' + (name || 'indexer'));
+    if (window.htmx) {
+        const url = slug
+            ? '/settings/indexers/add-form?template=' + encodeURIComponent(slug)
+            : '/settings/indexers/add-form';
+        window.htmx.ajax(
+            'GET',
+            url,
+            { target: '#indexer-modal-body', swap: 'innerHTML' }
+        );
+    }
+}
+// Backdrop-click + Escape dismissal. Re-bound on every section swap
+// because the modal element is replaced when #indexer-section
+// re-renders.
+(function() {
+    function bindIndexerModal() {
+        const modal = document.getElementById('indexer-modal');
+        if (!modal) return;
+        if (modal.dataset.bound === '1') return;
+        modal.dataset.bound = '1';
+        modal.addEventListener('click', function(ev) {
+            if (ev.target === modal) closeIndexerModal();
+        });
+    }
+    bindIndexerModal();
+    document.body.addEventListener('htmx:afterSwap', function(ev) {
+        if (ev.target && ev.target.id === 'indexer-section') {
+            bindIndexerModal();
+        }
+    });
+    document.addEventListener('keydown', function(ev) {
+        const modal = document.getElementById('indexer-modal');
+        if (!modal) return;
+        if (ev.key === 'Escape' && modal.style.display !== 'none') {
+            closeIndexerModal();
+        }
+    });
+})();
+
+// ── Indexer modal: kind-aware hint relabel ────────────────────────
+//
+// Same shape as the DC modal's `applyDcKindCopy` but for the
+// indexer Add/Edit form. The protocol-specific hint under the API
+// Key field calls out the wire format ("torznab spec" vs "newznab
+// spec") and the URL placeholder follows Prowlarr's per-protocol
+// path conventions. Without this, both kinds shared the torznab-
+// only hint copy, which read incorrectly when the user picked
+// newznab.
+const INDEXER_KIND_COPY = {
+    torznab: {
+        url_placeholder: 'https://prowlarr.local/{N}/api',
+        api_key_hint: "Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them. Find this key in Prowlarr Settings → General (or Jackett's UI).",
+    },
+    newznab: {
+        url_placeholder: 'https://nzb.indexer.example/api',
+        api_key_hint: "Sent in the request URL per newznab spec; the same key Sonarr/Radarr/Prowlarr use against this indexer. For Prowlarr-fronted indexers, find it in Prowlarr Settings → General; for direct-to-indexer setups, find it on the indexer's site (e.g. NZBGeek → Profile → API Key).",
+    },
+};
+function applyIndexerKindCopy(form, kind) {
+    if (!form) return;
+    const copy = INDEXER_KIND_COPY[kind] || INDEXER_KIND_COPY.torznab;
+    const urlInput = form.querySelector('[data-indexer-url-input]');
+    if (urlInput) urlInput.placeholder = copy.url_placeholder;
+    const apiKeyHint = form.querySelector('[data-indexer-api-key-hint]');
+    if (apiKeyHint) apiKeyHint.textContent = copy.api_key_hint;
+}
+function bindIndexerKindCopyToForm(form) {
+    if (!form || form.dataset.indexerKindBound === '1') return;
+    form.dataset.indexerKindBound = '1';
+    const kindSelect = form.querySelector('[data-indexer-kind-select]');
+    if (!kindSelect) return;
+    applyIndexerKindCopy(form, kindSelect.value);
+    kindSelect.addEventListener('change', function() {
+        applyIndexerKindCopy(form, kindSelect.value);
+    });
+}
+document.body.addEventListener('htmx:afterSettle', function(ev) {
+    if (ev.target && ev.target.id === 'indexer-modal-body') {
+        const form = ev.target.querySelector('form');
+        if (form) bindIndexerKindCopyToForm(form);
+    }
+});
 
 // #11.4 — CF export selector. Radios pick the mode, checkboxes pick the
 // ids, then two actions: download the file (via the existing GET endpoint)

--- a/templates/partials/settings/download_clients/add_form_body.html
+++ b/templates/partials/settings/download_clients/add_form_body.html
@@ -17,7 +17,11 @@
             </div>
             <div class="form-group">
                 <label for="dc-add-kind">Kind</label>
-                <select id="dc-add-kind" name="kind">
+                {# `data-dc-kind-select` lets the credential-relabel helper
+                   in static/js/settings.js find every kind <select> in the
+                   form regardless of which form (add vs edit) it lives in,
+                   without depending on the per-row id suffix. #}
+                <select id="dc-add-kind" name="kind" data-dc-kind-select>
                     <option value="qbittorrent" selected>qBittorrent</option>
                     <option value="deluge">Deluge</option>
                     <option value="transmission">Transmission</option>
@@ -28,25 +32,30 @@
         </div>
         <div class="form-group">
             <label for="dc-add-url">URL</label>
-            <input id="dc-add-url" type="url" name="url" required placeholder="http://localhost:8080">
-            <span class="form-hint">For Deluge / Transmission / rTorrent, point at the Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
+            <input id="dc-add-url" type="url" name="url" required placeholder="http://localhost:8080" data-dc-url-input>
+            <span class="form-hint" data-dc-url-hint>Point at the client's Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
         </div>
-        <div class="form-row">
-            <div class="form-group">
-                <label for="dc-add-username">Username</label>
+        {# `data-dc-credentials` marks the credential row so the
+           relabel helper can hide the username field for SAB (SAB
+           has no per-user auth — the password column carries the
+           API key) and relabel the password field as "API Key". #}
+        <div class="form-row" data-dc-credentials>
+            <div class="form-group" data-dc-username-group>
+                <label for="dc-add-username" data-dc-username-label>Username</label>
                 <input id="dc-add-username" type="text" name="username" autocomplete="off">
-                <span class="form-hint">Deluge ignores the username and uses password only; leave blank.</span>
+                <span class="form-hint" data-dc-username-hint>Deluge ignores the username and uses password only; leave blank.</span>
             </div>
             <div class="form-group">
-                <label for="dc-add-password">Password</label>
-                <input id="dc-add-password" type="password" name="password" autocomplete="new-password">
+                <label for="dc-add-password" data-dc-password-label>Password</label>
+                <input id="dc-add-password" type="password" name="password" autocomplete="new-password" data-dc-password-input>
+                <span class="form-hint" data-dc-password-hint style="display:none"></span>
             </div>
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="dc-add-label">Category / label</label>
+                <label for="dc-add-label" data-dc-label-label>Category / label</label>
                 <input id="dc-add-label" type="text" name="label" placeholder="anime">
-                <span class="form-hint">qBit calls this a "category", the others call it a "label". Ryokan tags every torrent it adds with this value and filters by it when listing.</span>
+                <span class="form-hint" data-dc-label-hint>qBit calls this a "category", the others call it a "label". Ryokan tags every torrent it adds with this value and filters by it when listing.</span>
             </div>
             <div class="form-group">
                 <label for="dc-add-download-path">Download path (as Ryokan sees it)</label>
@@ -60,13 +69,27 @@
                     <input type="checkbox" name="enabled" checked>
                     Enabled
                 </label>
+                <span class="form-hint">Disable to keep the row but exclude it from grab routing.</span>
             </div>
             <div class="form-group">
                 <label class="checkbox-label">
-                    <input type="checkbox" name="is_default" {% if first_client %}checked{% endif %}>
+                    {# Auto-checked when no row of this protocol is the
+                       current default. Initial render targets the qBit
+                       (default kind) torrent side; the kind-relabel JS
+                       in static/js/settings.js re-evaluates on
+                       dropdown change so SAB auto-checks Default when
+                       no usenet default exists. Hint text + initial-
+                       state semantics mirror the Edit form so users
+                       see the same copy regardless of which path they
+                       arrived through. #}
+                    <input type="checkbox" name="is_default"
+                           {% if first_torrent_client %}checked{% endif %}
+                           data-dc-default-checkbox
+                           data-first-torrent="{% if first_torrent_client %}1{% else %}0{% endif %}"
+                           data-first-usenet="{% if first_usenet_client %}1{% else %}0{% endif %}">
                     Default client
                 </label>
-                <span class="form-hint">Receives every grab without an explicit pin.</span>
+                <span class="form-hint">Receives every grab without an explicit indexer pin. Per-protocol; torrent and usenet defaults are independent.</span>
             </div>
         </div>
     </div>

--- a/templates/partials/settings/download_clients/edit_form_body.html
+++ b/templates/partials/settings/download_clients/edit_form_body.html
@@ -17,7 +17,10 @@
             </div>
             <div class="form-group">
                 <label for="dc-edit-kind-{{ row.id }}">Kind</label>
-                <select id="dc-edit-kind-{{ row.id }}" name="kind">
+                {# `data-dc-kind-select` — see add_form_body.html for the
+                   contract this attribute carries. The relabel helper
+                   in static/js/settings.js wires both forms via this. #}
+                <select id="dc-edit-kind-{{ row.id }}" name="kind" data-dc-kind-select>
                     <option value="qbittorrent" {% if row.kind == "qbittorrent" %}selected{% endif %}>qBittorrent</option>
                     <option value="deluge" {% if row.kind == "deluge" %}selected{% endif %}>Deluge</option>
                     <option value="transmission" {% if row.kind == "transmission" %}selected{% endif %}>Transmission</option>
@@ -28,25 +31,26 @@
         </div>
         <div class="form-group">
             <label for="dc-edit-url-{{ row.id }}">URL</label>
-            <input id="dc-edit-url-{{ row.id }}" type="url" name="url" required value="{{ row.url }}" placeholder="http://localhost:8080">
-            <span class="form-hint">For Deluge / Transmission / rTorrent, point at the Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
+            <input id="dc-edit-url-{{ row.id }}" type="url" name="url" required value="{{ row.url }}" placeholder="http://localhost:8080" data-dc-url-input>
+            <span class="form-hint" data-dc-url-hint>Point at the client's Web UI / RPC endpoint base. Ryokan appends the per-client path suffix automatically.</span>
         </div>
-        <div class="form-row">
-            <div class="form-group">
-                <label for="dc-edit-username-{{ row.id }}">Username</label>
+        <div class="form-row" data-dc-credentials>
+            <div class="form-group" data-dc-username-group>
+                <label for="dc-edit-username-{{ row.id }}" data-dc-username-label>Username</label>
                 <input id="dc-edit-username-{{ row.id }}" type="text" name="username" autocomplete="off" value="{{ row.username }}">
-                <span class="form-hint">Deluge ignores the username and uses password only; leave blank.</span>
+                <span class="form-hint" data-dc-username-hint>Deluge ignores the username and uses password only; leave blank.</span>
             </div>
             <div class="form-group">
-                <label for="dc-edit-password-{{ row.id }}">Password</label>
-                <input id="dc-edit-password-{{ row.id }}" type="password" name="password" autocomplete="new-password" value="{{ row.password }}">
+                <label for="dc-edit-password-{{ row.id }}" data-dc-password-label>Password</label>
+                <input id="dc-edit-password-{{ row.id }}" type="password" name="password" autocomplete="new-password" value="{{ row.password }}" data-dc-password-input>
+                <span class="form-hint" data-dc-password-hint style="display:none"></span>
             </div>
         </div>
         <div class="form-row">
             <div class="form-group">
-                <label for="dc-edit-label-{{ row.id }}">Category / label</label>
+                <label for="dc-edit-label-{{ row.id }}" data-dc-label-label>Category / label</label>
                 <input id="dc-edit-label-{{ row.id }}" type="text" name="label" value="{{ row.label }}" placeholder="anime">
-                <span class="form-hint">qBit calls this a "category", the others call it a "label".</span>
+                <span class="form-hint" data-dc-label-hint>qBit calls this a "category", the others call it a "label".</span>
             </div>
             <div class="form-group">
                 <label for="dc-edit-download-path-{{ row.id }}">Download path (as Ryokan sees it)</label>
@@ -64,10 +68,23 @@
             </div>
             <div class="form-group">
                 <label class="checkbox-label">
-                    <input type="checkbox" name="is_default" {% if row.is_default %}checked{% endif %}>
+                    {# Auto-check when no row of this protocol is the
+                       current default. `row.is_default` takes
+                       precedence (the checkbox starts checked if
+                       this row is already default); otherwise the
+                       per-protocol "first" flag fills in so editing
+                       the last torrent client when no torrent
+                       default exists auto-promotes it. The kind-
+                       relabel JS in static/js/settings.js re-evaluates
+                       on dropdown change. #}
+                    <input type="checkbox" name="is_default"
+                           {% if row.is_default || (row.kind == "sabnzbd" && first_usenet_client) || (row.kind != "sabnzbd" && first_torrent_client) %}checked{% endif %}
+                           data-dc-default-checkbox
+                           data-first-torrent="{% if first_torrent_client %}1{% else %}0{% endif %}"
+                           data-first-usenet="{% if first_usenet_client %}1{% else %}0{% endif %}">
                     Default client
                 </label>
-                <span class="form-hint">Receives every grab without an explicit pin. Exactly one row holds this flag at a time.</span>
+                <span class="form-hint">Receives every grab without an explicit indexer pin. Per-protocol; torrent and usenet defaults are independent.</span>
             </div>
         </div>
     </div>

--- a/templates/partials/settings/download_clients/list.html
+++ b/templates/partials/settings/download_clients/list.html
@@ -37,7 +37,7 @@
                 <div class="dc-card-header">
                     <div class="dc-card-title">
                         <strong class="dc-card-name">{{ row.name }}</strong>
-                        {% if row.is_default %}<span class="dc-default-pill" title="This client receives every grab without an explicit indexer pin">Default</span>{% endif %}
+                        {% if row.is_default %}<span class="dc-default-pill" title="Default {% if row.kind == "sabnzbd" %}usenet{% else %}torrent{% endif %} client — receives every {% if row.kind == "sabnzbd" %}newznab{% else %}torznab{% endif %} grab without an explicit indexer pin">Default</span>{% endif %}
                     </div>
                     {# Status pill — placeholder loads then HTMX swap-on-load
                        replaces with the probed version, or a static Disabled

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -1,336 +1,22 @@
-    <fieldset>
-        <legend>Indexers</legend>
-
-        {% if !indexers.is_empty() %}
-        <div class="table-scroll-wrap">
-        <table class="indexers-table">
-            <thead>
-                <tr>
-                    <th>Priority</th>
-                    <th>Name</th>
-                    <th>Kind</th>
-                    <th>URL</th>
-                    <th>Private</th>
-                    <th>Status</th>
-                    <th>RSS</th>
-                    <th></th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for idx in indexers %}
-                <tr>
-                    <td>{{ idx.priority }}</td>
-                    <td>{{ idx.name }}</td>
-                    <td>{{ idx.kind }}</td>
-                    <td><code>{{ idx.url }}</code></td>
-                    <td>{% if idx.is_private_tracker %}Yes{% else %}No{% endif %}</td>
-                    <td>{% if idx.enabled %}Enabled{% else %}Disabled{% endif %}</td>
-                    <td>
-                        {# Multi-RSS PR 1 — surface the per-indexer
-                           rss_enabled flag inline. The poll-result
-                           fields land on this same cell so the user
-                           can see "Off" / "Idle" / "✓ N items" / "✗
-                           Error" at a glance instead of digging into
-                           the edit form. #}
-                        {% if !idx.rss_enabled %}
-                        <span class="rss-pill rss-pill-off" title="RSS auto-sync disabled for this indexer">Off</span>
-                        {% else if !idx.rss_last_poll_error.is_empty() %}
-                        <span class="rss-pill rss-pill-error" title="{{ idx.rss_last_poll_error }}">✗ Error</span>
-                        {% else if let Some(_) = idx.rss_last_polled_at %}
-                        <span class="rss-pill rss-pill-ok" title="Last poll returned {{ idx.rss_last_item_count }} item{% if idx.rss_last_item_count == 1 %}{% else %}s{% endif %}">✓ {{ idx.rss_last_item_count }} items</span>
-                        {% else %}
-                        <span class="rss-pill rss-pill-idle" title="Enabled but not yet polled — first sync runs on the next interval">Idle</span>
-                        {% endif %}
-                    </td>
-                    <td>
-                        <a href="/settings?tab=indexers&edit_id={{ idx.id }}" class="btn btn-small">Edit</a>
-                        <form method="post" action="/settings/indexers/delete" style="display:inline"
-                              hx-post="/settings/indexers/delete"
-                              hx-target="closest tr"
-                              hx-swap="outerHTML"
-                              data-ryokan-confirm-title="Delete indexer?"
-                              data-ryokan-confirm-body="Remove '{{ idx.name }}' from Ryokan. Existing grab history is preserved with the indexer reference cleared. The deletion can't be undone; you'll need to re-add the row from scratch."
-                              data-ryokan-confirm-yes="Delete"
-                              data-ryokan-confirm-no="Cancel"
-                              data-ryokan-confirm-danger="1">
-                            <input type="hidden" name="id" value="{{ idx.id }}">
-                            <button type="submit" class="btn btn-danger btn-small">Delete</button>
-                        </form>
-                    </td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-        </div>
-        {% endif %}
-
-        {% if let Some(edit) = indexer_edit %}
-        <h3 class="settings-subheading">Edit Indexer</h3>
-        <p class="form-hint">
-            Updating <strong>{{ edit.name }}</strong>.
-            <a href="/settings?tab=indexers">Cancel and return to Add Indexer.</a>
-        </p>
-        <form method="post" action="/settings/indexers/upsert" class="settings-form settings-subform">
-            <input type="hidden" name="id" value="{{ edit.id }}">
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-edit-name">Name</label>
-                    <input id="indexer-edit-name" type="text" name="name" required maxlength="100" value="{{ edit.name }}">
-                </div>
-                <div class="form-group">
-                    <label for="indexer-edit-kind">Kind</label>
-                    <select id="indexer-edit-kind" name="kind">
-                        <option value="torznab" {% if edit.kind == "torznab" %}selected{% endif %}>torznab</option>
-                        <option value="newznab" {% if edit.kind == "newznab" %}selected{% endif %}>newznab</option>
-                    </select>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-edit-url">URL</label>
-                <input id="indexer-edit-url" type="url" name="url" required value="{{ edit.url }}">
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-edit-key">API Key</label>
-                <input id="indexer-edit-key" type="text" name="api_key" autocomplete="off" value="{{ edit.api_key }}">
-                <span class="form-hint">Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
-            </div>
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-edit-priority">Priority</label>
-                    <input id="indexer-edit-priority" type="number" name="priority" value="{{ edit.priority }}" min="1" max="50">
-                </div>
-                <div class="form-group">
-                    <label for="indexer-edit-min-seeders">Min Seeders</label>
-                    <input id="indexer-edit-min-seeders" type="number" name="min_seeders" value="{{ edit.min_seeders }}" min="0">
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-edit-timeout">Request Timeout (seconds)</label>
-                <input id="indexer-edit-timeout" type="number" name="request_timeout_secs"
-                       value="{% if let Some(secs) = edit.request_timeout_secs %}{{ secs }}{% endif %}"
-                       min="1" max="600" placeholder="30">
-                <span class="form-hint">Per-indexer override. Blank uses the default (30s, or RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS env). Range 1–600.</span>
-            </div>
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-edit-ratio">Seed Ratio</label>
-                    <input id="indexer-edit-ratio" type="number" name="seed_ratio" step="0.1" min="0"
-                           value="{% if let Some(r) = edit.seed_ratio %}{{ r }}{% endif %}"
-                           placeholder="(client default)">
-                    <span class="form-hint">Per-torrent seed ratio passed to the download client at add time. Blank inherits the client's global default.</span>
-                </div>
-                <div class="form-group">
-                    <label for="indexer-edit-seed-time">Seed Time (minutes)</label>
-                    <input id="indexer-edit-seed-time" type="number" name="seed_time_minutes" min="0"
-                           value="{% if let Some(m) = edit.seed_time_minutes %}{{ m }}{% endif %}"
-                           placeholder="(client default)">
-                    <span class="form-hint">Per-torrent minimum seed time. Blank inherits the client's global default.</span>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" name="enabled" {% if edit.enabled %}checked{% endif %}>
-                    Enabled
-                </label>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" name="is_private_tracker" {% if edit.is_private_tracker %}checked{% endif %}>
-                    Private tracker
-                </label>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" name="rss_enabled" {% if edit.rss_enabled %}checked{% endif %}>
-                    Enable RSS auto-sync
-                </label>
-                <span class="form-hint">When on, the master RSS sync polls this indexer's RSS feed for newly-uploaded releases on every interval (cadence on the General tab). Off keeps the indexer reachable for manual searches but skips it on the auto-sync. PT trackers usually want this on so new uploads grab promptly.</span>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-edit-dc">Download Client</label>
-                {# kind→protocol mapping below mirrors
-                   `services::download_client::protocol_for_client_kind`.
-                   Keep them in sync — adding a future client kind
-                   (e.g. NZBGet → usenet) means editing both. The JS
-                   in static/js/settings.js gates the picker by
-                   data-protocol; a missing/wrong value would leak
-                   protocol-mismatch saves through to the server-side
-                   guard. #}
-                <select id="indexer-edit-dc" name="download_client_id">
-                    <option value="">(use default)</option>
-                    {% for dc in download_clients %}
-                    <option value="{{ dc.id }}"
-                        data-protocol="{% if dc.kind == "sabnzbd" %}usenet{% else %}torrent{% endif %}"
-                        {% if let Some(pin) = edit.download_client_id %}{% if *pin == dc.id %}selected{% endif %}{% endif %}>
-                        {{ dc.name }}{% if dc.is_default %} (default){% endif %}
-                    </option>
-                    {% endfor %}
-                </select>
-                <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag. Torznab indexers can only be pinned to torrent clients; newznab indexers to usenet clients (SABnzbd).</span>
-            </div>
-
-            <button type="submit" class="btn btn-primary">Save Changes</button>
-        </form>
-        {% else if let Some(seed) = indexer_seed %}
-        <a href="/settings?tab=indexers" class="btn-icon indexer-seed-close"
-           aria-label="Back to indexer picker" title="Back to indexer picker">
-            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
-        </a>
-        {% if !seed.notes.is_empty() %}
-        <div class="indexer-seed-notes">
-            <strong>{{ seed.display_name }}:</strong> {{ seed.notes }}
-        </div>
-        {% endif %}
-        <form method="post" action="/settings/indexers/upsert" class="settings-form settings-subform">
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-add-name">Name</label>
-                    <input id="indexer-add-name" type="text" name="name" required maxlength="100"
-                           value="{{ seed.display_name }}">
-                </div>
-                <div class="form-group">
-                    <label for="indexer-add-kind">Kind</label>
-                    <select id="indexer-add-kind" name="kind">
-                        <option value="torznab" {% if seed.default_kind == "torznab" %}selected{% endif %}>torznab</option>
-                        <option value="newznab" {% if seed.default_kind == "newznab" %}selected{% endif %}>newznab</option>
-                    </select>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-add-url">URL</label>
-                <input id="indexer-add-url" type="url" name="url" required
-                       placeholder="{{ seed.url_placeholder }}">
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-add-key">API Key</label>
-                <input id="indexer-add-key" type="text" name="api_key" autocomplete="off"
-                       placeholder="from Prowlarr Settings &rarr; General">
-                <span class="form-hint">Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
-            </div>
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-add-priority">Priority</label>
-                    <input id="indexer-add-priority" type="number" name="priority" value="{{ seed.default_priority }}" min="1" max="50">
-                    <span class="form-hint">Lower = preferred. Range 1–50.</span>
-                </div>
-                <div class="form-group">
-                    <label for="indexer-add-min-seeders">Min Seeders</label>
-                    <input id="indexer-add-min-seeders" type="number" name="min_seeders" value="{{ seed.default_min_seeders }}" min="0">
-                    <span class="form-hint">Releases below this floor are dropped before scoring.</span>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-add-timeout">Request Timeout (seconds)</label>
-                <input id="indexer-add-timeout" type="number" name="request_timeout_secs" min="1" max="600" placeholder="30">
-                <span class="form-hint">Per-indexer override. Blank uses the default (30s).</span>
-            </div>
-
-            <div class="form-row">
-                <div class="form-group">
-                    <label for="indexer-add-ratio">Seed Ratio</label>
-                    <input id="indexer-add-ratio" type="number" name="seed_ratio" step="0.1" min="0"
-                           value="{% if let Some(r) = seed.default_seed_ratio %}{{ r }}{% endif %}"
-                           placeholder="(client default)">
-                    <span class="form-hint">Per-torrent seed ratio passed to the download client at add time.</span>
-                </div>
-                <div class="form-group">
-                    <label for="indexer-add-seed-time">Seed Time (minutes)</label>
-                    <input id="indexer-add-seed-time" type="number" name="seed_time_minutes" min="0"
-                           value="{% if let Some(m) = seed.default_seed_time_minutes %}{{ m }}{% endif %}"
-                           placeholder="(client default)">
-                    <span class="form-hint">Per-torrent minimum seed time.</span>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" name="enabled" checked>
-                    Enabled
-                </label>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    <input type="checkbox" name="is_private_tracker" {% if seed.is_private_tracker %}checked{% endif %}>
-                    Private tracker
-                </label>
-                <span class="form-hint">Marks this indexer as PT for the per-series upgrade opt-in.</span>
-            </div>
-
-            <div class="form-group">
-                <label class="checkbox-label">
-                    {# PT trackers default-on for RSS — they're the
-                       primary use case for the auto-sync (new
-                       uploads, freeleech windows, etc.). Public
-                       trackers default off. #}
-                    <input type="checkbox" name="rss_enabled" {% if seed.is_private_tracker %}checked{% endif %}>
-                    Enable RSS auto-sync
-                </label>
-                <span class="form-hint">When on, the master RSS sync polls this indexer's RSS feed on every interval. Off keeps the indexer reachable for manual searches but skips it on the auto-sync.</span>
-            </div>
-
-            <div class="form-group">
-                <label for="indexer-add-dc">Download Client</label>
-                <select id="indexer-add-dc" name="download_client_id">
-                    <option value="">(use default)</option>
-                    {% for dc in download_clients %}
-                    <option value="{{ dc.id }}"
-                        data-protocol="{% if dc.kind == "sabnzbd" %}usenet{% else %}torrent{% endif %}">
-                        {{ dc.name }}{% if dc.is_default %} (default){% endif %}
-                    </option>
-                    {% endfor %}
-                </select>
-                <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag. Torznab indexers can only be pinned to torrent clients; newznab indexers to usenet clients (SABnzbd).</span>
-            </div>
-
-            <button type="submit" class="btn btn-primary">Add Indexer</button>
-        </form>
-        {% else %}
-        <h3 class="settings-subheading">Add Indexer</h3>
-
-        <div class="indexer-catalog-grid">
-            {% for seed in indexer_catalog %}
-            <a class="indexer-catalog-card{% if seed.is_generic %} indexer-catalog-card-generic{% endif %}"
-               href="/settings?tab=indexers&amp;template={{ seed.slug }}">
-                <div class="indexer-catalog-card-header">
-                    <span class="indexer-catalog-card-name">{{ seed.display_name }}</span>
-                    {% if seed.is_private_tracker %}
-                    <span class="indexer-catalog-card-pill indexer-catalog-card-pill-private">PRIVATE</span>
-                    {% else if !seed.is_generic %}
-                    <span class="indexer-catalog-card-pill indexer-catalog-card-pill-public">PUBLIC</span>
-                    {% endif %}
-                </div>
-                <p class="indexer-catalog-card-blurb">{{ seed.blurb }}</p>
-            </a>
-            {% endfor %}
-        </div>
-        {% endif %}
-    </fieldset>
+    {# Indexers fieldset — owned by the section partial so a
+       successful HTMX upsert/delete can re-render the whole thing
+       (catalog grid + existing-indexer cards + modal) in one swap.
+       The previous URL-driven `?edit_id=N` / `?template=slug` inline-
+       form flow has been replaced by a click-to-modal flow that
+       mirrors the Download Clients section — see
+       static/js/settings.js#openIndexerEditModal +
+       openIndexerAddModal. #}
+{%~ include "partials/settings/indexers/list.html" ~%}
 
     {# Built-in Nyaa search routes through whichever download
        client this row points at. Empty selection = use the default
        client. Standalone form (not nested in any other) — POSTs
        to `/settings/indexers/nyaa-pin`, which writes
        `config.nyaa_download_client_id`. #}
-    {% if indexer_edit.is_none() && indexer_seed.is_none() %}
     <fieldset class="settings-form">
         <legend>Nyaa search</legend>
         <p class="form-hint" style="margin: 0 0 12px;">
-            Ryokan's built-in Nyaa search (the public-tracker hot path) isn't a torznab indexer row — pin it to a download client here. Only torrent clients are eligible since Nyaa returns magnets / .torrent URLs.
+            Ryokan's built-in Nyaa search (the public-tracker hot path) isn't a torznab indexer row; pin it to a download client here. Only torrent clients are eligible since Nyaa returns magnets / .torrent URLs.
         </p>
         <form method="post" action="/settings/indexers/nyaa-pin" class="settings-form settings-subform">
             <div class="form-group">
@@ -354,21 +40,17 @@
             <button type="submit" class="btn btn-primary">Save Nyaa pin</button>
         </form>
     </fieldset>
-    {% endif %}
 
     {# Multi-RSS PR G/H — user-supplied direct RSS feeds (e.g.
        SubsPlease's per-quality feeds). Distinct from the per-indexer
        RSS toggle above: those poll torznab/newznab indexers via
        their RSS endpoint and route through their indexer-level
        seed rules; direct feeds are arbitrary URLs that bypass the
-       indexer registry entirely. Same hidden-during-edit-flow
-       gating as Nyaa + autobrr so the user isn't distracted while
-       editing one indexer. #}
-    {% if indexer_edit.is_none() && indexer_seed.is_none() %}
+       indexer registry entirely. #}
     <fieldset class="settings-form">
         <legend>Direct RSS feeds</legend>
         <p class="form-hint" style="margin: 0 0 12px;">
-            User-supplied RSS URLs that don't go through Prowlarr / Jackett. The release-group RSS feeds from SubsPlease are the canonical use case — paste the per-quality feed URL and Ryokan picks up new episodes on every sync interval.
+            User-supplied RSS URLs that don't go through Prowlarr / Jackett. The release-group RSS feeds from SubsPlease are the canonical use case; paste the per-quality feed URL and Ryokan picks up new episodes on every sync interval.
         </p>
 
         {% if !direct_rss_feeds.is_empty() %}
@@ -457,21 +139,13 @@
             <button type="submit" class="btn btn-primary">Add RSS feed</button>
         </form>
     </fieldset>
-    {% endif %}
 
     {# Push receivers — webhook-driven release sources. autobrr's
        Webhook action POSTs releases at Ryokan's /api/webhook/autobrr
        endpoint; the API key here gates that endpoint. Lives on the
        Indexers tab (rather than Connections) because conceptually
        it's just another way releases reach Ryokan, alongside the
-       torznab / newznab indexer rows above.
-
-       Hidden while the user is in the picker pre-fill or row-edit
-       flow (they're focused on adding/editing one indexer; the
-       autobrr panel is unrelated context). The default picker view
-       still shows it so the panel is reachable from the Indexers
-       tab. #}
-    {% if indexer_edit.is_none() && indexer_seed.is_none() %}
+       torznab / newznab indexer rows above. #}
     {# `class="settings-form"` on the fieldset (not the form, since
        there's no form to wrap with — the regen-button binds to the
        external `autobrr-regen-form` sibling) makes the
@@ -546,4 +220,3 @@
             <span class="form-hint">Paste this into autobrr's Webhook action <em>Data (JSON)</em> field. Set Content-Type to <code>application/json</code> and add an <code>X-Api-Key</code> header with the API key above.</span>
         </div>
     </fieldset>
-    {% endif %}

--- a/templates/partials/settings/indexers/add_form_body.html
+++ b/templates/partials/settings/indexers/add_form_body.html
@@ -1,0 +1,164 @@
+{# Modal body for the Add flow. Returned by `GET /settings/
+   indexers/add-form?template=<slug>` and swapped into
+   `#indexer-modal-body` (innerHTML) when the user clicks one of
+   the catalog seed cards. `seed = None` (no template / unknown
+   slug) renders a blank Add form. #}
+<form method="post" action="/settings/indexers/upsert"
+      class="dc-modal-form"
+      hx-post="/settings/indexers/upsert"
+      hx-target="#indexer-section"
+      hx-swap="outerHTML">
+    {% if let Some(seed) = seed %}
+    {% if !seed.notes.is_empty() %}
+    <div class="indexer-seed-notes" style="margin: 0 24px 12px;">
+        <strong>{{ seed.display_name }}:</strong> {{ seed.notes }}
+    </div>
+    {% endif %}
+    {% endif %}
+    <div class="modal-body">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-add-name">Name</label>
+                <input id="indexer-add-name" type="text" name="name" required maxlength="100"
+                       value="{% if let Some(seed) = seed %}{{ seed.display_name }}{% endif %}"
+                       placeholder="e.g. Prowlarr">
+            </div>
+            <div class="form-group">
+                <label for="indexer-add-kind">Kind</label>
+                {# `data-indexer-kind-select` — wire-up for the kind-aware
+                   hint helper in static/js/settings.js. Same pattern as
+                   the DC modal's `data-dc-kind-select`. Swaps the API
+                   Key hint copy and the URL placeholder when the user
+                   flips between torznab and newznab. #}
+                <select id="indexer-add-kind" name="kind" data-indexer-kind-select>
+                    {% if let Some(seed) = seed %}
+                    <option value="torznab" {% if seed.default_kind == "torznab" %}selected{% endif %}>torznab</option>
+                    <option value="newznab" {% if seed.default_kind == "newznab" %}selected{% endif %}>newznab</option>
+                    {% else %}
+                    <option value="torznab" selected>torznab</option>
+                    <option value="newznab">newznab</option>
+                    {% endif %}
+                </select>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-add-url">URL</label>
+            <input id="indexer-add-url" type="url" name="url" required
+                   placeholder="{% if let Some(seed) = seed %}{{ seed.url_placeholder }}{% else %}https://prowlarr.local/{N}/api{% endif %}"
+                   data-indexer-url-input>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-add-key">API Key</label>
+            <input id="indexer-add-key" type="text" name="api_key" autocomplete="off"
+                   placeholder="from Prowlarr Settings &rarr; General">
+            <span class="form-hint" data-indexer-api-key-hint>Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-add-priority">Priority</label>
+                <input id="indexer-add-priority" type="number" name="priority"
+                       value="{% if let Some(seed) = seed %}{{ seed.default_priority }}{% else %}25{% endif %}"
+                       min="1" max="50">
+                <span class="form-hint">Lower = preferred. Range 1-50.</span>
+            </div>
+            <div class="form-group">
+                <label for="indexer-add-min-seeders">Min Seeders</label>
+                <input id="indexer-add-min-seeders" type="number" name="min_seeders"
+                       value="{% if let Some(seed) = seed %}{{ seed.default_min_seeders }}{% else %}1{% endif %}"
+                       min="0">
+                <span class="form-hint">Releases below this floor are dropped before scoring.</span>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-add-timeout">Request Timeout (seconds)</label>
+            <input id="indexer-add-timeout" type="number" name="request_timeout_secs" min="1" max="600" placeholder="30">
+            <span class="form-hint">Per-indexer override. Blank uses the default (30s).</span>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-add-ratio">Seed Ratio</label>
+                <input id="indexer-add-ratio" type="number" name="seed_ratio" step="0.1" min="0"
+                       value="{% if let Some(seed) = seed %}{% if let Some(r) = seed.default_seed_ratio %}{{ r }}{% endif %}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent seed ratio passed to the download client at add time.</span>
+            </div>
+            <div class="form-group">
+                <label for="indexer-add-seed-time">Seed Time (minutes)</label>
+                <input id="indexer-add-seed-time" type="number" name="seed_time_minutes" min="0"
+                       value="{% if let Some(seed) = seed %}{% if let Some(m) = seed.default_seed_time_minutes %}{{ m }}{% endif %}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent minimum seed time.</span>
+            </div>
+        </div>
+
+        {# `enabled` checkbox dropped — UX decision: disabling an
+           indexer via a hidden flag is rarely the right action; users
+           who don't want results from an indexer just delete the row.
+           Hidden input pins `enabled=on` so the upsert handler's
+           `is_some()` check still resolves true and the resulting row
+           lands in `services::indexers::list_enabled`'s WHERE-filter.
+           Kept the column in the schema (services::indexers and the
+           cache builder still WHERE-filter on it) — only removing the
+           UI surface. #}
+        <input type="hidden" name="enabled" value="on">
+
+        <div class="form-group">
+            <label class="checkbox-label">
+                <input type="checkbox" name="is_private_tracker"
+                       {% if let Some(seed) = seed %}{% if seed.is_private_tracker %}checked{% endif %}{% endif %}>
+                Private tracker
+            </label>
+            <span class="form-hint">Marks this indexer as PT for the per-series upgrade opt-in.</span>
+        </div>
+
+        <div class="form-group">
+            <label class="checkbox-label">
+                {# PT trackers default-on for RSS — they're the
+                   primary use case for the auto-sync (new uploads,
+                   freeleech windows, etc.). Public trackers default
+                   off. #}
+                <input type="checkbox" name="rss_enabled"
+                       {% if let Some(seed) = seed %}{% if seed.is_private_tracker %}checked{% endif %}{% endif %}>
+                Enable RSS auto-sync
+            </label>
+            <span class="form-hint">When enabled, RSS sync will poll this indexer's RSS feed for newly-uploaded releases on every interval.</span>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-add-dc">Download Client</label>
+            <select id="indexer-add-dc" name="download_client_id">
+                <option value="">(use default)</option>
+                {% for dc in download_clients %}
+                <option value="{{ dc.id }}"
+                    data-protocol="{% if dc.kind == "sabnzbd" %}usenet{% else %}torrent{% endif %}">
+                    {{ dc.name }}{% if dc.is_default %} (default){% endif %}
+                </option>
+                {% endfor %}
+            </select>
+            <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag. Torznab indexers can only be pinned to torrent clients; newznab indexers to usenet clients (SABnzbd).</span>
+        </div>
+    </div>
+    <div class="modal-footer">
+        {# Test button — works for unsaved configurations via the
+           stateless `/api/indexers/test` endpoint. `hx-include`
+           pulls every form field so kind / url / api_key flow
+           through; the JSON envelope is converted to a toast in
+           static/js/settings.js's `ryokan-indexer-test-result`
+           listener so the modal footer doesn't grow with the
+           result text. #}
+        <button type="button" class="btn btn-secondary"
+                hx-post="/api/indexers/test"
+                hx-include="closest form"
+                hx-swap="none"
+                hx-disabled-elt="this"
+                onclick="ryokanWaitForIndexerTest(this)">Test</button>
+        <span style="margin-right:auto"></span>
+        <button type="button" class="btn btn-secondary" onclick="closeIndexerModal()">Cancel</button>
+        <button type="submit" class="btn btn-primary">Add Indexer</button>
+    </div>
+</form>

--- a/templates/partials/settings/indexers/edit_form_body.html
+++ b/templates/partials/settings/indexers/edit_form_body.html
@@ -1,0 +1,130 @@
+{# Modal body for the Edit flow. Returned by `GET /settings/
+   indexers/{id}/edit-form` and swapped into `#indexer-modal-body`
+   (innerHTML) when the user clicks an existing-indexer card.
+   Same shape as add_form_body.html but pre-filled and carries a
+   hidden `id` so the upsert path runs as UPDATE not INSERT. #}
+<form method="post" action="/settings/indexers/upsert"
+      class="dc-modal-form"
+      hx-post="/settings/indexers/upsert"
+      hx-target="#indexer-section"
+      hx-swap="outerHTML">
+    <input type="hidden" name="id" value="{{ row.id }}">
+    <div class="modal-body">
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-edit-name-{{ row.id }}">Name</label>
+                <input id="indexer-edit-name-{{ row.id }}" type="text" name="name" required maxlength="100" value="{{ row.name }}">
+            </div>
+            <div class="form-group">
+                <label for="indexer-edit-kind-{{ row.id }}">Kind</label>
+                {# Same `data-indexer-kind-select` contract as the Add
+                   form — the relabel helper in static/js/settings.js
+                   wires both via this attribute. #}
+                <select id="indexer-edit-kind-{{ row.id }}" name="kind" data-indexer-kind-select>
+                    <option value="torznab" {% if row.kind == "torznab" %}selected{% endif %}>torznab</option>
+                    <option value="newznab" {% if row.kind == "newznab" %}selected{% endif %}>newznab</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-edit-url-{{ row.id }}">URL</label>
+            <input id="indexer-edit-url-{{ row.id }}" type="url" name="url" required value="{{ row.url }}" data-indexer-url-input>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-edit-key-{{ row.id }}">API Key</label>
+            <input id="indexer-edit-key-{{ row.id }}" type="text" name="api_key" autocomplete="off" value="{{ row.api_key }}">
+            <span class="form-hint" data-indexer-api-key-hint>Sent in the request URL per torznab spec; appears in Prowlarr / Jackett access logs and any reverse-proxy logs in front of them.</span>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-edit-priority-{{ row.id }}">Priority</label>
+                <input id="indexer-edit-priority-{{ row.id }}" type="number" name="priority" value="{{ row.priority }}" min="1" max="50">
+            </div>
+            <div class="form-group">
+                <label for="indexer-edit-min-seeders-{{ row.id }}">Min Seeders</label>
+                <input id="indexer-edit-min-seeders-{{ row.id }}" type="number" name="min_seeders" value="{{ row.min_seeders }}" min="0">
+            </div>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-edit-timeout-{{ row.id }}">Request Timeout (seconds)</label>
+            <input id="indexer-edit-timeout-{{ row.id }}" type="number" name="request_timeout_secs"
+                   value="{% if let Some(secs) = row.request_timeout_secs %}{{ secs }}{% endif %}"
+                   min="1" max="600" placeholder="30">
+            <span class="form-hint">Per-indexer override. Blank uses the default (30s, or RYOKAN_INDEXER_DEFAULT_TIMEOUT_SECS env). Range 1-600.</span>
+        </div>
+
+        <div class="form-row">
+            <div class="form-group">
+                <label for="indexer-edit-ratio-{{ row.id }}">Seed Ratio</label>
+                <input id="indexer-edit-ratio-{{ row.id }}" type="number" name="seed_ratio" step="0.1" min="0"
+                       value="{% if let Some(r) = row.seed_ratio %}{{ r }}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent seed ratio passed to the download client at add time. Blank inherits the client's global default.</span>
+            </div>
+            <div class="form-group">
+                <label for="indexer-edit-seed-time-{{ row.id }}">Seed Time (minutes)</label>
+                <input id="indexer-edit-seed-time-{{ row.id }}" type="number" name="seed_time_minutes" min="0"
+                       value="{% if let Some(m) = row.seed_time_minutes %}{{ m }}{% endif %}"
+                       placeholder="(client default)">
+                <span class="form-hint">Per-torrent minimum seed time. Blank inherits the client's global default.</span>
+            </div>
+        </div>
+
+        {# Enabled checkbox dropped from the UI — see add_form_body.html
+           for rationale. Hidden input keeps the wire shape so the
+           upsert handler's `enabled.is_some()` resolves true and
+           previously-disabled rows get re-enabled on the next save
+           (acceptable: the user clicked Edit, presumably to keep using
+           it). Existing disabled rows that aren't edited stay
+           disabled in the DB but become invisible on the UI. #}
+        <input type="hidden" name="enabled" value="on">
+
+        <div class="form-group">
+            <label class="checkbox-label">
+                <input type="checkbox" name="is_private_tracker" {% if row.is_private_tracker %}checked{% endif %}>
+                Private tracker
+            </label>
+        </div>
+
+        <div class="form-group">
+            <label class="checkbox-label">
+                <input type="checkbox" name="rss_enabled" {% if row.rss_enabled %}checked{% endif %}>
+                Enable RSS auto-sync
+            </label>
+            <span class="form-hint">When enabled, RSS sync will poll this indexer's RSS feed for newly-uploaded releases on every interval.</span>
+        </div>
+
+        <div class="form-group">
+            <label for="indexer-edit-dc-{{ row.id }}">Download Client</label>
+            <select id="indexer-edit-dc-{{ row.id }}" name="download_client_id">
+                <option value="">(use default)</option>
+                {% for dc in download_clients %}
+                <option value="{{ dc.id }}"
+                    data-protocol="{% if dc.kind == "sabnzbd" %}usenet{% else %}torrent{% endif %}"
+                    {% if let Some(pin) = row.download_client_id %}{% if *pin == dc.id %}selected{% endif %}{% endif %}>
+                    {{ dc.name }}{% if dc.is_default %} (default){% endif %}
+                </option>
+                {% endfor %}
+            </select>
+            <span class="form-hint">Pin grabs from this indexer to a specific download client. Leave on <em>(use default)</em> to route through whichever client has the default flag. Torznab indexers can only be pinned to torrent clients; newznab indexers to usenet clients (SABnzbd).</span>
+        </div>
+    </div>
+    <div class="modal-footer">
+        {# Test — passes the row's id alongside form fields so the
+           backend re-uses the warm cache entry. Same JSON envelope
+           shape and toast surfacing as the Add modal's Test. #}
+        <button type="button" class="btn btn-secondary"
+                hx-post="/api/indexers/test"
+                hx-include="closest form"
+                hx-swap="none"
+                hx-disabled-elt="this"
+                onclick="ryokanWaitForIndexerTest(this)">Test</button>
+        <span style="margin-right:auto"></span>
+        <button type="button" class="btn btn-secondary" onclick="closeIndexerModal()">Cancel</button>
+        <button type="submit" class="btn btn-primary">Save changes</button>
+    </div>
+</form>

--- a/templates/partials/settings/indexers/list.html
+++ b/templates/partials/settings/indexers/list.html
@@ -1,0 +1,169 @@
+{# Indexers section — mirrors the Download Clients card pattern.
+   Catalog seed cards (Add Indexer) on top, configured-indexer
+   cards below. Both surfaces open a shared modal: seed cards
+   fetch the Add form pre-filled with the seed's defaults; per-
+   indexer cards fetch the Edit form pre-filled with the row.
+
+   The whole section IS `#indexer-section` — the id sits on the
+   <fieldset> root, NOT on an inner <div>, so when an HTMX upsert
+   or delete returns this same partial via `hx-swap="outerHTML"`
+   the response replaces the fieldset 1:1. A previous version put
+   the id on an inner <div class="dc-section">; the outerHTML
+   swap then nested a fresh `<fieldset><legend>Indexers>` inside
+   the prior fieldset (the inner div was the swap target, but the
+   response was wrapped in the parent fieldset+legend), producing
+   a duplicate "Indexers" heading after the first save. The
+   `dc-section` class stays on the same node so the existing CSS
+   rules + the modal-rebind logic in `static/js/settings.js` that
+   listens for `htmx:afterSwap` on `#indexer-section` keep
+   working unchanged. #}
+<fieldset id="indexer-section" class="dc-section">
+    <legend>Indexers</legend>
+        <h3 class="settings-subheading" style="margin-top:0;">Add Indexer</h3>
+
+        {# Catalog grid — each tile opens the shared modal with the
+           matching seed pre-filled. The trailing "+ Add" tile opens
+           a blank Add form for users who want to skip the picker. #}
+        <div class="indexer-catalog-grid">
+            {% for seed in indexer_catalog %}
+            <div class="indexer-catalog-card{% if seed.is_generic %} indexer-catalog-card-generic{% endif %}"
+                 role="button"
+                 tabindex="0"
+                 data-indexer-slug="{{ seed.slug }}"
+                 data-indexer-name="{{ seed.display_name }}"
+                 onclick="openIndexerAddModal(this.dataset.indexerSlug, this.dataset.indexerName)"
+                 onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openIndexerAddModal(this.dataset.indexerSlug, this.dataset.indexerName); }"
+                 aria-label="Add {{ seed.display_name }} indexer">
+                <div class="indexer-catalog-card-header">
+                    <span class="indexer-catalog-card-name">{{ seed.display_name }}</span>
+                    {% if seed.is_private_tracker %}
+                    <span class="indexer-catalog-card-pill indexer-catalog-card-pill-private">PRIVATE</span>
+                    {% else if !seed.is_generic %}
+                    <span class="indexer-catalog-card-pill indexer-catalog-card-pill-public">PUBLIC</span>
+                    {% endif %}
+                </div>
+                <p class="indexer-catalog-card-blurb">{{ seed.blurb }}</p>
+            </div>
+            {% endfor %}
+        </div>
+
+        <h3 class="settings-subheading">Configured indexers</h3>
+
+        {# Existing-indexer cards — clickable body opens the Edit
+           modal; corner × deletes the row. Empty-state spans the
+           grid so the empty section reads as an instruction rather
+           than a blank panel. #}
+        <div class="dc-card-grid">
+            {% if indexers.is_empty() %}
+            <div class="dc-empty">
+                <p class="form-hint" style="margin: 0">No indexers configured yet. Pick a tile above to add one.</p>
+            </div>
+            {% endif %}
+
+            {% for idx in indexers %}
+            <article class="dc-card" id="indexer-card-{{ idx.id }}">
+                <div class="dc-card-body"
+                     role="button"
+                     tabindex="0"
+                     data-indexer-id="{{ idx.id }}"
+                     data-indexer-name="{{ idx.name }}"
+                     onclick="openIndexerEditModal(this.dataset.indexerId, this.dataset.indexerName)"
+                     onkeydown="if (event.key === 'Enter' || event.key === ' ') { event.preventDefault(); openIndexerEditModal(this.dataset.indexerId, this.dataset.indexerName); }"
+                     aria-label="Edit {{ idx.name }}">
+                    <div class="dc-card-header">
+                        <div class="dc-card-title">
+                            <strong class="dc-card-name">{{ idx.name }}</strong>
+                            {% if idx.is_private_tracker %}
+                            <span class="dc-default-pill" style="background: rgba(243, 139, 168, 0.18); color: var(--red, #f38ba8);" title="Private tracker">PT</span>
+                            {% endif %}
+                        </div>
+                        {# Status pill — server-rendered from the row.
+                           Disabled wins over RSS state; otherwise the
+                           pill reflects the most recent RSS poll
+                           (off / error / ok / idle). Same taxonomy
+                           the old table used. #}
+                        {% if !idx.enabled %}
+                        <span class="dc-status-pill dc-status-pill-disabled">Disabled</span>
+                        {% else if !idx.rss_enabled %}
+                        <span class="dc-status-pill dc-status-pill-ok" title="Search-only — RSS auto-sync off for this indexer">Enabled</span>
+                        {% else if !idx.rss_last_poll_error.is_empty() %}
+                        <span class="dc-status-pill dc-status-pill-err" title="{{ idx.rss_last_poll_error }}">RSS error</span>
+                        {% else if let Some(_) = idx.rss_last_polled_at %}
+                        <span class="dc-status-pill dc-status-pill-ok" title="Last poll returned {{ idx.rss_last_item_count }} item{% if idx.rss_last_item_count == 1 %}{% else %}s{% endif %}">&#10003; RSS ({{ idx.rss_last_item_count }})</span>
+                        {% else %}
+                        <span class="dc-status-pill dc-status-pill-loading" title="RSS enabled but not yet polled — first sync runs on the next interval">RSS idle</span>
+                        {% endif %}
+                    </div>
+                    <dl class="dc-card-meta">
+                        <div class="dc-card-meta-row">
+                            <dt>Kind</dt>
+                            <dd>{{ idx.kind }}</dd>
+                        </div>
+                        <div class="dc-card-meta-row">
+                            <dt>URL</dt>
+                            <dd><code>{{ idx.url }}</code></dd>
+                        </div>
+                        <div class="dc-card-meta-row">
+                            <dt>Priority</dt>
+                            <dd>{{ idx.priority }}</dd>
+                        </div>
+                        {% if let Some(pin) = idx.download_client_id %}
+                        <div class="dc-card-meta-row">
+                            <dt>Client</dt>
+                            <dd>{% for dc in download_clients %}{% if dc.id == *pin %}{{ dc.name }}{% endif %}{% endfor %}</dd>
+                        </div>
+                        {% endif %}
+                    </dl>
+                </div>
+                <div class="dc-card-actions" onclick="event.stopPropagation()">
+                    {# Test button moved into the Edit modal only —
+                       a per-card Test surface added clutter (and was
+                       rendering as an oversized white button while
+                       the per-icon-button scaling was unsettled).
+                       Users who want to test an existing indexer
+                       click the card, which opens the Edit modal,
+                       which carries the Test button in its footer. #}
+                    <form method="post" action="/settings/indexers/delete"
+                          hx-post="/settings/indexers/delete"
+                          hx-target="#indexer-section"
+                          hx-swap="outerHTML"
+                          data-ryokan-confirm-title="Delete indexer?"
+                          data-ryokan-confirm-body="Remove '{{ idx.name }}' from Ryokan. Existing grab history is preserved with the indexer reference cleared. The deletion can't be undone; you'll need to re-add the row from scratch."
+                          data-ryokan-confirm-yes="Delete"
+                          data-ryokan-confirm-no="Cancel"
+                          data-ryokan-confirm-danger="1"
+                          style="margin:0">
+                        <input type="hidden" name="id" value="{{ idx.id }}">
+                        <button type="submit" class="btn btn-icon-danger" title="Delete {{ idx.name }}" aria-label="Delete {{ idx.name }}">×</button>
+                    </form>
+                </div>
+            </article>
+            {% endfor %}
+        </div>
+
+        {# Shared modal — body content is replaced by HTMX on each
+           open (Add or Edit). Initial render is the blank Add form
+           so a section-partial swap (after a successful save) leaves
+           the modal at display:none with the right body for the
+           next Add click. #}
+        <div class="modal-backdrop" id="indexer-modal" style="display:none"
+             role="dialog" aria-modal="true" aria-labelledby="indexer-modal-title">
+            <div class="modal" style="max-width: 720px">
+                <div class="modal-header">
+                    <h3 id="indexer-modal-title">Add indexer</h3>
+                    <button class="btn-icon" type="button" onclick="closeIndexerModal()" aria-label="Close">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                    </button>
+                </div>
+                {# Empty on initial render — `openIndexerAddModal` /
+                   `openIndexerEditModal` fetch the right body via
+                   htmx.ajax on first click. Different from the DC
+                   modal (which pre-renders the Add form) because we
+                   want catalog-card clicks to land on a seed-pre-
+                   filled body, and pre-rendering one specific
+                   variant in the section partial would still need
+                   a swap on every other click anyway. #}
+                <div id="indexer-modal-body"></div>
+            </div>
+        </div>
+</fieldset>

--- a/tests/htmx_browser_e2e_settings_modals.rs
+++ b/tests/htmx_browser_e2e_settings_modals.rs
@@ -1,0 +1,242 @@
+//! Browser-e2e coverage for the indexer + download-client modal-form
+//! HTMX flows and the per-protocol Default-checkbox auto-check that
+//! landed alongside the SAB cleanup PR.
+//!
+//! Why these need a browser layer (per CLAUDE.md's PR 131 audit):
+//! the handler-layer tests in `tests/htmx_settings_delete.rs` exercise
+//! the response shape but can't catch:
+//!   - vendored htmx failing to load (fallback masquerades as success)
+//!   - `hx-vals` / `hx-include` form-encoding regressions
+//!   - `data-ryokan-confirm-*` typos that fall through to default copy
+//!   - per-page inline scripts (the DC auto-check default checkbox runs
+//!     in the browser, not on the server)
+//!
+//! Skips gracefully when geckodriver/WebDriver is unreachable; see
+//! `tests/htmx_browser_e2e.rs` for run instructions.
+
+use fantoccini::Locator;
+use ryokan::models::download_clients::{DownloadClientForm, insert as insert_download_client};
+use ryokan::models::indexers::{IndexerForm, insert as insert_indexer};
+use ryokan::test_support::{build_test_app_state, in_memory_pool};
+use sqlx::SqlitePool;
+use std::time::Duration;
+
+#[path = "common/browser_e2e.rs"]
+mod browser_e2e;
+use browser_e2e::{
+    assert_htmx_loaded, open_with_session, seed_user_session, spawn_app, try_connect_browser,
+};
+
+async fn seed_indexer(db: &SqlitePool, name: &str) -> i64 {
+    insert_indexer(
+        db,
+        IndexerForm {
+            name,
+            kind: "torznab",
+            url: "https://example.com/torznab",
+            api_key: "k",
+            priority: 25,
+            enabled: true,
+            is_private_tracker: false,
+            seed_ratio: None,
+            seed_time_minutes: None,
+            min_seeders: 1,
+            request_timeout_secs: None,
+            download_client_id: None,
+            rss_enabled: false,
+        },
+    )
+    .await
+    .expect("seed indexer")
+}
+
+async fn seed_dl_client(db: &SqlitePool, name: &str, kind: &str, is_default: bool) -> i64 {
+    insert_download_client(
+        db,
+        DownloadClientForm {
+            name,
+            kind,
+            url: "http://example.local",
+            username: "",
+            password: "",
+            label: "",
+            download_path: "",
+            enabled: true,
+            is_default,
+        },
+    )
+    .await
+    .expect("seed download client")
+}
+
+/// Clicking the Edit button on an indexer card fires an
+/// `hx-get="/settings/indexers/{id}/edit-form"` that swaps the modal
+/// body. The handler must return a populated form (Name, URL, API
+/// Key, Priority, etc.) bound to the row's existing values, not a
+/// blank shell. Pin the wire shape so a regex-replace refactor of the
+/// partial doesn't silently nullify the populated values.
+#[tokio::test]
+async fn indexer_edit_modal_loads_populated_form() {
+    let Ok(client) = try_connect_browser().await else {
+        return; // WebDriver unreachable — skip.
+    };
+
+    let db = in_memory_pool().await;
+    let state = build_test_app_state(db.clone(), None);
+    let session = seed_user_session(&db).await;
+    let indexer_id = seed_indexer(&db, "Test Indexer Alpha").await;
+    let addr = spawn_app(state).await;
+
+    open_with_session(&client, addr, &session, "/settings?tab=indexers")
+        .await
+        .expect("open settings");
+    let _ = assert_htmx_loaded(&client).await;
+
+    // Click the indexer card body — the whole card is a click
+    // target (`role="button"` on the body div with `data-indexer-id`),
+    // and `openIndexerEditModal` fetches the edit-form partial via
+    // `htmx.ajax` into `#indexer-modal-body`.
+    let card_body = client
+        .wait()
+        .at_most(Duration::from_secs(5))
+        .for_element(Locator::Css(&format!("[data-indexer-id=\"{indexer_id}\"]")))
+        .await
+        .expect("indexer card body");
+    card_body.click().await.expect("click card");
+
+    // Modal body should populate with the indexer's name pre-filled.
+    let name_input = client
+        .wait()
+        .at_most(Duration::from_secs(5))
+        .for_element(Locator::Css("#indexer-modal-body input[name=\"name\"]"))
+        .await
+        .expect("name input present");
+    let name_value = name_input.prop("value").await.expect("read value");
+    assert_eq!(
+        name_value.as_deref(),
+        Some("Test Indexer Alpha"),
+        "edit modal must populate Name from the indexer row, not render blank"
+    );
+
+    let _ = client.close().await;
+}
+
+/// `/api/indexers/test` POST should return a partial with an HX-Trigger
+/// header that fires a toast in the page. Pin that the handler sets
+/// the trigger and the toast helper picks it up — without this, a
+/// regression that drops the trigger header would leave the user
+/// staring at a hung modal with no feedback. The test only checks the
+/// POST shape directly via fetch (faster than driving the modal flow);
+/// the toast wiring is covered by base.js's existing handler.
+#[tokio::test]
+async fn indexer_test_endpoint_returns_partial_with_hx_trigger() {
+    let Ok(client) = try_connect_browser().await else {
+        return;
+    };
+
+    let db = in_memory_pool().await;
+    let state = build_test_app_state(db.clone(), None);
+    let session = seed_user_session(&db).await;
+    let addr = spawn_app(state).await;
+
+    open_with_session(&client, addr, &session, "/settings?tab=indexers")
+        .await
+        .expect("open settings");
+    let _ = assert_htmx_loaded(&client).await;
+
+    // Drive a fetch with bogus credentials so the test is deterministic
+    // (we don't care if the connect succeeds — only that the response
+    // includes an HX-Trigger header naming the toast event).
+    let script = r#"
+        const form = new FormData();
+        form.append("kind", "torznab");
+        form.append("url", "http://nonexistent.local");
+        form.append("api_key", "bogus");
+        const r = await fetch("/api/indexers/test", { method: "POST", body: form });
+        return {
+            status: r.status,
+            trigger: r.headers.get("HX-Trigger") || ""
+        };
+    "#;
+    // fantoccini::Client::execute_async shape — wrapper IIFE returns the value
+    // back through arguments[0].
+    let wrapped = format!(
+        "const cb = arguments[arguments.length - 1]; (async () => {{ {script} }})().then(cb);"
+    );
+    let result = client
+        .execute_async(&wrapped, vec![])
+        .await
+        .expect("fetch test endpoint");
+    let trigger = result
+        .get("trigger")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+    assert!(
+        trigger.contains("ryokan-indexer-test-result"),
+        "POST /api/indexers/test must set HX-Trigger naming the toast event; got: {trigger:?}"
+    );
+
+    let _ = client.close().await;
+}
+
+/// First-of-protocol grabs the Default checkbox automatically. When
+/// the pool already has a torrent client (qBit) but no usenet client,
+/// opening the Add modal with `kind=sabnzbd` selected should mark
+/// "Default" pre-checked because it's the first usenet entry. Pinned
+/// because the auto-check logic lives in inline template attributes
+/// (`data-first-torrent` / `data-first-usenet`) consumed by JS in
+/// `static/js/settings.js` — a typo in either side breaks the UX
+/// silently and the handler-layer tests can't see it.
+#[tokio::test]
+async fn add_dl_client_modal_auto_checks_default_for_first_of_protocol() {
+    let Ok(client) = try_connect_browser().await else {
+        return;
+    };
+
+    let db = in_memory_pool().await;
+    let state = build_test_app_state(db.clone(), None);
+    let session = seed_user_session(&db).await;
+    // Seed an existing torrent client so the user opening the Add
+    // modal isn't first-of-anything for torrent. SAB (when added)
+    // would still be first-of-usenet.
+    seed_dl_client(&db, "Test qBit", "qbittorrent", true).await;
+    let addr = spawn_app(state).await;
+
+    open_with_session(&client, addr, &session, "/settings?tab=download_clients")
+        .await
+        .expect("open download_clients tab");
+    let _ = assert_htmx_loaded(&client).await;
+
+    // Probe the rendered Add-form partial directly (the DC partial's
+    // data-first-* attrs are computed server-side based on the
+    // current pool — they're the SAME values regardless of which
+    // kind the user opens the modal for, because the fields are
+    // populated from `download_clients::list_all` row counts).
+    let html = client
+        .execute_async(
+            "const cb = arguments[arguments.length - 1]; \
+             fetch('/api/download-clients/add-form?kind=sabnzbd') \
+                .then(r => r.text()).then(cb);",
+            vec![],
+        )
+        .await
+        .expect("fetch add form")
+        .as_str()
+        .unwrap_or_default()
+        .to_string();
+
+    // The pool has one torrent (so first_torrent_client = false) but
+    // no usenet (so first_usenet_client = true). The Default checkbox
+    // for an SAB row should therefore be pre-checked.
+    assert!(
+        html.contains("data-first-torrent=\"0\""),
+        "expected data-first-torrent=\"0\" (pool already has qBit); got:\n{html}"
+    );
+    assert!(
+        html.contains("data-first-usenet=\"1\""),
+        "expected data-first-usenet=\"1\" (no usenet client yet); got:\n{html}"
+    );
+
+    let _ = client.close().await;
+}

--- a/tests/htmx_settings_delete.rs
+++ b/tests/htmx_settings_delete.rs
@@ -99,7 +99,14 @@ async fn seed_group(db: &SqlitePool) -> &'static str {
 // ─── Indexers ──────────────────────────────────────────────────────────
 
 #[tokio::test]
-async fn indexers_delete_returns_empty_200_for_htmx_request() {
+async fn indexers_delete_returns_section_partial_for_htmx_request() {
+    // Card-redesign follow-up — every state-changing HTMX action on
+    // the Indexers tab now returns the whole #indexer-section partial
+    // in one swap (cards re-render with the deleted row gone, the
+    // shared modal collapses back to display:none, and the empty-state
+    // CTA surfaces if the section went from 1→0). Previously this
+    // returned empty 200 + per-row outerHTML swap; both shapes are
+    // visible here so the tab body doesn't regress silently.
     let db = in_memory_pool().await;
     let id = seed_indexer(&db).await;
     let state = build_test_app_state(db.clone(), None);
@@ -113,12 +120,18 @@ async fn indexers_delete_returns_empty_200_for_htmx_request() {
     .into_response();
 
     assert_eq!(resp.status(), StatusCode::OK);
-    let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+    let body = axum::body::to_bytes(resp.into_body(), 64 * 1024)
         .await
         .expect("read body");
+    let html = std::str::from_utf8(&body).expect("partial is utf-8");
     assert!(
-        body.is_empty(),
-        "HTMX delete must return empty body so hx-swap=outerHTML removes the row"
+        html.contains("id=\"indexer-section\""),
+        "section root must be the swap target; got: {html}"
+    );
+    // Empty-state CTA renders since the deletion left the section at 0 rows.
+    assert!(
+        html.contains("No indexers configured"),
+        "empty-state CTA must render after the only row is deleted; got: {html}"
     );
 
     // Row actually deleted (sanity check the handler did the work).


### PR DESCRIPTION
## Summary

A grab-bag PR shaped by an extended SAB-debugging session that surfaced
multi-client routing gaps and an unsafe source-cleanup story, plus the
Download Clients / Indexers Settings UI redesigns that landed alongside.

### SAB / multi-client routing

The big one. SAB grabs landed correctly but every cleanup site silently
routed them to the torrent default (qBit), which 200s on unknown hashes,
so Ryokan thought it had cleaned up while the SAB job survived in
`complete/`. Plus the torrent-only paths (queue page, episode-progress
poll, manual pause/resume/delete API) never knew about Usenet jobs at
all.

- New `AppState::resolve_grab_client(download_client_id, hash)` with a
  layered fallback: stamped client id, then SAB-`nzo_id`-shape heuristic
  for legacy NULL stamps, then torrent default. Applied to
  `delete_episode_file`, `cancel_pending_episode`, `replace_episode`,
  the post-processing upgrade-replace, the series-remove path, and the
  `/api/downloads/{pause,resume,delete}` endpoints.
- `find_imported_for_episode` and `find_pending_for_episode` now read
  the `download_client_id` column (was hardcoded `None`), so the per-grab
  routing has something to route on.
- `mark_removed` is now unconditional after the per-grab cleanup body.
  It used to gate on `client.delete()` returning `Ok`, which left grabs
  stuck `imported` any time SAB returned a non-success on housekeeping.
- Downloads queue tab + `/api/torrents` poll endpoint fan out across
  every configured client so SAB jobs render alongside torrent jobs.

### SAB source-side cleanup

SAB's `del_files=1` is unreliable when its history `storage` field is
the parent complete dir (SAB refuses to recursively rm the root). Three
complementary cleanup channels run alongside `client.delete()`:

1. **Stamped source paths** (primary, fresh grabs) - new
   `imported_source_paths` JSON column on `grabbed_torrents`, stamped
   in `import_torrent` from the actual paths Ryokan hardlinked /
   copied / moved FROM. Mode-agnostic.
2. **Inode fallback** (legacy grabs without stamps) - capture the media
   file's inode pre-deletion, walk the grab's content_path looking for
   matching-inode files. Hardlink mode shares inodes so this finds the
   SAB-side source regardless of SAB's reported path.
3. **Orphan-source fallback** - when `find_imported_for_episode`
   returns empty (the polluted-stamps recovery case from the wide-walk
   bug), scan all imported grabs in the series for stamped paths whose
   inode matches the deleted media file.

Single-level parent prune only - earlier unbounded walk-up trashed a
user's entire `complete/` dir when it held only one job.

### SAB import-walk narrowing

Ported Sonarr's `Sabnzbd.cs::GetHistory` Title-matching ancestor
algorithm. New `canonical_job_path(storage, title)` resolves SAB's
reported storage to the actual per-job folder via three cases: storage
IS the job dir (basename matches title), storage points inside the job
dir (walk parents looking for title-named ancestor), or storage is the
parent complete dir (construct `<storage>/<title>/` candidate). Without
this narrowing, `walk_video_files` swept the whole complete dir,
hardlinked stranger episodes from sibling jobs, and triggered
upgrade-replace on unrelated grabs - flipping them to bogus
`state='replaced'` chains.

The `claims_this_episode` guard at the top of the per-file loop body
short-circuits stranger files BEFORE file-op, NFO write, episode-history
insert, OR upgrade-replace. Belt and suspenders alongside the path
narrowing.

### SAB delete-order fix

`mode=queue&name=delete` returns `status:true` unconditionally (SAB's
`_handle_queue` calls `report(output)` after `remove_multiple`
regardless of whether anything was removed). So queue-first-then-history
phantom-succeeded on every post-import delete and never sent
`del_files=1` to history. Now history-first, queue fallback. Same shape
Sonarr / Radarr's SAB clients use.

### Downloads queue scroll preservation

The 5s queue poller's `innerHTML` swap was resetting scroll because
`.rss-table-wrap` has its own scrollbar (`max-height: 680px;
overflow: auto`) - capturing `window.scrollY` was reading 0 the whole
time. Now captures `prevWrap.scrollTop` and restores after the swap.
Also short-circuits the swap when the rendered HTML is unchanged.

### Settings UI redesign

- **Download Clients tab**: clickable card-based picker, edit-in-modal
  with live version probe + always-visible delete button, per-protocol
  auto-check on the Default checkbox for the first client of each
  protocol. Modal copy synced between Add and Edit forms (qBit hint
  reflects 4.6.1+ random temp password behavior; SAB hint points at
  Config -> General -> Security -> API Key).
- **Indexers tab**: split into separate Add / Edit modal partials,
  RSS pill replacing the Test button on cards, new
  `settings_indexers_test_stateless` POST endpoint at
  `/api/indexers/test` (ASCII-only HX-Trigger payload to avoid
  Latin-1 mojibake).

### Other small things

- `add_torrent_returning_id` trait method + grab-time stamping so
  SAB nzo_ids end up on grab rows for the routing chain to use.
- `walk_video_files` post-processing fallback when `client.get_files`
  returns empty (SAB history-mode jobs).
- `cargo nextest` documented as the canonical local test runner in
  CLAUDE.md.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features test-support -- -D warnings`
- [x] `cargo nextest run --workspace --features test-support` - 2091 pass, 23 skipped
- [x] Manual: SAB grab + import + delete cycle on user's setup; verified
  source files removed from `complete/` and grab rows transition to
  `state='removed'` correctly
- [x] Manual: Downloads queue tab shows SAB jobs alongside torrent
  jobs and the 5s poller no longer resets scroll
- [x] Manual: Settings -> Download Clients and Indexers tabs use the
  new card + modal flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)