### PR TITLE
chore: sync Cargo.lock with 1.6.5 / GPL-3.0-or-later

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryokan"
-version = "1.6.0"
+version = "1.6.5"
 dependencies = [
  "ammonia",
  "anitomy",


### PR DESCRIPTION
## Summary

Cargo.toml landed at 1.6.5 in 8b770be but Cargo.lock kept its 1.6.0 ryokan stanza, so \`cargo build --locked\` (what CI runs) fails the manifest-vs-lockfile check. The 8b770be CI run already went red for this reason; the in-progress 84b50b3 run will hit the same wall.

This commit updates the ryokan \`[[package]]\` version line in Cargo.lock to 1.6.5 so --locked is happy again. No dependency changes.

## Test plan

- [x] \`cargo metadata\` regenerates the exact same diff (one-line version field).
- [x] No dep tree changes; \`cargo build --workspace --locked\` should pass.