### PR TITLE
feat(library): bulk operations (multi-select, monitor, delete)

### DIFF
--- a/src/handlers/library/bulk.rs
+++ b/src/handlers/library/bulk.rs
@@ -44,7 +44,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::models::log::LogCategory;
-use crate::models::{config, grabbed_torrents, series};
+use crate::models::{config, series};
 use crate::services::logger;
 
 /// Per-series outcome envelope returned from synchronous bulk endpoints.
@@ -113,6 +113,10 @@ pub async fn bulk_monitor(
     }
 
     let failed_ids: Vec<i64> = failed.iter().map(|f| f.series_id).collect();
+    // `mode` is user-supplied; sanitize before it lands in the log
+    // detail. Per-row's `remove_series` does the same for its log
+    // line. failed_ids is i64-only so safe to format directly.
+    let safe_mode = crate::handlers::auth::sanitize_for_log(&req.mode);
     logger::info(
         &state.db,
         LogCategory::Library,
@@ -123,7 +127,7 @@ pub async fn bulk_monitor(
         ),
         &format!(
             "action=monitor_set mode={} failed_ids={:?}",
-            req.mode, failed_ids
+            safe_mode, failed_ids
         ),
     )
     .await;
@@ -223,12 +227,17 @@ pub async fn bulk_delete(
 /// String>` so the loop can collect failures into `BulkOutcome.failed`
 /// without aborting the batch.
 ///
-/// Order of operations matters: torrent-client cleanup first (failures
-/// are best-effort; logged but not fatal), then on-disk folder removal,
-/// then `series::remove` for the DB cascade. If we DB-removed first,
-/// a subsequent `grabbed_torrents` lookup for the file/torrent
-/// cleanup would return nothing (FK cascade dropped the rows) and
-/// active torrents would orphan in their clients.
+/// Order of operations: torrent-client + folder cleanup via the
+/// shared [`super::cleanup::cleanup_series_files`] helper (which the
+/// per-row [`super::crud::remove_series`] handler also uses), then
+/// `series::remove` for the DB cascade. If the DB cascade ran first,
+/// the helper's `grabbed_torrents` lookup would return nothing (FK
+/// cascade dropped the rows) and active torrents would orphan.
+///
+/// Partial cleanup failures (folder refused / error, per-grab client
+/// errors) are surfaced as a `BulkFailure.reason` rather than counted
+/// as success — user needs to know when their `delete_files=true`
+/// request didn't actually remove the files.
 async fn delete_one_series(
     state: &AppState,
     series_id: i64,
@@ -236,47 +245,36 @@ async fn delete_one_series(
     media_root: Option<&str>,
 ) -> Result<(), String> {
     if delete_files {
-        // 1. Tell each grab's download client to drop the torrent +
-        //    its files. Best-effort: per-client failures log but don't
-        //    fail the series. The user explicitly asked for files-
-        //    out-too; a transient client outage shouldn't pin the
-        //    series in their library forever.
-        let hashes = grabbed_torrents::get_all_for_series(&state.db, series_id)
+        // Look up the series row for `folder_name` (and to detect
+        // stale-tab IDs where the row no longer exists). Per-row's
+        // handler does the same lookup; bulk has to do it too
+        // because the helper takes `folder_name: &str`.
+        let tracked = series::get_by_id(&state.db, series_id)
             .await
-            .map_err(|e| format!("list grabs: {e}"))?;
-        for &(_grab_id, ref hash, dc_id) in &hashes {
-            if hash.is_empty() {
-                continue;
-            }
-            if let Some(client) = state.resolve_grab_client(dc_id, hash).await {
-                let _ = client.delete(hash, true).await;
-            }
-        }
+            .map_err(|e| format!("lookup: {e}"))?;
+        let folder_name = tracked
+            .as_ref()
+            .map(|t| t.folder_name.as_str())
+            .unwrap_or("");
 
-        // 2. Remove the on-disk folder. spawn_blocking because
-        //    remove_dir_all walks every file and a deep BD library
-        //    folder can take a few seconds. media_root is None when
-        //    config wasn't loadable; in that case we skip file
-        //    removal but still proceed to the DB delete (the user
-        //    pressed Delete, the entry should disappear from their
-        //    library — orphaned files are recoverable).
-        if let Some(root) = media_root
-            && let Ok(Some(s)) = series::get_by_id(&state.db, series_id).await
-            && !s.folder_name.is_empty()
-        {
-            let folder = std::path::PathBuf::from(root).join(&s.folder_name);
-            if folder.exists() {
-                let folder_for_blocking = folder.clone();
-                let _ = tokio::task::spawn_blocking(move || {
-                    std::fs::remove_dir_all(folder_for_blocking)
-                })
-                .await;
-            }
+        let report =
+            super::cleanup::cleanup_series_files(state, series_id, folder_name, media_root).await?;
+        if !report.is_clean() {
+            // Don't `?` — DB cascade still runs even on partial
+            // cleanup so the library entry disappears (matches
+            // per-row behavior; user asked for delete and we
+            // honor that). Surface the partial-failure detail so
+            // the user sees what didn't get cleaned.
+            let reason = report.partial_failure_reason();
+            series::remove(&state.db, series_id)
+                .await
+                .map_err(|e| format!("db remove after partial cleanup: {e}"))?;
+            return Err(reason);
         }
     }
 
-    // 3. DB cascade. `series::remove` is the canonical path; it does
-    //    the rss_seen NULL-out + every other FK-cascading delete.
+    // DB cascade. `series::remove` is the canonical path; it does
+    // the rss_seen NULL-out + every other FK-cascading delete.
     series::remove(&state.db, series_id)
         .await
         .map_err(|e| format!("db remove: {e}"))
@@ -376,14 +374,12 @@ mod tests {
 
     #[tokio::test]
     async fn bulk_monitor_isolates_per_series_failures() {
-        // Mix a real id with a non-existent one. The non-existent
-        // one's UPDATE affects 0 rows in SQLite, which sqlx returns
-        // as Ok(()), so we won't actually see a failure for it via
-        // the model's update path. This test is therefore the
-        // happy-path case for the real id + a "no rows updated"
-        // case for the missing id, both succeed at the SQL layer.
-        // The test still pins the loop-continues-on-error contract
-        // by asserting the real id ends up in `succeeded`.
+        // Mix a real id with a non-existent one. After PR #164's
+        // preflight existence check, the missing id lands in
+        // `failed` (not silently swallowed), so the real id still
+        // writes successfully and the loop-continues-on-error
+        // contract is pinned in BOTH directions: real id in
+        // succeeded, missing id in failed.
         let pool = in_memory_pool().await;
         let a = insert_series(&pool, 1, "A").await;
         let req = BulkMonitorRequest {
@@ -393,6 +389,13 @@ mod tests {
         let state = crate::test_support::build_test_app_state(pool.clone(), None);
         let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
         assert!(outcome.succeeded.contains(&a));
+        assert_eq!(outcome.failed.len(), 1);
+        assert_eq!(outcome.failed[0].series_id, 99999);
+        assert!(
+            outcome.failed[0].reason.contains("no longer exists"),
+            "expected stale-id failure reason, got: {}",
+            outcome.failed[0].reason
+        );
         // Real id wrote successfully.
         let (mode, _) = read_monitor_state(&pool, a).await;
         assert_eq!(mode, "missing");
@@ -452,5 +455,212 @@ mod tests {
         let Json(outcome) = bulk_delete(axum::extract::State(state), Json(req)).await;
         assert!(outcome.succeeded.is_empty());
         assert!(outcome.failed.is_empty());
+    }
+
+    /// Persist a `Config` row with the given media_root for the
+    /// path-traversal test. The bulk handler reads `cfg.media_root`
+    /// once up front when `delete_files=true` and feeds it into
+    /// `cleanup_series_files` for the canonicalize+starts_with guard.
+    async fn save_media_root(db: &SqlitePool, media_root: &str) {
+        let cfg = crate::models::config::Config {
+            media_root: media_root.to_string(),
+            ..Default::default()
+        };
+        crate::models::config::save_config(db, &cfg)
+            .await
+            .expect("save config");
+    }
+
+    /// CVE-shape: pin the `series_canon.starts_with(&media_root_canon)`
+    /// guard for the bulk-delete path. PR #164 review flagged that the
+    /// previous `bulk::delete_one_series` skipped canonicalization
+    /// entirely — a corrupted `folder_name = "../escape"` would have
+    /// `remove_dir_all`'d an arbitrary directory. The shared
+    /// `cleanup_series_files` helper restores the guard; this test
+    /// pins it for bulk so a future regression on either the helper
+    /// or the bulk caller surfaces immediately.
+    #[tokio::test]
+    async fn bulk_delete_refuses_traversal_when_resolved_path_escapes_media_root() {
+        let tmp = tempfile::TempDir::new().expect("tempdir");
+        let media_root = tmp.path().join("media");
+        let escape = tmp.path().join("escape");
+        std::fs::create_dir(&media_root).unwrap();
+        std::fs::create_dir(&escape).unwrap();
+        let sentinel = escape.join("sentinel.txt");
+        std::fs::write(&sentinel, b"do not delete").unwrap();
+
+        let pool = in_memory_pool().await;
+        let series_id = insert_series(&pool, 1001, "Show").await;
+        // Override folder_name to the traversal payload — bypassing
+        // `set_folder`'s `sanitize_folder_name` validator that would
+        // normally reject this. Models a row predating the validator
+        // or one written by a manual SQL edit.
+        sqlx::query("UPDATE series SET folder_name = ? WHERE id = ?")
+            .bind("../escape")
+            .bind(series_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        save_media_root(&pool, media_root.to_str().unwrap()).await;
+        let state = crate::test_support::build_test_app_state(pool.clone(), None);
+
+        let req = BulkDeleteRequest {
+            series_ids: vec![series_id],
+            delete_files: true,
+        };
+        let Json(outcome) = bulk_delete(axum::extract::State(state), Json(req)).await;
+
+        // Series is still removed from the library DB (user asked to
+        // delete; we honor that), but the partial-cleanup signal
+        // surfaces as a BulkFailure so the user knows files weren't
+        // touched.
+        assert_eq!(outcome.succeeded.len(), 0);
+        assert_eq!(outcome.failed.len(), 1);
+        let failure = &outcome.failed[0];
+        assert_eq!(failure.series_id, series_id);
+        assert!(
+            failure.reason.contains("refused") || failure.reason.contains("outside media root"),
+            "expected traversal-refused reason, got: {}",
+            failure.reason
+        );
+
+        // Critical: the escape target survived. If the traversal guard
+        // ever flips, this assertion catches it.
+        assert!(sentinel.exists(), "escape target sentinel must survive");
+        assert!(escape.exists(), "escape dir must survive");
+        assert!(media_root.exists(), "media_root must survive");
+
+        // DB row is gone (delete still proceeds despite the partial
+        // cleanup; matches per-row's behavior of going through with
+        // the irreversible step).
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM series WHERE id = ?")
+            .bind(series_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, 0);
+    }
+
+    /// Issue #28 PR C — pin the `respects_seed_rules` skip-client-delete
+    /// branch for the bulk path. Previously `bulk::delete_one_series`
+    /// unconditionally called `client.delete(hash, true)`, which would
+    /// silently violate PT ratio policy for every grab on a 50-series
+    /// bulk delete. The shared helper now honors the flag; this test
+    /// pins it.
+    #[tokio::test]
+    async fn bulk_delete_honors_seed_rules() {
+        use crate::services::download_client::{
+            AddOutcome, DownloadClient, DownloadFile, DownloadItem, SelectiveOutcome,
+        };
+        use async_trait::async_trait;
+        use std::sync::{Arc, Mutex};
+
+        #[derive(Default)]
+        struct RecordingClient {
+            deletes: Mutex<Vec<String>>,
+        }
+
+        #[async_trait]
+        impl DownloadClient for RecordingClient {
+            async fn test(&self) -> Result<String, String> {
+                Ok("mock".into())
+            }
+            async fn add_torrent(&self, _url: &str, _hash: &str) -> Result<AddOutcome, String> {
+                Ok(AddOutcome::Added)
+            }
+            async fn add_torrent_with_file_filter(
+                &self,
+                _url: &str,
+                _hash: &str,
+                _pick: &mut (dyn for<'a> FnMut(&'a [String]) -> Option<Vec<usize>> + Send),
+            ) -> Result<SelectiveOutcome, String> {
+                Ok(SelectiveOutcome::FullDownload)
+            }
+            async fn list_scoped(&self) -> Result<Vec<DownloadItem>, String> {
+                Ok(vec![])
+            }
+            async fn get_files(&self, _hash: &str) -> Result<Vec<DownloadFile>, String> {
+                Ok(vec![])
+            }
+            async fn pause(&self, _hash: &str) -> Result<(), String> {
+                Ok(())
+            }
+            async fn resume(&self, _hash: &str) -> Result<(), String> {
+                Ok(())
+            }
+            async fn delete(&self, hash: &str, _delete_files: bool) -> Result<(), String> {
+                self.deletes.lock().unwrap().push(hash.to_string());
+                Ok(())
+            }
+            async fn set_file_wanted(
+                &self,
+                _hash: &str,
+                _files: &[usize],
+                _wanted: bool,
+            ) -> Result<(), String> {
+                Ok(())
+            }
+            fn sonarr_impl_name(&self) -> &'static str {
+                "QBittorrent"
+            }
+            fn protocol(&self) -> &'static str {
+                "torrent"
+            }
+        }
+
+        let pool = in_memory_pool().await;
+        let series_id = insert_series(&pool, 2001, "Show").await;
+        // Two grabs: one with the seed-rule flag set, one without. The
+        // flagged hash must NOT reach client.delete; the unflagged
+        // hash must.
+        let kept_hash = "kept-hash-aaa";
+        let removed_hash = "removed-hash-bbb";
+        crate::test_support::seed_grabbed_torrent(
+            &pool,
+            series_id,
+            kept_hash,
+            "kept.torrent",
+            &[1],
+        )
+        .await;
+        crate::test_support::seed_grabbed_torrent(
+            &pool,
+            series_id,
+            removed_hash,
+            "removed.torrent",
+            &[2],
+        )
+        .await;
+        sqlx::query("UPDATE grabbed_torrents SET respect_seed_rules = 1 WHERE hash = ?")
+            .bind(kept_hash)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let recorder = Arc::new(RecordingClient::default());
+        let client: Arc<dyn DownloadClient> = recorder.clone();
+        let state = crate::test_support::build_test_app_state(pool.clone(), Some(client));
+
+        let req = BulkDeleteRequest {
+            series_ids: vec![series_id],
+            delete_files: true,
+        };
+        let Json(_outcome) = bulk_delete(axum::extract::State(state), Json(req)).await;
+
+        let observed = recorder.deletes.lock().unwrap();
+        assert_eq!(
+            observed.len(),
+            1,
+            "exactly one client.delete expected; got {:?}",
+            observed
+        );
+        assert_eq!(
+            observed[0], removed_hash,
+            "non-seed-rule hash should be the only one deleted"
+        );
+        assert!(
+            !observed.contains(&kept_hash.to_string()),
+            "seed-rule-flagged hash must NOT reach client.delete"
+        );
     }
 }

--- a/src/handlers/library/bulk.rs
+++ b/src/handlers/library/bulk.rs
@@ -113,10 +113,18 @@ pub async fn bulk_monitor(
     }
 
     let failed_ids: Vec<i64> = failed.iter().map(|f| f.series_id).collect();
-    // `mode` is user-supplied; sanitize before it lands in the log
-    // detail. Per-row's `remove_series` does the same for its log
-    // line. failed_ids is i64-only so safe to format directly.
-    let safe_mode = crate::handlers::auth::sanitize_for_log(&req.mode);
+    // Log the canonical mode so the trail matches per-row's
+    // `set_monitoring` log line — that handler logs
+    // `MonitorMode::from_str(...).as_str()` (lowercase known value).
+    // Without this both `mode=ALL` and `mode=all` could land in the
+    // log depending on which path the user took, which makes the
+    // System → Logs filter brittle. Sentinel passes through verbatim
+    // because `MonitorMode::from_str` would coerce it to `future`.
+    let canonical_mode: &str = if req.mode == super::crud::MONITOR_MODE_SYNC_SENTINEL {
+        super::crud::MONITOR_MODE_SYNC_SENTINEL
+    } else {
+        crate::models::monitoring::MonitorMode::from_str(&req.mode).as_str()
+    };
     logger::info(
         &state.db,
         LogCategory::Library,
@@ -127,7 +135,7 @@ pub async fn bulk_monitor(
         ),
         &format!(
             "action=monitor_set mode={} failed_ids={:?}",
-            safe_mode, failed_ids
+            canonical_mode, failed_ids
         ),
     )
     .await;
@@ -264,11 +272,15 @@ async fn delete_one_series(
             // cleanup so the library entry disappears (matches
             // per-row behavior; user asked for delete and we
             // honor that). Surface the partial-failure detail so
-            // the user sees what didn't get cleaned.
+            // the user sees what didn't get cleaned. If `series::remove`
+            // *also* fails, concat both — the upstream
+            // traversal-refused / seed-rule signal is more interesting
+            // than the bare sqlx error and should land in the failure
+            // modal regardless.
             let reason = report.partial_failure_reason();
-            series::remove(&state.db, series_id)
-                .await
-                .map_err(|e| format!("db remove after partial cleanup: {e}"))?;
+            if let Err(e) = series::remove(&state.db, series_id).await {
+                return Err(format!("{reason}; db remove after partial cleanup: {e}"));
+            }
             return Err(reason);
         }
     }

--- a/src/handlers/library/bulk.rs
+++ b/src/handlers/library/bulk.rs
@@ -44,6 +44,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::AppState;
 use crate::models::log::LogCategory;
+use crate::models::{config, grabbed_torrents, series};
 use crate::services::logger;
 
 /// Per-series outcome envelope returned from synchronous bulk endpoints.
@@ -128,6 +129,157 @@ pub async fn bulk_monitor(
     .await;
 
     Json(BulkOutcome { succeeded, failed })
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct BulkDeleteRequest {
+    pub series_ids: Vec<i64>,
+    /// When true, also walks `grabbed_torrents` for each series and
+    /// asks the resolved download client to drop the torrent + its
+    /// files, then recursively removes the on-disk folder under
+    /// `media_root/<folder_name>`. When false, only the database
+    /// rows for the series are removed (cascade + `rss_seen`
+    /// NULL-out via [`series::remove`]); files stay on disk and
+    /// active torrents stay in their download clients.
+    pub delete_files: bool,
+}
+
+/// `POST /api/library/bulk/delete` — remove a list of series from the
+/// library. Per-series cleanup runs in a loop; failures don't abort
+/// the batch.
+///
+/// Recycle bin (#123) hasn't shipped yet, so `delete_files: true`
+/// performs a permanent unlink. The Confirmation modal in the
+/// frontend warns that this can't be undone. When recycle ships,
+/// the file-removal branch swaps to a recycle-bin call without
+/// changing this handler's wire shape.
+#[utoipa::path(
+    post,
+    path = "/api/library/bulk/delete",
+    tag = "Library",
+    summary = "Bulk-remove series from library",
+    request_body = BulkDeleteRequest,
+    responses(
+        (status = 200, description = "Outcome envelope; check `failed` for per-series errors", body = BulkOutcome),
+    ),
+)]
+pub async fn bulk_delete(
+    State(state): State<AppState>,
+    Json(req): Json<BulkDeleteRequest>,
+) -> Json<BulkOutcome> {
+    if req.series_ids.is_empty() {
+        return Json(BulkOutcome {
+            succeeded: vec![],
+            failed: vec![],
+        });
+    }
+
+    // Resolve media_root once at the top — bulk delete pays a single
+    // config fetch instead of N when delete_files is true. Returns
+    // None when config isn't loaded (shouldn't happen post-setup; we
+    // guard rather than crash).
+    let media_root: Option<String> = if req.delete_files {
+        config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .map(|c| c.media_root)
+    } else {
+        None
+    };
+
+    let mut succeeded = Vec::with_capacity(req.series_ids.len());
+    let mut failed = Vec::new();
+    for series_id in &req.series_ids {
+        match delete_one_series(&state, *series_id, req.delete_files, media_root.as_deref()).await {
+            Ok(()) => succeeded.push(*series_id),
+            Err(reason) => failed.push(BulkFailure {
+                series_id: *series_id,
+                reason,
+            }),
+        }
+    }
+
+    let failed_ids: Vec<i64> = failed.iter().map(|f| f.series_id).collect();
+    logger::info(
+        &state.db,
+        LogCategory::Library,
+        &format!(
+            "Bulk delete: {} succeeded, {} failed",
+            succeeded.len(),
+            failed.len()
+        ),
+        &format!(
+            "action=delete delete_files={} failed_ids={:?}",
+            req.delete_files, failed_ids
+        ),
+    )
+    .await;
+
+    Json(BulkOutcome { succeeded, failed })
+}
+
+/// Per-series delete worker for [`bulk_delete`]. Returns `Result<(),
+/// String>` so the loop can collect failures into `BulkOutcome.failed`
+/// without aborting the batch.
+///
+/// Order of operations matters: torrent-client cleanup first (failures
+/// are best-effort; logged but not fatal), then on-disk folder removal,
+/// then `series::remove` for the DB cascade. If we DB-removed first,
+/// a subsequent `grabbed_torrents` lookup for the file/torrent
+/// cleanup would return nothing (FK cascade dropped the rows) and
+/// active torrents would orphan in their clients.
+async fn delete_one_series(
+    state: &AppState,
+    series_id: i64,
+    delete_files: bool,
+    media_root: Option<&str>,
+) -> Result<(), String> {
+    if delete_files {
+        // 1. Tell each grab's download client to drop the torrent +
+        //    its files. Best-effort: per-client failures log but don't
+        //    fail the series. The user explicitly asked for files-
+        //    out-too; a transient client outage shouldn't pin the
+        //    series in their library forever.
+        let hashes = grabbed_torrents::get_all_for_series(&state.db, series_id)
+            .await
+            .map_err(|e| format!("list grabs: {e}"))?;
+        for &(_grab_id, ref hash, dc_id) in &hashes {
+            if hash.is_empty() {
+                continue;
+            }
+            if let Some(client) = state.resolve_grab_client(dc_id, hash).await {
+                let _ = client.delete(hash, true).await;
+            }
+        }
+
+        // 2. Remove the on-disk folder. spawn_blocking because
+        //    remove_dir_all walks every file and a deep BD library
+        //    folder can take a few seconds. media_root is None when
+        //    config wasn't loadable; in that case we skip file
+        //    removal but still proceed to the DB delete (the user
+        //    pressed Delete, the entry should disappear from their
+        //    library — orphaned files are recoverable).
+        if let Some(root) = media_root
+            && let Ok(Some(s)) = series::get_by_id(&state.db, series_id).await
+            && !s.folder_name.is_empty()
+        {
+            let folder = std::path::PathBuf::from(root).join(&s.folder_name);
+            if folder.exists() {
+                let folder_for_blocking = folder.clone();
+                let _ = tokio::task::spawn_blocking(move || {
+                    std::fs::remove_dir_all(folder_for_blocking)
+                })
+                .await;
+            }
+        }
+    }
+
+    // 3. DB cascade. `series::remove` is the canonical path; it does
+    //    the rss_seen NULL-out + every other FK-cascading delete.
+    series::remove(&state.db, series_id)
+        .await
+        .map_err(|e| format!("db remove: {e}"))
 }
 
 #[cfg(test)]
@@ -255,6 +407,49 @@ mod tests {
         };
         let state = crate::test_support::build_test_app_state(pool, None);
         let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
+        assert!(outcome.succeeded.is_empty());
+        assert!(outcome.failed.is_empty());
+    }
+
+    #[tokio::test]
+    async fn bulk_delete_removes_db_rows_when_delete_files_false() {
+        // Covers the "remove from library only" path: rows go from
+        // `series` (and cascade across the FK graph), files stay
+        // on disk. delete_files=false also skips the
+        // grabbed_torrents walk, so this test doesn't need a
+        // download client mock.
+        let pool = in_memory_pool().await;
+        let a = insert_series(&pool, 1, "A").await;
+        let b = insert_series(&pool, 2, "B").await;
+
+        let req = BulkDeleteRequest {
+            series_ids: vec![a, b],
+            delete_files: false,
+        };
+        let state = crate::test_support::build_test_app_state(pool.clone(), None);
+        let Json(outcome) = bulk_delete(axum::extract::State(state), Json(req)).await;
+
+        assert_eq!(outcome.succeeded.len(), 2);
+        assert!(outcome.failed.is_empty());
+        for id in [a, b] {
+            let exists: Option<(i64,)> = sqlx::query_as("SELECT id FROM series WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&pool)
+                .await
+                .unwrap();
+            assert!(exists.is_none(), "series {id} should be DB-removed");
+        }
+    }
+
+    #[tokio::test]
+    async fn bulk_delete_empty_selection_is_200_noop() {
+        let pool = in_memory_pool().await;
+        let req = BulkDeleteRequest {
+            series_ids: vec![],
+            delete_files: false,
+        };
+        let state = crate::test_support::build_test_app_state(pool, None);
+        let Json(outcome) = bulk_delete(axum::extract::State(state), Json(req)).await;
         assert!(outcome.succeeded.is_empty());
         assert!(outcome.failed.is_empty());
     }

--- a/src/handlers/library/bulk.rs
+++ b/src/handlers/library/bulk.rs
@@ -1,0 +1,261 @@
+//! Bulk library operations (issue #125).
+//!
+//! Per-series actions Ryokan supports today are "click a thing per row,"
+//! which scales poorly past two series. This module ships the JSON-API
+//! surface for bulk changes, starting with bulk monitor; subsequent PRs
+//! layer bulk re-search, bulk delete, bulk finished-mode, and bulk
+//! upgrades on top of the same `BulkOutcome` shape.
+//!
+//! ## Per-series failure isolation
+//!
+//! Every endpoint returns a structured outcome:
+//!
+//! ```json
+//! { "succeeded": [1, 2, 5, 7], "failed": [{ "series_id": 9, "reason": "..." }] }
+//! ```
+//!
+//! A per-series failure (DB error on series 9, missing folder, download
+//! client unreachable) is captured and the loop continues. All-or-nothing
+//! semantics would be wrong here — a single broken-folder series shouldn't
+//! block 49 valid operations from succeeding. The frontend renders a
+//! partial-failure toast + click-for-detail modal so the user sees which
+//! IDs failed and why.
+//!
+//! ## Empty selection is a 200 no-op
+//!
+//! Defense-in-depth: a request with an empty `series_ids` array returns
+//! 200 with empty `succeeded` / `failed` arrays. The toolbar UI is
+//! supposed to be hidden when nothing's selected, but a race-during-
+//! deselect or a JS bug could still send `{ "series_ids": [] }`. Don't
+//! 400 — a benign no-op is the right shape, and validates only that the
+//! request body deserialized.
+//!
+//! ## Audit logging
+//!
+//! After the per-series loop completes, each endpoint writes one
+//! batch-summary `LogCategory::Library` entry: succeeded / failed counts
+//! plus the failed IDs inline. Per-series log lines would flood System
+//! → Logs at 200-item bulk re-search; the single summary is the
+//! auditable "did the bulk action I did yesterday touch series X?"
+//! answer without drowning the filter.
+
+use axum::{Json, extract::State};
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::models::log::LogCategory;
+use crate::services::logger;
+
+/// Per-series outcome envelope returned from synchronous bulk endpoints.
+/// Async endpoints (bulk re-search) return a `ProgressRegistry` job ID
+/// instead and surface this same shape on the progress-completion event.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BulkOutcome {
+    pub succeeded: Vec<i64>,
+    pub failed: Vec<BulkFailure>,
+}
+
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct BulkFailure {
+    pub series_id: i64,
+    pub reason: String,
+}
+
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct BulkMonitorRequest {
+    pub series_ids: Vec<i64>,
+    /// Monitor mode value (`all` / `future` / `missing` / `existing` /
+    /// `none`) or the [`MONITOR_MODE_SYNC_SENTINEL`] string `"sync"`.
+    /// Picking the sentinel clears the per-series manual-override flag
+    /// so the next AL/MAL sync tick computes the mode; any other value
+    /// pins the mode and sets the manual-override flag.
+    ///
+    /// [`MONITOR_MODE_SYNC_SENTINEL`]: super::crud::MONITOR_MODE_SYNC_SENTINEL
+    pub mode: String,
+}
+
+/// `POST /api/library/bulk/monitor` — apply the same monitor-mode change
+/// to a list of series. Reuses `crud::apply_monitor_mode` per-series so
+/// the sentinel-clear and pin-mode branches stay in lockstep with the
+/// per-series handler.
+#[utoipa::path(
+    post,
+    path = "/api/library/bulk/monitor",
+    tag = "Library",
+    summary = "Bulk-set monitor mode",
+    request_body = BulkMonitorRequest,
+    responses(
+        (status = 200, description = "Outcome envelope; check `failed` for per-series errors", body = BulkOutcome),
+    ),
+)]
+pub async fn bulk_monitor(
+    State(state): State<AppState>,
+    Json(req): Json<BulkMonitorRequest>,
+) -> Json<BulkOutcome> {
+    if req.series_ids.is_empty() {
+        return Json(BulkOutcome {
+            succeeded: vec![],
+            failed: vec![],
+        });
+    }
+
+    let mut succeeded = Vec::with_capacity(req.series_ids.len());
+    let mut failed = Vec::new();
+    for series_id in &req.series_ids {
+        match super::crud::apply_monitor_mode(&state.db, *series_id, &req.mode).await {
+            Ok(()) => succeeded.push(*series_id),
+            Err(reason) => failed.push(BulkFailure {
+                series_id: *series_id,
+                reason,
+            }),
+        }
+    }
+
+    let failed_ids: Vec<i64> = failed.iter().map(|f| f.series_id).collect();
+    logger::info(
+        &state.db,
+        LogCategory::Library,
+        &format!(
+            "Bulk monitor change: {} succeeded, {} failed",
+            succeeded.len(),
+            failed.len()
+        ),
+        &format!(
+            "action=monitor_set mode={} failed_ids={:?}",
+            req.mode, failed_ids
+        ),
+    )
+    .await;
+
+    Json(BulkOutcome { succeeded, failed })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::in_memory_pool;
+    use sqlx::SqlitePool;
+
+    /// Insert a minimal series row sufficient for the monitor-mode
+    /// write paths to succeed. Returns the inserted id.
+    async fn insert_series(pool: &SqlitePool, anilist_id: i64, title: &str) -> i64 {
+        let row: (i64,) = sqlx::query_as(
+            "INSERT INTO series (anilist_id, title, monitor_mode, monitor_mode_manual_override)
+             VALUES (?, ?, 'future', 0)
+             RETURNING id",
+        )
+        .bind(anilist_id)
+        .bind(title)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        row.0
+    }
+
+    /// Read back the (mode, override_flag) tuple for assertions.
+    async fn read_monitor_state(pool: &SqlitePool, series_id: i64) -> (String, bool) {
+        let row: (String, bool) = sqlx::query_as(
+            "SELECT monitor_mode, monitor_mode_manual_override FROM series WHERE id = ?",
+        )
+        .bind(series_id)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+        row
+    }
+
+    #[tokio::test]
+    async fn bulk_monitor_applies_mode_to_every_id() {
+        let pool = in_memory_pool().await;
+        let a = insert_series(&pool, 1, "A").await;
+        let b = insert_series(&pool, 2, "B").await;
+        let c = insert_series(&pool, 3, "C").await;
+
+        let req = BulkMonitorRequest {
+            series_ids: vec![a, b, c],
+            mode: "all".to_string(),
+        };
+        let state = crate::test_support::build_test_app_state(pool.clone(), None);
+        let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
+
+        assert_eq!(outcome.succeeded.len(), 3);
+        assert!(outcome.failed.is_empty());
+        for id in [a, b, c] {
+            let (mode, override_flag) = read_monitor_state(&pool, id).await;
+            assert_eq!(mode, "all");
+            assert!(
+                override_flag,
+                "explicit-mode bulk should set the manual-override flag"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn bulk_monitor_sync_sentinel_clears_override_without_touching_mode() {
+        // Sentinel posture: clear `monitor_mode_manual_override`,
+        // leave `monitor_mode` alone (next sync tick fixes it).
+        // Tested separately because this branch silently drives
+        // different behavior than an explicit mode change.
+        let pool = in_memory_pool().await;
+        let id = insert_series(&pool, 1, "A").await;
+        // Pre-stamp it with an override so the sentinel has something
+        // to clear.
+        sqlx::query(
+            "UPDATE series SET monitor_mode = 'all', monitor_mode_manual_override = 1 WHERE id = ?",
+        )
+        .bind(id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let req = BulkMonitorRequest {
+            series_ids: vec![id],
+            mode: super::super::crud::MONITOR_MODE_SYNC_SENTINEL.to_string(),
+        };
+        let state = crate::test_support::build_test_app_state(pool.clone(), None);
+        let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
+
+        assert_eq!(outcome.succeeded, vec![id]);
+        assert!(outcome.failed.is_empty());
+        let (mode, override_flag) = read_monitor_state(&pool, id).await;
+        assert_eq!(mode, "all", "sentinel should NOT change the mode");
+        assert!(!override_flag, "sentinel should clear the override flag");
+    }
+
+    #[tokio::test]
+    async fn bulk_monitor_isolates_per_series_failures() {
+        // Mix a real id with a non-existent one. The non-existent
+        // one's UPDATE affects 0 rows in SQLite, which sqlx returns
+        // as Ok(()), so we won't actually see a failure for it via
+        // the model's update path. This test is therefore the
+        // happy-path case for the real id + a "no rows updated"
+        // case for the missing id, both succeed at the SQL layer.
+        // The test still pins the loop-continues-on-error contract
+        // by asserting the real id ends up in `succeeded`.
+        let pool = in_memory_pool().await;
+        let a = insert_series(&pool, 1, "A").await;
+        let req = BulkMonitorRequest {
+            series_ids: vec![a, 99999],
+            mode: "missing".to_string(),
+        };
+        let state = crate::test_support::build_test_app_state(pool.clone(), None);
+        let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
+        assert!(outcome.succeeded.contains(&a));
+        // Real id wrote successfully.
+        let (mode, _) = read_monitor_state(&pool, a).await;
+        assert_eq!(mode, "missing");
+    }
+
+    #[tokio::test]
+    async fn bulk_monitor_empty_selection_is_200_noop() {
+        let pool = in_memory_pool().await;
+        let req = BulkMonitorRequest {
+            series_ids: vec![],
+            mode: "all".to_string(),
+        };
+        let state = crate::test_support::build_test_app_state(pool, None);
+        let Json(outcome) = bulk_monitor(axum::extract::State(state), Json(req)).await;
+        assert!(outcome.succeeded.is_empty());
+        assert!(outcome.failed.is_empty());
+    }
+}

--- a/src/handlers/library/cleanup.rs
+++ b/src/handlers/library/cleanup.rs
@@ -66,8 +66,12 @@ impl SeriesCleanupReport {
     /// One-line summary for the bulk failure-modal copy. Only called
     /// when `is_clean()` is false; assembles the partial-failure
     /// reason out of the substage signals so the user sees what
-    /// didn't get cleaned. ASCII-only so HX-Trigger envelopes don't
-    /// mojibake (see CLAUDE.md "HX-Trigger payloads must be ASCII").
+    /// didn't get cleaned. The reason rides back to the frontend as
+    /// JSON via [`BulkOutcome`](super::bulk::BulkOutcome) — no
+    /// HX-Trigger involvement — so any UTF-8 the filesystem can
+    /// produce in `folder_detail` is fine to interpolate as-is.
+    ///
+    /// [`BulkOutcome`]: super::bulk::BulkOutcome
     pub fn partial_failure_reason(&self) -> String {
         let mut parts: Vec<String> = Vec::new();
         match self.folder_status {

--- a/src/handlers/library/cleanup.rs
+++ b/src/handlers/library/cleanup.rs
@@ -1,0 +1,249 @@
+//! Shared per-series file/torrent cleanup. Both the per-row Remove
+//! handler ([`crud::remove_series`]) and the bulk delete handler
+//! ([`bulk::delete_one_series`]) call into [`cleanup_series_files`] so
+//! the security-critical canonicalize-and-`starts_with` guard, the PT
+//! seed-rule honor (issue #28 PR C), the SAB stamped-source-path
+//! cleanup, and the Jellyfin refresh nudge all stay in lockstep.
+//!
+//! Before this lived in one place, the bulk path silently bypassed the
+//! traversal guard and the seed-rule check — issue surfaced in PR #164
+//! review. Whenever one path changes, the other has to change too;
+//! keeping them in one helper is the only way that doesn't drift.
+//!
+//! [`crud::remove_series`]: super::crud::remove_series
+//! [`bulk::delete_one_series`]: super::bulk
+
+use crate::AppState;
+use crate::models::grabbed_torrents;
+
+/// Outcome of a single series's filesystem + torrent cleanup pass. Each
+/// field tracks one substage so callers can compose their own UX:
+/// `crud::remove_series` serializes the whole report into its JSON
+/// response, while `bulk::delete_one_series` checks
+/// [`SeriesCleanupReport::is_clean`] to decide whether to count the
+/// series as `succeeded` or fold the partial-failure signal into a
+/// `BulkFailure.reason`.
+#[derive(Debug)]
+pub struct SeriesCleanupReport {
+    /// Count of grabs whose torrent client accepted the delete (or
+    /// whose seed rules say to keep seeding — counted as "handled" so
+    /// the user sees the grab was processed even though the file
+    /// stays on the seedbox).
+    pub torrents_removed: u64,
+    /// Per-grab error strings: `"Download client not configured"`,
+    /// `"<hash>: <client error>"`, or `"clear grabbed_torrents: <db
+    /// error>"`. Empty when every grab was handled cleanly.
+    pub torrent_failures: Vec<String>,
+    /// One of `"skipped"` (delete_files=false or empty media_root /
+    /// folder_name), `"removed"`, `"missing"` (canonicalize-NotFound;
+    /// folder already gone), `"refused"` (canonicalized series dir
+    /// resolves outside media_root — traversal guard tripped), or
+    /// `"error"` (canonicalize / remove_dir_all error).
+    pub folder_status: &'static str,
+    /// Detail for `folder_status`: the canonical removed path, the
+    /// outside-root resolution string, the error message, etc.
+    pub folder_detail: String,
+    /// `"skipped"` (no Jellyfin client configured), `"refreshed"`, or
+    /// `"error"`. Refresh runs whenever the cleanup actually does
+    /// work (delete_files=true); `"skipped"` is the no-Jellyfin
+    /// posture, distinct from "we didn't ask."
+    pub jellyfin_status: &'static str,
+}
+
+impl SeriesCleanupReport {
+    /// `true` when the cleanup completed without any partial-failure
+    /// signal — every torrent client accepted the delete and the
+    /// folder either removed cleanly, was already missing, or was
+    /// skipped (delete_files=false). Used by the bulk path to decide
+    /// whether to count the series as `succeeded` or fold the partial
+    /// signal into `BulkFailure.reason`. The per-row path doesn't use
+    /// this — its JSON response always reports the full breakdown.
+    pub fn is_clean(&self) -> bool {
+        self.torrent_failures.is_empty()
+            && matches!(self.folder_status, "removed" | "missing" | "skipped")
+    }
+
+    /// One-line summary for the bulk failure-modal copy. Only called
+    /// when `is_clean()` is false; assembles the partial-failure
+    /// reason out of the substage signals so the user sees what
+    /// didn't get cleaned. ASCII-only so HX-Trigger envelopes don't
+    /// mojibake (see CLAUDE.md "HX-Trigger payloads must be ASCII").
+    pub fn partial_failure_reason(&self) -> String {
+        let mut parts: Vec<String> = Vec::new();
+        match self.folder_status {
+            "refused" => parts.push("folder refused (resolves outside media root)".to_string()),
+            "error" => parts.push(format!("folder error: {}", self.folder_detail)),
+            _ => {}
+        }
+        if !self.torrent_failures.is_empty() {
+            parts.push(format!("torrent: {}", self.torrent_failures.join("; ")));
+        }
+        if parts.is_empty() {
+            "partial cleanup failure".to_string()
+        } else {
+            parts.join("; ")
+        }
+    }
+}
+
+/// Per-series cleanup pass shared by [`crud::remove_series`] and
+/// [`bulk::delete_one_series`]. Runs whenever the user asked for
+/// `delete_files=true`; callers that don't want filesystem cleanup
+/// shouldn't call this at all.
+///
+/// Order of operations matters and is the same as the original per-row
+/// implementation:
+///
+/// 1. List grabs for the series; for each non-empty hash that doesn't
+///    respect a still-active PT seed rule, resolve its download client
+///    and call `client.delete(hash, with_files=true)`. After the client
+///    delete, replay the import-time-stamped source paths so SAB jobs
+///    whose `storage` field is the parent complete-dir get cleaned up
+///    (the client's own delete is unreliable for those).
+/// 2. Drop the `grabbed_torrents` rows for the series so the table
+///    doesn't accumulate stale references to hashes the client just
+///    forgot.
+/// 3. Canonicalize `media_root`, canonicalize `media_root/<folder_name>`,
+///    assert the resolved series dir starts with the resolved media
+///    root, and only then `remove_dir_all`. The `starts_with` guard is
+///    the security-critical step — without it a corrupted `folder_name`
+///    (`"../escape"`) lets the user wipe arbitrary directories.
+///    Pinned by the `refuses_traversal_when_resolved_path_escapes_media_root`
+///    test in `crud/tests.rs` for per-row and the
+///    `bulk_delete_refuses_traversal_when_resolved_path_escapes_media_root`
+///    test in `bulk.rs` for bulk.
+/// 4. Nudge Jellyfin to rescan so the user's library doesn't show
+///    ghost entries until the next refresh tick. Best-effort; logged
+///    on failure but doesn't gate cleanup success.
+///
+/// The DB cascade (`series::remove`) is **not** part of this helper —
+/// callers run it after this returns, ordered last because it's the
+/// irreversible step.
+///
+/// [`crud::remove_series`]: super::crud::remove_series
+/// [`bulk::delete_one_series`]: super::bulk
+pub async fn cleanup_series_files(
+    state: &AppState,
+    series_id: i64,
+    folder_name: &str,
+    media_root: Option<&str>,
+) -> Result<SeriesCleanupReport, String> {
+    let mut report = SeriesCleanupReport {
+        torrents_removed: 0,
+        torrent_failures: Vec::new(),
+        folder_status: "skipped",
+        folder_detail: String::new(),
+        jellyfin_status: "skipped",
+    };
+
+    // 1. Per-grab download client cleanup. List-grabs failure is the
+    //    one preflight DB error that bubbles to the caller; everything
+    //    after this point folds errors into the report. Per-row's
+    //    handler turns the bubble into a 500 + log row; bulk turns it
+    //    into a BulkFailure entry. Letting one failed-DB-list silently
+    //    skip cleanup would leave the user wondering why "Delete with
+    //    files" left their on-disk folder intact.
+    let hashes = grabbed_torrents::get_all_for_series(&state.db, series_id)
+        .await
+        .map_err(|e| format!("list_grabbed_torrents: {e}"))?;
+
+    for &(grab_id, ref hash, dc_id) in &hashes {
+        if hash.is_empty() {
+            continue;
+        }
+        // Issue #28 PR C — preserve PT seed rules across removal. A
+        // user wiping a series typically wants ratio policies
+        // honored; the `grabbed_torrents` row gets dropped below
+        // either way (delete_all_for_series), so the upgrade sweep
+        // can't re-grab the same hash.
+        if grabbed_torrents::respects_seed_rules(&state.db, hash).await {
+            report.torrents_removed += 1;
+            continue;
+        }
+        let Some(client) = state.resolve_grab_client(dc_id, hash).await else {
+            report
+                .torrent_failures
+                .push("Download client not configured".to_string());
+            continue;
+        };
+        match client.delete(hash, true).await {
+            Ok(()) => report.torrents_removed += 1,
+            Err(err) => report.torrent_failures.push(format!("{}: {}", hash, err)),
+        }
+
+        // SAB stamped-source-path cleanup. Same rationale as
+        // `delete_episode_file`: the client's delete is unreliable
+        // for SAB jobs whose history `storage` field is the parent
+        // complete dir. Stamped paths are precise and mode-agnostic.
+        let stamped = grabbed_torrents::get_imported_source_paths(&state.db, grab_id).await;
+        if !stamped.is_empty() {
+            super::episodes::remove_stamped_source_paths(&stamped).await;
+        }
+    }
+
+    // 2. Drop grabbed_torrents rows so they don't dangle.
+    if let Err(err) = grabbed_torrents::delete_all_for_series(&state.db, series_id).await {
+        report
+            .torrent_failures
+            .push(format!("clear grabbed_torrents: {}", err));
+    }
+
+    // 3. Canonicalize+starts_with-gated folder removal. media_root is
+    //    None when the caller decided to skip filesystem cleanup
+    //    (config not loadable, or empty media_root). folder_name
+    //    being empty also short-circuits — we have no folder to
+    //    delete.
+    if let Some(root) = media_root
+        && !root.trim().is_empty()
+        && !folder_name.trim().is_empty()
+    {
+        let series_dir = std::path::Path::new(root).join(folder_name);
+        match tokio::fs::canonicalize(root).await {
+            Ok(media_root_canon) => match tokio::fs::canonicalize(&series_dir).await {
+                Ok(series_canon) if series_canon.starts_with(&media_root_canon) => {
+                    match tokio::fs::remove_dir_all(&series_canon).await {
+                        Ok(()) => {
+                            report.folder_status = "removed";
+                            report.folder_detail = series_canon.display().to_string();
+                        }
+                        Err(err) => {
+                            report.folder_status = "error";
+                            report.folder_detail = format!("{}: {}", series_canon.display(), err);
+                        }
+                    }
+                }
+                Ok(other) => {
+                    report.folder_status = "refused";
+                    report.folder_detail = format!(
+                        "resolves outside media root: {} -> {}",
+                        series_dir.display(),
+                        other.display()
+                    );
+                }
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                    report.folder_status = "missing";
+                    report.folder_detail = series_dir.display().to_string();
+                }
+                Err(err) => {
+                    report.folder_status = "error";
+                    report.folder_detail = format!("{}: {}", series_dir.display(), err);
+                }
+            },
+            Err(err) => {
+                report.folder_status = "error";
+                report.folder_detail = format!("media_root canonicalize: {}", err);
+            }
+        }
+    }
+
+    // 4. Nudge Jellyfin. Best-effort.
+    let jellyfin_opt = state.jellyfin.read().await.clone();
+    if let Some(jelly) = jellyfin_opt {
+        report.jellyfin_status = match jelly.refresh_library().await {
+            Ok(()) => "refreshed",
+            Err(_) => "error",
+        };
+    }
+
+    Ok(report)
+}

--- a/src/handlers/library/crud/mod.rs
+++ b/src/handlers/library/crud/mod.rs
@@ -511,6 +511,40 @@ pub async fn set_folder(
 /// tells the user "Will follow your AL/MAL list" until that happens.
 pub(crate) const MONITOR_MODE_SYNC_SENTINEL: &str = "sync";
 
+/// Apply a monitor-mode change to one series + recompute the per-episode
+/// monitoring rows that depend on it. Extracted from `set_monitoring`
+/// (the per-series handler) so `handlers::library::bulk` can reuse the
+/// same write path without duplicating the sentinel-vs-explicit branch.
+///
+/// Returns `Result<(), String>` to fit the bulk-handler aggregation
+/// shape (per-series failures collected into `BulkOutcome.failed`
+/// rather than aborting the batch). The string is user-displayable;
+/// callers may surface it directly in toasts / failure modals.
+pub(crate) async fn apply_monitor_mode(
+    db: &sqlx::SqlitePool,
+    series_id: i64,
+    mode_str: &str,
+) -> Result<(), String> {
+    if mode_str == MONITOR_MODE_SYNC_SENTINEL {
+        series::update_monitor_mode_manual_override(db, series_id, false)
+            .await
+            .map_err(|e| format!("Failed to clear monitor override: {e}"))?;
+    } else {
+        let mode = monitoring::MonitorMode::from_str(mode_str);
+        series::update_monitor_mode_with_override(db, series_id, mode.as_str(), true)
+            .await
+            .map_err(|e| format!("Failed to set monitor mode: {e}"))?;
+    }
+    // Best-effort recompute. A failure here means the per-episode
+    // monitor flags are stale until the next sync tick, but the
+    // primary write succeeded; report success to the caller and
+    // let the supervised loop fix the per-episode rows on its
+    // next pass. Same posture as the existing `set_monitoring`
+    // handler, which logs the recompute error and returns 200.
+    let _ = monitoring_service::recompute_series_monitoring(db, series_id).await;
+    Ok(())
+}
+
 #[utoipa::path(
     post,
     path = "/api/library/monitoring",

--- a/src/handlers/library/crud/mod.rs
+++ b/src/handlers/library/crud/mod.rs
@@ -289,141 +289,62 @@ pub async fn remove_series(
         Err(e) => return Err(fail_with(&state.db, series_id, "lookup", e.to_string()).await),
     };
 
-    let mut torrents_removed: u64 = 0;
-    let mut torrent_failures: Vec<String> = Vec::new();
-    let mut folder_status: &'static str = "skipped";
-    let mut folder_detail: String = String::new();
-
-    if delete_files && let Some(ref tracked) = tracked {
-        // 1. Tell qBittorrent to drop every torrent (with files) we ever
-        //    grabbed for this series.
-        let hashes = match grabbed_torrents::get_all_for_series(&state.db, series_id).await {
-            Ok(h) => h,
-            Err(e) => {
-                return Err(fail_with(
-                    &state.db,
-                    series_id,
-                    "list_grabbed_torrents",
-                    e.to_string(),
-                )
-                .await);
-            }
-        };
-
-        if !hashes.is_empty() {
-            // Per-grab client routing via `resolve_grab_client`. A
-            // series can have grabs across multiple clients (e.g.
-            // early SAB Usenet rip plus later qBit BD upgrade) AND
-            // legacy SAB grabs may have a NULL stamp; the helper's
-            // nzo_id-shape heuristic rescues those.
-            for &(id, ref hash, dc_id) in &hashes {
-                if hash.is_empty() {
-                    continue;
-                }
-                // Issue #28 PR C — preserve PT seed rules across
-                // series removal. A user wiping a series from the
-                // library typically wants ratio policies honored
-                // (their PT account's ratio is downstream of
-                // every grab). The grabbed_torrents row gets
-                // deleted below regardless via
-                // delete_all_for_series, so the upgrade sweep
-                // can't re-grab the same hash.
-                if grabbed_torrents::respects_seed_rules(&state.db, hash).await {
-                    torrents_removed += 1; // counted as "handled"
-                    continue;
-                }
-                let Some(client) = state.resolve_grab_client(dc_id, hash).await else {
-                    torrent_failures.push("Download client not configured".to_string());
-                    continue;
-                };
-                match client.delete(hash, true).await {
-                    Ok(()) => torrents_removed += 1,
-                    Err(err) => torrent_failures.push(format!("{}: {}", hash, err)),
-                }
-
-                // Source-side cleanup using import-time-stamped paths.
-                // Same rationale as `delete_episode_file`: the client's
-                // delete is unreliable for SAB jobs whose history
-                // `storage` field is the parent complete dir. Stamped
-                // paths are precise and mode-agnostic.
-                let stamped = grabbed_torrents::get_imported_source_paths(&state.db, id).await;
-                if !stamped.is_empty() {
-                    super::episodes::remove_stamped_source_paths(&stamped).await;
-                }
-            }
-        }
-
-        // 2. Drop the grabbed_torrents rows for this series so the table
-        //    doesn't accumulate stale references to hashes qBit just
-        //    forgot about.
-        if let Err(err) = grabbed_torrents::delete_all_for_series(&state.db, series_id).await {
-            torrent_failures.push(format!("clear grabbed_torrents: {}", err));
-        }
-
-        // 3. Delete the series media folder. Canonicalize + assert under
-        //    the configured media root before recursing.
-        let cfg_opt = config::get_config(&state.db).await.ok().flatten();
-        if let Some(cfg) = cfg_opt
-            && !tracked.folder_name.trim().is_empty()
-            && !cfg.media_root.trim().is_empty()
+    // Filesystem + torrent cleanup is shared with `bulk::delete_one_series`
+    // via the `cleanup_series_files` helper. Both paths went out of sync
+    // before — bulk silently bypassed the canonicalize+starts_with
+    // traversal guard and the issue-#28 PT seed-rule check (PR #164
+    // review). Single-helper keeps them in lockstep.
+    let cleanup_report: Option<super::cleanup::SeriesCleanupReport> = if delete_files
+        && let Some(ref tracked) = tracked
+    {
+        let media_root: Option<String> = config::get_config(&state.db)
+            .await
+            .ok()
+            .flatten()
+            .map(|c| c.media_root);
+        match super::cleanup::cleanup_series_files(
+            &state,
+            series_id,
+            &tracked.folder_name,
+            media_root.as_deref(),
+        )
+        .await
         {
-            let series_dir = std::path::Path::new(&cfg.media_root).join(&tracked.folder_name);
-            match tokio::fs::canonicalize(&cfg.media_root).await {
-                Ok(media_root_canon) => match tokio::fs::canonicalize(&series_dir).await {
-                    Ok(series_canon) if series_canon.starts_with(&media_root_canon) => {
-                        match tokio::fs::remove_dir_all(&series_canon).await {
-                            Ok(()) => {
-                                folder_status = "removed";
-                                folder_detail = series_canon.display().to_string();
-                            }
-                            Err(err) => {
-                                folder_status = "error";
-                                folder_detail = format!("{}: {}", series_canon.display(), err);
-                            }
-                        }
-                    }
-                    Ok(other) => {
-                        folder_status = "refused";
-                        folder_detail = format!(
-                            "resolves outside media root: {} -> {}",
-                            series_dir.display(),
-                            other.display()
-                        );
-                    }
-                    Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                        folder_status = "missing";
-                        folder_detail = series_dir.display().to_string();
-                    }
-                    Err(err) => {
-                        folder_status = "error";
-                        folder_detail = format!("{}: {}", series_dir.display(), err);
-                    }
-                },
-                Err(err) => {
-                    folder_status = "error";
-                    folder_detail = format!("media_root canonicalize: {}", err);
-                }
-            }
+            Ok(r) => Some(r),
+            Err(e) => return Err(fail_with(&state.db, series_id, "list_grabbed_torrents", e).await),
         }
-    }
+    } else {
+        None
+    };
 
-    // 4. Remove the DB tracking rows. This is the irreversible step, so
-    //    do it last — if filesystem cleanup blew up the operator can
-    //    still inspect the half-cleaned state via the Library page.
+    // Pull report fields back out for the response/log shape; using
+    // defaults when delete_files=false or `tracked` was None.
+    let torrents_removed = cleanup_report
+        .as_ref()
+        .map(|r| r.torrents_removed)
+        .unwrap_or(0);
+    let torrent_failures = cleanup_report
+        .as_ref()
+        .map(|r| r.torrent_failures.clone())
+        .unwrap_or_default();
+    let folder_status = cleanup_report
+        .as_ref()
+        .map(|r| r.folder_status)
+        .unwrap_or("skipped");
+    let folder_detail = cleanup_report
+        .as_ref()
+        .map(|r| r.folder_detail.clone())
+        .unwrap_or_default();
+    let jellyfin_status = cleanup_report
+        .as_ref()
+        .map(|r| r.jellyfin_status)
+        .unwrap_or("skipped");
+
+    // Remove the DB tracking rows. This is the irreversible step, so
+    // do it last — if filesystem cleanup blew up the operator can
+    // still inspect the half-cleaned state via the Library page.
     if let Err(e) = series::remove(&state.db, series_id).await {
         return Err(fail_with(&state.db, series_id, "delete_series", e.to_string()).await);
-    }
-
-    // 5. Nudge Jellyfin to rescan.
-    let mut jellyfin_status: &'static str = "skipped";
-    if delete_files {
-        let jellyfin_opt = state.jellyfin.read().await.clone();
-        if let Some(jelly) = jellyfin_opt {
-            jellyfin_status = match jelly.refresh_library().await {
-                Ok(()) => "refreshed",
-                Err(_) => "error",
-            };
-        }
     }
 
     // Scrub user-controlled strings for the log line.
@@ -525,6 +446,20 @@ pub(crate) async fn apply_monitor_mode(
     series_id: i64,
     mode_str: &str,
 ) -> Result<(), String> {
+    // Preflight existence check. Without this, both the sentinel-
+    // clear and explicit-pin SQL UPDATE paths return Ok(()) for a
+    // non-existent id (sqlite UPDATE-affects-0-rows is not an
+    // error). A stale-tab id from a slow-tab race would silently
+    // land in `BulkOutcome.succeeded` and the user would never see
+    // anything went wrong. Reported by PR #164 review.
+    let exists = series::get_by_id(db, series_id)
+        .await
+        .map_err(|e| format!("Lookup failed: {e}"))?
+        .is_some();
+    if !exists {
+        return Err(format!("Series {series_id} no longer exists"));
+    }
+
     if mode_str == MONITOR_MODE_SYNC_SENTINEL {
         series::update_monitor_mode_manual_override(db, series_id, false)
             .await

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::models::series;
 use crate::services::anilist;
 
+pub mod bulk;
 pub mod crud;
 pub mod episodes;
 pub mod pages;

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -5,6 +5,7 @@ use crate::models::series;
 use crate::services::anilist;
 
 pub mod bulk;
+pub mod cleanup;
 pub mod crud;
 pub mod episodes;
 pub mod pages;

--- a/src/main.rs
+++ b/src/main.rs
@@ -664,6 +664,10 @@ async fn main() {
             post(handlers::library::bulk::bulk_monitor),
         )
         .route(
+            "/api/library/bulk/delete",
+            post(handlers::library::bulk::bulk_delete),
+        )
+        .route(
             "/api/series/{anilist_id}/auto-search",
             post(handlers::library::search::auto_search_series),
         )

--- a/src/main.rs
+++ b/src/main.rs
@@ -660,6 +660,10 @@ async fn main() {
             post(handlers::library::crud::reclassify_episode),
         )
         .route(
+            "/api/library/bulk/monitor",
+            post(handlers::library::bulk::bulk_monitor),
+        )
+        .route(
             "/api/series/{anilist_id}/auto-search",
             post(handlers::library::search::auto_search_series),
         )

--- a/src/services/post_processing/mod.rs
+++ b/src/services/post_processing/mod.rs
@@ -1302,11 +1302,19 @@ async fn import_torrent(
                 // helper below would have to re-read.
                 if post.needs_review {
                     let verdict = post.label();
+                    // The event field is i32 representing the
+                    // percent (0..=100). `post.confidence` is f32 in
+                    // [0.0, 1.0], so cast directly truncates 0.50
+                    // to 0 — Discord then renders "0%" for any
+                    // sub-1.0 verdict, which is every needs-review
+                    // case. Multiply by 100 first so the value sent
+                    // matches the percent the user expects.
+                    let confidence_pct = (post.confidence * 100.0).round() as i32;
                     crate::services::notifications::emit_classifier_needs_review(
                         state,
                         target_series_id,
                         ep_num,
-                        post.confidence as i32,
+                        confidence_pct,
                         &verdict,
                     )
                     .await;

--- a/src/services/source/mod.rs
+++ b/src/services/source/mod.rs
@@ -161,6 +161,49 @@ pub fn aggregate(evidence: &[SourceEvidence]) -> ClassificationResult {
         return ClassificationResult::unknown();
     }
 
+    // Pre-aggregation: AAC-as-Web suppression when filename declares BD.
+    //
+    // Some BD-encoder groups (Anime Time, MTBB, smol, Beatrice-Raws,
+    // VCB-Studio's lighter variants, etc.) re-encode BluRay sources
+    // with AAC audio for size. The naive AAC=Web rules at the filename
+    // and ffprobe layers misfire on those releases: the filename
+    // already says `[BD]` at 0.95, but two AAC-Web pieces of evidence
+    // (filename "web audio (aac)" at 0.75 + ffprobe "AAC audio without
+    // lossless track" at 0.85) sum to 1.60, exactly tying the BD
+    // signal (0.95 BD-keyword + 0.65 temporal). Result: rule 4 fires,
+    // confidence drops to 0.50, the row needs review when in fact it's
+    // a clean BluRay encode.
+    //
+    // When filename has a high-confidence (≥0.90) BD-keyword evidence,
+    // AAC is a codec choice, not a source signal. Drop the AAC-Web
+    // evidence pieces (matched by detail prefix) before aggregation
+    // runs. If the user genuinely wants AAC to indicate Web, they need
+    // a release that doesn't also self-label as BD — that's the case
+    // where the rule still fires.
+    let has_strong_bd_filename_keyword = evidence.iter().any(|e| {
+        e.source == Source::BluRay
+            && e.origin == Origin::Filename
+            && e.confidence >= 0.90
+            && (e.detail.contains("BD keyword")
+                || e.detail.contains("Remux keyword")
+                || e.detail.contains("BluRay keyword"))
+    });
+    let evidence: Vec<SourceEvidence> = if has_strong_bd_filename_keyword {
+        evidence
+            .iter()
+            .filter(|e| {
+                let is_aac_web = e.source == Source::Web
+                    && (e.detail.starts_with("web audio (")
+                        || e.detail == "AAC audio without lossless track");
+                !is_aac_web
+            })
+            .cloned()
+            .collect()
+    } else {
+        evidence.to_vec()
+    };
+    let evidence = evidence.as_slice();
+
     // Rule 2's per-source sum is computed *first* so rule 1 can
     // cross-check its strong-signal decision against it. We build a
     // `(source, origin) -> sum` map, clamp each bucket at ORIGIN_MAX,
@@ -2090,5 +2133,74 @@ mod tests {
         // Without this guard, the while-loop would do hb.len() comparisons
         // against zero-length matches at every position and return true.
         assert!(!contains_word("anything goes here", ""));
+    }
+
+    #[test]
+    fn aggregate_suppresses_aac_web_when_filename_says_bd() {
+        // Regression: Solo Leveling S2 BD-AAC release (Anime Time)
+        // tied 1.60 vs 1.60 (filename BD 0.95 + temporal BD 0.65 vs
+        // filename "web audio (aac)" 0.75 + ffprobe AAC 0.85),
+        // tripping rule 4 and writing the row as needs-review WEB-1080p.
+        // With AAC-Web suppression in place when filename has strong BD
+        // keyword, the AAC pieces drop and BluRay wins cleanly.
+        let evidence = vec![
+            SourceEvidence::new(Source::BluRay, 0.95, Origin::Filename, "BD keyword"),
+            SourceEvidence::new(Source::Web, 0.75, Origin::Filename, "web audio (aac)"),
+            SourceEvidence::new(
+                Source::BluRay,
+                0.65,
+                Origin::Temporal,
+                "finished 1+ year ago + batch",
+            ),
+            SourceEvidence::new(
+                Source::Web,
+                0.85,
+                Origin::Ffprobe,
+                "AAC audio without lossless track",
+            ),
+        ];
+        let result = aggregate(&evidence);
+        assert_eq!(result.source, Source::BluRay);
+        assert!(
+            !result.needs_review,
+            "BD-with-AAC release should classify cleanly, not need review"
+        );
+        // After AAC-Web suppression, BluRay 0.95 is the only strong
+        // signal and rule 2 agrees, so rule 1's strong-shortcut fires.
+        // Either Rule1Strong or Rule2Sum is fine; the regression is
+        // about NOT landing in a conflict path.
+        assert!(
+            !matches!(
+                result.decision_rule,
+                DecisionRule::Rule4Conflict | DecisionRule::Rule5GroundTruthVeto
+            ),
+            "should land in a clean-win path, not a conflict path; got {:?}",
+            result.decision_rule
+        );
+        // Filtered evidence should not include the dropped AAC-Web pieces.
+        assert!(
+            result.evidence.iter().all(|e| !(e.source == Source::Web
+                && (e.detail.starts_with("web audio (")
+                    || e.detail == "AAC audio without lossless track"))),
+            "AAC-Web evidence should be filtered out when BD keyword is present"
+        );
+    }
+
+    #[test]
+    fn aggregate_keeps_aac_web_when_filename_lacks_bd() {
+        // Counter-case: AAC-Web evidence should still fire when there's
+        // no strong BD keyword in the filename. Releases with only AAC
+        // and no BD label legitimately come from streaming.
+        let evidence = vec![
+            SourceEvidence::new(Source::Web, 0.75, Origin::Filename, "web audio (aac)"),
+            SourceEvidence::new(
+                Source::Web,
+                0.85,
+                Origin::Ffprobe,
+                "AAC audio without lossless track",
+            ),
+        ];
+        let result = aggregate(&evidence);
+        assert_eq!(result.source, Source::Web);
     }
 }

--- a/static/css/modals.css
+++ b/static/css/modals.css
@@ -42,6 +42,20 @@
     flex: 1;
 }
 
+/* Generic modal footer. Settings/Notifications had their own copies
+   inline; consolidating here so every modal that uses .modal-footer
+   markup gets the same gap + padding without per-page CSS. */
+.modal-footer {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 16px 24px;
+    border-top: 1px solid var(--border);
+}
+.modal-footer .modal-footer-spacer {
+    flex: 1;
+}
+
 @media (max-width: 640px) {
     .modal-backdrop {
         padding: 0;

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -350,10 +350,11 @@
     width: 100%;
 }
 
-.monitor-option-list {
+.monitor-option-list,
+.monitor-options {
     display: flex;
     flex-direction: column;
-    gap: 6px;
+    gap: 8px;
 }
 
 .monitor-option-btn {

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -473,10 +473,16 @@
     box-shadow: 0 0 0 3px rgba(203, 166, 247, 0.35);
 }
 
-/* Checked: mauve fill, white check mark via inline SVG background.
-   Dark outer halo lifts the chip off bright cover art so the
-   selection is unmistakable. */
-.series-card-select:checked {
+/* Checked visual. Driven by BOTH `:checked` (the form-element state)
+   AND `.series-card.selected .series-card-select` (the JS-managed
+   class on the parent card). Belt-and-suspenders: we set both in JS
+   so either path succeeding keeps the visual in sync — important
+   because some hx-boost re-render cases were leaving `:checked`
+   out of step with our authoritative selection set.
+   Mauve fill, white check mark via inline SVG; dark outer halo
+   lifts the chip off bright cover art. */
+.series-card-select:checked,
+.series-card.selected > .series-card-select {
     background: var(--accent);
     border-color: var(--accent);
     box-shadow:
@@ -539,10 +545,14 @@
     padding: 6px 14px;
     border: none;
     border-radius: var(--radius);
+    /* Match `.nav-links a` exactly: 14px font, body-inherited line-
+       height (1.6 from base.css's `body`). The default UA stylesheet
+       on <button> sets `line-height: normal` which renders shorter
+       than the surrounding anchors, so we restate explicitly. */
     font-size: 14px;
     font-weight: 500;
     font-family: inherit;
-    line-height: 1.2;
+    line-height: 1.6;
     cursor: pointer;
     transition: color 0.15s, background 0.15s, transform 0.1s;
 }

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -638,11 +638,11 @@
 }
 
 .bulk-action-toolbar .btn-sm {
-    padding: 6px 14px;
+    padding: 6px 12px;
     font-size: 13px;
     font-weight: 600;
-    border-radius: 999px;
-    transition: background 0.15s ease-out, transform 0.1s ease-out;
+    border-radius: 7px;
+    transition: background 0.15s ease-out, transform 0.1s ease-out, border-color 0.15s ease-out, color 0.15s ease-out;
 }
 .bulk-action-toolbar .btn-sm:active {
     transform: scale(0.96);

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -599,6 +599,74 @@
     pointer-events: none;
 }
 
+/* Mobile bulk-select is punted — the Select toggle lives in
+   `.nav-links` (hidden below --bp-phone) so users can't enter
+   selection mode on mobile anyway. Belt-and-suspenders: hide the
+   toolbar unconditionally below the breakpoint to handle the
+   resize-from-desktop edge case (user shrinks viewport while in
+   selecting mode → toolbar would otherwise stay visible and clash
+   with the bottom mobile-tabbar). Mobile bulk ops as a feature is
+   tracked separately. */
+@media (max-width: 640px) {
+    .bulk-action-toolbar {
+        display: none !important;
+    }
+}
+
+/* Library header on mobile: stack vertically. The default
+   page-header-row is a flex row with the title on the left and
+   filter controls + Add Series on the right; below --bp-phone the
+   right side wraps awkwardly (title squeezed onto two lines, +Add
+   Series orphaned in the middle of the row). Stacking gives each
+   slot its own row so the layout reads top-to-bottom: title,
+   search + filters, Add Series. */
+@media (max-width: 640px) {
+    .library-header-row {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 12px;
+    }
+    .library-header-row h2 {
+        margin: 0;
+    }
+    /* Right-side wrapper: the filter form + Add Series share a
+       container <div> in the template. Let it flex-wrap so its
+       children stack cleanly. */
+    .library-header-row > div:last-child {
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+        align-items: stretch;
+    }
+    .library-filter-form {
+        flex-wrap: wrap;
+        width: 100%;
+        gap: 8px;
+    }
+    /* Search input goes full-width. The wide variant (no list
+       dropdown) was already 100% via the `width: 406px` rule
+       hitting the viewport cap; standardize. */
+    .library-filter-form .library-search-input,
+    .library-filter-form .library-search-input.library-search-input-wide {
+        width: 100%;
+        min-width: 0;
+    }
+    /* List + sort dropdowns + Clear share row 2; let them flex so
+       multiple controls fit on one mobile row when the list dropdown
+       is present. */
+    .library-filter-form .folder-select {
+        flex: 1 1 calc(50% - 4px);
+        width: auto;
+    }
+    /* Add Series button breaks to full-width with no left margin
+       (the original 32px sat next to the filters; on mobile it
+       just creates a misalignment). */
+    .library-header-row .btn-primary {
+        margin-left: 0 !important;
+        width: 100%;
+    }
+}
+
 /* Sticky bottom toolbar. Soft-rounded rectangle (was pill in earlier
    pass; squarer reads as "tool" rather than "toast") centered at the
    bottom, slides up when in selecting mode. The mauve glow ring

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -460,9 +460,17 @@
     }
 }
 
-/* Hover (unchecked): brighten the border so the chip reads as
-   "ready to click" without committing to mauve yet. */
-.library-grid.selecting .series-card:hover .series-card-select:not(:checked) {
+/* Hover-over-unselected: brighten the border so the chip reads as
+   "ready to click" without committing to mauve yet. The
+   `:not(.selected)` on the card is load-bearing: without it, this
+   rule's higher specificity (4,1 over the checked rule's 2,1)
+   overrode `.selected > .series-card-select`, so hovering a
+   selected chip would briefly flip the mauve back to dark — looked
+   like the checkmark was disappearing on hover. Excluding selected
+   cards from this rule keeps the mauve visual stable.
+   `:not(:checked)` is kept too as belt-and-suspenders for paths
+   where `:checked` latches but `.selected` somehow didn't. */
+.library-grid.selecting .series-card:not(.selected):hover .series-card-select:not(:checked) {
     border-color: rgba(232, 232, 240, 0.75);
     background: rgba(15, 15, 19, 0.75);
 }

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -591,46 +591,6 @@
     flex-shrink: 0;
 }
 
-/* Disabled action button: muted look so the user can tell the action
-   is gated on selection without reading the disabled attribute. */
-.bulk-action-toolbar .btn-sm:disabled {
-    opacity: 0.4;
-    cursor: not-allowed;
-    pointer-events: none;
-}
-
-/* Mobile bulk-select is allowed (the Select toggle is whitelisted
-   through .nav-links's mobile filter alongside the logout icon).
-   The toolbar's default `bottom: 24px` would put it on top of the
-   bottom mobile-tabbar (which is fixed at the viewport bottom);
-   bumping to 80px clears the tabbar's ~64px height plus an 8-12px
-   safety gap. Also let the toolbar shrink to fit the narrow
-   viewport so its buttons don't overflow the right edge. */
-@media (max-width: 640px) {
-    .bulk-action-toolbar {
-        bottom: 80px;
-        left: 12px;
-        right: 12px;
-        transform: translateY(140%);
-        max-width: calc(100vw - 24px);
-    }
-    .bulk-action-toolbar.visible {
-        transform: translateY(0);
-    }
-    .bulk-action-toolbar-inner {
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 8px;
-    }
-    .bulk-action-divider {
-        display: none;
-    }
-    .bulk-action-count {
-        flex: 1 1 100%;
-        text-align: center;
-    }
-}
-
 /* Library header on mobile: stack vertically. The default
    page-header-row is a flex row with the title on the left and
    filter controls + Add Series on the right; below --bp-phone the
@@ -745,14 +705,188 @@
     font-variant-numeric: tabular-nums;
 }
 
-.bulk-action-toolbar .btn-sm {
+/* Desktop bulk action buttons. Pill-internal buttons that ride next
+   to the count + dividers. The icon sits inline before the label;
+   on mobile the same markup gets restyled into stacked icon-on-top
+   tab slots via the @media block below. */
+.bulk-action-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
     padding: 6px 12px;
     font-size: 13px;
     font-weight: 600;
+    font-family: inherit;
+    line-height: 1.2;
     border-radius: 7px;
+    border: 1px solid transparent;
+    cursor: pointer;
     transition: background 0.15s ease-out, transform 0.1s ease-out, border-color 0.15s ease-out, color 0.15s ease-out;
 }
-.bulk-action-toolbar .btn-sm:active {
+.bulk-action-btn:active {
     transform: scale(0.96);
 }
+.bulk-action-btn .bulk-action-icon {
+    flex-shrink: 0;
+}
+.bulk-action-btn-ghost {
+    background: transparent;
+    color: var(--text-dim);
+    border-color: transparent;
+}
+.bulk-action-btn-ghost:hover {
+    color: var(--text);
+    background: var(--bg-elevated);
+}
+.bulk-action-btn-secondary {
+    background: var(--bg-elevated);
+    color: var(--text);
+    border-color: var(--border);
+}
+.bulk-action-btn-secondary:hover {
+    border-color: var(--border-accent);
+    background: var(--bg-card);
+}
+.bulk-action-btn-danger {
+    background: rgba(211, 125, 125, 0.15);
+    color: var(--red);
+    border-color: rgba(211, 125, 125, 0.3);
+}
+.bulk-action-btn-danger:hover {
+    background: rgba(211, 125, 125, 0.25);
+    border-color: var(--red);
+}
+.bulk-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
+}
 
+/* Count icon — hidden on desktop (just the text reads the badge),
+   shown on mobile as the visual cue for the "selected" slot. */
+.bulk-action-count-icon {
+    display: none;
+}
+
+/* Mobile bulk-action toolbar: replaces the bottom mobile-tabbar
+   while in selection mode rather than stacking on top of it.
+   Same markup as desktop; @media flips it from a centered pill
+   into a full-width tabbar-shaped slot row with icon-on-top
+   labels — visually parallels the .mobile-tabbar it replaces so
+   the page's bottom-row anchor doesn't shift mid-task. */
+@media (max-width: 640px) {
+    /* Hide the regular bottom mobile-tabbar while bulk-selecting so
+       the bulk action bar can take its viewport slot. JS toggles
+       body.bulk-selecting on enter/exit. */
+    body.bulk-selecting .mobile-tabbar {
+        display: none;
+    }
+
+    .bulk-action-toolbar {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        max-width: none;
+        transform: translateY(100%);
+        background: rgba(15, 15, 19, 0.96);
+        backdrop-filter: blur(12px) saturate(140%);
+        -webkit-backdrop-filter: blur(12px) saturate(140%);
+        border: none;
+        border-top: 1px solid var(--border);
+        border-radius: 0;
+        padding: 0;
+        box-shadow: 0 -8px 24px -8px rgba(0, 0, 0, 0.5);
+        transition: transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1);
+        opacity: 1;
+    }
+    .bulk-action-toolbar.visible {
+        transform: translateY(0);
+    }
+    .bulk-action-toolbar-inner {
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+        justify-content: space-around;
+        gap: 0;
+        flex-wrap: nowrap;
+        min-height: 56px;
+    }
+    .bulk-action-divider {
+        display: none;
+    }
+
+    /* Equal-width tab slots: each child of the inner row gets
+       flex: 1 1 0 so they distribute evenly across the viewport
+       width. Override the desktop pill button styles to icon-on-top,
+       label-below — the same shape as .mobile-tab. */
+    .bulk-action-toolbar-inner > .bulk-action-count,
+    .bulk-action-toolbar-inner > .bulk-action-btn {
+        flex: 1 1 0;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: 2px;
+        padding: 8px 4px 6px;
+        min-width: 0;
+        min-height: 56px;
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.2px;
+        border: none;
+        border-radius: 0;
+        margin: 0;
+        background: transparent;
+        white-space: normal;
+        text-align: center;
+    }
+
+    /* Hide the count slot entirely on mobile — the slot is too
+       narrow for "N selected" to read cleanly, and the empty
+       checkbox icon alone looks like a stray UI element. The
+       Select all button right beside it already shows the user
+       which slot drives selection. */
+    .bulk-action-toolbar-inner > .bulk-action-count {
+        display: none;
+    }
+
+    /* Stacked label below the icon. Match .mobile-tab-label. */
+    .bulk-action-btn .bulk-action-label {
+        font-size: 11px;
+        font-weight: 500;
+        letter-spacing: 0.2px;
+        line-height: 1.2;
+    }
+
+    /* Reset the variant background/border treatments so all slots
+       read as flat tab buttons; only the icon + label colors carry
+       the variant signal. */
+    .bulk-action-btn-ghost,
+    .bulk-action-btn-secondary,
+    .bulk-action-btn-danger {
+        background: transparent;
+        border-color: transparent;
+    }
+    .bulk-action-btn-ghost {
+        color: var(--text-dim);
+    }
+    .bulk-action-btn-secondary {
+        color: var(--text);
+    }
+    .bulk-action-btn-danger {
+        color: var(--red);
+    }
+    .bulk-action-btn-ghost:hover,
+    .bulk-action-btn-secondary:hover {
+        background: var(--bg-elevated);
+        color: var(--text-bright);
+    }
+    .bulk-action-btn-danger:hover {
+        background: rgba(211, 125, 125, 0.12);
+        color: var(--red);
+    }
+    .bulk-action-btn:active {
+        transform: none;
+        background: var(--bg-elevated);
+    }
+}

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -599,17 +599,35 @@
     pointer-events: none;
 }
 
-/* Mobile bulk-select is punted — the Select toggle lives in
-   `.nav-links` (hidden below --bp-phone) so users can't enter
-   selection mode on mobile anyway. Belt-and-suspenders: hide the
-   toolbar unconditionally below the breakpoint to handle the
-   resize-from-desktop edge case (user shrinks viewport while in
-   selecting mode → toolbar would otherwise stay visible and clash
-   with the bottom mobile-tabbar). Mobile bulk ops as a feature is
-   tracked separately. */
+/* Mobile bulk-select is allowed (the Select toggle is whitelisted
+   through .nav-links's mobile filter alongside the logout icon).
+   The toolbar's default `bottom: 24px` would put it on top of the
+   bottom mobile-tabbar (which is fixed at the viewport bottom);
+   bumping to 80px clears the tabbar's ~64px height plus an 8-12px
+   safety gap. Also let the toolbar shrink to fit the narrow
+   viewport so its buttons don't overflow the right edge. */
 @media (max-width: 640px) {
     .bulk-action-toolbar {
-        display: none !important;
+        bottom: 80px;
+        left: 12px;
+        right: 12px;
+        transform: translateY(140%);
+        max-width: calc(100vw - 24px);
+    }
+    .bulk-action-toolbar.visible {
+        transform: translateY(0);
+    }
+    .bulk-action-toolbar-inner {
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 8px;
+    }
+    .bulk-action-divider {
+        display: none;
+    }
+    .bulk-action-count {
+        flex: 1 1 100%;
+        text-align: center;
     }
 }
 
@@ -651,12 +669,16 @@
         width: 100%;
         min-width: 0;
     }
-    /* List + sort dropdowns + Clear share row 2; let them flex so
-       multiple controls fit on one mobile row when the list dropdown
-       is present. */
+    /* Each form control gets its own full-width row on mobile:
+       custom-list filter, search box, sort dropdown, Clear pill all
+       stack vertically. Sharing rows looked uneven (50/50 selects
+       collapsed unequally based on content width). Full-width is
+       cleaner and matches the +Add Series button's full-width row
+       below them. */
     .library-filter-form .folder-select {
-        flex: 1 1 calc(50% - 4px);
-        width: auto;
+        flex: 1 1 100%;
+        width: 100%;
+        min-width: 0;
     }
     /* Add Series button breaks to full-width with no left margin
        (the original 32px sat next to the filters; on mobile it

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -519,24 +519,47 @@
     border-color: var(--accent);
 }
 
-/* "Select" toggle button in the filter row. Default-mode look matches
-   the other btn-secondary pills; active state (mode on) inverts to
-   mauve fill so the user has a constant visual confirmation that
-   they're in selecting mode. */
-.bulk-select-toggle {
+/* "Select" toggle button in the topbar (base.html nav-links). Lives
+   here rather than in the page filter row so it sits in the
+   persistent topbar — the same place Sonarr surfaces its "Select
+   Series" page-mode toggle. Conditionally rendered only when
+   `page == "library"`; on other pages the button is not in the
+   DOM at all (so toggleBulkSelectMode() can't be invoked from
+   pages that don't load index.js).
+   Default-mode look matches the surrounding nav links; active
+   state (mode on) inverts to mauve fill for constant visual
+   confirmation that mode is on. */
+.nav-action.bulk-select-toggle {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    transition: background 0.15s ease-out, color 0.15s ease-out, border-color 0.15s ease-out;
+    background: transparent;
+    color: var(--text-dim);
+    padding: 6px 12px;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 13px;
+    font-weight: 500;
+    font-family: inherit;
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s, border-color 0.15s, transform 0.1s;
 }
-.bulk-select-toggle.active {
+.nav-action.bulk-select-toggle:hover {
+    color: var(--text);
+    background: var(--bg-elevated);
+    border-color: var(--border-accent);
+}
+.nav-action.bulk-select-toggle.active {
     background: var(--accent);
     border-color: var(--accent);
     color: var(--bg);
 }
-.bulk-select-toggle.active:hover {
+.nav-action.bulk-select-toggle.active:hover {
     background: var(--accent-hover);
     border-color: var(--accent-hover);
+}
+.nav-action.bulk-select-toggle:active {
+    transform: scale(0.97);
 }
 .bulk-select-toggle-icon {
     flex-shrink: 0;
@@ -558,9 +581,10 @@
     pointer-events: none;
 }
 
-/* Sticky bottom toolbar. Pill-shaped capsule centered at the bottom,
-   slides up when selection is non-empty. The mauve glow ring matches
-   the selected-card glow so the two visual surfaces feel paired. */
+/* Sticky bottom toolbar. Soft-rounded rectangle (was pill in earlier
+   pass; squarer reads as "tool" rather than "toast") centered at the
+   bottom, slides up when in selecting mode. The mauve glow ring
+   matches the selected-card glow so the two surfaces feel paired. */
 .bulk-action-toolbar {
     position: fixed;
     bottom: 24px;
@@ -570,8 +594,8 @@
     backdrop-filter: blur(16px) saturate(140%);
     -webkit-backdrop-filter: blur(16px) saturate(140%);
     border: 1px solid rgba(203, 166, 247, 0.3);
-    border-radius: 999px;
-    padding: 8px 8px 8px 18px;
+    border-radius: 12px;
+    padding: 8px 12px;
     box-shadow:
         0 12px 32px -8px rgba(0, 0, 0, 0.6),
         0 0 0 1px rgba(203, 166, 247, 0.12),

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -392,3 +392,80 @@
     color: var(--text-dim);
 }
 
+/* ── Bulk select (issue #125) ───────────────────────────────────────
+   Per-card checkbox overlay + sticky bottom toolbar. The card stays
+   navigable on body click; only the checkbox toggles selection. */
+
+.series-card {
+    position: relative;
+}
+
+.series-card-select {
+    position: absolute;
+    top: 8px;
+    left: 8px;
+    z-index: 2;
+    width: 20px;
+    height: 20px;
+    margin: 0;
+    cursor: pointer;
+    /* Default: muted so the unselected checkbox doesn't dominate the
+       cover. Becomes fully visible on card hover or once selected. */
+    opacity: 0.55;
+    transition: opacity 0.15s ease-out;
+    accent-color: var(--accent);
+}
+.series-card:hover .series-card-select,
+.series-card-select:focus,
+.series-card-select:checked {
+    opacity: 1;
+}
+
+/* Selection halo: mauve outline + soft glow so the user sees at-a-
+   glance which cards are in the bulk set without having to scan
+   checkboxes individually. */
+.series-card.selected {
+    border-color: var(--accent);
+    box-shadow: 0 0 0 1px var(--accent), 0 4px 12px rgba(203, 166, 247, 0.18);
+}
+
+/* Sticky bottom toolbar. Appears when at least one card is checked.
+   Centered horizontally; slides up from the bottom edge. */
+.bulk-action-toolbar {
+    position: fixed;
+    bottom: 18px;
+    left: 50%;
+    transform: translateX(-50%) translateY(120%);
+    background: var(--bg-elevated);
+    border: 1px solid var(--accent);
+    border-radius: 999px;
+    padding: 8px 14px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(203, 166, 247, 0.25);
+    z-index: 50;
+    transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+    opacity: 0;
+    pointer-events: none;
+}
+.bulk-action-toolbar.visible {
+    transform: translateX(-50%) translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+}
+.bulk-action-toolbar-inner {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: nowrap;
+}
+.bulk-action-count {
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text-bright);
+    padding-right: 4px;
+    white-space: nowrap;
+}
+.bulk-action-toolbar .btn-sm {
+    padding: 5px 12px;
+    font-size: 13px;
+}
+

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -405,10 +405,11 @@
     position: relative;
 }
 
-/* The checkbox is a real <input type="checkbox">, kept for
-   accessibility (keyboard focus, screen-reader semantics) and so the
-   :checked CSS state still drives the visual. We strip its native
-   appearance and re-skin from scratch. */
+/* The checkbox is a real <input type="checkbox">, kept for screen-
+   reader semantics and so the :checked CSS state drives the visual.
+   We strip its native appearance and re-skin from scratch. Hidden
+   entirely outside selecting mode (display: none); the parent grid
+   gets the .selecting class which reveals it. */
 .series-card-select {
     position: absolute;
     top: 10px;
@@ -420,6 +421,7 @@
     cursor: pointer;
     appearance: none;
     -webkit-appearance: none;
+    display: none;
 
     /* Glassy dark backdrop so the indicator stays visible regardless
        of cover-art brightness. backdrop-filter blurs the bit of cover
@@ -431,31 +433,38 @@
     border: 1.5px solid rgba(232, 232, 240, 0.35);
     border-radius: 7px;
 
-    /* Hidden by default; revealed on card hover or when checked. The
-       slight scale-up on reveal gives a tactile pop. */
-    opacity: 0;
-    transform: scale(0.85);
     transition:
-        opacity 0.18s ease-out,
-        transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1),
         background 0.18s ease-out,
         border-color 0.18s ease-out,
-        box-shadow 0.18s ease-out;
+        box-shadow 0.18s ease-out,
+        transform 0.12s ease-out;
 }
 
-/* Reveal on card hover, keyboard focus, or when checked. */
-.series-card:hover .series-card-select,
-.series-card-select:focus-visible,
-.series-card-select:checked {
-    opacity: 1;
-    transform: scale(1);
+/* In selecting mode, every card's chip is visible. The reveal is a
+   spring-scale + fade-in via a one-shot @keyframes so entering the
+   mode feels like a deliberate state change rather than an instant
+   pop. */
+.library-grid.selecting .series-card-select {
+    display: block;
+    animation: bulk-select-chip-in 0.22s cubic-bezier(0.34, 1.56, 0.64, 1) both;
 }
 
-/* Hover (unchecked): brighten the border so the indicator reads as
+@keyframes bulk-select-chip-in {
+    from {
+        opacity: 0;
+        transform: scale(0.6) translateY(-4px);
+    }
+    to {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+/* Hover (unchecked): brighten the border so the chip reads as
    "ready to click" without committing to mauve yet. */
-.series-card:hover .series-card-select:not(:checked) {
-    border-color: rgba(232, 232, 240, 0.7);
-    background: rgba(15, 15, 19, 0.7);
+.library-grid.selecting .series-card:hover .series-card-select:not(:checked) {
+    border-color: rgba(232, 232, 240, 0.75);
+    background: rgba(15, 15, 19, 0.75);
 }
 
 .series-card-select:focus-visible {
@@ -482,6 +491,15 @@
     background-size: 16px 16px;
 }
 
+/* In selecting mode, the card-hover lift turns into a "selectable"
+   cue (slightly different curve from default-mode hover so the user
+   senses the mode shift). The body click toggles selection rather
+   than navigating; cursor stays pointer. */
+.library-grid.selecting .series-card:hover {
+    transform: translateY(-1px);
+    border-color: var(--border-accent);
+}
+
 /* Selected card: thicker mauve border + soft mauve glow + a tiny lift
    so the selected state reads at-a-glance even when the user is
    scrolled past the checkbox. The transform is scoped to the card
@@ -498,6 +516,46 @@
     /* Override the existing card-hover transform so selected state
        wins on hover instead of competing transforms double-stacking. */
     transform: translateY(-3px);
+    border-color: var(--accent);
+}
+
+/* "Select" toggle button in the filter row. Default-mode look matches
+   the other btn-secondary pills; active state (mode on) inverts to
+   mauve fill so the user has a constant visual confirmation that
+   they're in selecting mode. */
+.bulk-select-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: background 0.15s ease-out, color 0.15s ease-out, border-color 0.15s ease-out;
+}
+.bulk-select-toggle.active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: var(--bg);
+}
+.bulk-select-toggle.active:hover {
+    background: var(--accent-hover);
+    border-color: var(--accent-hover);
+}
+.bulk-select-toggle-icon {
+    flex-shrink: 0;
+}
+
+/* Visual divider in the toolbar between groups (count | actions | done). */
+.bulk-action-divider {
+    width: 1px;
+    height: 18px;
+    background: rgba(255, 255, 255, 0.08);
+    flex-shrink: 0;
+}
+
+/* Disabled action button: muted look so the user can tell the action
+   is gated on selection without reading the disabled attribute. */
+.bulk-action-toolbar .btn-sm:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    pointer-events: none;
 }
 
 /* Sticky bottom toolbar. Pill-shaped capsule centered at the bottom,

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -526,37 +526,36 @@
    `page == "library"`; on other pages the button is not in the
    DOM at all (so toggleBulkSelectMode() can't be invoked from
    pages that don't load index.js).
-   Default-mode look matches the surrounding nav links; active
-   state (mode on) inverts to mauve fill for constant visual
-   confirmation that mode is on. */
+   Sizing matches `.nav-links a` exactly (same padding, same
+   font-size, no border) so the button height aligns with the
+   surrounding nav-link anchors. The active state (mode on) inverts
+   to a mauve fill for constant visual confirmation that mode is on. */
 .nav-action.bulk-select-toggle {
     display: inline-flex;
     align-items: center;
     gap: 6px;
     background: transparent;
     color: var(--text-dim);
-    padding: 6px 12px;
-    border: 1px solid var(--border);
+    padding: 6px 14px;
+    border: none;
     border-radius: var(--radius);
-    font-size: 13px;
+    font-size: 14px;
     font-weight: 500;
     font-family: inherit;
+    line-height: 1.2;
     cursor: pointer;
-    transition: color 0.15s, background 0.15s, border-color 0.15s, transform 0.1s;
+    transition: color 0.15s, background 0.15s, transform 0.1s;
 }
 .nav-action.bulk-select-toggle:hover {
     color: var(--text);
     background: var(--bg-elevated);
-    border-color: var(--border-accent);
 }
 .nav-action.bulk-select-toggle.active {
     background: var(--accent);
-    border-color: var(--accent);
     color: var(--bg);
 }
 .nav-action.bulk-select-toggle.active:hover {
     background: var(--accent-hover);
-    border-color: var(--accent-hover);
 }
 .nav-action.bulk-select-toggle:active {
     transform: scale(0.97);

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -374,6 +374,8 @@
 .monitor-option-btn.active {
     border-color: var(--accent);
     background: rgba(203, 166, 247, 0.08);
+    box-shadow: inset 3px 0 0 var(--accent);
+    padding-left: 17px;
 }
 
 .monitor-option-btn:hover:not(.active) {
@@ -393,56 +395,133 @@
 }
 
 /* ── Bulk select (issue #125) ───────────────────────────────────────
-   Per-card checkbox overlay + sticky bottom toolbar. The card stays
-   navigable on body click; only the checkbox toggles selection. */
+   Custom-styled selection indicator that hides until hover (or until
+   the card is selected), with a mauve fill and SVG check mark on the
+   selected state. The native checkbox styling clashed against the
+   cover art and read as a system-form element bolted onto the UI;
+   this version stays out of the way until invoked. */
 
 .series-card {
     position: relative;
 }
 
+/* The checkbox is a real <input type="checkbox">, kept for
+   accessibility (keyboard focus, screen-reader semantics) and so the
+   :checked CSS state still drives the visual. We strip its native
+   appearance and re-skin from scratch. */
 .series-card-select {
     position: absolute;
-    top: 8px;
-    left: 8px;
+    top: 10px;
+    left: 10px;
     z-index: 2;
-    width: 20px;
-    height: 20px;
+    width: 24px;
+    height: 24px;
     margin: 0;
     cursor: pointer;
-    /* Default: muted so the unselected checkbox doesn't dominate the
-       cover. Becomes fully visible on card hover or once selected. */
-    opacity: 0.55;
-    transition: opacity 0.15s ease-out;
-    accent-color: var(--accent);
+    appearance: none;
+    -webkit-appearance: none;
+
+    /* Glassy dark backdrop so the indicator stays visible regardless
+       of cover-art brightness. backdrop-filter blurs the bit of cover
+       behind the indicator, giving it a frosted-glass quality that
+       matches the rest of the dark UI. */
+    background: rgba(15, 15, 19, 0.55);
+    backdrop-filter: blur(8px) saturate(120%);
+    -webkit-backdrop-filter: blur(8px) saturate(120%);
+    border: 1.5px solid rgba(232, 232, 240, 0.35);
+    border-radius: 7px;
+
+    /* Hidden by default; revealed on card hover or when checked. The
+       slight scale-up on reveal gives a tactile pop. */
+    opacity: 0;
+    transform: scale(0.85);
+    transition:
+        opacity 0.18s ease-out,
+        transform 0.18s cubic-bezier(0.34, 1.56, 0.64, 1),
+        background 0.18s ease-out,
+        border-color 0.18s ease-out,
+        box-shadow 0.18s ease-out;
 }
+
+/* Reveal on card hover, keyboard focus, or when checked. */
 .series-card:hover .series-card-select,
-.series-card-select:focus,
+.series-card-select:focus-visible,
 .series-card-select:checked {
     opacity: 1;
+    transform: scale(1);
 }
 
-/* Selection halo: mauve outline + soft glow so the user sees at-a-
-   glance which cards are in the bulk set without having to scan
-   checkboxes individually. */
+/* Hover (unchecked): brighten the border so the indicator reads as
+   "ready to click" without committing to mauve yet. */
+.series-card:hover .series-card-select:not(:checked) {
+    border-color: rgba(232, 232, 240, 0.7);
+    background: rgba(15, 15, 19, 0.7);
+}
+
+.series-card-select:focus-visible {
+    outline: none;
+    border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(203, 166, 247, 0.35);
+}
+
+/* Checked: mauve fill, white check mark via inline SVG background.
+   Dark outer halo lifts the chip off bright cover art so the
+   selection is unmistakable. */
+.series-card-select:checked {
+    background: var(--accent);
+    border-color: var(--accent);
+    box-shadow:
+        0 0 0 2px rgba(15, 15, 19, 0.6),
+        0 2px 8px rgba(203, 166, 247, 0.4);
+    /* Inline SVG check mark — using #0f0f13 (page bg) as the stroke
+       color so the check reads as "carved out" rather than "drawn on
+       top of." */
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%230f0f13' stroke-width='3.5' stroke-linecap='round' stroke-linejoin='round'><polyline points='5,12 10,17 19,8'/></svg>");
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: 16px 16px;
+}
+
+/* Selected card: thicker mauve border + soft mauve glow + a tiny lift
+   so the selected state reads at-a-glance even when the user is
+   scrolled past the checkbox. The transform is scoped to the card
+   itself so the card grid reflows minimally. */
 .series-card.selected {
     border-color: var(--accent);
-    box-shadow: 0 0 0 1px var(--accent), 0 4px 12px rgba(203, 166, 247, 0.18);
+    box-shadow:
+        0 0 0 1px var(--accent),
+        0 8px 24px -4px rgba(203, 166, 247, 0.35),
+        0 2px 8px rgba(203, 166, 247, 0.18);
+    transform: translateY(-2px);
+}
+.series-card.selected:hover {
+    /* Override the existing card-hover transform so selected state
+       wins on hover instead of competing transforms double-stacking. */
+    transform: translateY(-3px);
 }
 
-/* Sticky bottom toolbar. Appears when at least one card is checked.
-   Centered horizontally; slides up from the bottom edge. */
+/* Sticky bottom toolbar. Pill-shaped capsule centered at the bottom,
+   slides up when selection is non-empty. The mauve glow ring matches
+   the selected-card glow so the two visual surfaces feel paired. */
 .bulk-action-toolbar {
     position: fixed;
-    bottom: 18px;
+    bottom: 24px;
     left: 50%;
-    transform: translateX(-50%) translateY(120%);
-    background: var(--bg-elevated);
-    border: 1px solid var(--accent);
+    transform: translateX(-50%) translateY(140%);
+    background: rgba(22, 22, 29, 0.92);
+    backdrop-filter: blur(16px) saturate(140%);
+    -webkit-backdrop-filter: blur(16px) saturate(140%);
+    border: 1px solid rgba(203, 166, 247, 0.3);
     border-radius: 999px;
-    padding: 8px 14px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.45), 0 0 0 1px rgba(203, 166, 247, 0.25);
+    padding: 8px 8px 8px 18px;
+    box-shadow:
+        0 12px 32px -8px rgba(0, 0, 0, 0.6),
+        0 0 0 1px rgba(203, 166, 247, 0.12),
+        0 0 24px -4px rgba(203, 166, 247, 0.25);
     z-index: 50;
-    transition: transform 0.18s ease-out, opacity 0.18s ease-out;
+    transition:
+        transform 0.22s cubic-bezier(0.34, 1.56, 0.64, 1),
+        opacity 0.22s ease-out;
     opacity: 0;
     pointer-events: none;
 }
@@ -454,18 +533,36 @@
 .bulk-action-toolbar-inner {
     display: flex;
     align-items: center;
-    gap: 12px;
+    gap: 10px;
     flex-wrap: nowrap;
 }
+
+/* Count badge: mauve text, bold, with a thin separator pipe. The
+   number gets the display-font treatment so it pulls focus naturally. */
 .bulk-action-count {
+    font-family: 'Murecho', system-ui, sans-serif;
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--text-bright);
+    letter-spacing: 0.01em;
+    white-space: nowrap;
+    padding-right: 6px;
+    border-right: 1px solid rgba(255, 255, 255, 0.08);
+    margin-right: 4px;
+}
+.bulk-action-count #bulk-action-count-num {
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
+}
+
+.bulk-action-toolbar .btn-sm {
+    padding: 6px 14px;
     font-size: 13px;
     font-weight: 600;
-    color: var(--text-bright);
-    padding-right: 4px;
-    white-space: nowrap;
+    border-radius: 999px;
+    transition: background 0.15s ease-out, transform 0.1s ease-out;
 }
-.bulk-action-toolbar .btn-sm {
-    padding: 5px 12px;
-    font-size: 13px;
+.bulk-action-toolbar .btn-sm:active {
+    transform: scale(0.96);
 }
 

--- a/static/css/topbar.css
+++ b/static/css/topbar.css
@@ -67,9 +67,42 @@
 
 .nav-logout { color: var(--text-dim) !important; }
 
+/* Mobile-only icon logout. Hidden on desktop (where the text "Logout"
+   in nav-links handles the action); revealed on mobile via the
+   media query below. The icon button takes the same .nav-links
+   slot the text version did but renders as a small square instead. */
+.nav-logout-mobile {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    color: var(--text-dim);
+    border-radius: var(--radius);
+    transition: color 0.15s, background 0.15s;
+}
+.nav-logout-mobile:hover {
+    color: var(--text);
+    background: var(--bg-elevated);
+}
+.nav-logout-mobile svg {
+    flex-shrink: 0;
+}
+
 @media (max-width: 640px) {
+    /* Keep .nav-links flexed on mobile but hide every child except
+       the mobile logout icon, which becomes the only thing visible
+       in the topbar's right slot. The bottom mobile-tabbar handles
+       primary nav. */
     .nav-links {
+        display: flex;
+        gap: 0;
+    }
+    .nav-links > *:not(.nav-logout-mobile) {
         display: none;
+    }
+    .nav-logout-mobile {
+        display: inline-flex;
     }
     .mobile-tabbar {
         display: flex;

--- a/static/css/topbar.css
+++ b/static/css/topbar.css
@@ -91,14 +91,16 @@
 
 @media (max-width: 640px) {
     /* Keep .nav-links flexed on mobile but hide every child except
-       the mobile logout icon, which becomes the only thing visible
-       in the topbar's right slot. The bottom mobile-tabbar handles
-       primary nav. */
+       (a) the mobile logout icon and (b) the bulk-select toggle on
+       the library page. Primary nav lives in the bottom
+       mobile-tabbar; the topbar's right slot is reserved for
+       page-mode actions (Select) and account actions (Logout). */
     .nav-links {
         display: flex;
-        gap: 0;
+        gap: 6px;
+        align-items: center;
     }
-    .nav-links > *:not(.nav-logout-mobile) {
+    .nav-links > *:not(.nav-logout-mobile):not(.bulk-select-toggle) {
         display: none;
     }
     .nav-logout-mobile {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -376,7 +376,7 @@ function selectAllVisibleSeries() {
     document.querySelectorAll('.series-card').forEach(function (card) {
         // Skip cards filtered out by liveLibrarySearch (display: none).
         if (card.style.display === 'none') return;
-        var id = parseInt(card.dataset.seriesId, 10);
+        var id = parseInt(card.id.slice(7), 10);
         if (!id || bulkSelectedIds.has(id)) return;
         bulkSelectedIds.add(id);
         card.classList.add('selected');
@@ -396,7 +396,7 @@ function areAllVisibleSelected() {
         var card = cards[i];
         if (card.style.display === 'none') continue;
         anyVisible = true;
-        var id = parseInt(card.dataset.seriesId, 10);
+        var id = parseInt(card.id.slice(7), 10);
         if (!id || !bulkSelectedIds.has(id)) {
             allSelected = false;
             break;
@@ -413,7 +413,7 @@ function toggleSelectAllVisible() {
     if (areAllVisibleSelected()) {
         document.querySelectorAll('.series-card').forEach(function (card) {
             if (card.style.display === 'none') return;
-            var id = parseInt(card.dataset.seriesId, 10);
+            var id = parseInt(card.id.slice(7), 10);
             if (!id || !bulkSelectedIds.has(id)) return;
             bulkSelectedIds.delete(id);
             card.classList.remove('selected');
@@ -653,7 +653,7 @@ if (!window.__ryokanBulkSelectInit) {
         if (!card) return;
         ev.preventDefault();
         ev.stopPropagation();
-        var id = parseInt(card.dataset.seriesId, 10);
+        var id = parseInt(card.id.slice(7), 10);
         if (!id) return;
         toggleSeriesSelectById(id);
     }, true);

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -379,10 +379,65 @@ function selectAllVisibleSeries() {
     renderBulkToolbar();
 }
 
+// True when every visible card is in the selected set (and there's at
+// least one visible card). Drives the Select-all toggle's label.
+function areAllVisibleSelected() {
+    var anyVisible = false;
+    var allSelected = true;
+    var cards = document.querySelectorAll('.series-card');
+    for (var i = 0; i < cards.length; i++) {
+        var card = cards[i];
+        if (card.style.display === 'none') continue;
+        anyVisible = true;
+        var id = parseInt(card.dataset.seriesId, 10);
+        if (!id || !bulkSelectedIds.has(id)) {
+            allSelected = false;
+            break;
+        }
+    }
+    return anyVisible && allSelected;
+}
+
+// Toggle the Select-all action: if every visible card is already
+// selected, deselect all visible. Otherwise select all visible.
+// Bound to the toolbar's #bulk-action-select-all-btn.
+function toggleSelectAllVisible() {
+    if (!bulkSelectMode) return;
+    if (areAllVisibleSelected()) {
+        document.querySelectorAll('.series-card').forEach(function (card) {
+            if (card.style.display === 'none') return;
+            var id = parseInt(card.dataset.seriesId, 10);
+            if (!id || !bulkSelectedIds.has(id)) return;
+            bulkSelectedIds.delete(id);
+            card.classList.remove('selected');
+            var cb = card.querySelector('.series-card-select');
+            if (cb) cb.checked = false;
+        });
+    } else {
+        selectAllVisibleSeries();
+    }
+    renderBulkToolbar();
+}
+
+// Inline chip click handler. Stops propagation + preventDefault so
+// the parent <a>'s navigation doesn't fire even when the document-
+// level delegation hasn't been re-attached (hx-boost re-renders the
+// grid; document-level events survive but inline handlers are
+// replaced with the new DOM, so making the chip own its click
+// guarantees correct behavior regardless of listener state).
+function bulkChipClick(ev, seriesId) {
+    ev.stopPropagation();
+    ev.preventDefault();
+    if (!bulkSelectMode) return;
+    toggleSeriesSelectById(seriesId);
+}
+
 function renderBulkToolbar() {
     var bar = document.getElementById('bulk-action-toolbar');
     var num = document.getElementById('bulk-action-count-num');
     var monitorBtn = document.getElementById('bulk-action-monitor-btn');
+    var deleteBtn = document.getElementById('bulk-action-delete-btn');
+    var selectAllBtn = document.getElementById('bulk-action-select-all-btn');
     if (!bar || !num) return;
     num.textContent = String(bulkSelectedIds.size);
     // Toolbar visibility tracks selecting MODE, not selection count —
@@ -395,7 +450,12 @@ function renderBulkToolbar() {
         bar.hidden = true;
         bar.classList.remove('visible');
     }
-    if (monitorBtn) monitorBtn.disabled = bulkSelectedIds.size === 0;
+    var hasSelection = bulkSelectedIds.size > 0;
+    if (monitorBtn) monitorBtn.disabled = !hasSelection;
+    if (deleteBtn) deleteBtn.disabled = !hasSelection;
+    if (selectAllBtn) {
+        selectAllBtn.textContent = areAllVisibleSelected() ? 'Deselect all' : 'Select all';
+    }
 }
 
 function clearBulkSelection() {
@@ -496,8 +556,12 @@ function renderBulkOutcome(outcome, verb) {
     var ok = (outcome.succeeded || []).length;
     var bad = (outcome.failed || []).length;
     if (!window.ryokanToast) return;
-    var modal = document.getElementById('bulk-monitor-modal');
-    if (modal) modal.style.display = 'none';
+    // Close any open bulk modal — different actions trigger from
+    // different modals but the outcome rendering is shared.
+    ['bulk-monitor-modal', 'bulk-delete-modal'].forEach(function (id) {
+        var m = document.getElementById(id);
+        if (m) m.style.display = 'none';
+    });
 
     if (bad === 0) {
         // All succeeded: toast + exit mode (which clears selection).
@@ -542,39 +606,116 @@ function renderBulkOutcome(outcome, verb) {
 
 // One-shot global listeners. The `__ryokan*` boot guard pattern keeps
 // hx-boost re-execs of this file from accumulating duplicate handlers
-// on every nav-back into /.
+// on every nav-back into /. Delegated click + keydown listeners are
+// attached to `document` rather than the library grid because the
+// grid element gets replaced on hx-boost navigation; document-level
+// listeners survive the swap. Inline `onclick` on the chip itself
+// belt-and-suspenders this for the chip-specific case.
 if (!window.__ryokanBulkSelectInit) {
     window.__ryokanBulkSelectInit = true;
 
-    // Delegated click handler on the grid. In selecting mode this
-    // intercepts every card click, preventDefaults the parent <a>'s
+    // Document-level delegated click. In selecting mode, intercepts
+    // every card-body click, preventDefaults the parent <a>'s
     // navigation, and toggles selection. Outside selecting mode it
-    // does nothing — cards navigate as normal.
-    var grid = document.getElementById('library-grid');
-    if (grid) {
-        grid.addEventListener('click', function (ev) {
-            if (!bulkSelectMode) return;
-            var card = ev.target.closest('.series-card');
-            if (!card) return;
-            ev.preventDefault();
-            ev.stopPropagation();
-            var id = parseInt(card.dataset.seriesId, 10);
-            if (!id) return;
-            toggleSeriesSelectById(id);
-        });
-    }
+    // returns early. Skips clicks already handled inline by the chip
+    // itself (those have stopPropagation, but defense-in-depth).
+    document.addEventListener('click', function (ev) {
+        if (!bulkSelectMode) return;
+        // Inline chip handler already handled this; don't double-toggle.
+        if (ev.target.classList && ev.target.classList.contains('series-card-select')) {
+            return;
+        }
+        var card = ev.target.closest && ev.target.closest('.series-card');
+        if (!card) return;
+        ev.preventDefault();
+        ev.stopPropagation();
+        var id = parseInt(card.dataset.seriesId, 10);
+        if (!id) return;
+        toggleSeriesSelectById(id);
+    });
 
-    // Esc: exits the bulk monitor modal first if open; otherwise
-    // exits selecting mode (which clears the selection on the way out).
+    // Esc: exits the bulk delete modal first if open, then bulk
+    // monitor modal, then selecting mode (clears selection on the
+    // way out).
     document.addEventListener('keydown', function (ev) {
         if (ev.key !== 'Escape') return;
-        var modal = document.getElementById('bulk-monitor-modal');
-        if (modal && modal.style.display !== 'none' && modal.style.display !== '') {
-            modal.style.display = 'none';
+        var deleteModal = document.getElementById('bulk-delete-modal');
+        if (deleteModal && deleteModal.style.display !== 'none' && deleteModal.style.display !== '') {
+            deleteModal.style.display = 'none';
+            return;
+        }
+        var monitorModal = document.getElementById('bulk-monitor-modal');
+        if (monitorModal && monitorModal.style.display !== 'none' && monitorModal.style.display !== '') {
+            monitorModal.style.display = 'none';
             return;
         }
         if (bulkSelectMode) {
             exitBulkSelectMode();
+        }
+    });
+}
+
+// ── Bulk delete modal ──────────────────────────────────────────────
+
+function openBulkDeleteModal() {
+    if (bulkSelectedIds.size === 0) return;
+    var modal = document.getElementById('bulk-delete-modal');
+    var count = document.getElementById('bulk-delete-count');
+    var checkbox = document.getElementById('bulk-delete-files-toggle');
+    var confirmBtn = document.getElementById('bulk-delete-confirm-btn');
+    if (count) count.textContent = String(bulkSelectedIds.size);
+    if (checkbox) checkbox.checked = false;
+    if (confirmBtn) {
+        confirmBtn.disabled = false;
+        confirmBtn.textContent = 'Remove from library';
+    }
+    if (modal) modal.style.display = 'flex';
+}
+
+function closeBulkDeleteModal(event) {
+    if (event && event.target && event.currentTarget && event.target !== event.currentTarget) {
+        if (!event.target.closest('.btn-icon') && !event.target.classList.contains('btn-secondary')) {
+            return;
+        }
+    }
+    var modal = document.getElementById('bulk-delete-modal');
+    if (modal) modal.style.display = 'none';
+}
+
+function confirmBulkDelete() {
+    if (bulkSelectedIds.size === 0) return;
+    var ids = Array.from(bulkSelectedIds);
+    var checkbox = document.getElementById('bulk-delete-files-toggle');
+    var deleteFiles = !!(checkbox && checkbox.checked);
+    var confirmBtn = document.getElementById('bulk-delete-confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Removing…';
+    }
+    fetch('/api/library/bulk/delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ series_ids: ids, delete_files: deleteFiles })
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (outcome) {
+        // Remove succeeded cards from the DOM directly — they're
+        // gone server-side, so leaving them in the grid would be
+        // misleading. Failed cards stay (per renderBulkOutcome's
+        // partial-failure logic).
+        (outcome.succeeded || []).forEach(function (id) {
+            var card = document.getElementById('series-' + id);
+            if (card) card.remove();
+        });
+        renderBulkOutcome(outcome, 'Removed from library');
+    })
+    .catch(function (e) {
+        if (confirmBtn) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Remove from library';
+        }
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'error', title: 'Bulk delete failed', body: (e && e.message) || 'Network error', log: true });
         }
     });
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -288,3 +288,202 @@ function escAttr(s) {
     if (!s) return '';
     return s.replace(/&/g,'&amp;').replace(/'/g,'&#39;').replace(/"/g,'&quot;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
 }
+
+// ── Bulk select (issue #125) ────────────────────────────────────────
+//
+// Selection state lives client-side; refresh clears it (matches the
+// user's mental model — "I selected some cards on this page", not "I
+// have a persistent selection that survives reloads"). A `Set` keyed
+// by integer series id; the card's `.selected` class is the visual
+// projection of membership.
+
+var bulkSelectedIds = new Set();
+var bulkPendingMode = null;
+
+function toggleSeriesSelect(event, seriesId) {
+    // Stop propagation so the parent <a> (whose href is /series/<id>)
+    // doesn't navigate when the user clicks the checkbox itself.
+    event.stopPropagation();
+    var card = document.getElementById('series-' + seriesId);
+    if (!card) return;
+    var checkbox = card.querySelector('.series-card-select');
+    var checked = checkbox ? checkbox.checked : false;
+    if (checked) {
+        bulkSelectedIds.add(seriesId);
+        card.classList.add('selected');
+    } else {
+        bulkSelectedIds.delete(seriesId);
+        card.classList.remove('selected');
+    }
+    renderBulkToolbar();
+}
+
+function renderBulkToolbar() {
+    var bar = document.getElementById('bulk-action-toolbar');
+    var num = document.getElementById('bulk-action-count-num');
+    if (!bar || !num) return;
+    num.textContent = String(bulkSelectedIds.size);
+    if (bulkSelectedIds.size > 0) {
+        bar.hidden = false;
+        bar.classList.add('visible');
+    } else {
+        bar.hidden = true;
+        bar.classList.remove('visible');
+    }
+}
+
+function clearBulkSelection() {
+    bulkSelectedIds.forEach(function (id) {
+        var card = document.getElementById('series-' + id);
+        if (card) {
+            card.classList.remove('selected');
+            var cb = card.querySelector('.series-card-select');
+            if (cb) cb.checked = false;
+        }
+    });
+    bulkSelectedIds.clear();
+    renderBulkToolbar();
+}
+
+function openBulkMonitorModal() {
+    if (bulkSelectedIds.size === 0) return;
+    var modal = document.getElementById('bulk-monitor-modal');
+    var count = document.getElementById('bulk-monitor-count');
+    var confirmBtn = document.getElementById('bulk-monitor-confirm-btn');
+    if (count) count.textContent = String(bulkSelectedIds.size);
+    bulkPendingMode = null;
+    if (confirmBtn) confirmBtn.disabled = true;
+    document.querySelectorAll('#bulk-monitor-options .monitor-option-btn').forEach(function (btn) {
+        btn.classList.remove('active');
+        btn.onclick = function () { selectBulkMonitorMode(btn); };
+    });
+    if (modal) modal.style.display = 'flex';
+}
+
+function closeBulkMonitorModal(event) {
+    // Allow the close button + backdrop click + explicit programmatic
+    // close to all hit this. The backdrop click sets event.target ===
+    // event.currentTarget; the close button uses .btn-icon. Anything
+    // else (e.g. clicks bubbling up from inside the panel) is ignored.
+    if (event && event.target && event.currentTarget && event.target !== event.currentTarget) {
+        if (!event.target.closest('.btn-icon') && !event.target.classList.contains('btn-secondary')) {
+            return;
+        }
+    }
+    var modal = document.getElementById('bulk-monitor-modal');
+    if (modal) modal.style.display = 'none';
+}
+
+function selectBulkMonitorMode(btn) {
+    document.querySelectorAll('#bulk-monitor-options .monitor-option-btn').forEach(function (b) {
+        b.classList.remove('active');
+    });
+    btn.classList.add('active');
+    bulkPendingMode = btn.dataset.mode;
+    var confirmBtn = document.getElementById('bulk-monitor-confirm-btn');
+    if (confirmBtn) confirmBtn.disabled = false;
+}
+
+function confirmBulkMonitor() {
+    if (!bulkPendingMode || bulkSelectedIds.size === 0) return;
+    var ids = Array.from(bulkSelectedIds);
+    var mode = bulkPendingMode;
+    var confirmBtn = document.getElementById('bulk-monitor-confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Applying…';
+    }
+    fetch('/api/library/bulk/monitor', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ series_ids: ids, mode: mode })
+    })
+    .then(function (r) { return r.json(); })
+    .then(function (outcome) {
+        renderBulkOutcome(outcome, 'Monitor mode updated');
+        // Page reload after the toast briefly displays. Per-episode
+        // monitor flags are recomputed server-side; the index page
+        // doesn't render those per-card so a partial DOM update would
+        // be a wash. Future bulk actions that affect visible badges
+        // (delete, upgrades) will refresh in place.
+        setTimeout(function () { location.reload(); }, 600);
+    })
+    .catch(function (e) {
+        if (confirmBtn) {
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Apply';
+        }
+        if (window.ryokanToast) {
+            window.ryokanToast({ kind: 'error', title: 'Bulk update failed', body: (e && e.message) || 'Network error', log: true });
+        }
+    });
+}
+
+// Render a BulkOutcome ({ succeeded: [], failed: [{series_id, reason}] })
+// as a toast. All-success → success toast. All-failure → error toast,
+// selection preserved so the user can retry without re-selecting.
+// Partial → warn toast; succeeded IDs cleared from selection,
+// failed IDs remain selected so the user sees which ones to address.
+//
+// Reused across all bulk actions; the `verb` argument is the user-
+// facing summary noun ("Monitor mode updated" / "Series deleted" / etc.).
+function renderBulkOutcome(outcome, verb) {
+    var ok = (outcome.succeeded || []).length;
+    var bad = (outcome.failed || []).length;
+    if (!window.ryokanToast) return;
+    if (bad === 0) {
+        window.ryokanToast({ kind: 'success', title: verb, body: ok + ' succeeded', log: false, duration: 3000 });
+        var modal = document.getElementById('bulk-monitor-modal');
+        if (modal) modal.style.display = 'none';
+        clearBulkSelection();
+    } else if (ok === 0) {
+        var first = outcome.failed[0];
+        var summary = bad + ' failed';
+        if (first) summary += '; ' + (first.reason || 'unknown error');
+        window.ryokanToast({ kind: 'error', title: verb + ' failed', body: summary, log: true });
+    } else {
+        var failedSet = new Set(outcome.failed.map(function (f) { return f.series_id; }));
+        var stillSelected = new Set();
+        bulkSelectedIds.forEach(function (id) {
+            if (failedSet.has(id)) {
+                stillSelected.add(id);
+            } else {
+                var c = document.getElementById('series-' + id);
+                if (c) {
+                    c.classList.remove('selected');
+                    var cb = c.querySelector('.series-card-select');
+                    if (cb) cb.checked = false;
+                }
+            }
+        });
+        bulkSelectedIds = stillSelected;
+        renderBulkToolbar();
+        window.ryokanToast({
+            kind: 'warn',
+            title: verb,
+            body: ok + ' succeeded, ' + bad + ' failed (selection still shows the failures)',
+            log: true,
+            duration: 6000
+        });
+        var modal2 = document.getElementById('bulk-monitor-modal');
+        if (modal2) modal2.style.display = 'none';
+    }
+}
+
+// One-shot Esc-to-clear listener. The `__ryokan*` boot guard pattern
+// keeps hx-boost re-execs of this file from accumulating duplicate
+// handlers on every nav-back into /.
+if (!window.__ryokanBulkSelectInit) {
+    window.__ryokanBulkSelectInit = true;
+    document.addEventListener('keydown', function (ev) {
+        if (ev.key !== 'Escape') return;
+        var modal = document.getElementById('bulk-monitor-modal');
+        if (modal && modal.style.display !== 'none' && modal.style.display !== '') {
+            modal.style.display = 'none';
+            return;
+        }
+        if (bulkSelectedIds.size > 0) {
+            clearBulkSelection();
+        }
+    });
+}

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -291,45 +291,111 @@ function escAttr(s) {
 
 // ── Bulk select (issue #125) ────────────────────────────────────────
 //
-// Selection state lives client-side; refresh clears it (matches the
-// user's mental model — "I selected some cards on this page", not "I
-// have a persistent selection that survives reloads"). A `Set` keyed
-// by integer series id; the card's `.selected` class is the visual
-// projection of membership.
+// Sonarr-style "edit mode" pattern. The "Select" toggle in the filter
+// row enters bulk-select mode, which makes every card a checkbox
+// target instead of a navigation link. Default browsing is unaffected;
+// the toolbar + checkboxes only appear when the user explicitly opts
+// in. Selection state lives client-side; mode exit clears it.
+//
+// Keyed by integer series id; the card's `.selected` class is the
+// visual projection of membership.
 
+var bulkSelectMode = false;
 var bulkSelectedIds = new Set();
 var bulkPendingMode = null;
 
-function toggleSeriesSelect(event, seriesId) {
-    // Stop propagation so the parent <a> (whose href is /series/<id>)
-    // doesn't navigate when the user clicks the checkbox itself.
-    event.stopPropagation();
+// Enter / exit bulk-select mode. The mode flag drives:
+//   - .library-grid.selecting class (CSS shows the chip on every card,
+//     suppresses the card-hover transform).
+//   - The "Select" toggle's appearance (becomes mauve-active when on).
+//   - The bottom toolbar's visibility.
+//   - The delegated click handler's preventDefault behavior on cards.
+function toggleBulkSelectMode() {
+    if (bulkSelectMode) {
+        exitBulkSelectMode();
+    } else {
+        enterBulkSelectMode();
+    }
+}
+
+function enterBulkSelectMode() {
+    bulkSelectMode = true;
+    var grid = document.getElementById('library-grid');
+    if (grid) grid.classList.add('selecting');
+    var toggle = document.getElementById('bulk-select-toggle');
+    if (toggle) {
+        toggle.classList.add('active');
+        var label = toggle.querySelector('.bulk-select-toggle-label');
+        if (label) label.textContent = 'Cancel';
+    }
+    renderBulkToolbar();
+}
+
+function exitBulkSelectMode() {
+    bulkSelectMode = false;
+    var grid = document.getElementById('library-grid');
+    if (grid) grid.classList.remove('selecting');
+    var toggle = document.getElementById('bulk-select-toggle');
+    if (toggle) {
+        toggle.classList.remove('active');
+        var label = toggle.querySelector('.bulk-select-toggle-label');
+        if (label) label.textContent = 'Select';
+    }
+    clearBulkSelection();
+    renderBulkToolbar();
+}
+
+// Toggle one series's selection state. Called from the delegated
+// click handler on the library grid (which preventDefaults the
+// card's <a> navigation while in selecting mode).
+function toggleSeriesSelectById(seriesId) {
     var card = document.getElementById('series-' + seriesId);
     if (!card) return;
     var checkbox = card.querySelector('.series-card-select');
-    var checked = checkbox ? checkbox.checked : false;
-    if (checked) {
-        bulkSelectedIds.add(seriesId);
-        card.classList.add('selected');
-    } else {
+    if (bulkSelectedIds.has(seriesId)) {
         bulkSelectedIds.delete(seriesId);
         card.classList.remove('selected');
+        if (checkbox) checkbox.checked = false;
+    } else {
+        bulkSelectedIds.add(seriesId);
+        card.classList.add('selected');
+        if (checkbox) checkbox.checked = true;
     }
+    renderBulkToolbar();
+}
+
+function selectAllVisibleSeries() {
+    if (!bulkSelectMode) return;
+    document.querySelectorAll('.series-card').forEach(function (card) {
+        // Skip cards filtered out by liveLibrarySearch (display: none).
+        if (card.style.display === 'none') return;
+        var id = parseInt(card.dataset.seriesId, 10);
+        if (!id || bulkSelectedIds.has(id)) return;
+        bulkSelectedIds.add(id);
+        card.classList.add('selected');
+        var cb = card.querySelector('.series-card-select');
+        if (cb) cb.checked = true;
+    });
     renderBulkToolbar();
 }
 
 function renderBulkToolbar() {
     var bar = document.getElementById('bulk-action-toolbar');
     var num = document.getElementById('bulk-action-count-num');
+    var monitorBtn = document.getElementById('bulk-action-monitor-btn');
     if (!bar || !num) return;
     num.textContent = String(bulkSelectedIds.size);
-    if (bulkSelectedIds.size > 0) {
+    // Toolbar visibility tracks selecting MODE, not selection count —
+    // the user wants context that they're in select mode even with
+    // nothing selected yet. Action buttons disable when N == 0.
+    if (bulkSelectMode) {
         bar.hidden = false;
         bar.classList.add('visible');
     } else {
         bar.hidden = true;
         bar.classList.remove('visible');
     }
+    if (monitorBtn) monitorBtn.disabled = bulkSelectedIds.size === 0;
 }
 
 function clearBulkSelection() {
@@ -401,12 +467,11 @@ function confirmBulkMonitor() {
     .then(function (r) { return r.json(); })
     .then(function (outcome) {
         renderBulkOutcome(outcome, 'Monitor mode updated');
-        // Page reload after the toast briefly displays. Per-episode
-        // monitor flags are recomputed server-side; the index page
-        // doesn't render those per-card so a partial DOM update would
-        // be a wash. Future bulk actions that affect visible badges
-        // (delete, upgrades) will refresh in place.
-        setTimeout(function () { location.reload(); }, 600);
+        // No reload necessary — the library page doesn't render
+        // per-episode monitor state. Series-detail pages will reflect
+        // the new monitor mode on next visit. Future bulk actions
+        // that affect visible badges (delete, upgrades) will refresh
+        // their per-card state in place from the response.
     })
     .catch(function (e) {
         if (confirmBtn) {
@@ -431,17 +496,24 @@ function renderBulkOutcome(outcome, verb) {
     var ok = (outcome.succeeded || []).length;
     var bad = (outcome.failed || []).length;
     if (!window.ryokanToast) return;
+    var modal = document.getElementById('bulk-monitor-modal');
+    if (modal) modal.style.display = 'none';
+
     if (bad === 0) {
+        // All succeeded: toast + exit mode (which clears selection).
         window.ryokanToast({ kind: 'success', title: verb, body: ok + ' succeeded', log: false, duration: 3000 });
-        var modal = document.getElementById('bulk-monitor-modal');
-        if (modal) modal.style.display = 'none';
-        clearBulkSelection();
+        exitBulkSelectMode();
     } else if (ok === 0) {
+        // All failed: keep mode open + selection intact so the user
+        // can retry without re-selecting.
         var first = outcome.failed[0];
         var summary = bad + ' failed';
         if (first) summary += '; ' + (first.reason || 'unknown error');
         window.ryokanToast({ kind: 'error', title: verb + ' failed', body: summary, log: true });
     } else {
+        // Partial: succeeded IDs cleared from selection, failed IDs
+        // remain so the user sees what still needs attention. Mode
+        // stays on.
         var failedSet = new Set(outcome.failed.map(function (f) { return f.series_id; }));
         var stillSelected = new Set();
         bulkSelectedIds.forEach(function (id) {
@@ -465,16 +537,35 @@ function renderBulkOutcome(outcome, verb) {
             log: true,
             duration: 6000
         });
-        var modal2 = document.getElementById('bulk-monitor-modal');
-        if (modal2) modal2.style.display = 'none';
     }
 }
 
-// One-shot Esc-to-clear listener. The `__ryokan*` boot guard pattern
-// keeps hx-boost re-execs of this file from accumulating duplicate
-// handlers on every nav-back into /.
+// One-shot global listeners. The `__ryokan*` boot guard pattern keeps
+// hx-boost re-execs of this file from accumulating duplicate handlers
+// on every nav-back into /.
 if (!window.__ryokanBulkSelectInit) {
     window.__ryokanBulkSelectInit = true;
+
+    // Delegated click handler on the grid. In selecting mode this
+    // intercepts every card click, preventDefaults the parent <a>'s
+    // navigation, and toggles selection. Outside selecting mode it
+    // does nothing — cards navigate as normal.
+    var grid = document.getElementById('library-grid');
+    if (grid) {
+        grid.addEventListener('click', function (ev) {
+            if (!bulkSelectMode) return;
+            var card = ev.target.closest('.series-card');
+            if (!card) return;
+            ev.preventDefault();
+            ev.stopPropagation();
+            var id = parseInt(card.dataset.seriesId, 10);
+            if (!id) return;
+            toggleSeriesSelectById(id);
+        });
+    }
+
+    // Esc: exits the bulk monitor modal first if open; otherwise
+    // exits selecting mode (which clears the selection on the way out).
     document.addEventListener('keydown', function (ev) {
         if (ev.key !== 'Escape') return;
         var modal = document.getElementById('bulk-monitor-modal');
@@ -482,8 +573,8 @@ if (!window.__ryokanBulkSelectInit) {
             modal.style.display = 'none';
             return;
         }
-        if (bulkSelectedIds.size > 0) {
-            clearBulkSelection();
+        if (bulkSelectMode) {
+            exitBulkSelectMode();
         }
     });
 }

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -322,6 +322,12 @@ function enterBulkSelectMode() {
     bulkSelectMode = true;
     var grid = document.getElementById('library-grid');
     if (grid) grid.classList.add('selecting');
+    // Body class lets the mobile-tabbar hide itself via CSS while
+    // the bulk action bar takes its place at the bottom of the
+    // viewport. Desktop CSS doesn't touch the regular mobile-tabbar
+    // (which is already display:none above --bp-phone) so this is a
+    // no-op for desktop; mobile uses it.
+    document.body.classList.add('bulk-selecting');
     var toggle = document.getElementById('bulk-select-toggle');
     if (toggle) {
         toggle.classList.add('active');
@@ -335,6 +341,7 @@ function exitBulkSelectMode() {
     bulkSelectMode = false;
     var grid = document.getElementById('library-grid');
     if (grid) grid.classList.remove('selecting');
+    document.body.classList.remove('bulk-selecting');
     var toggle = document.getElementById('bulk-select-toggle');
     if (toggle) {
         toggle.classList.remove('active');
@@ -442,7 +449,16 @@ function renderBulkToolbar() {
     if (monitorBtn) monitorBtn.disabled = !hasSelection;
     if (deleteBtn) deleteBtn.disabled = !hasSelection;
     if (selectAllBtn) {
-        selectAllBtn.textContent = areAllVisibleSelected() ? 'Deselect all' : 'Select all';
+        // The button now contains an inline SVG icon plus a `.bulk-action-label`
+        // span; don't `textContent =` the whole button (that would wipe the
+        // icon). Update just the label span.
+        var selectAllLabel = selectAllBtn.querySelector('.bulk-action-label');
+        var label = areAllVisibleSelected() ? 'Deselect all' : 'Select all';
+        if (selectAllLabel) {
+            selectAllLabel.textContent = label;
+        } else {
+            selectAllBtn.textContent = label;
+        }
     }
 }
 

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -419,18 +419,6 @@ function toggleSelectAllVisible() {
     renderBulkToolbar();
 }
 
-// Inline chip click handler. Stops propagation + preventDefault so
-// the parent <a>'s navigation doesn't fire even when the document-
-// level delegation hasn't been re-attached (hx-boost re-renders the
-// grid; document-level events survive but inline handlers are
-// replaced with the new DOM, so making the chip own its click
-// guarantees correct behavior regardless of listener state).
-function bulkChipClick(ev, seriesId) {
-    ev.stopPropagation();
-    ev.preventDefault();
-    if (!bulkSelectMode) return;
-    toggleSeriesSelectById(seriesId);
-}
 
 function renderBulkToolbar() {
     var bar = document.getElementById('bulk-action-toolbar');
@@ -478,7 +466,14 @@ function openBulkMonitorModal() {
     var confirmBtn = document.getElementById('bulk-monitor-confirm-btn');
     if (count) count.textContent = String(bulkSelectedIds.size);
     bulkPendingMode = null;
-    if (confirmBtn) confirmBtn.disabled = true;
+    // Reset both `disabled` AND `textContent` because a previous Apply
+    // that succeeded left textContent at "Applying…" and the modal
+    // close didn't reset it. Without this the second open shows the
+    // stale text.
+    if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Apply';
+    }
     document.querySelectorAll('#bulk-monitor-options .monitor-option-btn').forEach(function (btn) {
         btn.classList.remove('active');
         btn.onclick = function () { selectBulkMonitorMode(btn); };
@@ -555,13 +550,22 @@ function confirmBulkMonitor() {
 function renderBulkOutcome(outcome, verb) {
     var ok = (outcome.succeeded || []).length;
     var bad = (outcome.failed || []).length;
-    if (!window.ryokanToast) return;
-    // Close any open bulk modal — different actions trigger from
-    // different modals but the outcome rendering is shared.
+    // Close any open bulk modal FIRST — the early-return below on
+    // missing toast helper would otherwise leave the modal open with
+    // a stuck "Applying…" button. Modal cleanup is independent of
+    // toast availability.
     ['bulk-monitor-modal', 'bulk-delete-modal'].forEach(function (id) {
         var m = document.getElementById(id);
         if (m) m.style.display = 'none';
     });
+    // Defensive: reset the bulk-monitor confirm button so a subsequent
+    // openBulkMonitorModal opens with "Apply", not stale "Applying…".
+    var confirmBtn = document.getElementById('bulk-monitor-confirm-btn');
+    if (confirmBtn) {
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Apply';
+    }
+    if (!window.ryokanToast) return;
 
     if (bad === 0) {
         // All succeeded: toast + exit mode (which clears selection).
@@ -609,22 +613,26 @@ function renderBulkOutcome(outcome, verb) {
 // on every nav-back into /. Delegated click + keydown listeners are
 // attached to `document` rather than the library grid because the
 // grid element gets replaced on hx-boost navigation; document-level
-// listeners survive the swap. Inline `onclick` on the chip itself
-// belt-and-suspenders this for the chip-specific case.
+// listeners survive the swap.
 if (!window.__ryokanBulkSelectInit) {
     window.__ryokanBulkSelectInit = true;
 
-    // Document-level delegated click. In selecting mode, intercepts
-    // every card-body click, preventDefaults the parent <a>'s
-    // navigation, and toggles selection. Outside selecting mode it
-    // returns early. Skips clicks already handled inline by the chip
-    // itself (those have stopPropagation, but defense-in-depth).
+    // Document-level capture-phase click delegation. In selecting
+    // mode, intercepts every click that lands inside a .series-card
+    // (chip OR card body), preventDefaults the parent <a>'s
+    // navigation, and toggles selection.
+    //
+    // Capture phase (third arg `true`) is load-bearing: HTMX's body-
+    // wide hx-boost listener handles clicks in the bubble phase, so
+    // a bubble-phase listener here would race with HTMX. Capture
+    // fires outermost-in (document → body → ... → target), so our
+    // capture listener runs BEFORE any element-level listener,
+    // including HTMX's body-level one. preventDefault + stopPropagation
+    // here means the click never reaches HTMX or the <a>'s default
+    // navigation — the chip click works regardless of what happened
+    // before us.
     document.addEventListener('click', function (ev) {
         if (!bulkSelectMode) return;
-        // Inline chip handler already handled this; don't double-toggle.
-        if (ev.target.classList && ev.target.classList.contains('series-card-select')) {
-            return;
-        }
         var card = ev.target.closest && ev.target.closest('.series-card');
         if (!card) return;
         ev.preventDefault();
@@ -632,7 +640,7 @@ if (!window.__ryokanBulkSelectInit) {
         var id = parseInt(card.dataset.seriesId, 10);
         if (!id) return;
         toggleSeriesSelectById(id);
-    });
+    }, true);
 
     // Esc: exits the bulk delete modal first if open, then bulk
     // monitor modal, then selecting mode (clears selection on the

--- a/templates/base.html
+++ b/templates/base.html
@@ -146,6 +146,21 @@
             <a href="/downloads" class="{% if page == "downloads" %}active{% endif %}">Downloads</a>
             <a href="/settings" class="{% if page == "settings" %}active{% endif %}">Settings</a>
             <a href="/system" class="{% if page == "system" %}active{% endif %}">System</a>
+            {# Bulk-select toggle. Library-only — hidden on every other
+               page since it acts on the library card grid. The button
+               lives here (not in index.html's filter row) so the
+               affordance is in the persistent topbar, matching how
+               Sonarr surfaces "Select Series" as a top-level page-mode
+               toggle rather than an inline filter control. #}
+            {% if page == "library" %}
+            <button type="button" id="bulk-select-toggle" class="nav-action bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
+                <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="9 11 12 14 22 4"/>
+                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+                </svg>
+                <span class="bulk-select-toggle-label">Select</span>
+            </button>
+            {% endif %}
             <a href="/logout" class="nav-logout" hx-boost="false">Logout</a>
         </div>
     </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -142,16 +142,14 @@
         <a href="/" class="nav-brand"><span class="brand-kanji">旅館</span><span class="brand-latin">Ryokan</span></a>
         <div class="nav-links">
             <a href="/" class="{% if page == "library" %}active{% endif %}">Library</a>
-            <a href="/search" class="{% if page == "search" %}active{% endif %}">Search</a>
-            <a href="/downloads" class="{% if page == "downloads" %}active{% endif %}">Downloads</a>
-            <a href="/settings" class="{% if page == "settings" %}active{% endif %}">Settings</a>
-            <a href="/system" class="{% if page == "system" %}active{% endif %}">System</a>
             {# Bulk-select toggle. Library-only — hidden on every other
-               page since it acts on the library card grid. The button
-               lives here (not in index.html's filter row) so the
-               affordance is in the persistent topbar, matching how
-               Sonarr surfaces "Select Series" as a top-level page-mode
-               toggle rather than an inline filter control. #}
+               page since it acts on the library card grid. Lives
+               immediately after the Library link so the affordance
+               sits at the natural read-order start of the nav.
+               Library page only; on every other page the button is not
+               in the DOM at all and toggleBulkSelectMode() (defined
+               in index.js) is undefined since index.js doesn't load
+               either. #}
             {% if page == "library" %}
             <button type="button" id="bulk-select-toggle" class="nav-action bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
                 <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -161,6 +159,10 @@
                 <span class="bulk-select-toggle-label">Select</span>
             </button>
             {% endif %}
+            <a href="/search" class="{% if page == "search" %}active{% endif %}">Search</a>
+            <a href="/downloads" class="{% if page == "downloads" %}active{% endif %}">Downloads</a>
+            <a href="/settings" class="{% if page == "settings" %}active{% endif %}">Settings</a>
+            <a href="/system" class="{% if page == "system" %}active{% endif %}">System</a>
             <a href="/logout" class="nav-logout" hx-boost="false">Logout</a>
         </div>
     </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -164,6 +164,21 @@
             <a href="/settings" class="{% if page == "settings" %}active{% endif %}">Settings</a>
             <a href="/system" class="{% if page == "system" %}active{% endif %}">System</a>
             <a href="/logout" class="nav-logout" hx-boost="false">Logout</a>
+            {# Mobile-only icon-version of Logout. The desktop nav-links
+               group is `display: none` below --bp-phone, but we need a
+               way to log out from mobile (the bottom mobile-tabbar's
+               5 slots don't include Logout). The mobile media query
+               flips .nav-links back on but hides every child except
+               this icon-button — so on mobile the topbar shows the
+               brand + this single logout icon, and on desktop it
+               shows everything else but hides this icon. #}
+            <a href="/logout" class="nav-logout-mobile" hx-boost="false" aria-label="Logout" title="Logout">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+                    <polyline points="16 17 21 12 16 7"/>
+                    <line x1="21" y1="12" x2="9" y2="12"/>
+                </svg>
+            </a>
         </div>
     </nav>
     <main class="content">

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,18 +126,16 @@
     <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}" data-series-id="{{ s.id }}">
         {# Bulk-select checkbox overlay (issue #125). Hidden until the
            library grid enters .selecting mode (see static/js/index.js
-           toggleBulkSelectMode). The inline onclick stops propagation
-           AND default — without preventDefault, the parent <a>'s
-           navigation can still fire because the click bubbled up
-           before our document-level delegation got to preventDefault
-           it on hx-boosted pages where the listener wasn't yet
-           re-attached. Inline-handling here makes chip clicks
-           always-do-the-right-thing regardless of listener state. #}
+           toggleBulkSelectMode). All click handling happens in a
+           document-level capture-phase listener in index.js — running
+           there guarantees we fire before HTMX's body-wide hx-boost
+           listener can react to the click, regardless of whether the
+           click landed on the chip or on the card body. The chip
+           itself is just a styled <input>; no inline onclick needed. #}
         <input type="checkbox"
                class="series-card-select"
                aria-label="Select for bulk action"
-               tabindex="-1"
-               onclick="bulkChipClick(event, {{ s.id }})">
+               tabindex="-1">
         <div class="series-cover">
             {% if !s.cover_url.is_empty() %}
             {# Decorative — the title renders as visible text in

--- a/templates/index.html
+++ b/templates/index.html
@@ -232,7 +232,7 @@
             </button>
         </div>
         <div class="modal-body">
-            <p class="form-hint">Apply the same monitor mode to <span id="bulk-monitor-count">0</span> selected series.</p>
+            <p class="form-hint" style="margin: 0 0 16px;">Apply the same monitor mode to <span id="bulk-monitor-count">0</span> selected series.</p>
             <div class="monitor-options" id="bulk-monitor-options">
                 <button type="button" class="monitor-option-btn" data-mode="all">All episodes</button>
                 <button type="button" class="monitor-option-btn" data-mode="future">Future only</button>

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,7 +87,14 @@
                was removed. Successively trimmed as the row grew —
                first for the always-reserved Clear slot, then for
                the height-matched (and so wider) dropdowns + search. #}
-            <button class="btn btn-primary" style="margin-left: 32px;" onclick="openAddModal()">+ Add Series</button>
+            <button type="button" id="bulk-select-toggle" class="btn btn-secondary btn-pill bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
+                <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline class="bulk-select-toggle-icon-default" points="9 11 12 14 22 4"/>
+                    <path class="bulk-select-toggle-icon-default" d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+                </svg>
+                <span class="bulk-select-toggle-label">Select</span>
+            </button>
+            <button class="btn btn-primary" style="margin-left: 12px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>
@@ -124,14 +131,18 @@
 <div class="library-grid" id="library-grid">
     {% for s in library %}
     <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}" data-series-id="{{ s.id }}">
-        {# Bulk-select checkbox overlay (issue #125). Stops propagation
-           on click so the parent <a> doesn't navigate. State is mirrored
-           to the card via a `selected` class for the highlighted look;
-           the actual selection set lives in JS. #}
+        {# Bulk-select checkbox overlay (issue #125). Hidden until the
+           library grid enters .selecting mode (see static/js/index.js
+           toggleBulkSelectMode). In mode, the entire card body becomes
+           a click target for selection — the .library-grid delegated
+           handler in index.js preventDefaults the parent <a>'s
+           navigation and toggles selection, so we don't need an inline
+           onclick here. The native input stays for keyboard +
+           screen-reader semantics. #}
         <input type="checkbox"
                class="series-card-select"
                aria-label="Select for bulk action"
-               onclick="toggleSeriesSelect(event, {{ s.id }})">
+               tabindex="-1">
         <div class="series-cover">
             {% if !s.cover_url.is_empty() %}
             {# Decorative — the title renders as visible text in
@@ -168,15 +179,20 @@
 </div>
 {% endif %}
 
-{# Bulk action toolbar (issue #125). Hidden until at least one card is
-   checked; toggled via the `.visible` class from JS. Sticks to the
-   bottom of the viewport so it stays in reach while the user scrolls
-   through the grid selecting more cards. #}
+{# Bulk action toolbar (issue #125). Mounted as soon as the user
+   enters bulk-select mode (see toggleBulkSelectMode in index.js).
+   Bottom-stuck so it stays reachable while the user scrolls the
+   grid selecting more cards. The action buttons (currently Set
+   monitor mode) act on the selected set; "Done" exits mode +
+   clears selection. #}
 <div id="bulk-action-toolbar" class="bulk-action-toolbar" aria-live="polite" hidden>
     <div class="bulk-action-toolbar-inner">
         <span class="bulk-action-count"><span id="bulk-action-count-num">0</span> selected</span>
-        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()">Set monitor mode</button>
-        <button type="button" class="btn btn-ghost btn-sm" onclick="clearBulkSelection()">Clear</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="selectAllVisibleSeries()">Select all</button>
+        <span class="bulk-action-divider" aria-hidden="true"></span>
+        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()" id="bulk-action-monitor-btn">Set monitor mode</button>
+        <span class="bulk-action-divider" aria-hidden="true"></span>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="exitBulkSelectMode()">Done</button>
     </div>
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -87,14 +87,7 @@
                was removed. Successively trimmed as the row grew —
                first for the always-reserved Clear slot, then for
                the height-matched (and so wider) dropdowns + search. #}
-            <button type="button" id="bulk-select-toggle" class="btn btn-secondary btn-pill bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
-                <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <polyline class="bulk-select-toggle-icon-default" points="9 11 12 14 22 4"/>
-                    <path class="bulk-select-toggle-icon-default" d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
-                </svg>
-                <span class="bulk-select-toggle-label">Select</span>
-            </button>
-            <button class="btn btn-primary" style="margin-left: 12px;" onclick="openAddModal()">+ Add Series</button>
+            <button class="btn btn-primary" style="margin-left: 32px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>
 </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -126,16 +126,18 @@
     <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}" data-series-id="{{ s.id }}">
         {# Bulk-select checkbox overlay (issue #125). Hidden until the
            library grid enters .selecting mode (see static/js/index.js
-           toggleBulkSelectMode). In mode, the entire card body becomes
-           a click target for selection — the .library-grid delegated
-           handler in index.js preventDefaults the parent <a>'s
-           navigation and toggles selection, so we don't need an inline
-           onclick here. The native input stays for keyboard +
-           screen-reader semantics. #}
+           toggleBulkSelectMode). The inline onclick stops propagation
+           AND default — without preventDefault, the parent <a>'s
+           navigation can still fire because the click bubbled up
+           before our document-level delegation got to preventDefault
+           it on hx-boosted pages where the listener wasn't yet
+           re-attached. Inline-handling here makes chip clicks
+           always-do-the-right-thing regardless of listener state. #}
         <input type="checkbox"
                class="series-card-select"
                aria-label="Select for bulk action"
-               tabindex="-1">
+               tabindex="-1"
+               onclick="bulkChipClick(event, {{ s.id }})">
         <div class="series-cover">
             {% if !s.cover_url.is_empty() %}
             {# Decorative — the title renders as visible text in
@@ -175,17 +177,48 @@
 {# Bulk action toolbar (issue #125). Mounted as soon as the user
    enters bulk-select mode (see toggleBulkSelectMode in index.js).
    Bottom-stuck so it stays reachable while the user scrolls the
-   grid selecting more cards. The action buttons (currently Set
-   monitor mode) act on the selected set; "Done" exits mode +
-   clears selection. #}
+   grid selecting more cards. Layout: count, select-all toggle,
+   action buttons (gated on N > 0), exit. #}
 <div id="bulk-action-toolbar" class="bulk-action-toolbar" aria-live="polite" hidden>
     <div class="bulk-action-toolbar-inner">
         <span class="bulk-action-count"><span id="bulk-action-count-num">0</span> selected</span>
-        <button type="button" class="btn btn-ghost btn-sm" onclick="selectAllVisibleSeries()">Select all</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="toggleSelectAllVisible()" id="bulk-action-select-all-btn">Select all</button>
         <span class="bulk-action-divider" aria-hidden="true"></span>
-        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()" id="bulk-action-monitor-btn">Set monitor mode</button>
+        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()" id="bulk-action-monitor-btn" disabled>Set monitor mode</button>
+        <button type="button" class="btn btn-danger btn-sm" onclick="openBulkDeleteModal()" id="bulk-action-delete-btn" disabled>Delete</button>
         <span class="bulk-action-divider" aria-hidden="true"></span>
         <button type="button" class="btn btn-ghost btn-sm" onclick="exitBulkSelectMode()">Done</button>
+    </div>
+</div>
+
+{# Bulk delete confirmation modal. Distinct from the per-row
+   data-ryokan-confirm-* pattern because we collect a delete-files
+   checkbox alongside the confirmation. Recycle bin (#123) hasn't
+   shipped yet, so file removal is a permanent unlink — confirmation
+   copy emphasises "cannot be undone." #}
+<div class="modal-backdrop" id="bulk-delete-modal" style="display:none" onclick="closeBulkDeleteModal(event)">
+    <div class="modal" onclick="event.stopPropagation()" style="max-width: 520px">
+        <div class="modal-header">
+            <h3>Remove from library</h3>
+            <button type="button" class="btn-icon" onclick="closeBulkDeleteModal(event)" aria-label="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <div class="modal-body">
+            <p style="margin: 0 0 12px;">Remove <strong><span id="bulk-delete-count">0</span> series</strong> from your library.</p>
+            <label class="checkbox-row" style="display:flex; align-items:flex-start; gap:10px; padding:10px 12px; border:1px solid var(--border); border-radius: var(--radius); background: var(--bg-elevated);">
+                <input type="checkbox" id="bulk-delete-files-toggle" style="margin-top: 3px;">
+                <span>
+                    <strong style="display:block; color: var(--text-bright); font-size: 14px;">Also delete files from disk</strong>
+                    <span class="form-hint" style="display:block; margin-top: 2px;">Permanently remove the on-disk media folders and tell every download client to drop the active torrents. <strong style="color: var(--red);">Cannot be undone.</strong></span>
+                </span>
+            </label>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" onclick="closeBulkDeleteModal(event)">Cancel</button>
+            <span class="modal-footer-spacer"></span>
+            <button type="button" id="bulk-delete-confirm-btn" class="btn btn-danger" onclick="confirmBulkDelete()">Remove from library</button>
+        </div>
     </div>
 </div>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -123,7 +123,15 @@
 {% else %}
 <div class="library-grid" id="library-grid">
     {% for s in library %}
-    <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}">
+    <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}" data-series-id="{{ s.id }}">
+        {# Bulk-select checkbox overlay (issue #125). Stops propagation
+           on click so the parent <a> doesn't navigate. State is mirrored
+           to the card via a `selected` class for the highlighted look;
+           the actual selection set lives in JS. #}
+        <input type="checkbox"
+               class="series-card-select"
+               aria-label="Select for bulk action"
+               onclick="toggleSeriesSelect(event, {{ s.id }})">
         <div class="series-cover">
             {% if !s.cover_url.is_empty() %}
             {# Decorative — the title renders as visible text in
@@ -159,6 +167,47 @@
     {% endfor %}
 </div>
 {% endif %}
+
+{# Bulk action toolbar (issue #125). Hidden until at least one card is
+   checked; toggled via the `.visible` class from JS. Sticks to the
+   bottom of the viewport so it stays in reach while the user scrolls
+   through the grid selecting more cards. #}
+<div id="bulk-action-toolbar" class="bulk-action-toolbar" aria-live="polite" hidden>
+    <div class="bulk-action-toolbar-inner">
+        <span class="bulk-action-count"><span id="bulk-action-count-num">0</span> selected</span>
+        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()">Set monitor mode</button>
+        <button type="button" class="btn btn-ghost btn-sm" onclick="clearBulkSelection()">Clear</button>
+    </div>
+</div>
+
+{# Bulk monitor mode picker. Reuses the .modal primitives. Distinct
+   from the per-series #monitor-modal because the bulk flow needs to
+   collect a single mode choice for many series rather than one. #}
+<div class="modal-backdrop" id="bulk-monitor-modal" style="display:none" onclick="closeBulkMonitorModal(event)">
+    <div class="modal" onclick="event.stopPropagation()" style="max-width: 520px">
+        <div class="modal-header">
+            <h3>Set monitor mode</h3>
+            <button type="button" class="btn-icon" onclick="closeBulkMonitorModal(event)" aria-label="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <div class="modal-body">
+            <p class="form-hint">Apply the same monitor mode to <span id="bulk-monitor-count">0</span> selected series.</p>
+            <div class="monitor-options" id="bulk-monitor-options">
+                <button type="button" class="monitor-option-btn" data-mode="all">All episodes</button>
+                <button type="button" class="monitor-option-btn" data-mode="future">Future only</button>
+                <button type="button" class="monitor-option-btn" data-mode="missing">Missing</button>
+                <button type="button" class="monitor-option-btn" data-mode="existing">Existing</button>
+                <button type="button" class="monitor-option-btn" data-mode="none">None</button>
+                <button type="button" class="monitor-option-btn" data-mode="sync">Sync from AL/MAL</button>
+            </div>
+        </div>
+        <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" onclick="closeBulkMonitorModal(event)">Cancel</button>
+            <button type="button" id="bulk-monitor-confirm-btn" class="btn btn-primary" onclick="confirmBulkMonitor()" disabled>Apply</button>
+        </div>
+    </div>
+</div>
 
 <div class="modal-backdrop" id="add-modal" style="display:none" onclick="closeAddModal(event)">
     <div class="modal" onclick="event.stopPropagation()">

--- a/templates/index.html
+++ b/templates/index.html
@@ -123,7 +123,7 @@
 {% else %}
 <div class="library-grid" id="library-grid">
     {% for s in library %}
-    <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}" data-series-id="{{ s.id }}">
+    <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}">
         {# Bulk-select checkbox overlay (issue #125). Hidden until the
            library grid enters .selecting mode (see static/js/index.js
            toggleBulkSelectMode). All click handling happens in a

--- a/templates/index.html
+++ b/templates/index.html
@@ -174,18 +174,40 @@
 
 {# Bulk action toolbar (issue #125). Mounted as soon as the user
    enters bulk-select mode (see toggleBulkSelectMode in index.js).
-   Bottom-stuck so it stays reachable while the user scrolls the
-   grid selecting more cards. Layout: count, select-all toggle,
-   action buttons (gated on N > 0), exit. #}
+   Two layouts share the same markup:
+   - Desktop: pill at the bottom of the viewport (default styling).
+   - Mobile: replaces the bottom mobile-tabbar with tab-shaped slots
+     (icon-on-top, label-below), driven by the @media block in
+     index.css. JS toggles `body.bulk-selecting` so the regular
+     mobile-tabbar can hide itself out of the way.
+   Each button carries an SVG icon — visible always, but on desktop
+   it sits inline next to the label and on mobile it stacks above. #}
 <div id="bulk-action-toolbar" class="bulk-action-toolbar" aria-live="polite" hidden>
     <div class="bulk-action-toolbar-inner">
-        <span class="bulk-action-count"><span id="bulk-action-count-num">0</span> selected</span>
-        <button type="button" class="btn btn-ghost btn-sm" onclick="toggleSelectAllVisible()" id="bulk-action-select-all-btn">Select all</button>
+        <span class="bulk-action-count">
+            <span class="bulk-action-count-icon" aria-hidden="true">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+            </span>
+            <span class="bulk-action-count-text"><span id="bulk-action-count-num">0</span> selected</span>
+        </span>
+        <button type="button" class="bulk-action-btn bulk-action-btn-ghost" onclick="toggleSelectAllVisible()" id="bulk-action-select-all-btn">
+            <svg class="bulk-action-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+            <span class="bulk-action-label">Select all</span>
+        </button>
         <span class="bulk-action-divider" aria-hidden="true"></span>
-        <button type="button" class="btn btn-secondary btn-sm" onclick="openBulkMonitorModal()" id="bulk-action-monitor-btn" disabled>Set monitor mode</button>
-        <button type="button" class="btn btn-danger btn-sm" onclick="openBulkDeleteModal()" id="bulk-action-delete-btn" disabled>Delete</button>
+        <button type="button" class="bulk-action-btn bulk-action-btn-secondary" onclick="openBulkMonitorModal()" id="bulk-action-monitor-btn" disabled>
+            <svg class="bulk-action-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+            <span class="bulk-action-label">Set monitor mode</span>
+        </button>
+        <button type="button" class="bulk-action-btn bulk-action-btn-danger" onclick="openBulkDeleteModal()" id="bulk-action-delete-btn" disabled>
+            <svg class="bulk-action-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/><path d="M9 6V4a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"/></svg>
+            <span class="bulk-action-label">Delete</span>
+        </button>
         <span class="bulk-action-divider" aria-hidden="true"></span>
-        <button type="button" class="btn btn-ghost btn-sm" onclick="exitBulkSelectMode()">Done</button>
+        <button type="button" class="bulk-action-btn bulk-action-btn-ghost" onclick="exitBulkSelectMode()">
+            <svg class="bulk-action-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+            <span class="bulk-action-label">Done</span>
+        </button>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary

- **Bulk library operations** (closes #125): Select toggle on the library page enters multi-select mode; cards gain a checkbox chip and a bottom toolbar surfaces Select all / Set monitor mode / Delete / Done. Per-series failure isolation via a \`BulkOutcome\` envelope so one bad series doesn't sink the rest. Phase 1 ships bulk monitor + bulk delete; bulk re-search and bulk finished-mode are tracked for a follow-up.
- **Classifier fix**: Solo Leveling BD-AAC misclassification — filename BD keyword now suppresses AAC-Web evidence pre-aggregation; Discord webhook confidence stuck at 0% due to f32 truncation, now reports rounded percent.
- **Mobile UX**: Logout icon in topbar (no path to log out before this), library header stacks vertically below 640px so +Add Series isn't orphaned, and the bulk action bar replaces the bottom mobile-tabbar during selection rather than stacking on top of it.

## Test plan

- [x] \`cargo nextest run --workspace --features test-support\` green
- [x] \`cargo clippy --workspace --all-targets --features test-support -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean
- [x] Manual: library Select toggle, check chip on cards, bulk monitor + bulk delete confirms work; failures show per-series breakdown
- [x] Manual mobile: bulk toolbar slides in flush at the bottom (no double-stacked tabbar); logout icon visible in topbar; library header stacks vertically
- [x] Manual: Discord webhook confidence reads as a percent, not 0

\U0001F916 Generated with [Claude Code](https://claude.com/claude-code)