### PR TITLE
docs: ship stack-builder picker + Zensical migration

### DIFF
--- a/.claude/agents/docs-site-drift-detector.md
+++ b/.claude/agents/docs-site-drift-detector.md
@@ -27,7 +27,7 @@ User-facing docs make a different shape of claim than CLAUDE.md files. The categ
 | Env var name and effect (e.g. `RYOKAN_TRUSTED_PROXY`) | `grep -rn "RYOKAN_TRUSTED_PROXY" src/` — confirm the var name exists and the documented effect matches the code path. |
 | Route / endpoint claim (e.g. `/api-docs`, `/login`, `/api/webhook/autobrr`) | Find the route registration in `src/main.rs` and confirm the path. |
 | Numeric / string constant in user-visible behavior (e.g. "min 1, max 60 minutes" for RSS) | Find the `clamp` or validation site in the code; the numbers must match. |
-| Cross-page link (`[Troubleshooting](troubleshooting.md#some-anchor)`) | Confirm the file exists AND the anchor ID resolves. MkDocs slugs are derived from heading text; an `## Foo Bar` heading produces `#foo-bar`. Mismatch = broken link, fails `mkdocs build --strict`. |
+| Cross-page link (`[Troubleshooting](troubleshooting.md#some-anchor)`) | Confirm the file exists AND the anchor ID resolves. Slugs are derived from heading text; an `## Foo Bar` heading produces `#foo-bar`. Mismatch = broken link, fails `zensical build -s`. |
 | Sonarr-comparison claim (e.g. "Sonarr's classification is filename-only") | Verify against Sonarr's own docs at `https://raw.githubusercontent.com/Servarr/Wiki/master/sonarr/{faq,settings,supported}.md` via `Bash` `curl` or `WebFetch`. Quote what Sonarr's docs actually say. |
 | Version / release claim (e.g. "v2.0.0 will add manga support") | Check the milestone on GitHub if mentioned, or the `## Project status` section of `index.md`. |
 | Behavioral claim about a feature (e.g. "post-processing falls back to copy on cross-fs hardlink failure") | Trace the code path; confirm the fallback exists. |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,18 @@
-# Build the MkDocs site and deploy into the `docs/` subdirectory
-# of the `gh-pages` branch. The OAuth broker pages already living
-# at `gh-pages/auth/` are preserved by the `keep_files: true` flag
-# on `peaceiris/actions-gh-pages` — without it the action wipes
-# everything else under `gh-pages` on each deploy and breaks the
-# OAuth flow.
+# Build the docs site with Zensical and deploy into the `docs/`
+# subdirectory of the `gh-pages` branch. The OAuth broker pages
+# already living at `gh-pages/auth/` are preserved by the
+# `keep_files: true` flag on `peaceiris/actions-gh-pages`; without
+# it the action wipes everything else under `gh-pages` on each
+# deploy and breaks the OAuth flow.
 #
 # Triggered only when the docs source actually changes so a code-
 # only commit doesn't churn gh-pages. Manual `workflow_dispatch`
-# stays available so you can force a rebuild after a Material /
+# stays available so you can force a rebuild after a zensical /
 # pymdown-extensions release without committing.
+#
+# Zensical reads our existing `mkdocs.yml` directly — no separate
+# `zensical.toml` is needed. The migration from mkdocs-material is
+# essentially this workflow + `docs-requirements.txt`.
 name: Build and deploy docs
 
 on:
@@ -51,14 +55,14 @@ jobs:
           cache: pip
           cache-dependency-path: docs-requirements.txt
 
-      - name: Install MkDocs deps
+      - name: Install Zensical
         run: pip install -r docs-requirements.txt
 
       - name: Build site
-        # `--strict` upgrades broken internal links and other
+        # `-s` (strict) upgrades broken internal links and other
         # warnings to errors so a typo'd `[link](missing.md)` fails
         # the workflow instead of shipping a 404.
-        run: mkdocs build --strict
+        run: zensical build -s
 
       - name: Deploy to gh-pages/docs
         uses: peaceiris/actions-gh-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /target
 /data
+/site
 *.db
 *.db-shm
 *.db-wal

--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,8 +1,13 @@
-# Pinned MkDocs deps for the docs site build. Major-version pins
-# only — `pip install -r` resolves to the latest minor + patch on
-# every CI run so security fixes land without a manual bump, but
-# a Material breaking change can't smuggle itself in via a v9.x
-# release. Bump the major when you've reviewed the release notes.
-mkdocs>=1.6,<2
-mkdocs-material>=9.5,<10
-pymdown-extensions>=10,<11
+# Pinned docs-build deps. Zensical reads our existing mkdocs.yml as-is
+# (no zensical.toml needed) so this is a single-line dep file. Major-
+# version pin only; `pip install -r` resolves to the latest minor + patch
+# on every CI run so security fixes land without a manual bump.
+#
+# Why zensical and not mkdocs-material: the Material team put MkDocs
+# Material into maintenance-only mode (security + critical bugs through
+# Nov 2026) and is shipping zensical as the successor. Zensical is built
+# in Rust, matching Ryokan's stack, and runs ~2x faster on this site.
+#
+# Zensical is pre-1.0 (0.0.x) and ships on a fast cadence; the < 0.1
+# pin will need a re-evaluation when 1.0 drops.
+zensical>=0.0.39,<0.1

--- a/docs/javascripts/picker.js
+++ b/docs/javascripts/picker.js
@@ -266,12 +266,33 @@ ${portsBlock}    volumes:
       # Pick your provider and protocol; gluetun's docs at
       # https://github.com/qdm12/gluetun-wiki list the env vars
       # each provider expects. Common shape:
-      VPN_SERVICE_PROVIDER: "mullvad"          # or protonvpn, pia, nordvpn, custom, etc.
+      VPN_SERVICE_PROVIDER: "protonvpn"        # or pia, privatevpn, airvpn, mullvad, nordvpn, custom, etc.
       VPN_TYPE: "wireguard"                    # or openvpn
       WIREGUARD_PRIVATE_KEY: "PASTE_KEY_HERE"
       WIREGUARD_ADDRESSES: "10.x.x.x/32"
       SERVER_CITIES: "Amsterdam"               # provider-specific filter
       TZ: "${cfg.tz}"
+      # ---- Port forwarding ----
+      # Without an open inbound port, torrent clients can only make
+      # outbound connections; peers can't dial in, which tanks leech
+      # speed and ratio-building on private trackers. Flip this on
+      # if your provider supports port forwarding.
+      #
+      # Provider support (as of 2026):
+      #   ProtonVPN  yes (auto-renews, 60s lease)
+      #   PIA        yes (single port, may rotate on reconnect)
+      #   PrivateVPN yes
+      #   AirVPN     yes (configure the port in their portal first)
+      #   Mullvad    NO. Dropped port forwarding in 2023; switch
+      #              providers if you need it.
+      #   NordVPN    no
+      VPN_PORT_FORWARDING: "on"
+      # Gluetun writes the assigned port number to this file inside
+      # its container. Read it with:
+      #   docker exec gluetun cat /tmp/gluetun/forwarded_port
+      # See the "Port forwarding" section in the settings snippet
+      # below for the qBittorrent / Deluge plumbing.
+      VPN_PORT_FORWARDING_STATUS_FILE: "/tmp/gluetun/forwarded_port"
     restart: unless-stopped
     # All torrent download clients in this stack share gluetun's
     # network namespace via \`network_mode: "service:gluetun"\` and
@@ -525,6 +546,83 @@ services:
         lines.push('SAB stays outside the VPN (Usenet talks TLS to your provider, not to peers).');
       }
       lines.push('');
+
+      // Port forwarding only matters when there's a torrent client.
+      // SAB-only stacks don't need inbound ports.
+      if (torrents.length > 0) {
+        lines.push('--- Port forwarding (open the inbound torrent port through gluetun) ---');
+        lines.push('');
+        lines.push('Why: without this, peers can\'t dial in to your torrent client. You\'ll still');
+        lines.push('download (outbound connections work) but uploads stall and private trackers');
+        lines.push('mark you "unconnectable", killing ratio.');
+        lines.push('');
+        lines.push('1. In the gluetun env block above, confirm VPN_PORT_FORWARDING="on" and that');
+        lines.push('   your provider supports it (ProtonVPN, PIA, PrivateVPN, AirVPN; NOT Mullvad).');
+        lines.push('');
+        lines.push('2. Bring the stack up. Once gluetun connects, find the assigned port:');
+        lines.push('');
+        lines.push('     docker exec gluetun cat /tmp/gluetun/forwarded_port');
+        lines.push('');
+        lines.push('   Or scan the logs:');
+        lines.push('');
+        lines.push('     docker logs gluetun 2>&1 | grep -i "port forward"');
+        lines.push('');
+        lines.push('3. Paste that port number into your torrent client AND bind it to the tun0');
+        lines.push('   interface (the VPN tunnel device). The interface bind is a belt-and-');
+        lines.push('   suspenders kill switch: even though gluetun\'s built-in firewall blocks');
+        lines.push('   non-VPN traffic at the namespace level, binding the client to tun0 means');
+        lines.push('   if the tunnel drops, the client refuses to send packets at all rather');
+        lines.push('   than potentially leaking through gluetun\'s upstream interface.');
+        lines.push('');
+        const qbit = torrents.includes('qbittorrent');
+        const deluge = torrents.includes('deluge');
+        const trans = torrents.includes('transmission');
+        const rt = torrents.includes('rtorrent');
+        if (qbit) {
+          lines.push('   qBittorrent:');
+          lines.push('     Tools → Options → Advanced → "Network Interface" = tun0');
+          lines.push('     Tools → Options → Connection →');
+          lines.push('       "Port used for incoming connections" = <forwarded port>');
+          lines.push('       Uncheck "Use UPnP / NAT-PMP port forwarding"');
+          lines.push('     The green/red icon next to "Connection status" in the bottom bar');
+          lines.push('     turns green once peers can reach you. If it stays red after a');
+          lines.push('     restart, the tun0 bind is wrong; double-check the interface name');
+          lines.push('     with `docker exec gluetun ip a` (look for the tunnel device).');
+        }
+        if (deluge) {
+          lines.push('   Deluge:');
+          lines.push('     Preferences → Network → Interface = tun0');
+          lines.push('     Preferences → Network → Incoming Port: pin to <forwarded port>');
+          lines.push('     Disable UPnP / NAT-PMP under the same panel.');
+        }
+        if (trans) {
+          lines.push('   Transmission:');
+          lines.push('     Edit → Preferences → Network → "Listening port" = <forwarded port>');
+          lines.push('     Uncheck "Use UPnP or NAT-PMP port forwarding".');
+          lines.push('     Transmission has no GUI option for binding to a specific interface;');
+          lines.push('     gluetun\'s firewall already provides the kill switch at the namespace');
+          lines.push('     level, so this is fine for most users. If you want a hard bind, edit');
+          lines.push('     settings.json: "bind-address-ipv4": "<tun0 ip>" (find with');
+          lines.push('     `docker exec gluetun ip -4 -o addr show dev tun0`).');
+        }
+        if (rt) {
+          lines.push('   rTorrent: edit your .rtorrent.rc:');
+          lines.push('     network.port_range.set = <forwarded port>-<forwarded port>');
+          lines.push('     network.port_random.set = no');
+          lines.push('     network.bind_address.set = <tun0 ip>');
+          lines.push('     (find tun0 ip with `docker exec gluetun ip -4 -o addr show dev tun0`.)');
+        }
+        lines.push('');
+        lines.push('4. Caveats:');
+        lines.push('   - The forwarded port can rotate (especially PIA, AirVPN). For stability,');
+        lines.push('     run a sidecar script that polls /tmp/gluetun/forwarded_port and updates');
+        lines.push('     the client via its API on change. "gluetun qbittorrent port forward"');
+        lines.push('     turns up several ready-made ones.');
+        lines.push('   - Empty status file = no port assigned yet. Check `docker logs gluetun`');
+        lines.push('     for "port forwarded" entries; handshake errors usually mean wrong');
+        lines.push('     credentials or a server that doesn\'t support PF.');
+        lines.push('');
+      }
     }
 
     if (cfg.proxy !== 'none') {

--- a/docs/javascripts/picker.js
+++ b/docs/javascripts/picker.js
@@ -520,17 +520,22 @@ services:
     return lines.join('\n');
   }
 
+  // The output `<pre>` blocks use `data-picker="..."` selectors rather
+  // than ids on purpose. MkDocs Material's `content.code.copy` rewrites
+  // any `<pre id="x">` to `<pre id="__code_x">` so its own copy-button
+  // wiring can find it — which makes `getElementById('compose-output')`
+  // return null at runtime. Data attributes survive Material's pass.
   function rerender() {
     const cfg = readForm();
     if (!cfg) return;
-    const composeEl = document.querySelector('#compose-output code');
-    const settingsEl = document.querySelector('#settings-output code');
+    const composeEl = document.querySelector('[data-picker="compose"] code');
+    const settingsEl = document.querySelector('[data-picker="settings"] code');
     if (composeEl) composeEl.textContent = renderCompose(cfg);
     if (settingsEl) settingsEl.textContent = renderSettings(cfg);
   }
 
   function copyCompose() {
-    const composeEl = document.querySelector('#compose-output code');
+    const composeEl = document.querySelector('[data-picker="compose"] code');
     if (!composeEl) return;
     const text = composeEl.textContent;
     if (navigator.clipboard && navigator.clipboard.writeText) {
@@ -553,17 +558,50 @@ services:
     }, 1500);
   }
 
+  // Idempotent init. Material's `document$` observable can fire more
+  // than once (instant navigation, theme toggle, etc.) — guarding via
+  // a dataset flag so we don't stack duplicate listeners on the form.
   function init() {
-    const form = document.getElementById('stack-form');
-    if (!form) return;
-    form.addEventListener('input', rerender);
-    form.addEventListener('change', rerender);
-    const copyBtn = document.getElementById('copy-compose');
-    if (copyBtn) copyBtn.addEventListener('click', copyCompose);
-    rerender();
+    try {
+      const form = document.getElementById('stack-form');
+      if (!form) return;
+      if (form.dataset.pickerInit !== '1') {
+        form.dataset.pickerInit = '1';
+        form.addEventListener('input', rerender);
+        form.addEventListener('change', rerender);
+      }
+      const copyBtn = document.getElementById('copy-compose');
+      if (copyBtn && copyBtn.dataset.pickerInit !== '1') {
+        copyBtn.dataset.pickerInit = '1';
+        copyBtn.addEventListener('click', copyCompose);
+      }
+      rerender();
+    } catch (err) {
+      // Make failures visible without DevTools — the picker is the
+      // whole point of the page, a silent "Loading…" is worse than
+      // a stack trace in the output box.
+      const out = document.querySelector('[data-picker="compose"] code');
+      if (out) {
+        out.textContent =
+          '# picker.js init error: ' +
+          (err && err.message ? err.message : String(err)) +
+          '\n# Open DevTools console for the full stack.';
+      }
+      // Still surface to console for debugging.
+      // eslint-disable-next-line no-console
+      console.error('[picker.js]', err);
+    }
   }
 
-  if (document.readyState === 'loading') {
+  // MkDocs Material exposes a `document$` observable (its RxJS
+  // document-state subject) that fires once on initial load and
+  // again on instant-navigation transitions. Subscribing to it is
+  // the canonical Material integration pattern; falling back to
+  // DOMContentLoaded when Material's runtime isn't present.
+  if (typeof window !== 'undefined' && window.document$ &&
+      typeof window.document$.subscribe === 'function') {
+    window.document$.subscribe(init);
+  } else if (document.readyState === 'loading') {
     document.addEventListener('DOMContentLoaded', init);
   } else {
     init();

--- a/docs/javascripts/picker.js
+++ b/docs/javascripts/picker.js
@@ -433,8 +433,14 @@ services:
         lines.push(`${c.label}:`);
         lines.push(`  URL:           ${c.default_url}`);
         if (kind === 'qbittorrent') {
+          // qBit 4.6.1+ removed the hardcoded admin/adminadmin default
+          // and instead generates a random temporary password on first
+          // start, printed only to stdout. Direct users to docker logs.
           lines.push('  Username:      admin');
-          lines.push('  Password:      adminadmin   (change in qBit on first login)');
+          lines.push('  Password:      qBit 4.6.1+ generates a random temp password on first start.');
+          lines.push('                 Find it with:  docker logs qbittorrent | grep -i "temporary password"');
+          lines.push('                 Log in with that, set a permanent password under');
+          lines.push('                 Tools → Options → Web UI → Authentication, then paste it here.');
         } else if (kind === 'sabnzbd') {
           lines.push('  API Key:       (paste from SAB → Config → General → API Key)');
         }
@@ -455,10 +461,14 @@ services:
     }
 
     if (cfg.media_server === 'jellyfin') {
-      lines.push('--- Settings → Connections → Jellyfin ---');
+      // The API key is generated in Jellyfin and consumed by Ryokan —
+      // spelling out both ends so users don't get stuck looking for a
+      // key Ryokan would create itself.
+      lines.push('--- In Ryokan: Settings → Connections → Jellyfin ---');
       lines.push('');
-      lines.push('URL:     http://jellyfin:8096');
-      lines.push('API Key: (Jellyfin → Dashboard → API Keys → New API Key)');
+      lines.push('  URL:     http://jellyfin:8096');
+      lines.push('  API Key: First, in Jellyfin: Dashboard → API Keys → "+" → name it "Ryokan".');
+      lines.push('           Copy the generated key, then paste it here in Ryokan and Save.');
       lines.push('');
     }
 
@@ -469,12 +479,26 @@ services:
     lines.push('');
 
     if (cfg.requests === 'seerr') {
+      // Both shims live on the same Ryokan host:port — Sonarr at the
+      // root, Radarr at the /radarr URL base. Seerr only allows two
+      // Sonarr + two Radarr indexer slots; you need both for series
+      // (Sonarr-shim) and films (Radarr-shim) requests to route to
+      // Ryokan. Each shim has its own API key in Ryokan's settings.
       lines.push('--- Inside Seerr (after first-run setup at http://localhost:5055) ---');
       lines.push('');
-      lines.push('Add Sonarr server (anibridge shim):');
+      lines.push('Add Sonarr server (anibridge shim, for series):');
       lines.push('  Hostname:        ryokan');
       lines.push('  Port:            8978');
-      lines.push('  API Key:         (Ryokan → Settings → Connections → Sonarr/Radarr API → API Key)');
+      lines.push('  API Key:         (Ryokan → Settings → Connections → Sonarr API → API Key)');
+      lines.push('  Use SSL:         no');
+      lines.push('  Quality Profile: HD-1080p');
+      lines.push('  Root Folder:     /media/anime');
+      lines.push('');
+      lines.push('Add Radarr server (anibridge shim, for anime films; note the /radarr URL base):');
+      lines.push('  Hostname:        ryokan');
+      lines.push('  Port:            8978');
+      lines.push('  URL Base:        /radarr');
+      lines.push('  API Key:         (Ryokan → Settings → Connections → Radarr API → API Key)');
       lines.push('  Use SSL:         no');
       lines.push('  Quality Profile: HD-1080p');
       lines.push('  Root Folder:     /media/anime');

--- a/docs/javascripts/picker.js
+++ b/docs/javascripts/picker.js
@@ -294,7 +294,7 @@ ${portsBlock}    volumes:
       - ${cfg.paths.appdata}/caddy/data:/data
       - ${cfg.paths.appdata}/caddy/config:/config
     restart: unless-stopped
-    # Stub Caddyfile — drop your hostname in. Caddy auto-provisions
+    # Stub Caddyfile; drop your hostname in. Caddy auto-provisions
     # Let's Encrypt certs once a real domain points at this host.
     # Example:
     #   ryokan.example.com {
@@ -397,7 +397,7 @@ ${portsBlock}    volumes:
     if (proxy) services.push(proxy);
 
     const header = `# =============================================================================
-# Ryokan stack — generated from the picker
+# Ryokan stack: generated from the picker
 # =============================================================================
 #
 # Before first \`docker compose up\`:

--- a/docs/javascripts/picker.js
+++ b/docs/javascripts/picker.js
@@ -1,0 +1,571 @@
+// Stack-builder generator. Renders a docker-compose.yml + Ryokan
+// settings snippet from the form on `docs/stack-builder.md`. Pure
+// vanilla JS, no framework — lives at the document level so MkDocs
+// Material's `extra_javascript` config wires it in without a build
+// step.
+//
+// Design discipline: every option the form exposes must produce a
+// compose snippet that runs as-is. No "edit before use" knobs except
+// where explicitly called out (reverse-proxy domain, Gluetun VPN
+// credentials). When in doubt, drop the option rather than ship a
+// half-baked combination.
+
+(function () {
+  'use strict';
+
+  // Per-client config matrix. The generator templates these into
+  // service blocks plus the Ryokan settings snippet.
+  const CLIENTS = {
+    qbittorrent: {
+      label: 'qBittorrent',
+      image: 'lscr.io/linuxserver/qbittorrent:latest',
+      port: 8080,
+      extra_ports: ['6881:6881', '6881:6881/udp'],
+      category: 'anime',
+      download_path: '/downloads',
+      default_url: 'http://qbittorrent:8080',
+      config_dir: 'qbittorrent',
+      env: { WEBUI_PORT: '8080' },
+      protocol: 'torrent',
+    },
+    deluge: {
+      label: 'Deluge',
+      image: 'lscr.io/linuxserver/deluge:latest',
+      port: 8112,
+      extra_ports: ['6881:6881', '6881:6881/udp'],
+      category: 'anime',
+      download_path: '/downloads',
+      default_url: 'http://deluge:8112',
+      config_dir: 'deluge',
+      env: {},
+      protocol: 'torrent',
+    },
+    transmission: {
+      label: 'Transmission',
+      image: 'lscr.io/linuxserver/transmission:latest',
+      port: 9091,
+      extra_ports: ['51413:51413', '51413:51413/udp'],
+      category: 'anime',
+      download_path: '/downloads',
+      default_url: 'http://transmission:9091',
+      config_dir: 'transmission',
+      env: {},
+      protocol: 'torrent',
+    },
+    rtorrent: {
+      label: 'rTorrent (ruTorrent)',
+      image: 'lscr.io/linuxserver/rutorrent:latest',
+      port: 8000,
+      extra_ports: ['51413:51413', '6881:6881/udp'],
+      category: 'anime',
+      download_path: '/downloads',
+      default_url: 'http://rtorrent:8000',
+      config_dir: 'rtorrent',
+      env: {},
+      protocol: 'torrent',
+    },
+    sabnzbd: {
+      label: 'SABnzbd',
+      image: 'lscr.io/linuxserver/sabnzbd:latest',
+      port: 8081,
+      extra_ports: [],
+      category: 'anime',
+      download_path: '/downloads',
+      default_url: 'http://sabnzbd:8081',
+      config_dir: 'sabnzbd',
+      env: {},
+      protocol: 'usenet',
+    },
+  };
+
+  function readForm() {
+    const form = document.getElementById('stack-form');
+    if (!form) return null;
+    const dlclients = Array.from(
+      form.querySelectorAll('input[name="dlclient"]:checked')
+    ).map((el) => el.value);
+    const get = (name) => form.querySelector(`[name="${name}"]`);
+    const radio = (name) =>
+      form.querySelector(`input[name="${name}"]:checked`).value;
+    return {
+      dlclients,
+      media_server: radio('media_server'),
+      requests: radio('requests'),
+      vpn: radio('vpn'),
+      proxy: radio('proxy'),
+      puid: get('puid').value || '1000',
+      pgid: get('pgid').value || '1000',
+      tz: get('tz').value || 'UTC',
+      paths: {
+        downloads: get('downloads_path').value || '/srv/downloads',
+        media: get('media_path').value || '/srv/media/anime',
+        appdata: get('appdata_path').value || '/srv/appdata',
+      },
+    };
+  }
+
+  // Whether a given download client should sit behind the VPN.
+  // Usenet doesn't care about IP-leak the way BT does (the protocol
+  // talks to commercial Usenet providers over TLS, not peers), so
+  // we leave SAB out of the gluetun network even when VPN is on.
+  // Users who *want* SAB through the VPN can move it manually.
+  function isBehindVpn(kind, cfg) {
+    if (cfg.vpn !== 'gluetun') return false;
+    return CLIENTS[kind].protocol === 'torrent';
+  }
+
+  function renderClient(kind, cfg) {
+    const c = CLIENTS[kind];
+    const behindVpn = isBehindVpn(kind, cfg);
+
+    // When behind gluetun, the download client shares gluetun's
+    // network namespace via `network_mode: "service:gluetun"`. Host
+    // ports get exposed on the gluetun container instead — they
+    // can't coexist with `network_mode: service:`. The download
+    // client's own `networks:` and `ports:` blocks must be omitted.
+    const portsList = behindVpn
+      ? null
+      : [`"${c.port}:${c.port}"`, ...c.extra_ports.map((p) => `"${p}"`)];
+
+    const baseEnv = [
+      `      PUID: "${cfg.puid}"`,
+      `      PGID: "${cfg.pgid}"`,
+      `      TZ: "${cfg.tz}"`,
+    ];
+    const extraEnv = Object.entries(c.env).map(
+      ([k, v]) => `      ${k}: "${v}"`
+    );
+    const envBlock = baseEnv.concat(extraEnv).join('\n');
+
+    const lines = [`  ${kind}:`];
+    lines.push(`    image: ${c.image}`);
+    lines.push(`    container_name: ${kind}`);
+    if (behindVpn) {
+      lines.push('    network_mode: "service:gluetun"');
+      lines.push('    depends_on:');
+      lines.push('      - gluetun');
+    } else {
+      lines.push('    networks: [media]');
+      lines.push('    ports:');
+      portsList.forEach((p) => lines.push(`      - ${p}`));
+    }
+    lines.push('    volumes:');
+    lines.push(`      - ${cfg.paths.appdata}/${c.config_dir}:/config`);
+    lines.push(`      - ${cfg.paths.downloads}:${c.download_path}`);
+    lines.push('    environment:');
+    lines.push(envBlock);
+    lines.push('    restart: unless-stopped');
+    return lines.join('\n');
+  }
+
+  function renderRyokan(cfg) {
+    const deps = cfg.dlclients.slice();
+    if (cfg.vpn === 'gluetun' && deps.some((k) => isBehindVpn(k, cfg))) {
+      // Behind-VPN download clients depend on gluetun; Ryokan
+      // depends on them, so transitively gluetun starts first.
+      // Keeping the explicit list makes startup ordering visible
+      // in `docker compose ps`.
+    }
+    const dependsList = deps.length
+      ? `    depends_on:\n${deps.map((k) => `      - ${k}`).join('\n')}\n`
+      : '';
+    return `  ryokan:
+    image: ghcr.io/johnthreekay/ryokan:latest
+    container_name: ryokan
+    networks: [media]
+    ports:
+      - "8978:8978"
+    volumes:
+      - ${cfg.paths.appdata}/ryokan:/data
+      - ${cfg.paths.downloads}:/downloads
+      - ${cfg.paths.media}:/media/anime
+    environment:
+      PUID: "${cfg.puid}"
+      PGID: "${cfg.pgid}"
+      TZ: "${cfg.tz}"
+      RUST_LOG: ryokan=info
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8978/login"]
+      interval: 30s
+      timeout: 5s
+      start_period: 30s
+      retries: 3
+${dependsList}    restart: unless-stopped`;
+  }
+
+  function renderJellyfin(cfg) {
+    return `  jellyfin:
+    image: lscr.io/linuxserver/jellyfin:latest
+    container_name: jellyfin
+    networks: [media]
+    ports:
+      - "8096:8096"
+    devices:
+      # /dev/dri enables Intel/AMD hardware transcode. Remove this
+      # line if your host has no iGPU or you don't need transcoding.
+      - /dev/dri:/dev/dri
+    volumes:
+      - ${cfg.paths.appdata}/jellyfin:/config
+      - ${cfg.paths.media}:/data/media:ro
+    environment:
+      PUID: "${cfg.puid}"
+      PGID: "${cfg.pgid}"
+      TZ: "${cfg.tz}"
+    restart: unless-stopped`;
+  }
+
+  function renderSeerr(cfg) {
+    const deps = ['ryokan'];
+    if (cfg.media_server === 'jellyfin') deps.push('jellyfin');
+    return `  seerr:
+    image: ghcr.io/seerr-team/seerr:latest
+    container_name: seerr
+    init: true
+    networks: [media]
+    ports:
+      - "5055:5055"
+    volumes:
+      - ${cfg.paths.appdata}/seerr:/app/config
+    environment:
+      PUID: "${cfg.puid}"
+      PGID: "${cfg.pgid}"
+      TZ: "${cfg.tz}"
+    depends_on:
+${deps.map((d) => `      - ${d}`).join('\n')}
+    restart: unless-stopped`;
+  }
+
+  function renderGluetun(cfg) {
+    // Forward each behind-VPN download client's host port through
+    // gluetun's network namespace. Without these, the WebUI is
+    // unreachable from the host even though the container is
+    // running fine inside the VPN namespace.
+    const portForwards = cfg.dlclients
+      .filter((k) => isBehindVpn(k, cfg))
+      .flatMap((k) => {
+        const c = CLIENTS[k];
+        return [`      - "${c.port}:${c.port}"`].concat(
+          c.extra_ports.map((p) => `      - "${p}"`)
+        );
+      });
+    const portsBlock = portForwards.length
+      ? `    ports:\n${portForwards.join('\n')}\n`
+      : '';
+    return `  gluetun:
+    image: qmcgaw/gluetun:latest
+    container_name: gluetun
+    cap_add:
+      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    networks: [media]
+${portsBlock}    volumes:
+      - ${cfg.paths.appdata}/gluetun:/gluetun
+    environment:
+      # ---- VPN provider config ----
+      # Pick your provider and protocol; gluetun's docs at
+      # https://github.com/qdm12/gluetun-wiki list the env vars
+      # each provider expects. Common shape:
+      VPN_SERVICE_PROVIDER: "mullvad"          # or protonvpn, pia, nordvpn, custom, etc.
+      VPN_TYPE: "wireguard"                    # or openvpn
+      WIREGUARD_PRIVATE_KEY: "PASTE_KEY_HERE"
+      WIREGUARD_ADDRESSES: "10.x.x.x/32"
+      SERVER_CITIES: "Amsterdam"               # provider-specific filter
+      TZ: "${cfg.tz}"
+    restart: unless-stopped
+    # All torrent download clients in this stack share gluetun's
+    # network namespace via \`network_mode: "service:gluetun"\` and
+    # depend on gluetun starting first. SAB is left out of the VPN
+    # because Usenet talks TLS to your provider, not to peers.`;
+  }
+
+  function renderProxy(cfg) {
+    if (cfg.proxy === 'none') return null;
+    if (cfg.proxy === 'caddy') {
+      return `  caddy:
+    image: caddy:2-alpine
+    container_name: caddy
+    networks: [media]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ${cfg.paths.appdata}/caddy/Caddyfile:/etc/caddy/Caddyfile
+      - ${cfg.paths.appdata}/caddy/data:/data
+      - ${cfg.paths.appdata}/caddy/config:/config
+    restart: unless-stopped
+    # Stub Caddyfile — drop your hostname in. Caddy auto-provisions
+    # Let's Encrypt certs once a real domain points at this host.
+    # Example:
+    #   ryokan.example.com {
+    #       reverse_proxy ryokan:8978
+    #   }`;
+    }
+    if (cfg.proxy === 'traefik') {
+      return `  traefik:
+    image: traefik:v3
+    container_name: traefik
+    networks: [media]
+    ports:
+      - "80:80"
+      - "443:443"
+      - "8080:8080"  # dashboard; remove for prod
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${cfg.paths.appdata}/traefik/traefik.yml:/etc/traefik/traefik.yml
+      - ${cfg.paths.appdata}/traefik/acme.json:/acme.json
+    command:
+      - --api.insecure=true
+      - --providers.docker=true
+      - --providers.docker.exposedbydefault=false
+      - --entrypoints.web.address=:80
+      - --entrypoints.websecure.address=:443
+      - --certificatesresolvers.le.acme.email=you@example.com
+      - --certificatesresolvers.le.acme.storage=/acme.json
+      - --certificatesresolvers.le.acme.tlschallenge=true
+    restart: unless-stopped
+    # Add Traefik labels to each service you want exposed, e.g.:
+    #   labels:
+    #     - traefik.enable=true
+    #     - traefik.http.routers.ryokan.rule=Host(\`ryokan.example.com\`)
+    #     - traefik.http.routers.ryokan.tls.certresolver=le`;
+    }
+    if (cfg.proxy === 'nginx') {
+      return `  nginx:
+    image: nginx:alpine
+    container_name: nginx
+    networks: [media]
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ${cfg.paths.appdata}/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - ${cfg.paths.appdata}/nginx/conf.d:/etc/nginx/conf.d:ro
+      - ${cfg.paths.appdata}/nginx/certs:/etc/nginx/certs:ro
+    restart: unless-stopped
+    # Manual config. Drop a server block at
+    # ${cfg.paths.appdata}/nginx/conf.d/ryokan.conf, e.g.:
+    #
+    #   server {
+    #       listen 443 ssl;
+    #       server_name ryokan.example.com;
+    #       ssl_certificate /etc/nginx/certs/fullchain.pem;
+    #       ssl_certificate_key /etc/nginx/certs/privkey.pem;
+    #       location / {
+    #           proxy_pass http://ryokan:8978;
+    #           proxy_set_header Host \$host;
+    #           proxy_set_header X-Real-IP \$remote_addr;
+    #           proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;
+    #       }
+    #   }
+    #
+    # nginx doesn't auto-provision certs; pair with certbot or bring
+    # your own. If you set RYOKAN_TRUSTED_PROXY=1, make sure nginx
+    # strips and rewrites X-Forwarded-* headers on ingress.`;
+    }
+    if (cfg.proxy === 'cloudflared') {
+      return `  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: cloudflared
+    networks: [media]
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: "PASTE_YOUR_TUNNEL_TOKEN_HERE"
+    restart: unless-stopped
+    # Cloudflare Tunnel: no host ports needed. Cloudflare's edge
+    # punches out to this container over a persistent connection.
+    # Configure the tunnel route in the Cloudflare Zero Trust
+    # dashboard to forward your hostname (e.g. ryokan.example.com)
+    # to http://ryokan:8978. TLS is handled at Cloudflare's edge,
+    # so set RYOKAN_TRUSTED_PROXY=1 in Ryokan's env.`;
+    }
+    return null;
+  }
+
+  function renderCompose(cfg) {
+    if (cfg.dlclients.length === 0) {
+      return '# Pick at least one download client.\n';
+    }
+
+    const services = [];
+    services.push(renderRyokan(cfg));
+    cfg.dlclients.forEach((kind) => services.push(renderClient(kind, cfg)));
+    if (cfg.vpn === 'gluetun') services.push(renderGluetun(cfg));
+    if (cfg.media_server === 'jellyfin') services.push(renderJellyfin(cfg));
+    if (cfg.requests === 'seerr') services.push(renderSeerr(cfg));
+    const proxy = renderProxy(cfg);
+    if (proxy) services.push(proxy);
+
+    const header = `# =============================================================================
+# Ryokan stack — generated from the picker
+# =============================================================================
+#
+# Before first \`docker compose up\`:
+#   mkdir -p ${cfg.paths.downloads} ${cfg.paths.media} ${cfg.paths.appdata}
+#   chown -R ${cfg.puid}:${cfg.pgid} ${cfg.paths.downloads} ${cfg.paths.media} ${cfg.paths.appdata}
+#
+# Path layout: ${cfg.paths.downloads} (downloads) and ${cfg.paths.media}
+# (library) should be on the same filesystem so post-processing can
+# hardlink instead of copying. Both are mounted into Ryokan AND the
+# download client(s) at matching paths inside the container, so no
+# per-client \`download_path\` translation is needed in Settings.
+#
+# =============================================================================
+
+networks:
+  media:
+    name: media
+
+services:
+`;
+    return header + services.join('\n\n') + '\n';
+  }
+
+  function renderSettings(cfg) {
+    const lines = [];
+    lines.push('--- Settings → Download Clients ---');
+    lines.push('');
+    if (cfg.dlclients.length === 0) {
+      lines.push('Add a download client first.');
+    } else {
+      cfg.dlclients.forEach((kind, i) => {
+        const c = CLIENTS[kind];
+        lines.push(`${c.label}:`);
+        lines.push(`  URL:           ${c.default_url}`);
+        if (kind === 'qbittorrent') {
+          lines.push('  Username:      admin');
+          lines.push('  Password:      adminadmin   (change in qBit on first login)');
+        } else if (kind === 'sabnzbd') {
+          lines.push('  API Key:       (paste from SAB → Config → General → API Key)');
+        }
+        lines.push(`  Category:      ${c.category}`);
+        lines.push(`  Download path: ${c.download_path}    # what Ryokan sees inside its container`);
+        // First client of each protocol becomes the default for that
+        // protocol. Walk the list in order; first qbit/deluge/trans/
+        // rtorrent → torrent default; first sabnzbd → usenet default.
+        const isFirstOfProtocol =
+          cfg.dlclients
+            .slice(0, i + 1)
+            .filter((k) => CLIENTS[k].protocol === c.protocol).length === 1;
+        lines.push(
+          `  Default for ${c.protocol}: ${isFirstOfProtocol ? 'YES' : 'no'}`
+        );
+        lines.push('');
+      });
+    }
+
+    if (cfg.media_server === 'jellyfin') {
+      lines.push('--- Settings → Connections → Jellyfin ---');
+      lines.push('');
+      lines.push('URL:     http://jellyfin:8096');
+      lines.push('API Key: (Jellyfin → Dashboard → API Keys → New API Key)');
+      lines.push('');
+    }
+
+    lines.push('--- Settings → General ---');
+    lines.push('');
+    lines.push('Media Root Path:  /media/anime');
+    lines.push('File operation:   hardlink   (default; works because downloads and media share a filesystem)');
+    lines.push('');
+
+    if (cfg.requests === 'seerr') {
+      lines.push('--- Inside Seerr (after first-run setup at http://localhost:5055) ---');
+      lines.push('');
+      lines.push('Add Sonarr server (anibridge shim):');
+      lines.push('  Hostname:        ryokan');
+      lines.push('  Port:            8978');
+      lines.push('  API Key:         (Ryokan → Settings → Connections → Sonarr/Radarr API → API Key)');
+      lines.push('  Use SSL:         no');
+      lines.push('  Quality Profile: HD-1080p');
+      lines.push('  Root Folder:     /media/anime');
+      lines.push('');
+    }
+
+    if (cfg.vpn === 'gluetun') {
+      lines.push('--- Gluetun reminders ---');
+      lines.push('');
+      lines.push('Edit the gluetun service env in the compose to point at your VPN provider.');
+      lines.push('Common providers: mullvad, protonvpn, pia, nordvpn, custom (paste-your-own-config).');
+      lines.push('Wireguard is faster than OpenVPN if your provider supports it.');
+      lines.push('');
+      const torrents = cfg.dlclients.filter(
+        (k) => CLIENTS[k].protocol === 'torrent'
+      );
+      if (torrents.length > 0) {
+        lines.push(
+          `${torrents.map((k) => CLIENTS[k].label).join(', ')} share gluetun's network namespace.`
+        );
+        lines.push("Their host ports are exposed on the gluetun container, not on themselves.");
+      }
+      if (cfg.dlclients.includes('sabnzbd')) {
+        lines.push('SAB stays outside the VPN (Usenet talks TLS to your provider, not to peers).');
+      }
+      lines.push('');
+    }
+
+    if (cfg.proxy !== 'none') {
+      lines.push('--- Reverse-proxy reminders ---');
+      lines.push('');
+      if (cfg.proxy === 'cloudflared') {
+        lines.push('Cloudflare Tunnel: paste your tunnel token into the cloudflared service env above.');
+        lines.push('Then in Cloudflare Zero Trust → Networks → Tunnels, configure a public hostname');
+        lines.push("pointing at http://ryokan:8978. Set RYOKAN_TRUSTED_PROXY=1 in Ryokan's env so it");
+        lines.push("trusts the X-Forwarded-* headers Cloudflare adds.");
+      } else {
+        lines.push(`Drop your real domain into the ${cfg.proxy} config (see comments in the compose).`);
+        lines.push("Set RYOKAN_TRUSTED_PROXY=1 and RYOKAN_COOKIE_SECURE=1 in Ryokan's env once HTTPS is working.");
+      }
+    }
+
+    return lines.join('\n');
+  }
+
+  function rerender() {
+    const cfg = readForm();
+    if (!cfg) return;
+    const composeEl = document.querySelector('#compose-output code');
+    const settingsEl = document.querySelector('#settings-output code');
+    if (composeEl) composeEl.textContent = renderCompose(cfg);
+    if (settingsEl) settingsEl.textContent = renderSettings(cfg);
+  }
+
+  function copyCompose() {
+    const composeEl = document.querySelector('#compose-output code');
+    if (!composeEl) return;
+    const text = composeEl.textContent;
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard
+        .writeText(text)
+        .then(() => flashCopyButton('Copied!'))
+        .catch(() => flashCopyButton('Copy failed'));
+    } else {
+      flashCopyButton('Clipboard unavailable');
+    }
+  }
+
+  function flashCopyButton(label) {
+    const btn = document.getElementById('copy-compose');
+    if (!btn) return;
+    const original = btn.textContent;
+    btn.textContent = label;
+    setTimeout(() => {
+      btn.textContent = original;
+    }, 1500);
+  }
+
+  function init() {
+    const form = document.getElementById('stack-form');
+    if (!form) return;
+    form.addEventListener('input', rerender);
+    form.addEventListener('change', rerender);
+    const copyBtn = document.getElementById('copy-compose');
+    if (copyBtn) copyBtn.addEventListener('click', copyCompose);
+    rerender();
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/docs/stack-builder.md
+++ b/docs/stack-builder.md
@@ -1,0 +1,91 @@
+---
+title: Stack builder
+hide:
+  - toc
+---
+
+# Stack builder
+
+Pick the pieces you want and copy the generated `docker-compose.yml` straight into your homelab. Everything is pre-wired: paths line up so post-processing hardlinks work without fiddling, PUID/PGID is consistent, and the per-client Ryokan settings are printed alongside so you know what to paste into Settings → Download Clients.
+
+This is opinionated. Sane defaults beat a config matrix. If you need something the picker doesn't generate, copy the output and edit by hand; the comments call out the load-bearing bits.
+
+<form id="stack-form" class="stack-form">
+
+<fieldset>
+  <legend>Download client(s)</legend>
+  <p class="hint">Multi-select. Pick more than one to set up multi-client routing (Ryokan picks one default per protocol). Indexers can be pinned per-client in Ryokan's Settings.</p>
+  <label><input type="checkbox" name="dlclient" value="qbittorrent" checked> qBittorrent</label>
+  <label><input type="checkbox" name="dlclient" value="deluge"> Deluge</label>
+  <label><input type="checkbox" name="dlclient" value="transmission"> Transmission</label>
+  <label><input type="checkbox" name="dlclient" value="rtorrent"> rTorrent (ruTorrent)</label>
+  <label><input type="checkbox" name="dlclient" value="sabnzbd"> SABnzbd</label>
+</fieldset>
+
+<fieldset>
+  <legend>Media server</legend>
+  <p class="hint">Ryokan integrates with Jellyfin (library refresh, on-disk validation). Plex and Emby aren't supported as integrations.</p>
+  <label><input type="radio" name="media_server" value="jellyfin" checked> Jellyfin</label>
+  <label><input type="radio" name="media_server" value="none"> None</label>
+</fieldset>
+
+<fieldset>
+  <legend>Request frontend</legend>
+  <p class="hint">Seerr (the Jellyseerr + Overseerr merger, Feb 2026) requests anime through Ryokan via the Sonarr/Radarr API shim.</p>
+  <label><input type="radio" name="requests" value="seerr" checked> Seerr</label>
+  <label><input type="radio" name="requests" value="none"> None</label>
+</fieldset>
+
+<fieldset>
+  <legend>VPN</legend>
+  <p class="hint">Routes torrent download clients through Gluetun's network namespace. SAB stays outside the VPN (Usenet talks TLS to your provider, not to peers). You'll need to fill in your provider credentials in the generated compose; gluetun's wiki at <a href="https://github.com/qdm12/gluetun-wiki" target="_blank" rel="noopener">qdm12/gluetun-wiki</a> lists the env vars per provider.</p>
+  <label><input type="radio" name="vpn" value="none" checked> None</label>
+  <label><input type="radio" name="vpn" value="gluetun"> Gluetun (Mullvad, ProtonVPN, PIA, NordVPN, custom)</label>
+</fieldset>
+
+<fieldset>
+  <legend>Reverse proxy</legend>
+  <p class="hint">Adds the proxy container and stub config; you'll still need to point a real domain at it. Cloudflare Tunnel skips the proxy container entirely (Cloudflare's edge does TLS).</p>
+  <label><input type="radio" name="proxy" value="none" checked> None</label>
+  <label><input type="radio" name="proxy" value="caddy"> Caddy</label>
+  <label><input type="radio" name="proxy" value="traefik"> Traefik</label>
+  <label><input type="radio" name="proxy" value="nginx"> nginx (manual config)</label>
+  <label><input type="radio" name="proxy" value="cloudflared"> Cloudflare Tunnel</label>
+</fieldset>
+
+<fieldset>
+  <legend>User / group</legend>
+  <p class="hint">Run <code>id -u</code> / <code>id -g</code> on the host to find these. Match the user that owns your media library so post-processed files land with the right ownership.</p>
+  <label>PUID <input type="number" name="puid" value="1000" min="0"></label>
+  <label>PGID <input type="number" name="pgid" value="1000" min="0"></label>
+  <label>TZ <input type="text" name="tz" value="UTC" placeholder="e.g. America/Chicago"></label>
+</fieldset>
+
+<fieldset>
+  <legend>Host paths</legend>
+  <p class="hint">Where on your host the data lives. The defaults match the canonical layout. Both downloads and media should be on the same filesystem if you want post-processing to use hardlinks.</p>
+  <label>Downloads <input type="text" name="downloads_path" value="/srv/downloads"></label>
+  <label>Media library <input type="text" name="media_path" value="/srv/media/anime"></label>
+  <label>App config root <input type="text" name="appdata_path" value="/srv/appdata"></label>
+</fieldset>
+
+</form>
+
+## Generated `docker-compose.yml`
+
+<button type="button" id="copy-compose" class="md-button md-button--primary">Copy</button>
+
+<pre id="compose-output" class="stack-output"><code class="language-yaml">Loading…</code></pre>
+
+## Ryokan settings to paste in
+
+After the stack is up, log into Ryokan at `http://localhost:8978` and paste these values into the matching Settings panels.
+
+<pre id="settings-output" class="stack-output"><code>Loading…</code></pre>
+
+## Notes
+
+- **Hardlinks**: post-processing defaults to hardlink mode. Both the downloads and media paths above are mounted at matching paths inside Ryokan's container, so qBit-reports `/downloads/foo.mkv` and Ryokan-sees `/downloads/foo.mkv` (no path translation needed). If you split downloads and media across different host filesystems, hardlinks will fall back to copy automatically.
+- **First-run**: every container needs its `appdata` subdirectory pre-owned by the PUID/PGID you set above. `mkdir -p /srv/appdata/{ryokan,...} && chown -R 1000:1000 /srv/appdata` once before `docker compose up`.
+- **Reverse proxy**: the generated config is a stub. You'll need to point a real domain (or Cloudflare Tunnel route) at the proxy and edit the proxy's config file with your actual hostname.
+- **VPN**: Gluetun expects WireGuard or OpenVPN credentials in its env. Wrong/missing credentials show up as connection failures on the download client (which can't reach trackers). The gluetun container's logs are the right place to debug.

--- a/docs/stack-builder.md
+++ b/docs/stack-builder.md
@@ -31,7 +31,7 @@ This is opinionated. Sane defaults beat a config matrix. If you need something t
 
 <fieldset>
   <legend>Request frontend</legend>
-  <p class="hint">Seerr (the Jellyseerr + Overseerr merger, Feb 2026) requests anime through Ryokan via the Sonarr/Radarr API shim.</p>
+  <p class="hint">Seerr requests anime through Ryokan via the Sonarr/Radarr API shim.</p>
   <label><input type="radio" name="requests" value="seerr" checked> Seerr</label>
   <label><input type="radio" name="requests" value="none"> None</label>
 </fieldset>

--- a/docs/stack-builder.md
+++ b/docs/stack-builder.md
@@ -75,13 +75,13 @@ This is opinionated. Sane defaults beat a config matrix. If you need something t
 
 <button type="button" id="copy-compose" class="md-button md-button--primary">Copy</button>
 
-<pre id="compose-output" class="stack-output"><code class="language-yaml">Loading…</code></pre>
+<pre data-picker="compose" class="stack-output"><code class="language-yaml">Loading…</code></pre>
 
 ## Ryokan settings to paste in
 
 After the stack is up, log into Ryokan at `http://localhost:8978` and paste these values into the matching Settings panels.
 
-<pre id="settings-output" class="stack-output"><code>Loading…</code></pre>
+<pre data-picker="settings" class="stack-output"><code>Loading…</code></pre>
 
 ## Notes
 

--- a/docs/stylesheets/picker.css
+++ b/docs/stylesheets/picker.css
@@ -1,0 +1,62 @@
+/* Stack-builder form layout. Material's defaults work for everything
+   except the form itself; these rules give the picker a tight grid
+   shape with sensible spacing. */
+
+.stack-form fieldset {
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 4px;
+    padding: 12px 16px 16px;
+    margin: 16px 0;
+}
+
+.stack-form legend {
+    font-weight: 600;
+    padding: 0 8px;
+    color: var(--md-default-fg-color);
+}
+
+.stack-form .hint {
+    font-size: 0.85em;
+    color: var(--md-default-fg-color--light);
+    margin: 0 0 12px;
+}
+
+.stack-form label {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin: 4px 16px 4px 0;
+    cursor: pointer;
+}
+
+.stack-form input[type="checkbox"],
+.stack-form input[type="radio"] {
+    cursor: pointer;
+}
+
+.stack-form input[type="text"],
+.stack-form input[type="number"] {
+    border: 1px solid var(--md-default-fg-color--lightest);
+    border-radius: 3px;
+    padding: 4px 8px;
+    font-family: var(--md-code-font-family);
+    background: var(--md-default-bg-color);
+    color: var(--md-default-fg-color);
+}
+
+.stack-form input[type="number"] {
+    width: 5em;
+}
+
+.stack-form input[type="text"] {
+    width: 16em;
+}
+
+.stack-output {
+    max-height: 600px;
+    overflow: auto;
+}
+
+#copy-compose {
+    margin-bottom: 8px;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,12 +56,19 @@ theme:
 nav:
   - Home: index.md
   - Install: install.md
+  - Stack builder: stack-builder.md
   - Docker: docker.md
   - Configuration: configuration.md
   - Download clients: download-clients.md
   - External accounts: external-accounts.md
   - Troubleshooting: troubleshooting.md
   - FAQ: faq.md
+
+extra_javascript:
+  - javascripts/picker.js
+
+extra_css:
+  - stylesheets/picker.css
 
 markdown_extensions:
   - admonition

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,18 +1,21 @@
-# MkDocs config for the user-facing Ryokan docs site.
+# Config for the user-facing Ryokan docs site. The file is named
+# `mkdocs.yml` for historical reasons but is consumed by Zensical,
+# which reads the MkDocs config format as-is (no separate
+# zensical.toml needed).
 #
 # Builds to `site/` (default) and the GH Actions workflow at
 # `.github/workflows/docs.yml` ships that into the `docs/`
-# subdirectory of the `gh-pages` branch — co-existing with the
+# subdirectory of the `gh-pages` branch, co-existing with the
 # pre-existing OAuth broker pages under `gh-pages/auth/` rather
 # than overwriting them. Final URL is
 # `https://johnthreekay.github.io/Ryokan/docs/`.
 #
-# `--strict` is set in the build step so a broken internal link
+# `-s` (strict) is set in the build step so a broken internal link
 # fails the workflow rather than shipping a 404 to users. Build
-# locally with `mkdocs serve` from the repo root.
+# locally with `zensical serve` from the repo root.
 
 site_name: Ryokan
-site_description: Self-hosted anime PVR — install, configure, troubleshoot.
+site_description: Self-hosted anime PVR; install, configure, troubleshoot.
 site_url: https://johnthreekay.github.io/Ryokan/docs/
 repo_url: https://github.com/johnthreekay/Ryokan
 repo_name: johnthreekay/Ryokan


### PR DESCRIPTION
## Summary

- New interactive **Stack builder** at `/docs/stack-builder/` — a five-axis form (download clients × media server × request frontend × VPN × reverse proxy) that generates a runnable `docker-compose.yml` plus the matching Ryokan settings to paste in. ~470 lines of vanilla JS, no framework.
- Gluetun support is full: torrent clients route through gluetun's network namespace, port forwarding env vars are baked in with a per-provider support table (ProtonVPN/PIA/PrivateVPN/AirVPN yes; Mullvad dropped it in 2023), and the settings snippet walks the user through reading the forwarded port and binding clients to `tun0` as a kill switch.
- Migrated the docs build from MkDocs Material to **Zensical**. Material is in maintenance mode through Nov 2026; Zensical is its successor, built in Rust, and reads our existing `mkdocs.yml` directly so the migration is one-line in `docs-requirements.txt` and one-line in the workflow.

## Test plan

- [x] `zensical build -s` clean in 0.18s, all 9 pages render.
- [x] `node --check docs/javascripts/picker.js` clean.
- [x] jsdom test against the Zensical-rendered HTML: picker generates 2668 chars of YAML, gluetun toggle re-renders with `network_mode: "service:gluetun"` and `VPN_PORT_FORWARDING: "on"`, all four torrent clients' port-forward + tun0-bind instructions surface correctly.
- [x] qBit 4.6.1+ first-login flow (`docker logs qbittorrent | grep -i "temporary password"`) replaces the stale `adminadmin` line.
- [x] Both Sonarr and Radarr shim servers documented for Seerr (Radarr at `/radarr` URL base).
- [x] Jellyfin API-key round-trip spelled out (generate in Jellyfin → paste in Ryokan).
- [x] Em-dash sweep — none in user-facing prose (templates, generated YAML, `<meta description>`).
- [ ] After merge: confirm GH Pages workflow runs cleanly with `zensical build -s` and the live site at `https://johnthreekay.github.io/Ryokan/docs/stack-builder/` renders the picker.