### PR TITLE
docs: lead "Get started" with the stack builder and order the rest

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -16,13 +16,20 @@ A self-hosted **anime PVR** written in Rust. Searches indexers for releases, sco
 
 ## Get started
 
-<div class="grid cards" markdown>
+!!! tip "Fastest path: the Stack builder"
+    The **[Stack builder](stack-builder.md)** generates a runnable `docker-compose.yml` from a checkbox form: pick your download client(s), media server (Jellyfin), request frontend (Seerr), VPN (Gluetun with port-forwarding), reverse proxy (Caddy / Traefik / nginx / Cloudflare Tunnel), and host paths. Paths line up so post-processing hardlinks work without fiddling, the per-protocol default download client is wired automatically, and the matching Ryokan settings are printed alongside so you know what to paste into Settings → Download Clients after first boot. **Most users should start here.**
 
-- **[Install](install.md)**: `cargo run` for local dev, Docker Compose for prod.
-- **[Docker setup](docker.md)**: volumes, PUID/PGID, environment variables.
-- **[Configuration](configuration.md)**: quality profiles, Custom Formats, post-processing modes.
-- **[Download clients](download-clients.md)**: per-client setup notes and quirks.
-- **[External accounts](external-accounts.md)**: link AniList/MAL for watch-list sync.
-- **[Troubleshooting](troubleshooting.md)**: rate limits, missing categories, the "where did my grab go" cases.
+### If you'd rather roll your own
 
-</div>
+Work through these in order; later steps assume the earlier ones are done.
+
+1. **[Install](install.md)**: Docker pull (recommended) or build from source. Spin up Ryokan at `http://localhost:8978` and create the admin account.
+2. **[Docker setup](docker.md)**: volume mounts, PUID/PGID, the full environment-variable reference. Worth skimming even if the Stack builder generated your compose, since it explains what each `RYOKAN_*` flag does.
+3. **[Download clients](download-clients.md)**: point Ryokan at qBittorrent, Deluge, Transmission, rTorrent, or SABnzbd. Per-client wire quirks live here. Multiple clients are supported and route per-grab.
+4. **[Configuration](configuration.md)**: quality profiles, Custom Formats, post-processing mode (default hardlink). The TRaSH-Guides anime CFs ship as one-click defaults; reach for custom ones once you have a feel for what gets grabbed.
+5. **[External accounts](external-accounts.md)**: link AniList or MAL so your watch list pulls into Ryokan. Optional but the main reason most people self-host this.
+
+### If something's wrong
+
+- **[Troubleshooting](troubleshooting.md)**: rate limits, missing categories, "where did my grab go" cases.
+- **[FAQ](faq.md)**: common questions, including the Sonarr-comparison and "does it support X" answers.


### PR DESCRIPTION
The flat grid of cards under "Get started" treated all six docs pages as equally weighted, which (a) hid the new stack builder one click deep and (b) gave new users no signal about which order to read in.

New shape:

* **Tip admonition up top** points the firehose at the Stack builder with a one-paragraph pitch (download client / media server / VPN / reverse proxy / paths) ending in "Most users should start here."
* **"Roll your own" sub-section** is a numbered list (1-5) instead of an unordered grid, since the steps actually do depend on each other: install -> docker plumbing -> download clients -> quality config -> watch-list sync. Each entry now carries a sentence on *why* you'd read it, not just what it covers.
* **"If something's wrong"** splits Troubleshooting and the FAQ into a dedicated bucket so they don't get glanced past as "another setup step."