### PR TITLE
feat: calendar epic — in-app page + iCal subscription feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ Axum 0.8 + Tokio · SQLite via sqlx 0.8 (`default-features = false` + `runtime-t
 
 ## Code Layout (`src/`)
 
-- **`handlers/`** — Axum route handlers. Page/feature modules: `library`, `search`, `downloads`, `settings`, `system`, `auth`, `media`, `help`, `progress`, `grab` (interactive file-picker — `/api/grab/{preview,confirm,heartbeat,cancel}`), `oauth` (AL+MAL link/submit/unlink/sync-now under `/settings/oauth/*`), `webhook/` (autobrr push at `/api/webhook/autobrr`), plus `sonarr_compat` / `radarr_compat` (the anibridge shims), `arr_auth` (shared API-key middleware), `arr_shared` (DTOs shared between shim sides). Auth deep dive: **`src/handlers/auth/CLAUDE.md`**.
+- **`handlers/`** — Axum route handlers. Page/feature modules: `library`, `search`, `downloads`, `settings`, `system`, `auth`, `media`, `help`, `progress`, `grab` (interactive file-picker — `/api/grab/{preview,confirm,heartbeat,cancel}`), `oauth` (AL+MAL link/submit/unlink/sync-now under `/settings/oauth/*`), `webhook/` (autobrr push at `/api/webhook/autobrr`), `calendar` (issues #115 + #116 — in-app `/calendar` page + iCal feed at `/api/calendar.ics`), `api_keys` (issue #114 scoped API keys CRUD), `scoped_auth` (`require_calendar_scope` and friends), `notifications` (issue #118 test-provider endpoint), plus `sonarr_compat` / `radarr_compat` (the anibridge shims), `arr_auth` (shared API-key middleware), `arr_shared` (DTOs shared between shim sides). Auth deep dive: **`src/handlers/auth/CLAUDE.md`**.
 - **`services/`** — Business logic + external API clients.
   - Metadata chain: `anilist/` → `jikan` → `kitsu`, plus `mal` (OAuth-authenticated, distinct from `jikan` which is the public-fallback path).
   - `download_client/` — trait + **5 client impls** (qBit / Deluge / Transmission / rtorrent / **sabnzbd**) + `DownloadClientPool` for multi-client routing. Wire quirks + pool: **`src/services/download_client/CLAUDE.md`**.
@@ -86,9 +86,11 @@ Axum 0.8 + Tokio · SQLite via sqlx 0.8 (`default-features = false` + `runtime-t
   - `crypto.rs` — AEAD wrapper for OAuth tokens. `oauth_state.rs` (PKCE verifier store), `user_score.rs`.
   - `nyaa/`, `seadex.rs`, `rss/`, `anibridge.rs`, `interactive_search_cache.rs`, `indexer_catalog.rs` (provisioning), `task_registry.rs` (in-memory supervised-task lifecycle).
   - `post_processing/` — moves/renames completed downloads (hardlink/copy/move). `nfo.rs`, `artwork.rs`, `media.rs`, `jellyfin.rs`.
-  - `monitoring.rs`, `progress.rs`, `library_link.rs`, `grab_commit.rs`, `grab_sweep.rs`, `metadata_sync.rs`, `html.rs`, `sanitize.rs`, `logger.rs`.
+  - `calendar.rs` (calendar reader — joins `episode_airings ⨝ series`), `airing_refresh.rs` (12h supervised stamper that walks AL `Page.airingSchedules` and writes `episode_airings`).
+  - `notifications/` — outbound providers (`webhook.rs`, `discord.rs`), `event.rs` event taxonomy, `store.rs` cache.
+  - `monitoring.rs`, `progress.rs`, `library_link.rs`, `grab_commit.rs`, `grab_sweep.rs`, `metadata_sync.rs`, `html.rs`, `sanitize.rs`, `logger.rs`, `relative_time.rs`.
   - AL deep dive: **`src/services/anilist/CLAUDE.md`**.
-- **`models/`** — DB access + schema. `migrations/` owns most `CREATE TABLE` / `ALTER TABLE`. A few tables own their `CREATE TABLE` next to their model module (`custom_formats`, `group_source_map` + `schema_migrations`, `media_probe_cache`, `nyaa_description_cache`). Notable additions beyond the obvious: `download_clients` (one row per configured client, keyed by id; `is_default` rows are scoped per-protocol — torrent vs usenet — both can coexist), `indexers` (torznab/newznab rows with caps cache + per-indexer `download_client_id` pin), `direct_rss_feeds` (per-feed configuration for direct sources like SubsPlease).
+- **`models/`** — DB access + schema. `migrations/` owns most `CREATE TABLE` / `ALTER TABLE`. A few tables own their `CREATE TABLE` next to their model module (`custom_formats`, `group_source_map` + `schema_migrations`, `media_probe_cache`, `nyaa_description_cache`). Notable additions beyond the obvious: `download_clients` (one row per configured client, keyed by id; `is_default` rows are scoped per-protocol — torrent vs usenet — both can coexist), `indexers` (torznab/newznab rows with caps cache + per-indexer `download_client_id` pin), `direct_rss_feeds` (per-feed configuration for direct sources like SubsPlease), `episode_airings` (#115/#116 — local cache of AL airing schedules; FK on `series_id` is `ON DELETE CASCADE`, range-scan index on `airing_at`; the calendar reader joins this against `series` instead of round-tripping to AL per-request).
 - **`templates/`** — Askama templates. HTMX patterns + per-page JS lifecycle: **`templates/CLAUDE.md`**.
 - **`static/`** — Modular CSS (`base.css`, `topbar.css`, `forms.css`, `badges.css`, `modals.css` loaded everywhere + per-page `pages/<name>.css`) and per-page `static/js/*.js`. No bundler. Non-CSS/JS assets: `static/default_custom_formats.json` (embedded via `include_str!` at compile time), `static/fonts/` (Murecho woff2 subsets — Latin + Japanese, weights 500-800), `static/licenses/` (third-party LICENSE texts surfaced in System → About), `static/vendor/` (HTMX bundles).
 - **`tests/`** — Integration tests (binary crates importing `ryokan` as a lib). Browser-e2e harness for HTMX UI assertions. **`tests/CLAUDE.md`**.
@@ -109,6 +111,8 @@ Defined in `src/lib.rs`. Fields:
 - `oauth_state: OAuthStateStore` — in-memory store for pending MAL OAuth attempts (PKCE verifier between `/start` and `/submit`). 10-minute TTL. AL has no entry — implicit grant, no per-attempt server state.
 - `start_time: chrono::DateTime<Utc>` — wall-clock timestamp captured at boot. Used by Sonarr/Radarr `system_status` so Seerr's UI pill reports actual liveness; the prior hardcoded `2024-01-01T00:00:00Z` claimed the indexer had been up over a year regardless of when Ryokan restarted.
 - `tasks: TaskRegistry = Arc<RwLock<HashMap<&'static str, Arc<TaskState>>>>` — supervised-task lifecycle metadata. Each `supervise()` loop registers itself once at startup, mutates atomics on its `Arc<TaskState>` on every iteration (no further locking until a snapshot read). Distinct from the DB-backed `scheduled_task_runs` table — `tasks` is the in-memory live status view (running / backoff, restart count, last exit kind, current backoff) served at `/api/system/tasks` for the System page.
+- `dc_status_cache: DcStatusCache = Arc<Mutex<HashMap<i64, (Instant, DcStatusEntry)>>>` — per-download-client probe-result cache, **10-min TTL** (`DC_STATUS_CACHE_TTL`). Without it, every page load and every hx-boost re-entry into Settings → Download Clients re-runs the network probe (50-500ms healthy / up to 5s unreachable) and the "Probing…" pills flash to real status at staggered times. Wiped per-id on every `download_clients` row CRUD so a credential edit re-probes immediately rather than masking failures for the full TTL.
+- `notification_providers: NotificationProviders` — issue #118 swap-on-write cache for outbound notification providers (webhook / Discord). Same `Arc<RwLock<Arc<Vec<_>>>>` shape as `custom_formats` / `indexers` — read lock releases before the per-provider fan-out begins. `services::notifications::dispatch` early-returns on empty so every hook point is a no-op until at least one provider is configured.
 
 ## Download-client routing (multi-client pool)
 
@@ -131,11 +135,12 @@ Defined in `src/lib.rs`. Fields:
 
 ## Background tasks
 
-Each runs as a `tokio::spawn` loop in `main.rs` wrapped in `supervise()`. The supervised list (10 tasks: `progress_sweep`, `rss_sync`, `post_processing`, `grab_sweep`, `external_sync`, `cleanup`, `library_classify`, `metadata_refresh`, `upgrade_search`, `anibridge_refresh`) and intervals are inline in `main.rs` — grep `supervise(&` for the canonical names. Non-obvious bits the code doesn't explain on its own:
+Each runs as a `tokio::spawn` loop in `main.rs` wrapped in `supervise()`. The supervised list (11 tasks: `progress_sweep`, `rss_sync`, `post_processing`, `grab_sweep`, `external_sync`, `cleanup`, `library_classify`, `metadata_refresh`, `upgrade_search`, `anibridge_refresh`, `airing_refresh`) and intervals are inline in `main.rs` — grep `supervise(&` for the canonical names. Non-obvious bits the code doesn't explain on its own:
 
 - **Restart policy is exponential backoff**, not flat 5s: `MIN_BACKOFF = 5s`, `MAX_BACKOFF = 30 min`, `HEALTHY_RUNTIME = 60s`. Healthy ≥60s run resets to 5s; <60s exit doubles up to 30 min.
 - **Two layers of status tracking** — `scheduled_task_runs` DB table is the historical record (System page per-task history pane); `AppState.tasks: TaskRegistry` is the in-memory live status served at `/api/system/tasks` (lock-free atomics, snapshot-on-read).
 - **`external_sync` quirks**: 1-min outer tick re-reads `config.external_sync_interval_minutes` (Settings change takes effect within 60s); `consecutive_errors`-driven exponential skip (2^errors intervals, capped at 5 → 32× multiplier, with 24h ceiling so a 7-day cadence can't get pushed seven months by five errors); `has_linked_account` early-out so no `scheduled_task_runs` row burns when no account is linked.
+- **`airing_refresh` shape (#115/#116)**: 12h supervised tick + manual trigger at `POST /api/tasks/airing-refresh`; both share `services::airing_refresh::AIRING_REFRESH_LOCK` (`tokio::sync::Mutex<()>`) so a manual click during the scheduled tick returns "already running" rather than queuing. Library add path also calls `refresh_for_series` inline (fire-and-forget) so freshly-added series show up in the calendar without waiting for the next 12h tick. Past-window prune retains 14 days. Mirrors Sonarr's `Episode.AirDateUtc` shape — stamp once, serve from DB on the calendar's hot path; the calendar reader has no in-process cache because the indexed range-scan is cheap enough on its own.
 
 ## Cross-cutting conventions
 
@@ -179,6 +184,7 @@ Static `LazyLock`s crossing request boundaries — inventory:
 - `services::rss::RSS_SYNC_LOCK` — `try_lock` + readable error so manual run during a tick doesn't queue.
 - `services::external_sync::EXTERNAL_SYNC_LOCK` — same shape; Sync-now click during the supervised loop returns "already running."
 - `services::upgrade::UPGRADE_LOCK` — same `try_lock` shape; manual upgrade-search button returns "already running" rather than queuing during the supervised tick.
+- `services::airing_refresh::AIRING_REFRESH_LOCK` — same `try_lock` shape (#115/#116); the 12h supervised tick and the `POST /api/tasks/airing-refresh` manual trigger share this lock so a click during the scheduled tick returns "already running" rather than double-stamping the AL budget.
 - `services::nyaa::NYAA_CONCURRENCY` (`Semaphore`) — bounds Nyaa fan-out concurrency so a wide auto-search target list can't burst-attack the scraper.
 - `services::crypto::ENCRYPTION_KEY` — the AEAD key. Crashing at LazyLock force is intentional.
 - `handlers::settings::CONFIG_WRITE_LOCK` (`tokio::sync::Mutex<()>`) — serializes handler-level read-modify-write of `Config`. Multi-process deployment (which Ryokan doesn't support) would need DB-level locking instead.
@@ -195,12 +201,13 @@ Static `LazyLock`s crossing request boundaries — inventory:
 
 ## Routes
 
-Five route groups in `main.rs`, each with a different auth layer — pick the right group when adding a new route:
+Six route groups in `main.rs`, each with a different auth layer — pick the right group when adding a new route:
 
 - **`public_routes`** — unauthenticated; wrapped in `csrf_public` so POSTs still enforce Origin/Referer (`/login`, `/setup`, `/forgot-password`).
 - **`protected_routes`** — behind `require_auth` cookie middleware. Default for all UI routes and web-UI-facing API endpoints.
 - **`sonarr_routes`** and **`radarr_routes`** — merged *outside* the cookie-auth layer; use `arr_auth::check_api_key` instead. Two separate routers because Seerr only allows two Sonarr + two Radarr indexer slots and both shims must coexist on one host/port.
 - **`webhook_routes`** — outside cookie-auth; each receiver carries its own API-key middleware.
+- **`calendar_routes`** — outside cookie-auth; carries `require_calendar_scope` (scoped-API-key middleware from #114) so iCal subscribers (Apple Calendar / Google Calendar / Thunderbird, which can't carry cookies) can reach `/api/calendar.ics`. Same scoped-key shape as the future `search`-scoped surfaces planned on top of #114.
 
 There is no `/healthz`. **The Docker healthcheck deliberately probes `/login`** (200 with no auth, no config dependency, no side effects) rather than the auth-gated `/api/health`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2835,7 +2835,7 @@ dependencies = [
 
 [[package]]
 name = "ryokan"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "ammonia",
  "anitomy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ryokan"
-version = "1.7.1"
+version = "1.8.0"
 edition = "2024"
 authors = ["John K"]
 license = "GPL-3.0-or-later"

--- a/docs/calendar.md
+++ b/docs/calendar.md
@@ -1,0 +1,56 @@
+# Calendar
+
+Ryokan's calendar shows what's airing for the shows in your library. It lives at `/calendar` from the top nav, between Library and Search. There's also a subscription feed if you'd rather see new episodes inside Apple Calendar, Google Calendar, or Thunderbird alongside the rest of your week.
+
+## Views
+
+Three quick toggles at the top of the page:
+
+- **This week**: list view. Each day is a sticky header with the episodes airing that day stacked beneath. Today gets a colored stripe so your eye lands there.
+- **Next week**: same shape, but the next seven days.
+- **This month**: calendar grid view. Sun-to-Sat rows for the current month; each cell holds the episodes for that day.
+
+## What you'll see on each episode
+
+- The series cover thumbnail and title.
+- The episode number (E01, E02, ...). Each anime "season" in Ryokan is its own series with its own E1, E2 numbering, so an episode of *Re:Zero 4th Season* shows as E01 of that series, not S04E01 of the franchise.
+- A **Premiere** badge (in the list) or a small **★** (in the grid) on E01 of any series, so you can spot where a new cour starts.
+- Whether the series is **Monitored**. This is the same flag the rest of Ryokan uses to decide whether to grab episodes for it.
+
+Click an episode to jump to its series page.
+
+## Filtering
+
+- **Search**: type into the box to filter the list down. The search matches across all the title variants Ryokan knows about (romaji, English, native), so "attack on titan" finds *Shingeki no Kyojin* even if your title language is set to romaji.
+- **Monitored only**: hide series Ryokan isn't tracking. Useful when your library has both actively-monitored shows and stuff you've added but turned monitoring off for.
+
+## Subscribing from your calendar app
+
+Click the **iCal Link** button in the page header. The modal:
+
+1. Asks you to pick an API key with the `calendar` scope (create one on **Settings → API Keys** if you don't have one yet).
+2. Builds the full subscription URL. The key is part of the URL, so treat it like a password.
+3. Has a Copy button to put the URL on your clipboard.
+
+Then in your calendar app:
+
+- **Apple Calendar**: File → New Calendar Subscription, paste the URL.
+- **Google Calendar**: Other calendars → + → From URL, paste the URL.
+- **Thunderbird**: New Calendar → On the Network → iCalendar (ICS), paste the URL.
+
+The feed defaults to the next 30 days. If you want a wider or narrower window, append `?days=N` to the URL (capped at 90). Append `?monitored=true` to only see monitored series.
+
+## How fresh is the data?
+
+Air times come from AniList. Ryokan refreshes them every 12 hours and stores its own copy, so the calendar page doesn't have to call AniList every time you load it. Two things to know:
+
+- A newly-added series shows up within seconds. Ryokan grabs its air times right after you add it, not on the next 12-hour refresh.
+- If AniList updates an episode's air time, you'll see the change within 12 hours. If you want it sooner, go to **System → Tasks → airing_refresh** and click Run now.
+
+## Series Ryokan adds via MAL
+
+A few series in your library may have come from MAL instead of AniList. These are usually older or obscure titles that AniList doesn't have a record for. Those won't show up on the calendar, because the calendar's air-time data only comes from AniList. Most shows are on AniList and won't be affected.
+
+---
+
+*Last updated: 2026-05-09.*

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ Changes apply on save; no restart needed.
 Third-party services Ryokan talks to.
 
 - **AniList / MyAnimeList accounts**: OAuth-linked for watch-list sync. When linked, anime you mark "watching" (or "planning", "completed", etc.) on AniList or MAL get auto-added to your Ryokan library on the next sync tick. Setup walkthrough: [External accounts](external-accounts.md).
-- **Sync interval (minutes)**: how often the watch-list sync runs. Default 30 minutes; minimum 15, maximum 10080 (7 days). Values below 15 round up automatically on save.
+- **Sync interval (minutes)**: how often the watch-list sync runs. Default 30 minutes; minimum 15, maximum 10080 (7 days). The form won't let you type anything below 15. If a value somehow ends up outside that range, it falls back to 30.
 - **Jellyfin**: server URL and API key. Lets Ryokan trigger a Jellyfin library refresh after each import and validate that imported files actually landed on disk. URL is `http://jellyfin:8096` when Ryokan and Jellyfin share a Docker compose; if they're on different hosts or in separate composes, use your host's LAN IP and the host-mapped port.
 - **Sonarr / Radarr API shim (anibridge)**: exposes a Sonarr-compatible and Radarr-compatible API so request frontends like Seerr can ask Ryokan for anime the same way they'd ask Sonarr for TV. The Sonarr side lives at `/api/v3/...`, the Radarr side at `/radarr/api/v3/...`. Each has its own API key.
 - **autobrr webhook**: accepts inbound webhooks at `/api/webhook/autobrr`. [autobrr](https://autobrr.com) is a separate self-hosted tool that watches IRC announce channels for new releases and pushes matches as HTTP webhooks; this is the receiving side. The webhook has its own API key with a dedicated regenerate button, so an accidental tab POST can't silently rotate or wipe it.
@@ -55,6 +55,13 @@ A per-group reputation map. Tells the classifier things like "VCB-Studio always 
 
 The mapping auto-populates as Ryokan observes grabs (it learns from the filenames a group tends to use); manual overrides take precedence.
 
+## API Keys
+
+Issue API keys for outside tools that need to talk to Ryokan. Each key gets a name, a list of permissions ("scopes") that decide what the key can do, and shows you the key text once when you create it. Save it then; if you lose it, regenerate.
+
+- **calendar**: lets the key read the iCal subscription feed. Calendar apps (Apple Calendar, Google Calendar, Thunderbird) can't log in like a browser, so the subscription URL carries the key in the URL itself. The [Calendar](calendar.md) page has a button that builds the full URL for you.
+- **admin**: covers everything. Use it sparingly; prefer narrower scopes when one fits.
+
 ## General
 
 Day-to-day knobs.
@@ -76,4 +83,4 @@ A few runtime toggles live on the **System** page rather than under Settings, in
 
 ---
 
-*Last updated: 2026-05-07.*
+*Last updated: 2026-05-09.*

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -33,6 +33,7 @@ Yes. Ryokan exposes a Swagger UI at `/api-docs` and the OpenAPI JSON at `/api-do
 
 - **Cookie auth** for the web-UI-facing endpoints (whatever the browser uses; you log in with username + password).
 - **API-key auth** for the Sonarr / Radarr-compatible shim that Seerr and friends call (`X-Api-Key` header or `?apikey=` query string, configured in **Settings → Connections**).
+- **Per-tool API keys** for narrower jobs. Right now the calendar subscription feed at `/api/calendar.ics` is the main one. Create a key with the `calendar` permission on **Settings → API Keys** and the [Calendar](calendar.md) page builds the subscription URL for you.
 
 ## How do I back up?
 
@@ -44,4 +45,4 @@ If you're using the [quick start's](quick-start.md) `/srv/docker/ryokan` bind-mo
 
 ---
 
-*Last updated: 2026-05-07.*
+*Last updated: 2026-05-09.*

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ If you've used Sonarr for TV, the shape is the same. Ryokan is just the anime-tu
 - **Search multiple sources at once.** Built-in [Nyaa](https://nyaa.si) search, torznab and newznab indexers via Prowlarr or Jackett, direct RSS feeds, and autobrr webhooks all merge into one ranked result list.
 - **Pick the best release automatically.** A quality profile, [TRaSH-Guides](https://trash-guides.info)-compatible Custom Formats (the same scoring rules Sonarr uses), and optional [SeaDex](https://releases.moe) picks (a community-curated list of best anime releases) decide what gets grabbed.
 - **Re-grab when something better lands.** Set a quality cutoff once; Ryokan watches for upgrades and replaces older grabs as higher-scoring releases show up.
+- **See what's airing this week.** A built-in [Calendar](calendar.md) shows upcoming episodes for the shows in your library, as a list or a month grid. You can also subscribe to it from your phone or laptop's calendar app.
 - **Use the download client you already have.** qBittorrent, Deluge, Transmission, rTorrent, or SABnzbd. Run more than one at once and Ryokan routes per-grab.
 - **Land files in your library automatically.** Hardlink (default; keeps the torrent seeding), copy, or move.
 - **Plug into Seerr.** Ryokan exposes a Sonarr/Radarr-compatible API so Seerr requests anime the same way it asks Sonarr for TV.
@@ -39,4 +40,4 @@ If you'd rather build the stack yourself, work through these in order:
 
 ---
 
-*Last updated: 2026-05-07.*
+*Last updated: 2026-05-09.*

--- a/docs/system.md
+++ b/docs/system.md
@@ -29,7 +29,7 @@ The RSS poll cadence is set in **Settings → General → RSS Sync Interval**. M
 
 ## Scheduled Tasks
 
-Status of Ryokan's background tasks: external_sync (watch-list sync), post_processing (move imported files into the library), grab_sweep (reconcile pending grabs against the download client's state), upgrade_search (look for better releases of already-grabbed episodes), library_classify, metadata_refresh, and a handful more.
+Status of Ryokan's background tasks: external_sync (watch-list sync), post_processing (move imported files into the library), grab_sweep (reconcile pending grabs against the download client's state), upgrade_search (look for better releases of already-grabbed episodes), library_classify, metadata_refresh, airing_refresh (refreshes the air times that show up on the [Calendar](calendar.md)), and a handful more.
 
 Each row shows last-run time, status (ok / warn / error / running), restart count if the task crashed and got restarted, and current backoff if it's in a failure cycle.
 

--- a/licenses/THIRD_PARTY_LICENSES.html
+++ b/licenses/THIRD_PARTY_LICENSES.html
@@ -8798,7 +8798,7 @@ insights.
                 <h3 id="GPL-3.0-or-later">GNU General Public License v3.0 or later</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/ryokan ">ryokan 1.7.1</a></li>
+                    <li><a href=" https://crates.io/crates/ryokan ">ryokan 1.8.0</a></li>
                 </ul>
                 <pre class="license-text">                    GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,6 +73,7 @@ nav:
   - Guides:
     - Configuration: configuration.md
     - Configuration (cont.): system.md
+    - Calendar: calendar.md
     - Download clients: download-clients.md
     - External accounts: external-accounts.md
   - Troubleshooting: troubleshooting.md

--- a/src/handlers/auth/mod.rs
+++ b/src/handlers/auth/mod.rs
@@ -121,7 +121,7 @@ pub(crate) fn login_clear(key: &str) {
 /// default would let an attacker spoof a fresh IP per attempt and defeat
 /// the per-IP login throttle. Flip this on only when Ryokan is behind a
 /// proxy that overwrites the headers on ingress.
-static TRUST_PROXY_HEADERS: LazyLock<bool> = LazyLock::new(|| {
+pub(crate) static TRUST_PROXY_HEADERS: LazyLock<bool> = LazyLock::new(|| {
     std::env::var("RYOKAN_TRUSTED_PROXY")
         .map(|v| {
             let v = v.trim().to_ascii_lowercase();

--- a/src/handlers/calendar.rs
+++ b/src/handlers/calendar.rs
@@ -18,9 +18,13 @@
 //! "RFC-5545 compatible enough for Google + Apple + Thunderbird").
 //!
 //! Per VEVENT:
-//! - `SUMMARY`: `<series_title> S01E<episode>` (anime convention =
-//!   always Season 1; matches `services/post_processing/mod.rs`'s
-//!   on-disk naming shape).
+//! - `SUMMARY`: `<series_title> · E<episode>`. Each anime "season"
+//!   in Ryokan is its own series with its own E1..EN numbering, so
+//!   a hardcoded `S01` would read as wrong when the title already
+//!   names the season ("Re:Zero ... 4th Season S01E07"). The
+//!   on-disk naming in `services/post_processing` keeps S01E for
+//!   Sonarr/Plex compat; the user-facing calendar entry doesn't
+//!   need that constraint.
 //! - `DTSTART` / `DTEND`: from `airing_at` + `duration_minutes`.
 //! - `UID`: `ryokan-<series_id>-<episode>@ryokan.local` — stable
 //!   across feed fetches so calendar clients dedupe.
@@ -44,7 +48,8 @@ use axum::{
     http::{HeaderMap, HeaderName, StatusCode, header},
     response::{Html, IntoResponse, Response},
 };
-use axum_htmx::HxRequest;
+use axum_htmx::{HxBoosted, HxRequest};
+use chrono::{Datelike, TimeZone};
 use serde::{Deserialize, Serialize};
 
 use crate::AppState;
@@ -54,14 +59,55 @@ use crate::services::calendar::{self, DEFAULT_FORWARD_DAYS, UpcomingEpisode};
 const NOW_PLUS_7_DAYS_THRESHOLD: i64 = 7 * 86400;
 
 /// "Next week" needs an offset start (skip the first 7 days). All
-/// other ranges start from now. Returns `(from_offset_days,
-/// length_days)`.
+/// other week-shaped ranges start from now. Returns
+/// `(from_offset_days, length_days)`.
+///
+/// `month` is *not* served by this function — it's a calendar-month
+/// grid view, not a sliding-window list, so the handler computes
+/// its own from/to from the calendar month containing "now."
 fn range_to_window(range: &str) -> (i64, i64) {
     match range {
         "next_week" | "next-week" => (7, 7),
-        "month" => (0, 30),
         _ => (0, 7),
     }
+}
+
+/// Compute the from/to window for the month-grid view: the calendar
+/// weeks (Sun-start) covering the month containing `now_utc`. The
+/// grid extends to the Sunday on or before the 1st and the Saturday
+/// on or after the last day of the month, so a 4-week or 6-week
+/// grid is always a clean rectangle.
+fn month_grid_window(now_utc: chrono::DateTime<chrono::Utc>) -> (i64, i64) {
+    let first_of_month = chrono::Utc
+        .with_ymd_and_hms(now_utc.year(), now_utc.month(), 1, 0, 0, 0)
+        .single()
+        .expect("first-of-month is always valid");
+    let next_month_first = if now_utc.month() == 12 {
+        chrono::Utc
+            .with_ymd_and_hms(now_utc.year() + 1, 1, 1, 0, 0, 0)
+            .single()
+            .expect("next-january is always valid")
+    } else {
+        chrono::Utc
+            .with_ymd_and_hms(now_utc.year(), now_utc.month() + 1, 1, 0, 0, 0)
+            .single()
+            .expect("next-month-first is always valid")
+    };
+    let last_of_month = next_month_first - chrono::Duration::days(1);
+    let grid_start = sunday_on_or_before(first_of_month);
+    // Grid end is exclusive — Saturday on/after last day, then +1.
+    let grid_end_exclusive = saturday_on_or_after(last_of_month) + chrono::Duration::days(1);
+    (grid_start.timestamp(), grid_end_exclusive.timestamp())
+}
+
+fn sunday_on_or_before(d: chrono::DateTime<chrono::Utc>) -> chrono::DateTime<chrono::Utc> {
+    let offset = d.weekday().num_days_from_sunday() as i64;
+    d - chrono::Duration::days(offset)
+}
+
+fn saturday_on_or_after(d: chrono::DateTime<chrono::Utc>) -> chrono::DateTime<chrono::Utc> {
+    let offset = 6_i64 - d.weekday().num_days_from_sunday() as i64;
+    d + chrono::Duration::days(offset)
 }
 
 #[derive(Debug, Deserialize)]
@@ -83,12 +129,15 @@ struct CalendarPageTemplate {
     /// Active range token — drives the toggle's selected state.
     range: String,
     monitored_only: bool,
-    /// Pre-grouped day buckets — the template iterates these
-    /// directly. HTMX swaps render the same `partials/calendar/
-    /// list.html` partial against this same shape, so the
-    /// initial paint and the swap paint produce identical
-    /// markup.
+    /// `"list"` for week-shaped ranges, `"grid"` for month. Drives
+    /// the body partial selection in the template.
+    view_mode: String,
+    /// Pre-grouped day buckets for the list view. Empty when
+    /// `view_mode == "grid"`.
     day_buckets: Vec<DayBucket>,
+    /// Pre-built calendar-month grid for the grid view. Empty
+    /// (`weeks: vec![]`) when `view_mode == "list"`.
+    month_grid: MonthGrid,
     /// Calendar-scoped API keys for the Subscribe section. Filtered
     /// to enabled keys with the `calendar` or `admin` scope so
     /// users only see ones that'd actually authorize the feed.
@@ -140,19 +189,56 @@ struct CalendarKeyOption {
     name: String,
 }
 
+/// One cell in the month-grid view. Cells outside the current
+/// calendar month are still rendered (faded) so each row is a
+/// complete Sun→Sat week.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MonthCell {
+    /// UTC midnight Unix timestamp for this cell's day. Lets the
+    /// JS today-highlighter match against the same key list-view
+    /// uses.
+    pub day_key: i64,
+    /// Day-of-month number (1-31). Just the day, e.g. `12`.
+    pub day_number: u32,
+    /// `true` when this cell is "now"'s UTC date — drives the
+    /// today accent in CSS so first paint doesn't flash.
+    pub is_today: bool,
+    /// `true` when this cell falls inside the visible calendar
+    /// month. Cells outside (the leading/trailing week padding)
+    /// render faded.
+    pub is_in_current_month: bool,
+    /// Episodes airing on this day, in airing-time order.
+    pub episodes: Vec<EpisodeView>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct MonthGrid {
+    /// Render-ready label, e.g. `"May 2026"`.
+    pub month_label: String,
+    /// 4–6 weeks, each a Sun→Sat row of 7 cells.
+    pub weeks: Vec<Vec<MonthCell>>,
+}
+
 /// `GET /calendar` — the in-app calendar page. Cookie-auth gated
 /// (sits inside the `protected_routes` group).
 ///
-/// Branches on `HxRequest`:
-/// - `HX-Request: true` → renders just the `partials/calendar/list.html`
-///   partial. Used by the range-tab swap path so changing the range
-///   only replaces `#calendar-list` instead of the whole body.
-/// - Plain GET → renders the full page. Used on direct URL hits,
-///   browser back/forward to the page, and the no-JS fallback for
-///   the range tabs.
+/// Render branching:
+/// - `HX-Request: true` *and not* `HX-Boosted: true` → renders just
+///   the `partials/calendar/list.html` partial. This matches the
+///   range-tab swap path (explicit `hx-get` against `#calendar-list`)
+///   so changing the range only replaces the list region.
+/// - Boosted nav (clicking the topbar Calendar link sends
+///   `HX-Request` *and* `HX-Boosted`) or plain GET → full page.
+///   Used on direct URL hits, browser back/forward, and the no-JS
+///   fallback for the range tabs.
+///
+/// The boost-vs-swap discriminator is load-bearing: returning the
+/// partial on a boosted nav strips the page chrome (header, range
+/// tabs, modal) and leaves the user staring at a bare list.
 pub async fn page(
     State(state): State<AppState>,
     HxRequest(is_htmx): HxRequest,
+    HxBoosted(is_boosted): HxBoosted,
     Query(params): Query<CalendarPageQuery>,
 ) -> Html<String> {
     let cfg = config::get_config(&state.db)
@@ -163,10 +249,20 @@ pub async fn page(
     let range = params.range.unwrap_or_else(|| "this_week".to_string());
     let monitored_only = params.monitored.unwrap_or(false);
 
-    let (offset_days, length_days) = range_to_window(&range);
-    let now = chrono::Utc::now().timestamp();
-    let from = now + offset_days * 86400;
-    let to = from + length_days * 86400;
+    let now_utc = chrono::Utc::now();
+    let now = now_utc.timestamp();
+    let view_mode = if range == "month" { "grid" } else { "list" };
+
+    // Window selection: list ranges slide N days from now;
+    // grid uses the calendar weeks containing the current
+    // month so the rendered grid is always a clean rectangle.
+    let (from, to) = if view_mode == "grid" {
+        month_grid_window(now_utc)
+    } else {
+        let (offset_days, length_days) = range_to_window(&range);
+        let f = now + offset_days * 86400;
+        (f, f + length_days * 86400)
+    };
 
     let episodes = calendar::fetch_upcoming(&state.db, &cfg, from, to, monitored_only)
         .await
@@ -187,29 +283,46 @@ pub async fn page(
         })
         .collect();
 
-    let day_buckets = group_by_day(&episode_views);
+    let (day_buckets, month_grid) = if view_mode == "grid" {
+        (
+            Vec::new(),
+            build_month_grid(&episode_views, now_utc, from, to),
+        )
+    } else {
+        (group_by_day(&episode_views), MonthGrid::default())
+    };
 
-    // HTMX request → just the list partial (the swappable
-    // region inside #calendar-list). Skips the calendar_keys
-    // load + the page chrome since neither belongs in the
-    // partial.
-    if is_htmx {
-        let partial = CalendarListPartial {
-            day_buckets,
-            library_is_empty,
+    // HTMX swap (range tabs, monitored toggle) → just the body
+    // partial for the active view. A boosted full-page nav also
+    // carries `HX-Request` but expects a full body, so it falls
+    // through to the page render below.
+    if is_htmx && !is_boosted {
+        return if view_mode == "grid" {
+            let partial = CalendarGridPartial {
+                month_grid,
+                library_is_empty,
+            };
+            Html(partial.render().unwrap_or_default())
+        } else {
+            let partial = CalendarListPartial {
+                day_buckets,
+                library_is_empty,
+            };
+            Html(partial.render().unwrap_or_default())
         };
-        return Html(partial.render().unwrap_or_default());
     }
 
     // Full page render — includes chrome (range tabs, filters,
-    // iCal modal) plus the partial body.
+    // iCal modal) plus the body partial.
     let calendar_keys = collect_calendar_keys(&state.db).await;
     let tmpl = CalendarPageTemplate {
         page: "calendar".to_string(),
         title_language: cfg.title_language.clone(),
         range,
         monitored_only,
+        view_mode: view_mode.to_string(),
         day_buckets,
+        month_grid,
         calendar_keys,
         library_is_empty,
     };
@@ -221,6 +334,60 @@ pub async fn page(
 struct CalendarListPartial {
     day_buckets: Vec<DayBucket>,
     library_is_empty: bool,
+}
+
+#[derive(Template)]
+#[template(path = "partials/calendar/grid.html")]
+struct CalendarGridPartial {
+    month_grid: MonthGrid,
+    library_is_empty: bool,
+}
+
+/// Build the Sun→Sat calendar grid for the month containing
+/// `now_utc`. The `from`/`to` window is the same one passed to
+/// [`calendar::fetch_upcoming`], so cells are guaranteed to fall
+/// inside the fetched episode range.
+fn build_month_grid(
+    episodes: &[EpisodeView],
+    now_utc: chrono::DateTime<chrono::Utc>,
+    from: i64,
+    to_exclusive: i64,
+) -> MonthGrid {
+    use std::collections::HashMap;
+    let mut by_day: HashMap<i64, Vec<EpisodeView>> = HashMap::new();
+    for ep in episodes {
+        let day_key = ep.airing_at - ep.airing_at.rem_euclid(86400);
+        by_day.entry(day_key).or_default().push(ep.clone());
+    }
+    for v in by_day.values_mut() {
+        v.sort_by_key(|e| e.airing_at);
+    }
+
+    let today_key = now_utc.timestamp() - now_utc.timestamp().rem_euclid(86400);
+    let current_month = now_utc.month();
+    let month_label = now_utc.format("%B %Y").to_string();
+
+    let mut weeks: Vec<Vec<MonthCell>> = Vec::new();
+    let mut cur = from;
+    while cur < to_exclusive {
+        let mut week: Vec<MonthCell> = Vec::with_capacity(7);
+        for _ in 0..7 {
+            let dt = chrono::DateTime::<chrono::Utc>::from_timestamp(cur, 0)
+                .unwrap_or_else(|| chrono::Utc.timestamp_opt(0, 0).single().unwrap());
+            let cell = MonthCell {
+                day_key: cur,
+                day_number: dt.day(),
+                is_today: cur == today_key,
+                is_in_current_month: dt.month() == current_month,
+                episodes: by_day.remove(&cur).unwrap_or_default(),
+            };
+            week.push(cell);
+            cur += 86400;
+        }
+        weeks.push(week);
+    }
+
+    MonthGrid { month_label, weeks }
 }
 
 async fn library_has_no_positive_al_series(db: &sqlx::SqlitePool) -> bool {
@@ -416,7 +583,7 @@ fn render_ical(
         let start_utc = format_ical_utc(ep.airing_at);
         let duration_secs = (ep.duration_minutes.max(1) as i64) * 60;
         let end_utc = format_ical_utc(ep.airing_at + duration_secs);
-        let summary = format!("{} S01E{:02}", ep.series_title, ep.episode);
+        let summary = format!("{} \u{00B7} E{:02}", ep.series_title, ep.episode);
         let uid = format!("ryokan-{}-{}@ryokan.local", ep.series_id, ep.episode);
         let status = if ep.airing_at - now_unix > NOW_PLUS_7_DAYS_THRESHOLD {
             "TENTATIVE"
@@ -542,8 +709,9 @@ mod tests {
         // DTSTART is the UTC airing time.
         assert!(body.contains("DTSTART:"));
         assert!(body.contains("DTEND:"));
-        // SUMMARY is `<title> S01E<NN>` zero-padded.
-        assert!(body.contains("SUMMARY:Test Series S01E07\r\n"));
+        // SUMMARY is `<title> · E<NN>` zero-padded; no S01 prefix
+        // because each anime "season" is its own Ryokan series.
+        assert!(body.contains("SUMMARY:Test Series \u{00B7} E07\r\n"));
         // URL uses the host header.
         assert!(body.contains("URL:http://ryokan.example:8978/series/42\r\n"));
     }
@@ -587,5 +755,111 @@ mod tests {
         let now = 1_700_000_000_i64;
         let body = render_ical(&[ep(99, 1, 1, now + 3600, true)], "romaji", None, now);
         assert!(body.contains("URL:/series/99\r\n"));
+    }
+
+    /// `2026-05-01` is a Friday → Sun-on-or-before is 2026-04-26
+    /// (Sunday). `2026-05-31` is a Sunday → Sat-on-or-after is
+    /// 2026-06-06 (Saturday). Grid spans 6 full weeks = 42 days.
+    #[test]
+    fn month_grid_window_spans_full_weeks_around_may_2026() {
+        let now = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 9, 12, 0, 0)
+            .single()
+            .unwrap();
+        let (from, to) = month_grid_window(now);
+        let from_dt = chrono::DateTime::<chrono::Utc>::from_timestamp(from, 0).unwrap();
+        let to_dt = chrono::DateTime::<chrono::Utc>::from_timestamp(to, 0).unwrap();
+        assert_eq!(from_dt.format("%Y-%m-%d").to_string(), "2026-04-26");
+        assert_eq!(to_dt.format("%Y-%m-%d").to_string(), "2026-06-07");
+        // 6 weeks × 7 days × 86400 sec.
+        assert_eq!(to - from, 6 * 7 * 86400);
+    }
+
+    /// `2026-02-01` is a Sunday → grid starts on the 1st itself.
+    /// `2026-02-28` is a Saturday → grid ends on the 28th. 4 weeks.
+    #[test]
+    fn month_grid_window_compacts_to_4_weeks_when_aligned() {
+        let now = chrono::Utc
+            .with_ymd_and_hms(2026, 2, 14, 0, 0, 0)
+            .single()
+            .unwrap();
+        let (from, to) = month_grid_window(now);
+        assert_eq!(to - from, 4 * 7 * 86400);
+    }
+
+    #[test]
+    fn month_grid_handles_december_year_rollover() {
+        let now = chrono::Utc
+            .with_ymd_and_hms(2026, 12, 15, 0, 0, 0)
+            .single()
+            .unwrap();
+        let (from, to) = month_grid_window(now);
+        // Window must be a positive multiple of 7 days.
+        let span_days = (to - from) / 86400;
+        assert!((4 * 7..=6 * 7).contains(&span_days));
+        assert_eq!(span_days % 7, 0);
+    }
+
+    fn ev(series_id: i64, episode: i32, airing_at: i64, monitored: bool) -> EpisodeView {
+        EpisodeView {
+            series_id,
+            series_title: "Test".to_string(),
+            cover_url: String::new(),
+            episode,
+            airing_at,
+            monitored,
+            search_haystack: "test".to_string(),
+        }
+    }
+
+    #[test]
+    fn build_month_grid_buckets_episodes_to_correct_cells() {
+        let now = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 9, 12, 0, 0)
+            .single()
+            .unwrap();
+        let (from, to) = month_grid_window(now);
+        // Two episodes on May 12 (Tue) at 09:00 and 21:00 UTC.
+        let may12_09 = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 12, 9, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp();
+        let may12_21 = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 12, 21, 0, 0)
+            .single()
+            .unwrap()
+            .timestamp();
+        let eps = vec![ev(1, 5, may12_21, true), ev(2, 1, may12_09, false)];
+        let grid = build_month_grid(&eps, now, from, to);
+        // Find the May 12 cell.
+        let mut found: Option<&MonthCell> = None;
+        for week in &grid.weeks {
+            for cell in week {
+                if cell.day_number == 12 && cell.is_in_current_month {
+                    found = Some(cell);
+                }
+            }
+        }
+        let cell = found.expect("May 12 should be in grid");
+        assert_eq!(cell.episodes.len(), 2);
+        // Sorted by airing_at ascending.
+        assert_eq!(cell.episodes[0].airing_at, may12_09);
+        assert_eq!(cell.episodes[1].airing_at, may12_21);
+    }
+
+    #[test]
+    fn build_month_grid_marks_today_cell() {
+        let now = chrono::Utc
+            .with_ymd_and_hms(2026, 5, 9, 18, 0, 0)
+            .single()
+            .unwrap();
+        let (from, to) = month_grid_window(now);
+        let grid = build_month_grid(&[], now, from, to);
+        let today_cells: Vec<&MonthCell> =
+            grid.weeks.iter().flatten().filter(|c| c.is_today).collect();
+        assert_eq!(today_cells.len(), 1);
+        assert_eq!(today_cells[0].day_number, 9);
+        assert!(today_cells[0].is_in_current_month);
     }
 }

--- a/src/handlers/calendar.rs
+++ b/src/handlers/calendar.rs
@@ -37,10 +37,12 @@
 //!
 //! ## Caching
 //!
-//! Server-side: 15-min cache in `services::calendar`.
-//! HTTP-side: `Cache-Control: public, max-age=600` + `ETag` derived
-//! from `max(airing_at)` so calendar clients honor conditional GETs
-//! for free.
+//! Server-side: the calendar reader joins against the local
+//! `episode_airings` table, kept fresh by the 12h `airing_refresh`
+//! supervised task — no per-request AL fetch, no in-process cache.
+//! HTTP-side: `Cache-Control: public, max-age=600` + an `ETag`
+//! hashed over each event's `(series_id, episode, airing_at)`
+//! tuple, so calendar clients honor conditional GETs for free.
 
 use askama::Template;
 use axum::{
@@ -148,9 +150,8 @@ struct CalendarPageTemplate {
     library_is_empty: bool,
 }
 
-/// Per-episode wire shape for both the server template and the
-/// JSON endpoint. Pre-formats per-day-grouping fields so the
-/// client doesn't have to re-derive them.
+/// Per-episode template input. Pre-formats per-day-grouping
+/// fields so the client doesn't have to re-derive them.
 #[derive(Debug, Clone, Serialize)]
 pub struct EpisodeView {
     pub series_id: i64,
@@ -499,8 +500,13 @@ pub async fn ical_feed(
         }
     };
 
-    let host = extract_host(&headers);
-    let body = render_ical(&episodes, &cfg.title_language, host.as_deref(), now);
+    let host_and_scheme = extract_host_and_scheme(&headers);
+    let body = render_ical(
+        &episodes,
+        &cfg.title_language,
+        host_and_scheme.as_ref(),
+        now,
+    );
     let etag = etag_for(&episodes);
 
     // Conditional GET — if the client sent the same etag they're
@@ -544,19 +550,43 @@ pub async fn ical_feed(
 }
 
 /// Best-effort extraction of the request's external host so the
-/// iCal `URL` field can deep-link back to the series page.
-/// Prefers `X-Forwarded-Host` then `Host`; returns None when
-/// neither header is parseable, in which case the URL field is
-/// emitted as a relative path.
-fn extract_host(headers: &HeaderMap) -> Option<String> {
-    if let Some(h) = headers
-        .get("x-forwarded-host")
-        .or_else(|| headers.get(header::HOST))
-        && let Ok(s) = h.to_str()
-    {
-        return Some(s.to_string());
+/// iCal `URL` field can deep-link back to the series page. Returns
+/// `(host, scheme)` when resolvable, or `None` when nothing is
+/// trustworthy enough to emit (in which case the URL field falls
+/// back to a relative path).
+///
+/// `X-Forwarded-Host` and `X-Forwarded-Proto` are honored only
+/// when `RYOKAN_TRUSTED_PROXY` is set, matching the auth path's
+/// header-trust contract: trusting them by default would let any
+/// HTTP client write whatever they want into iCal events. With
+/// the flag off we use the request's `Host` header (browsers /
+/// HTTP clients always set this, and an attacker can't usefully
+/// spoof it for someone else's calendar feed) and default the
+/// scheme to `http`.
+fn extract_host_and_scheme(headers: &HeaderMap) -> Option<(String, &'static str)> {
+    let trust = *crate::handlers::auth::TRUST_PROXY_HEADERS;
+    let host = if trust {
+        headers
+            .get("x-forwarded-host")
+            .or_else(|| headers.get(header::HOST))
+    } else {
+        headers.get(header::HOST)
     }
-    None
+    .and_then(|h| h.to_str().ok())?
+    .to_string();
+    let scheme = if trust {
+        match headers
+            .get("x-forwarded-proto")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.split(',').next().unwrap_or(s).trim().to_ascii_lowercase())
+        {
+            Some(ref s) if s == "https" => "https",
+            _ => "http",
+        }
+    } else {
+        "http"
+    };
+    Some((host, scheme))
 }
 
 /// Hand-rolled iCalendar 2.0 text. RFC 5545 compatible enough for
@@ -566,7 +596,7 @@ fn extract_host(headers: &HeaderMap) -> Option<String> {
 fn render_ical(
     episodes: &[UpcomingEpisode],
     _title_language: &str,
-    host: Option<&str>,
+    host_and_scheme: Option<&(String, &'static str)>,
     now_unix: i64,
 ) -> String {
     // CRLF line endings per RFC 5545 §3.1. Some clients are lax
@@ -595,27 +625,34 @@ fn render_ical(
         } else {
             "Not monitored"
         };
-        let description = format!("AniList ID: {}\\n{}", ep.anilist_id, mon_label);
-        let url = match host {
-            Some(h) => format!("http://{}/series/{}", h, ep.series_id),
+        // Real `\n` here, not the two-char escape `\\n`. RFC 5545
+        // §3.3.11 says newlines inside TEXT values must be encoded
+        // as the two-char sequence `\n`, and `escape_ical_text`'s
+        // `'\n' => "\\n"` arm handles the encoding. Writing
+        // `"\\n"` here would emit literal backslash-n on the wire.
+        let description = format!("AniList ID: {}\n{}", ep.anilist_id, mon_label);
+        let url = match host_and_scheme {
+            Some((h, scheme)) => format!("{}://{}/series/{}", scheme, h, ep.series_id),
             None => format!("/series/{}", ep.series_id),
         };
 
         out.push_str("BEGIN:VEVENT\r\n");
         // DTSTAMP is required per RFC 5545; use now as the
         // server-side stamp. Some validators reject events
-        // without it.
-        out.push_str(&format!("DTSTAMP:{}\r\n", format_ical_utc(now_unix)));
-        out.push_str(&format!("UID:{}\r\n", escape_ical_text(&uid)));
-        out.push_str(&format!("DTSTART:{}\r\n", start_utc));
-        out.push_str(&format!("DTEND:{}\r\n", end_utc));
-        out.push_str(&format!("SUMMARY:{}\r\n", escape_ical_text(&summary)));
-        out.push_str(&format!(
-            "DESCRIPTION:{}\r\n",
-            escape_ical_text(&description)
-        ));
-        out.push_str(&format!("URL:{}\r\n", escape_ical_text(&url)));
-        out.push_str(&format!("STATUS:{}\r\n", status));
+        // without it. Every content line below routes through
+        // `push_folded_line` so a long title (the SUMMARY/UID
+        // most likely to overflow) gets the §3.1 75-octet fold.
+        push_folded_line(&mut out, &format!("DTSTAMP:{}", format_ical_utc(now_unix)));
+        push_folded_line(&mut out, &format!("UID:{}", escape_ical_text(&uid)));
+        push_folded_line(&mut out, &format!("DTSTART:{}", start_utc));
+        push_folded_line(&mut out, &format!("DTEND:{}", end_utc));
+        push_folded_line(&mut out, &format!("SUMMARY:{}", escape_ical_text(&summary)));
+        push_folded_line(
+            &mut out,
+            &format!("DESCRIPTION:{}", escape_ical_text(&description)),
+        );
+        push_folded_line(&mut out, &format!("URL:{}", escape_ical_text(&url)));
+        push_folded_line(&mut out, &format!("STATUS:{}", status));
         out.push_str("END:VEVENT\r\n");
     }
 
@@ -651,13 +688,59 @@ fn escape_ical_text(s: &str) -> String {
     out
 }
 
-/// Build an ETag from `max(airing_at)` across the included events.
-/// Conditional-GET-friendly because the same set of events
-/// produces the same etag, and adding/removing events shifts the
-/// max (or the count, accounted for via the prefix).
+/// Build an ETag by hashing every event's identity tuple
+/// `(series_id, episode, airing_at)`. Conditional-GET-friendly
+/// because the same set of events hashes the same way, and any
+/// shift (an episode shifted, a series added or removed) changes
+/// the digest. The previous shape used `(count, max(airing_at))`
+/// which collided when two distinct sets shared a count and a max
+/// — narrow in practice, but a hash over the full identity space
+/// is correctness-preserving and just as cheap.
 fn etag_for(episodes: &[UpcomingEpisode]) -> String {
-    let max_airing = episodes.iter().map(|e| e.airing_at).max().unwrap_or(0);
-    format!("\"{}-{}\"", episodes.len(), max_airing)
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::hash::DefaultHasher::new();
+    episodes.len().hash(&mut hasher);
+    for e in episodes {
+        e.series_id.hash(&mut hasher);
+        e.episode.hash(&mut hasher);
+        e.airing_at.hash(&mut hasher);
+    }
+    format!("\"{:x}\"", hasher.finish())
+}
+
+/// Fold a content line per RFC 5545 §3.1: lines longer than 75
+/// octets are split with CRLF followed by a single space, which
+/// the parser folds back together. Splits respect UTF-8 char
+/// boundaries — the 75-octet limit is byte-based, but cutting
+/// mid-codepoint would corrupt non-ASCII titles.
+///
+/// Emits a trailing `\r\n` so callers can write a complete content
+/// line in one push.
+fn push_folded_line(out: &mut String, line: &str) {
+    const MAX: usize = 75;
+    let bytes = line.as_bytes();
+    if bytes.len() <= MAX {
+        out.push_str(line);
+        out.push_str("\r\n");
+        return;
+    }
+    let mut start = 0;
+    let mut first = true;
+    while start < bytes.len() {
+        let budget = if first { MAX } else { MAX - 1 }; // continuation lines start with a space
+        let mut end = (start + budget).min(bytes.len());
+        // Walk back to the nearest UTF-8 char boundary.
+        while end < bytes.len() && !line.is_char_boundary(end) {
+            end -= 1;
+        }
+        if !first {
+            out.push(' ');
+        }
+        out.push_str(&line[start..end]);
+        out.push_str("\r\n");
+        start = end;
+        first = false;
+    }
 }
 
 #[cfg(test)]
@@ -697,10 +780,11 @@ mod tests {
     #[test]
     fn vevent_carries_uid_dtstart_dtend_status() {
         let now = 1_700_000_000_i64; // somewhere in 2023
+        let host = ("ryokan.example:8978".to_string(), "http");
         let body = render_ical(
             &[ep(42, 100, 7, now + 3 * 86400, true)],
             "romaji",
-            Some("ryokan.example:8978"),
+            Some(&host),
             now,
         );
         assert!(body.contains("UID:ryokan-42-7@ryokan.local\r\n"));
@@ -714,6 +798,18 @@ mod tests {
         assert!(body.contains("SUMMARY:Test Series \u{00B7} E07\r\n"));
         // URL uses the host header.
         assert!(body.contains("URL:http://ryokan.example:8978/series/42\r\n"));
+        // DESCRIPTION line break is RFC-5545 `\n`, not literal `\\n`.
+        // After escape_ical_text the wire-form is single-backslash-n
+        // sandwiched between the two parts.
+        assert!(body.contains("DESCRIPTION:AniList ID: 100\\nMonitored\r\n"));
+    }
+
+    #[test]
+    fn vevent_url_picks_https_when_scheme_is_passed() {
+        let now = 1_700_000_000_i64;
+        let host = ("ryokan.example".to_string(), "https");
+        let body = render_ical(&[ep(7, 1, 1, now + 3600, true)], "romaji", Some(&host), now);
+        assert!(body.contains("URL:https://ryokan.example/series/7\r\n"));
     }
 
     #[test]

--- a/src/handlers/calendar.rs
+++ b/src/handlers/calendar.rs
@@ -1,0 +1,591 @@
+//! iCal calendar feed (issue #115).
+//!
+//! `GET /api/calendar.ics` — returns an iCalendar 2.0 document
+//! covering the next N days of upcoming episodes (default 30) for
+//! the user's library. Subscribed by Google Calendar / Apple
+//! Calendar / Thunderbird via the per-key URL surfaced in the
+//! Settings → Calendar panel.
+//!
+//! Auth: `calendar`-scoped API key (`require_calendar_scope`
+//! middleware in `handlers::scoped_auth`). Calendar subscribers
+//! can't carry cookies, which is why the scoped-key system in
+//! #114 had to land first.
+//!
+//! ## Output shape
+//!
+//! Hand-rolled iCalendar 2.0 text (no `ics`-crate dependency —
+//! the format is small and the round-trip we care about is just
+//! "RFC-5545 compatible enough for Google + Apple + Thunderbird").
+//!
+//! Per VEVENT:
+//! - `SUMMARY`: `<series_title> S01E<episode>` (anime convention =
+//!   always Season 1; matches `services/post_processing/mod.rs`'s
+//!   on-disk naming shape).
+//! - `DTSTART` / `DTEND`: from `airing_at` + `duration_minutes`.
+//! - `UID`: `ryokan-<series_id>-<episode>@ryokan.local` — stable
+//!   across feed fetches so calendar clients dedupe.
+//! - `DESCRIPTION`: monitoring state + grabbed status.
+//! - `URL`: deep link back to `/series/{id}` on the request's host
+//!   (best-effort; falls back to a relative URL if the host can't
+//!   be resolved).
+//! - `STATUS`: `TENTATIVE` for episodes >7 days out (AL airing
+//!   schedules can shift), `CONFIRMED` for the next 7 days.
+//!
+//! ## Caching
+//!
+//! Server-side: 15-min cache in `services::calendar`.
+//! HTTP-side: `Cache-Control: public, max-age=600` + `ETag` derived
+//! from `max(airing_at)` so calendar clients honor conditional GETs
+//! for free.
+
+use askama::Template;
+use axum::{
+    extract::{Query, State},
+    http::{HeaderMap, HeaderName, StatusCode, header},
+    response::{Html, IntoResponse, Response},
+};
+use axum_htmx::HxRequest;
+use serde::{Deserialize, Serialize};
+
+use crate::AppState;
+use crate::models::config;
+use crate::services::calendar::{self, DEFAULT_FORWARD_DAYS, UpcomingEpisode};
+
+const NOW_PLUS_7_DAYS_THRESHOLD: i64 = 7 * 86400;
+
+/// "Next week" needs an offset start (skip the first 7 days). All
+/// other ranges start from now. Returns `(from_offset_days,
+/// length_days)`.
+fn range_to_window(range: &str) -> (i64, i64) {
+    match range {
+        "next_week" | "next-week" => (7, 7),
+        "month" => (0, 30),
+        _ => (0, 7),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CalendarPageQuery {
+    /// `this_week` (default), `next_week`, or `month`.
+    #[serde(default)]
+    pub range: Option<String>,
+    /// `?monitored=true` filters to only monitored series. Default
+    /// off — surfaces every airing series.
+    #[serde(default)]
+    pub monitored: Option<bool>,
+}
+
+#[derive(Template)]
+#[template(path = "calendar.html")]
+struct CalendarPageTemplate {
+    page: String,
+    title_language: String,
+    /// Active range token — drives the toggle's selected state.
+    range: String,
+    monitored_only: bool,
+    /// Pre-grouped day buckets — the template iterates these
+    /// directly. HTMX swaps render the same `partials/calendar/
+    /// list.html` partial against this same shape, so the
+    /// initial paint and the swap paint produce identical
+    /// markup.
+    day_buckets: Vec<DayBucket>,
+    /// Calendar-scoped API keys for the Subscribe section. Filtered
+    /// to enabled keys with the `calendar` or `admin` scope so
+    /// users only see ones that'd actually authorize the feed.
+    calendar_keys: Vec<CalendarKeyOption>,
+    /// True when the user has at least one positive-AL-id series in
+    /// their library; drives the empty-state copy ("add a series"
+    /// vs. "no episodes airing in this range").
+    library_is_empty: bool,
+}
+
+/// Per-episode wire shape for both the server template and the
+/// JSON endpoint. Pre-formats per-day-grouping fields so the
+/// client doesn't have to re-derive them.
+#[derive(Debug, Clone, Serialize)]
+pub struct EpisodeView {
+    pub series_id: i64,
+    pub series_title: String,
+    pub cover_url: String,
+    pub episode: i32,
+    /// Unix epoch seconds (UTC). The client renders this in the
+    /// user's local timezone via `new Date(unixTs * 1000)`.
+    pub airing_at: i64,
+    pub monitored: bool,
+    /// Lowercase concatenation of every title variant (romaji +
+    /// english + native + db-stored) so the page's series-name
+    /// search input matches against any of them, not just the
+    /// resolved `title_language` form. Server-precomputed once.
+    pub search_haystack: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DayBucket {
+    /// Render-ready day label, e.g. `"Monday, May 12"`. Server-
+    /// formatted in UTC for the initial render; the client may
+    /// re-group by browser-local date if it cares (most won't —
+    /// the day boundary at UTC matches the airingAt value the
+    /// browser would compute back).
+    pub label: String,
+    /// UTC midnight Unix timestamp for this bucket's day. Used
+    /// client-side to highlight the today-section and let the
+    /// initial-load auto-scroll find it.
+    pub day_key: i64,
+    pub episodes: Vec<EpisodeView>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct CalendarKeyOption {
+    id: i64,
+    name: String,
+}
+
+/// `GET /calendar` — the in-app calendar page. Cookie-auth gated
+/// (sits inside the `protected_routes` group).
+///
+/// Branches on `HxRequest`:
+/// - `HX-Request: true` → renders just the `partials/calendar/list.html`
+///   partial. Used by the range-tab swap path so changing the range
+///   only replaces `#calendar-list` instead of the whole body.
+/// - Plain GET → renders the full page. Used on direct URL hits,
+///   browser back/forward to the page, and the no-JS fallback for
+///   the range tabs.
+pub async fn page(
+    State(state): State<AppState>,
+    HxRequest(is_htmx): HxRequest,
+    Query(params): Query<CalendarPageQuery>,
+) -> Html<String> {
+    let cfg = config::get_config(&state.db)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+    let range = params.range.unwrap_or_else(|| "this_week".to_string());
+    let monitored_only = params.monitored.unwrap_or(false);
+
+    let (offset_days, length_days) = range_to_window(&range);
+    let now = chrono::Utc::now().timestamp();
+    let from = now + offset_days * 86400;
+    let to = from + length_days * 86400;
+
+    let episodes = calendar::fetch_upcoming(&state.db, &cfg, from, to, monitored_only)
+        .await
+        .unwrap_or_default();
+
+    let library_is_empty = library_has_no_positive_al_series(&state.db).await;
+
+    let episode_views: Vec<EpisodeView> = episodes
+        .into_iter()
+        .map(|e| EpisodeView {
+            series_id: e.series_id,
+            series_title: e.series_title,
+            cover_url: e.cover_url,
+            episode: e.episode,
+            airing_at: e.airing_at,
+            monitored: e.monitored,
+            search_haystack: e.search_haystack,
+        })
+        .collect();
+
+    let day_buckets = group_by_day(&episode_views);
+
+    // HTMX request → just the list partial (the swappable
+    // region inside #calendar-list). Skips the calendar_keys
+    // load + the page chrome since neither belongs in the
+    // partial.
+    if is_htmx {
+        let partial = CalendarListPartial {
+            day_buckets,
+            library_is_empty,
+        };
+        return Html(partial.render().unwrap_or_default());
+    }
+
+    // Full page render — includes chrome (range tabs, filters,
+    // iCal modal) plus the partial body.
+    let calendar_keys = collect_calendar_keys(&state.db).await;
+    let tmpl = CalendarPageTemplate {
+        page: "calendar".to_string(),
+        title_language: cfg.title_language.clone(),
+        range,
+        monitored_only,
+        day_buckets,
+        calendar_keys,
+        library_is_empty,
+    };
+    Html(tmpl.render().unwrap_or_default())
+}
+
+#[derive(Template)]
+#[template(path = "partials/calendar/list.html")]
+struct CalendarListPartial {
+    day_buckets: Vec<DayBucket>,
+    library_is_empty: bool,
+}
+
+async fn library_has_no_positive_al_series(db: &sqlx::SqlitePool) -> bool {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM series WHERE anilist_id > 0")
+        .fetch_one(db)
+        .await
+        .unwrap_or(0);
+    count == 0
+}
+
+async fn collect_calendar_keys(db: &sqlx::SqlitePool) -> Vec<CalendarKeyOption> {
+    let keys = crate::models::api_key::list(db).await.unwrap_or_default();
+    keys.into_iter()
+        .filter(|k| k.enabled && k.scopes.iter().any(|s| s == "calendar" || s == "admin"))
+        .map(|k| CalendarKeyOption {
+            id: k.id,
+            name: k.name,
+        })
+        .collect()
+}
+
+/// Group a flat episode list into day buckets keyed by the date
+/// portion of `airing_at` (UTC). Server-side grouping so the
+/// initial render is one pass; the JS-driven re-render uses the
+/// same logic against the JSON wire shape.
+fn group_by_day(episodes: &[EpisodeView]) -> Vec<DayBucket> {
+    use std::collections::BTreeMap;
+    let mut by_date: BTreeMap<i64, Vec<EpisodeView>> = BTreeMap::new();
+    for ep in episodes {
+        // Collapse to UTC midnight so two episodes on the same UTC
+        // date sort into the same bucket.
+        let day_key = ep.airing_at - (ep.airing_at.rem_euclid(86400));
+        by_date.entry(day_key).or_default().push(ep.clone());
+    }
+    by_date
+        .into_iter()
+        .map(|(day_key, eps)| DayBucket {
+            label: chrono::DateTime::<chrono::Utc>::from_timestamp(day_key, 0)
+                .map(|dt| dt.format("%A, %b %-d").to_string())
+                .unwrap_or_default(),
+            day_key,
+            episodes: eps,
+        })
+        .collect()
+}
+
+/// Query string for the iCal endpoint. Both fields opt-in; the
+/// default behavior is "next 30 days, every airing series."
+#[derive(Debug, Deserialize)]
+pub struct IcalQuery {
+    /// Forward window in days. Capped at 90 server-side so a
+    /// `?days=10000` request can't blow up the AL fetch budget.
+    #[serde(default)]
+    pub days: Option<i64>,
+    /// `?monitored=true` filters to only monitored series. Default
+    /// off — the unconditional default surfaces every airing
+    /// series so users can browse "what's coming up" beyond their
+    /// own list.
+    #[serde(default)]
+    pub monitored: Option<bool>,
+}
+
+const MAX_DAYS: i64 = 90;
+
+/// `GET /api/calendar.ics`. Wired in `main.rs` behind the
+/// `require_calendar_scope` middleware so only `calendar`-scoped
+/// API keys reach it.
+pub async fn ical_feed(
+    State(state): State<AppState>,
+    Query(params): Query<IcalQuery>,
+    headers: HeaderMap,
+) -> Response {
+    let cfg = match config::get_config(&state.db).await {
+        Ok(Some(c)) => c,
+        Ok(None) | Err(_) => {
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(header::RETRY_AFTER, "5")],
+                "Ryokan config not yet available",
+            )
+                .into_response();
+        }
+    };
+
+    let days = params
+        .days
+        .unwrap_or(DEFAULT_FORWARD_DAYS)
+        .clamp(1, MAX_DAYS);
+    let monitored_only = params.monitored.unwrap_or(false);
+    let now = chrono::Utc::now().timestamp();
+    let from = now;
+    let to = now + days * 86400;
+
+    let episodes = match calendar::fetch_upcoming(&state.db, &cfg, from, to, monitored_only).await {
+        Ok(v) => v,
+        Err(e) => {
+            // Surface the AL failure-prefix taxonomy as the right
+            // HTTP shape: 503 + Retry-After for transient issues so
+            // calendar clients back off (they rage-poll on 401 less
+            // than on 5xx). Pure 4xx for misconfig isn't reachable
+            // here — the auth middleware already gated; any error
+            // bubbling out is upstream.
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                [(header::RETRY_AFTER, "60")],
+                format!("Calendar fetch failed: {e}"),
+            )
+                .into_response();
+        }
+    };
+
+    let host = extract_host(&headers);
+    let body = render_ical(&episodes, &cfg.title_language, host.as_deref(), now);
+    let etag = etag_for(&episodes);
+
+    // Conditional GET — if the client sent the same etag they're
+    // already showing, return 304 with empty body.
+    if let Some(if_none_match) = headers.get(header::IF_NONE_MATCH)
+        && let Ok(s) = if_none_match.to_str()
+        && s == etag.as_str()
+    {
+        return (StatusCode::NOT_MODIFIED, [(header::ETAG, etag.as_str())]).into_response();
+    }
+
+    let mut response_headers = vec![
+        (
+            header::CONTENT_TYPE,
+            "text/calendar; charset=utf-8".to_string(),
+        ),
+        (header::CACHE_CONTROL, "public, max-age=600".to_string()),
+        (header::ETAG, etag),
+    ];
+    // `Content-Disposition` so a direct browser hit downloads as
+    // ryokan.ics rather than rendering inline as text/plain. Some
+    // calendar apps (Apple Calendar, Outlook) want the file path
+    // to end in `.ics` for their auto-import handlers.
+    response_headers.push((
+        HeaderName::from_static("content-disposition"),
+        "inline; filename=\"ryokan.ics\"".to_string(),
+    ));
+
+    let header_pairs: Vec<(HeaderName, String)> = response_headers;
+    let mut builder = Response::builder().status(StatusCode::OK);
+    for (name, value) in header_pairs {
+        builder = builder.header(name, value);
+    }
+    builder.body(body.into()).unwrap_or_else(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Failed to build response",
+        )
+            .into_response()
+    })
+}
+
+/// Best-effort extraction of the request's external host so the
+/// iCal `URL` field can deep-link back to the series page.
+/// Prefers `X-Forwarded-Host` then `Host`; returns None when
+/// neither header is parseable, in which case the URL field is
+/// emitted as a relative path.
+fn extract_host(headers: &HeaderMap) -> Option<String> {
+    if let Some(h) = headers
+        .get("x-forwarded-host")
+        .or_else(|| headers.get(header::HOST))
+        && let Ok(s) = h.to_str()
+    {
+        return Some(s.to_string());
+    }
+    None
+}
+
+/// Hand-rolled iCalendar 2.0 text. RFC 5545 compatible enough for
+/// Google Calendar / Apple Calendar / Thunderbird auto-subscribe;
+/// not a complete implementation (no recurring events, no VTIMEZONE,
+/// no per-event TIMEZONE — every DTSTART is plain UTC `Z`-suffixed).
+fn render_ical(
+    episodes: &[UpcomingEpisode],
+    _title_language: &str,
+    host: Option<&str>,
+    now_unix: i64,
+) -> String {
+    // CRLF line endings per RFC 5545 §3.1. Some clients are lax
+    // about LF, but Apple Calendar specifically rejects mixed.
+    let mut out = String::with_capacity(256 + episodes.len() * 256);
+    out.push_str("BEGIN:VCALENDAR\r\n");
+    out.push_str("VERSION:2.0\r\n");
+    out.push_str("PRODID:-//Ryokan//Calendar 1.0//EN\r\n");
+    out.push_str("CALSCALE:GREGORIAN\r\n");
+    out.push_str("METHOD:PUBLISH\r\n");
+    out.push_str("X-WR-CALNAME:Ryokan\r\n");
+
+    for ep in episodes {
+        let start_utc = format_ical_utc(ep.airing_at);
+        let duration_secs = (ep.duration_minutes.max(1) as i64) * 60;
+        let end_utc = format_ical_utc(ep.airing_at + duration_secs);
+        let summary = format!("{} S01E{:02}", ep.series_title, ep.episode);
+        let uid = format!("ryokan-{}-{}@ryokan.local", ep.series_id, ep.episode);
+        let status = if ep.airing_at - now_unix > NOW_PLUS_7_DAYS_THRESHOLD {
+            "TENTATIVE"
+        } else {
+            "CONFIRMED"
+        };
+        let mon_label = if ep.monitored {
+            "Monitored"
+        } else {
+            "Not monitored"
+        };
+        let description = format!("AniList ID: {}\\n{}", ep.anilist_id, mon_label);
+        let url = match host {
+            Some(h) => format!("http://{}/series/{}", h, ep.series_id),
+            None => format!("/series/{}", ep.series_id),
+        };
+
+        out.push_str("BEGIN:VEVENT\r\n");
+        // DTSTAMP is required per RFC 5545; use now as the
+        // server-side stamp. Some validators reject events
+        // without it.
+        out.push_str(&format!("DTSTAMP:{}\r\n", format_ical_utc(now_unix)));
+        out.push_str(&format!("UID:{}\r\n", escape_ical_text(&uid)));
+        out.push_str(&format!("DTSTART:{}\r\n", start_utc));
+        out.push_str(&format!("DTEND:{}\r\n", end_utc));
+        out.push_str(&format!("SUMMARY:{}\r\n", escape_ical_text(&summary)));
+        out.push_str(&format!(
+            "DESCRIPTION:{}\r\n",
+            escape_ical_text(&description)
+        ));
+        out.push_str(&format!("URL:{}\r\n", escape_ical_text(&url)));
+        out.push_str(&format!("STATUS:{}\r\n", status));
+        out.push_str("END:VEVENT\r\n");
+    }
+
+    out.push_str("END:VCALENDAR\r\n");
+    out
+}
+
+/// Format a Unix epoch seconds value as an RFC 5545 UTC timestamp:
+/// `YYYYMMDDTHHMMSSZ`. The `Z` suffix marks UTC; without it the
+/// time gets interpreted as floating local time and shows up
+/// shifted in subscribers' calendars.
+fn format_ical_utc(unix_secs: i64) -> String {
+    chrono::DateTime::<chrono::Utc>::from_timestamp(unix_secs, 0)
+        .map(|dt| dt.format("%Y%m%dT%H%M%SZ").to_string())
+        .unwrap_or_else(|| "19700101T000000Z".to_string())
+}
+
+/// Escape per RFC 5545 §3.3.11. Backslash, comma, semicolon get
+/// escaped; literal newlines become `\n`. Carriage returns are
+/// dropped (they'd be re-introduced by the line wrapper).
+fn escape_ical_text(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            ',' => out.push_str("\\,"),
+            ';' => out.push_str("\\;"),
+            '\n' => out.push_str("\\n"),
+            '\r' => {}
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+/// Build an ETag from `max(airing_at)` across the included events.
+/// Conditional-GET-friendly because the same set of events
+/// produces the same etag, and adding/removing events shifts the
+/// max (or the count, accounted for via the prefix).
+fn etag_for(episodes: &[UpcomingEpisode]) -> String {
+    let max_airing = episodes.iter().map(|e| e.airing_at).max().unwrap_or(0);
+    format!("\"{}-{}\"", episodes.len(), max_airing)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ep(
+        series_id: i64,
+        anilist_id: i32,
+        episode: i32,
+        airing_at: i64,
+        monitored: bool,
+    ) -> UpcomingEpisode {
+        UpcomingEpisode {
+            series_id,
+            anilist_id,
+            series_title: "Test Series".to_string(),
+            episode,
+            airing_at,
+            duration_minutes: 24,
+            monitored,
+            cover_url: String::new(),
+            search_haystack: "test series".to_string(),
+        }
+    }
+
+    #[test]
+    fn empty_calendar_renders_valid_skeleton() {
+        let body = render_ical(&[], "romaji", None, 0);
+        assert!(body.starts_with("BEGIN:VCALENDAR\r\n"));
+        assert!(body.contains("VERSION:2.0\r\n"));
+        assert!(body.contains("PRODID:-//Ryokan//Calendar 1.0//EN\r\n"));
+        assert!(body.ends_with("END:VCALENDAR\r\n"));
+        assert!(!body.contains("BEGIN:VEVENT"));
+    }
+
+    #[test]
+    fn vevent_carries_uid_dtstart_dtend_status() {
+        let now = 1_700_000_000_i64; // somewhere in 2023
+        let body = render_ical(
+            &[ep(42, 100, 7, now + 3 * 86400, true)],
+            "romaji",
+            Some("ryokan.example:8978"),
+            now,
+        );
+        assert!(body.contains("UID:ryokan-42-7@ryokan.local\r\n"));
+        // 3 days out → CONFIRMED, not TENTATIVE.
+        assert!(body.contains("STATUS:CONFIRMED\r\n"));
+        // DTSTART is the UTC airing time.
+        assert!(body.contains("DTSTART:"));
+        assert!(body.contains("DTEND:"));
+        // SUMMARY is `<title> S01E<NN>` zero-padded.
+        assert!(body.contains("SUMMARY:Test Series S01E07\r\n"));
+        // URL uses the host header.
+        assert!(body.contains("URL:http://ryokan.example:8978/series/42\r\n"));
+    }
+
+    #[test]
+    fn far_out_episodes_get_tentative_status() {
+        let now = 1_700_000_000_i64;
+        // 14 days out → past the 7-day threshold → TENTATIVE.
+        let body = render_ical(&[ep(1, 1, 1, now + 14 * 86400, true)], "romaji", None, now);
+        assert!(body.contains("STATUS:TENTATIVE\r\n"));
+    }
+
+    #[test]
+    fn etag_is_stable_for_same_events() {
+        let now = 1_700_000_000_i64;
+        let evs = vec![
+            ep(1, 1, 1, now + 86400, true),
+            ep(2, 2, 1, now + 2 * 86400, false),
+        ];
+        let a = etag_for(&evs);
+        let b = etag_for(&evs);
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn etag_changes_when_max_airing_changes() {
+        let now = 1_700_000_000_i64;
+        let a = etag_for(&[ep(1, 1, 1, now + 86400, true)]);
+        let b = etag_for(&[ep(1, 1, 1, now + 2 * 86400, true)]);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn description_text_escape_handles_special_chars() {
+        let escaped = escape_ical_text("a, b; c\\d\nE");
+        assert_eq!(escaped, "a\\, b\\; c\\\\d\\nE");
+    }
+
+    #[test]
+    fn url_falls_back_to_relative_when_no_host() {
+        let now = 1_700_000_000_i64;
+        let body = render_ical(&[ep(99, 1, 1, now + 3600, true)], "romaji", None, now);
+        assert!(body.contains("URL:/series/99\r\n"));
+    }
+}

--- a/src/handlers/library/crud/mod.rs
+++ b/src/handlers/library/crud/mod.rs
@@ -142,6 +142,30 @@ pub async fn add_series(
             }
         });
 
+        // Stamp upcoming episode air dates inline so the
+        // calendar's local-DB read returns this series on the very
+        // next request rather than waiting for the next 12h
+        // `airing_refresh` tick. One AL roundtrip (single
+        // mediaId_in element) — negligible against the 30/min
+        // budget. Quiet on failure; the supervised task will pick
+        // it up later.
+        let airing_db = state.db.clone();
+        let airing_title = tracked.title.clone();
+        let airing_id = id;
+        tokio::spawn(async move {
+            if let Err(err) =
+                crate::services::airing_refresh::refresh_for_series(&airing_db, airing_id).await
+            {
+                logger::warn(
+                    &airing_db,
+                    LogCategory::AniList,
+                    &format!("Failed to stamp airings for {}", airing_title),
+                    &err,
+                )
+                .await;
+            }
+        });
+
         // Issue #53: kick off a one-shot classification scan for just
         // this series. If the user's media root already has files for
         // this show (pre-existing rip, manual drop, migration from

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod calendar;
 pub mod downloads;
 pub mod grab;
 pub mod help;

--- a/src/handlers/system/mod.rs
+++ b/src/handlers/system/mod.rs
@@ -17,7 +17,9 @@ use crate::models::{
     log::{self, LogCategory, LogLevel},
     rss, scheduled_tasks,
 };
-use crate::services::{logger, metadata_sync, post_processing, rss as rss_service, upgrade};
+use crate::services::{
+    airing_refresh, logger, metadata_sync, post_processing, rss as rss_service, upgrade,
+};
 
 /// Wrap a handler body in a detached `tokio::spawn` so the work runs
 /// to completion even when the client navigates away mid-flight.
@@ -1080,6 +1082,57 @@ pub async fn api_force_metadata_refresh(
         Ok::<_, (StatusCode, String)>(Json(serde_json::json!({
             "ok": failed == 0,
             "message": format!("Metadata refresh complete. Refreshed: {}. Failed: {}.", refreshed, failed),
+        })))
+    })
+    .await?
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/tasks/airing-refresh",
+    tag = "System",
+    summary = "Trigger airing-schedule refresh",
+    description = "Manually re-stamp the local `episode_airings` cache used by the calendar. Skips with `already running` if the supervised task is currently in flight.",
+    responses(
+        (status = 200, description = "Refresh report", body = serde_json::Value),
+    ),
+)]
+pub async fn api_force_airing_refresh(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
+    detached_task(async move {
+        // try_lock so a manual trigger during the 12h scheduled
+        // tick returns "already running" rather than queuing —
+        // mirrors the rss_sync / external_sync / upgrade_search
+        // shapes.
+        let Ok(_guard) = airing_refresh::AIRING_REFRESH_LOCK.try_lock() else {
+            return Ok::<_, (StatusCode, String)>(Json(serde_json::json!({
+                "ok": false,
+                "message": "Airing refresh is already running",
+            })));
+        };
+        let _ = scheduled_tasks::mark_started(
+            &state.db,
+            "airing_refresh",
+            "Manual airing refresh started",
+        )
+        .await;
+        let (status, message, detail) = match airing_refresh::refresh_all(&state.db).await {
+            Ok(summary) => {
+                let s = if summary.al_failures > 0 { "warn" } else { "ok" };
+                let msg = format!(
+                    "Airing refresh complete. Series: {}. Upserted: {}. Pruned: {}.",
+                    summary.series_scanned, summary.airings_upserted, summary.airings_pruned,
+                );
+                (s, msg, summary.detail())
+            }
+            Err(err) => ("error", format!("Airing refresh failed: {err}"), err),
+        };
+        let _ =
+            scheduled_tasks::mark_finished(&state.db, "airing_refresh", status, &detail).await;
+        Ok::<_, (StatusCode, String)>(Json(serde_json::json!({
+            "ok": status != "error",
+            "message": message,
         })))
     })
     .await?

--- a/src/handlers/system/mod.rs
+++ b/src/handlers/system/mod.rs
@@ -1119,7 +1119,11 @@ pub async fn api_force_airing_refresh(
         .await;
         let (status, message, detail) = match airing_refresh::refresh_all(&state.db).await {
             Ok(summary) => {
-                let s = if summary.al_failures > 0 { "warn" } else { "ok" };
+                let s = if summary.al_failures > 0 {
+                    "warn"
+                } else {
+                    "ok"
+                };
                 let msg = format!(
                     "Airing refresh complete. Series: {}. Upserted: {}. Pruned: {}.",
                     summary.series_scanned, summary.airings_upserted, summary.airings_pruned,
@@ -1128,8 +1132,7 @@ pub async fn api_force_airing_refresh(
             }
             Err(err) => ("error", format!("Airing refresh failed: {err}"), err),
         };
-        let _ =
-            scheduled_tasks::mark_finished(&state.db, "airing_refresh", status, &detail).await;
+        let _ = scheduled_tasks::mark_finished(&state.db, "airing_refresh", status, &detail).await;
         Ok::<_, (StatusCode, String)>(Json(serde_json::json!({
             "ok": status != "error",
             "message": message,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1038,6 +1038,14 @@ async fn main() {
         )
         .route("/api/system/tasks", get(handlers::system::api_system_tasks))
         .route("/help", get(handlers::help::help_page))
+        // Issue #116 — in-app calendar page. Cookie-auth gated
+        // (rest of protected_routes); the iCal feed at
+        // /api/calendar.ics is the parallel scoped-key surface
+        // wired via `calendar_routes` further down. The same
+        // handler serves full-page renders and HTMX partial
+        // swaps (it branches on HxRequest), so there's no
+        // separate JSON route.
+        .route("/calendar", get(handlers::calendar::page))
         .route("/api/logs/poll", get(handlers::system::api_logs_poll))
         .route("/api/logs/clear", post(handlers::system::api_logs_clear))
         .route("/api/logs/export", get(handlers::system::api_logs_export))
@@ -1186,6 +1194,19 @@ async fn main() {
         )
         .with_state(state.clone());
 
+    // Issue #115 — iCal calendar feed. Lives in its own router
+    // group so it can carry the `require_calendar_scope`
+    // middleware (scoped-API-key auth from #114) instead of
+    // cookie-auth — calendar subscribers (Google Calendar / Apple
+    // Calendar / Thunderbird) can't carry cookies.
+    let calendar_routes = Router::new()
+        .route("/api/calendar.ics", get(handlers::calendar::ical_feed))
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            handlers::scoped_auth::require_calendar_scope,
+        ))
+        .with_state(state.clone());
+
     // Brotli/gzip compression. The series detail template is ~80KB of HTML
     // and style.css is ~64KB — both highly compressible (lots of repeated
     // tokens, whitespace), and they ship on every page navigation. Axum
@@ -1212,6 +1233,7 @@ async fn main() {
         .merge(protected_routes)
         .merge(sonarr_routes)
         .merge(radarr_routes)
+        .merge(calendar_routes)
         .merge(webhook_routes)
         .nest_service(
             "/static",

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,6 +114,7 @@ use services::{
         handlers::system::api_rss_sync,
         handlers::system::api_rss_clear_history,
         handlers::system::api_force_metadata_refresh,
+        handlers::system::api_force_airing_refresh,
         handlers::system::api_force_cleanup,
         handlers::system::api_force_post_processing,
         handlers::system::api_force_library_classify,
@@ -1009,6 +1010,10 @@ async fn main() {
             post(handlers::system::api_force_metadata_refresh),
         )
         .route(
+            "/api/tasks/airing-refresh",
+            post(handlers::system::api_force_airing_refresh),
+        )
+        .route(
             "/api/tasks/cleanup",
             post(handlers::system::api_force_cleanup),
         )
@@ -1315,6 +1320,14 @@ async fn main() {
     .await;
     let _ = models::scheduled_tasks::touch_definition(
         &db,
+        "airing_refresh",
+        "Episode air-date refresh",
+        "Every 12 hours",
+        true,
+    )
+    .await;
+    let _ = models::scheduled_tasks::touch_definition(
+        &db,
         "library_classify",
         "Library classify sweep",
         "Every 6 hours",
@@ -1488,6 +1501,76 @@ async fn main() {
                     }
                 },
             )
+            .await;
+        });
+    }
+
+    // Background task: refresh stamped episode air dates every 12
+    // hours so the calendar reads from a freshly-warmed local table
+    // instead of round-tripping to AniList per-request. Mirrors
+    // Sonarr's `Episode.AirDateUtc` shape — one stamp at refresh
+    // time, then the calendar's hot path is a plain SQL range scan
+    // against `idx_episode_airings_at`. The refresh service holds
+    // its own lock so a manual-trigger handler can't race the
+    // scheduled tick. Startup delay is computed from
+    // `scheduled_task_runs.last_finished_at` so a process restart
+    // mid-window doesn't re-fire the sweep.
+    {
+        let airing_db = db.clone();
+        let task_registry_airing = state.tasks.clone();
+        tokio::spawn(async move {
+            supervise(&task_registry_airing, "airing_refresh", move || {
+                let db = airing_db.clone();
+                async move {
+                    let period = services::airing_refresh::REFRESH_INTERVAL;
+                    let delay = models::scheduled_tasks::duration_until_next_run(
+                        &db,
+                        "airing_refresh",
+                        period,
+                    )
+                    .await;
+                    tokio::time::sleep(delay).await;
+                    loop {
+                        // Hold the process-wide lock for the duration
+                        // of the run so a manual-trigger doesn't
+                        // double up.
+                        let _guard = services::airing_refresh::AIRING_REFRESH_LOCK.lock().await;
+                        let _ = models::scheduled_tasks::mark_started(
+                            &db,
+                            "airing_refresh",
+                            "Refreshing episode air dates",
+                        )
+                        .await;
+                        match services::airing_refresh::refresh_all(&db).await {
+                            Ok(summary) => {
+                                let status = if summary.al_failures > 0 {
+                                    "warn"
+                                } else {
+                                    "ok"
+                                };
+                                let _ = models::scheduled_tasks::mark_finished(
+                                    &db,
+                                    "airing_refresh",
+                                    status,
+                                    &summary.detail(),
+                                )
+                                .await;
+                            }
+                            Err(err) => {
+                                let _ = models::scheduled_tasks::mark_finished(
+                                    &db,
+                                    "airing_refresh",
+                                    "error",
+                                    &err,
+                                )
+                                .await;
+                            }
+                        }
+                        drop(_guard);
+                        tokio::time::sleep(period).await;
+                    }
+                }
+            })
             .await;
         });
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,9 +371,9 @@ async fn main() {
     });
 
     // WAL mode lets readers run concurrently with a writer, which matters a
-    // lot here: seven background tasks (rss_sync, post_processing, cleanup,
-    // library_classify, metadata_refresh, upgrade_search, anibridge_refresh)
-    // all share this pool with the request path. In the default DELETE
+    // lot here: every supervised background task (grep `supervise(&` for the
+    // canonical names — currently 11) shares this pool with the request
+    // path. In the default DELETE
     // journal mode every writer takes a whole-database lock and stalls the
     // next page load behind whatever scheduled_tasks row update or log insert
     // happens to be running. `synchronous=NORMAL` is safe under WAL (durable

--- a/src/models/episode_airings.rs
+++ b/src/models/episode_airings.rs
@@ -1,0 +1,235 @@
+//! Local cache of AniList airing schedules.
+//!
+//! Each row is one upcoming-or-recent episode for a Ryokan series,
+//! stamped from AL's `Page.airingSchedules` query. The
+//! `services::airing_refresh` supervised task writes these every
+//! 12h; the `services::calendar` reader joins them against `series`
+//! to render the in-app calendar + the iCal feed without round-
+//! tripping to AL per-request.
+//!
+//! Schema lives in `models/migrations/mod.rs` (the table + the
+//! `idx_episode_airings_at` range-scan index). FK on `series_id`
+//! is `ON DELETE CASCADE` so deleting a series automatically purges
+//! its stamped airings.
+//!
+//! ## Why a local table
+//!
+//! Sonarr's `Episode.AirDateUtc` shape: refresh once, serve from
+//! the DB forever (until the next refresh tick). Saves the per-
+//! request AL cost — load-bearing because AL's degraded
+//! airingSchedules budget is 30/min, easy for a popping-off iCal
+//! poller fleet to drain.
+
+use sqlx::SqlitePool;
+
+/// One upserted row. Mirrors the columns 1:1.
+#[derive(Debug, Clone)]
+pub struct EpisodeAiring {
+    pub series_id: i64,
+    pub episode: i32,
+    pub airing_at: i64,
+    pub duration_minutes: i32,
+}
+
+/// Upsert a batch of airings for a single series. Caller is
+/// responsible for chunking by series — this lets us run one
+/// transaction per series so a partial-failure on series N+1 leaves
+/// series 1..N already-stamped rows intact.
+///
+/// On conflict (series_id, episode) the existing row is overwritten
+/// — AL is the source of truth and the new row's `airing_at` /
+/// `duration_minutes` may differ (a series shifted its air date).
+pub async fn upsert_for_series(
+    db: &SqlitePool,
+    series_id: i64,
+    rows: &[EpisodeAiring],
+) -> Result<(), sqlx::Error> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let mut tx = db.begin().await?;
+    for r in rows {
+        sqlx::query(
+            "INSERT INTO episode_airings \
+                (series_id, episode, airing_at, duration_minutes, refreshed_at) \
+             VALUES (?, ?, ?, ?, strftime('%s','now')) \
+             ON CONFLICT(series_id, episode) DO UPDATE SET \
+                airing_at = excluded.airing_at, \
+                duration_minutes = excluded.duration_minutes, \
+                refreshed_at = excluded.refreshed_at",
+        )
+        .bind(series_id)
+        .bind(r.episode)
+        .bind(r.airing_at)
+        .bind(r.duration_minutes)
+        .execute(&mut *tx)
+        .await?;
+    }
+    tx.commit().await
+}
+
+/// Delete every airing for a series. Used when the user removes a
+/// series via a path that doesn't go through the FK cascade
+/// (e.g. external_sync removal pruning); a no-op if FK already
+/// fired.
+#[allow(dead_code)]
+pub async fn delete_for_series(db: &SqlitePool, series_id: i64) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM episode_airings WHERE series_id = ?")
+        .bind(series_id)
+        .execute(db)
+        .await?;
+    Ok(result.rows_affected())
+}
+
+/// Drop airings whose `airing_at` is more than `older_than_secs`
+/// seconds in the past. Called from the refresh task to keep the
+/// table from growing unbounded — there's no value in retaining
+/// last-month's episodes once the calendar's "this week" / "this
+/// month" windows have moved past them.
+pub async fn prune_older_than(db: &SqlitePool, older_than_unix: i64) -> Result<u64, sqlx::Error> {
+    let result = sqlx::query("DELETE FROM episode_airings WHERE airing_at < ?")
+        .bind(older_than_unix)
+        .execute(db)
+        .await?;
+    Ok(result.rows_affected())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn pool() -> SqlitePool {
+        crate::test_support::in_memory_pool().await
+    }
+
+    async fn add_series(pool: &SqlitePool, anilist_id: i64, title: &str) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "INSERT INTO series (anilist_id, title, monitor_mode) \
+             VALUES (?, ?, 'all') RETURNING id",
+        )
+        .bind(anilist_id)
+        .bind(title)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn upsert_inserts_then_overwrites_on_conflict() {
+        let pool = pool().await;
+        let series_id = add_series(&pool, 1, "Test").await;
+
+        let rows = vec![EpisodeAiring {
+            series_id,
+            episode: 1,
+            airing_at: 1_700_000_000,
+            duration_minutes: 24,
+        }];
+        upsert_for_series(&pool, series_id, &rows).await.unwrap();
+
+        // Same (series_id, episode) but a shifted airing_at — the
+        // upsert must overwrite, not duplicate or fail.
+        let rows = vec![EpisodeAiring {
+            series_id,
+            episode: 1,
+            airing_at: 1_700_000_000 + 86_400,
+            duration_minutes: 25,
+        }];
+        upsert_for_series(&pool, series_id, &rows).await.unwrap();
+
+        let row: (i64, i64) = sqlx::query_as(
+            "SELECT airing_at, duration_minutes FROM episode_airings \
+             WHERE series_id = ? AND episode = ?",
+        )
+        .bind(series_id)
+        .bind(1)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(row.0, 1_700_000_000 + 86_400);
+        assert_eq!(row.1, 25);
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM episode_airings WHERE series_id = ?")
+                .bind(series_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[tokio::test]
+    async fn series_delete_cascades_to_airings() {
+        let pool = pool().await;
+        // FK enforcement is opt-in per-connection in SQLite.
+        sqlx::query("PRAGMA foreign_keys = ON")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let series_id = add_series(&pool, 1, "Test").await;
+        upsert_for_series(
+            &pool,
+            series_id,
+            &[EpisodeAiring {
+                series_id,
+                episode: 1,
+                airing_at: 1_700_000_000,
+                duration_minutes: 24,
+            }],
+        )
+        .await
+        .unwrap();
+
+        sqlx::query("DELETE FROM series WHERE id = ?")
+            .bind(series_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM episode_airings")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0, "FK cascade should clear airings");
+    }
+
+    #[tokio::test]
+    async fn prune_drops_only_past_rows() {
+        let pool = pool().await;
+        let series_id = add_series(&pool, 1, "Test").await;
+        upsert_for_series(
+            &pool,
+            series_id,
+            &[
+                EpisodeAiring {
+                    series_id,
+                    episode: 1,
+                    airing_at: 1_000,
+                    duration_minutes: 24,
+                },
+                EpisodeAiring {
+                    series_id,
+                    episode: 2,
+                    airing_at: 2_000,
+                    duration_minutes: 24,
+                },
+                EpisodeAiring {
+                    series_id,
+                    episode: 3,
+                    airing_at: 3_000,
+                    duration_minutes: 24,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        let dropped = prune_older_than(&pool, 2_500).await.unwrap();
+        assert_eq!(dropped, 2);
+        let remaining: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM episode_airings")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(remaining, 1);
+    }
+}

--- a/src/models/migrations/mod.rs
+++ b/src/models/migrations/mod.rs
@@ -2703,6 +2703,40 @@ pub async fn migrate(db: &SqlitePool) -> Result<(), sqlx::Error> {
         .await
         .ok();
 
+    // Issue #115/#116 follow-up — local cache of AniList airing
+    // schedules. Sonarr stamps episode air dates on its local
+    // `Episode.AirDateUtc` column at series-refresh time and serves
+    // the calendar from a plain SQL range scan, never hitting the
+    // upstream metadata provider on the hot path. We mirror that:
+    // a 12h `airing_refresh` supervised task pulls AL's
+    // `Page.airingSchedules` for every positive-AL-id series and
+    // writes upcoming episodes here. The calendar then reads from
+    // this table joined against `series` instead of round-tripping
+    // to AL per-request, preserving the 30/min degraded budget.
+    //
+    // Series removal cascades (FK) so deleted series automatically
+    // drop their stamped airings.
+    sqlx::query(
+        "CREATE TABLE IF NOT EXISTS episode_airings (
+            series_id        INTEGER NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+            episode          INTEGER NOT NULL,
+            airing_at        INTEGER NOT NULL,
+            duration_minutes INTEGER NOT NULL DEFAULT 24,
+            refreshed_at     INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+            PRIMARY KEY (series_id, episode)
+        )",
+    )
+    .execute(db)
+    .await
+    .ok();
+    // Range-scan index for the calendar's primary `WHERE airing_at
+    // BETWEEN @from AND @to` query. Mirrors Sonarr's
+    // `idx_episodes_air_date_utc`.
+    sqlx::query("CREATE INDEX IF NOT EXISTS idx_episode_airings_at ON episode_airings (airing_at)")
+        .execute(db)
+        .await
+        .ok();
+
     Ok(())
 }
 

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod custom_formats;
 pub mod direct_rss_feeds;
 pub mod download_clients;
+pub mod episode_airings;
 pub mod episode_tags;
 pub mod external_accounts;
 pub mod grabbed_torrents;

--- a/src/services/airing_refresh.rs
+++ b/src/services/airing_refresh.rs
@@ -1,0 +1,271 @@
+//! Refresh stamp upcoming episode air dates into the local
+//! `episode_airings` table.
+//!
+//! Two entry points:
+//! - [`refresh_all`] walks every positive-AL-id series in the
+//!   library, batches the AL `Page.airingSchedules` query, and
+//!   upserts the result. Called every 12h by the
+//!   `airing_refresh` supervised task in `main.rs`.
+//! - [`refresh_for_series`] does the same for a single series.
+//!   Called inline from the library add path so a freshly-added
+//!   series shows up in the calendar without waiting for the
+//!   next 12h tick.
+//!
+//! ## Why we don't fetch on demand anymore
+//!
+//! The previous calendar implementation hit
+//! `airing_schedules::fetch_airing_schedules` per-request and held
+//! a 15-min in-process cache. AL's degraded budget on this query
+//! is 30/min, so a fleet of iCal subscribers polling every 15 min
+//! could drain the budget regardless of cache. Sonarr's
+//! `Episode.AirDateUtc` shape — stamp at refresh time, serve from
+//! DB on the hot path — is strictly better at zero per-request AL
+//! cost. This module is the stamping side; `services::calendar` is
+//! the read side.
+
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use sqlx::Row;
+use sqlx::SqlitePool;
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::models::episode_airings::{self, EpisodeAiring};
+use crate::services::anilist::airing_schedules;
+
+/// Default forward window the refresh stamps. 90 days matches the
+/// iCal feed's `?days` cap. Anything past 90 days is best handled
+/// by the next 12h refresh tick anyway — AL's air dates that far
+/// out are typically TBA / placeholder and shift before they fire.
+const FORWARD_WINDOW_DAYS: i64 = 90;
+
+/// Past-window. Calendar's `this_week` view only needs +0 days,
+/// but allowing a small back-window means past episodes that
+/// shifted to "today" still render correctly when their original
+/// stamp was a few hours behind.
+const BACKWARD_WINDOW_DAYS: i64 = 1;
+
+/// How long to retain past airings in the DB before pruning. Two
+/// weeks is enough for the calendar's "this week" / "next week"
+/// views to never see a hole, plus a buffer for anyone hitting a
+/// stale URL.
+const RETAIN_PAST_DAYS: i64 = 14;
+
+/// Process-wide lock so the supervised loop and a manual refresh
+/// trigger don't run side-by-side and double-stamp / 429 the AL
+/// budget. `try_lock` shape matches `RSS_SYNC_LOCK` /
+/// `EXTERNAL_SYNC_LOCK` — a manual run while the scheduled run is
+/// in flight returns "already running" rather than queuing.
+pub static AIRING_REFRESH_LOCK: LazyLock<TokioMutex<()>> = LazyLock::new(|| TokioMutex::new(()));
+
+/// Aggregate result of a refresh sweep — surfaced in the System →
+/// Tasks page via `scheduled_tasks::mark_finished` detail string.
+#[derive(Debug, Default, Clone)]
+pub struct RefreshSummary {
+    pub series_scanned: usize,
+    pub airings_upserted: usize,
+    pub airings_pruned: u64,
+    pub al_failures: usize,
+}
+
+impl RefreshSummary {
+    pub fn detail(&self) -> String {
+        format!(
+            "series={}, upserted={}, pruned={}, failures={}",
+            self.series_scanned, self.airings_upserted, self.airings_pruned, self.al_failures,
+        )
+    }
+}
+
+/// Refresh airings for every positive-AL-id series in the library.
+/// Returns a summary regardless of partial AL failures — the lock
+/// is held by the caller (the supervised task or the manual
+/// trigger handler), so internally we don't try_lock again.
+pub async fn refresh_all(db: &SqlitePool) -> Result<RefreshSummary, String> {
+    let series = load_series_ids(db).await?;
+    refresh_inner(db, &series).await
+}
+
+/// Refresh airings for a single series. Used by the library add
+/// path so freshly-added series show up in the calendar without
+/// waiting for the next 12h tick. Quiet on AL failures — the
+/// background task will pick the series up on its next sweep.
+pub async fn refresh_for_series(db: &SqlitePool, series_id: i64) -> Result<RefreshSummary, String> {
+    let row: Option<i64> =
+        sqlx::query_scalar("SELECT anilist_id FROM series WHERE id = ? AND anilist_id > 0")
+            .bind(series_id)
+            .fetch_optional(db)
+            .await
+            .map_err(|e| format!("series lookup: {e}"))?;
+    let Some(anilist_id) = row else {
+        // Series doesn't exist or is a Jikan-fallback (negative AL
+        // id sentinel). Either way there's nothing to fetch — AL
+        // can't serve airings for these, and the caller treats this
+        // as a soft no-op.
+        return Ok(RefreshSummary::default());
+    };
+    refresh_inner(
+        db,
+        &[SeriesRef {
+            id: series_id,
+            anilist_id: anilist_id as i32,
+        }],
+    )
+    .await
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SeriesRef {
+    id: i64,
+    anilist_id: i32,
+}
+
+async fn load_series_ids(db: &SqlitePool) -> Result<Vec<SeriesRef>, String> {
+    let rows = sqlx::query("SELECT id, anilist_id FROM series WHERE anilist_id > 0")
+        .fetch_all(db)
+        .await
+        .map_err(|e| format!("series id query: {e}"))?;
+    let mut out = Vec::with_capacity(rows.len());
+    for r in rows {
+        let id: i64 = r.try_get("id").unwrap_or(0);
+        let anilist_id: i64 = r.try_get("anilist_id").unwrap_or(0);
+        if id > 0 && anilist_id > 0 {
+            out.push(SeriesRef {
+                id,
+                anilist_id: anilist_id as i32,
+            });
+        }
+    }
+    Ok(out)
+}
+
+async fn refresh_inner(db: &SqlitePool, series: &[SeriesRef]) -> Result<RefreshSummary, String> {
+    let mut summary = RefreshSummary {
+        series_scanned: series.len(),
+        ..Default::default()
+    };
+    if series.is_empty() {
+        // Still prune so a fully-emptied library doesn't keep stale rows.
+        summary.airings_pruned = prune(db).await.unwrap_or(0);
+        return Ok(summary);
+    }
+
+    let now = chrono::Utc::now().timestamp();
+    let from = now - BACKWARD_WINDOW_DAYS * 86_400;
+    let to = now + FORWARD_WINDOW_DAYS * 86_400;
+
+    let ids: Vec<i32> = series.iter().map(|s| s.anilist_id).collect();
+    let schedules = match airing_schedules::fetch_airing_schedules(&ids, from, to).await {
+        Ok(s) => s,
+        Err(e) => {
+            // Surface the AL failure in the summary but don't abort
+            // the prune step — old rows should still age out even
+            // if we couldn't fetch new ones.
+            summary.al_failures = 1;
+            tracing::warn!(target: "ryokan::airing_refresh", "airingSchedules fetch failed: {e}");
+            summary.airings_pruned = prune(db).await.unwrap_or(0);
+            return Ok(summary);
+        }
+    };
+
+    // Group the flat schedule list by AL id so we can run one
+    // upsert transaction per series.
+    use std::collections::HashMap;
+    let mut by_anilist_id: HashMap<i32, Vec<EpisodeAiring>> = HashMap::new();
+    for s in schedules {
+        // Map AL id back to Ryokan series_id. Drop schedules for
+        // ids we didn't ask about (defensive — `mediaId_in` should
+        // restrict, but AL has surprised us before).
+        let Some(series_ref) = series.iter().find(|sr| sr.anilist_id == s.media_id) else {
+            continue;
+        };
+        by_anilist_id
+            .entry(s.media_id)
+            .or_default()
+            .push(EpisodeAiring {
+                series_id: series_ref.id,
+                episode: s.episode,
+                airing_at: s.airing_at,
+                duration_minutes: s.duration_minutes.unwrap_or(24),
+            });
+    }
+
+    for (al_id, rows) in by_anilist_id {
+        // The first row carries the series_id; all rows for one al
+        // id share it.
+        let series_id = rows[0].series_id;
+        match episode_airings::upsert_for_series(db, series_id, &rows).await {
+            Ok(()) => summary.airings_upserted += rows.len(),
+            Err(e) => {
+                summary.al_failures += 1;
+                tracing::warn!(
+                    target: "ryokan::airing_refresh",
+                    "upsert failed for series_id={series_id} al_id={al_id}: {e}"
+                );
+            }
+        }
+    }
+
+    summary.airings_pruned = prune(db).await.unwrap_or(0);
+    Ok(summary)
+}
+
+async fn prune(db: &SqlitePool) -> Result<u64, String> {
+    let cutoff = chrono::Utc::now().timestamp() - RETAIN_PAST_DAYS * 86_400;
+    episode_airings::prune_older_than(db, cutoff)
+        .await
+        .map_err(|e| format!("airings prune: {e}"))
+}
+
+/// Span of one refresh tick — used to seed the supervised task's
+/// startup sleep so a process restart mid-window doesn't re-fire
+/// the sweep. Mirrors `metadata_refresh`'s 12h cadence.
+pub const REFRESH_INTERVAL: Duration = Duration::from_secs(12 * 60 * 60);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn pool() -> SqlitePool {
+        crate::test_support::in_memory_pool().await
+    }
+
+    #[tokio::test]
+    async fn refresh_with_empty_library_runs_prune_and_returns_empty_summary() {
+        let pool = pool().await;
+        let summary = refresh_all(&pool).await.unwrap();
+        assert_eq!(summary.series_scanned, 0);
+        assert_eq!(summary.airings_upserted, 0);
+        assert_eq!(summary.al_failures, 0);
+    }
+
+    #[tokio::test]
+    async fn refresh_for_negative_id_series_is_noop() {
+        let pool = pool().await;
+        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'all')")
+            .bind(-12345_i64)
+            .bind("MAL-only")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let id: i64 = sqlx::query_scalar("SELECT id FROM series WHERE anilist_id = -12345")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        let summary = refresh_for_series(&pool, id).await.unwrap();
+        // No AL fetch, no upsert, no failure.
+        assert_eq!(summary.airings_upserted, 0);
+        assert_eq!(summary.al_failures, 0);
+    }
+
+    #[test]
+    fn summary_detail_string_is_human_readable() {
+        let s = RefreshSummary {
+            series_scanned: 17,
+            airings_upserted: 42,
+            airings_pruned: 3,
+            al_failures: 1,
+        };
+        assert_eq!(s.detail(), "series=17, upserted=42, pruned=3, failures=1");
+    }
+}

--- a/src/services/anilist/airing_schedules.rs
+++ b/src/services/anilist/airing_schedules.rs
@@ -16,9 +16,11 @@
 //!
 //! Per the parent CLAUDE.md "Airing schedule batch query" note: the
 //! AL rate limit degrades to **30/min** on this endpoint, so the
-//! caller (`services::calendar`) layers a 15-min server-side cache
-//! on top so a thundering herd of iCal subscribers doesn't drain
-//! the budget.
+//! caller (`services::airing_refresh`) only fires this query on its
+//! 12h supervised tick and writes the result to the local
+//! `episode_airings` table; calendar requests never round-trip to
+//! AL so a thundering herd of iCal subscribers doesn't drain the
+//! budget.
 
 use serde_json::json;
 
@@ -245,8 +247,3 @@ async fn fetch_page(
     }
     Ok((out, has_next))
 }
-
-// Suppress dead-code on the duration-default constant; it'll be
-// referenced once `services::calendar` lands the iCal emitter.
-#[allow(dead_code)]
-const _DEFAULT_DURATION_MINUTES: i32 = 24;

--- a/src/services/anilist/airing_schedules.rs
+++ b/src/services/anilist/airing_schedules.rs
@@ -1,0 +1,252 @@
+//! `Page.airingSchedules` batch fetcher (issue #115 — calendar feed).
+//!
+//! Returns every upcoming-or-recent episode for a list of AniList
+//! media IDs in a single AL query (paged through `Page.pageInfo`'s
+//! `hasNextPage`). Used by `services::calendar` as the data source
+//! for both the iCal feed and the in-app calendar page.
+//!
+//! ## Why this lives here
+//!
+//! AL-specific concerns (GraphQL shape, rate-limit pacing,
+//! cooldown-on-429/5xx, header-driven throttle adjustment) all
+//! belong inside `services::anilist`. The cache + DB join layers
+//! live in `services::calendar` so the AL/transport part can be
+//! tested in isolation against a wiremock fixture without
+//! materializing a series table.
+//!
+//! Per the parent CLAUDE.md "Airing schedule batch query" note: the
+//! AL rate limit degrades to **30/min** on this endpoint, so the
+//! caller (`services::calendar`) layers a 15-min server-side cache
+//! on top so a thundering herd of iCal subscribers doesn't drain
+//! the budget.
+
+use serde_json::json;
+
+use super::rate_limit::{
+    ANILIST_COOLDOWN_DEFAULT, extract_graphql_error, record_rate_limit_headers,
+    set_anilist_cooldown, throttle_before_anilist_request,
+};
+use super::{HTTP_CLIENT, anilist_api_base};
+
+/// One row of AL's `Page.airingSchedules` response. Exactly the
+/// shape the GraphQL query asks for; transformation into the
+/// caller-friendly [`UpcomingEpisode`](crate::services::calendar::UpcomingEpisode)
+/// happens in `services::calendar`.
+#[derive(Debug, Clone)]
+pub struct AiringSchedule {
+    pub episode: i32,
+    pub airing_at: i64,
+    pub media_id: i32,
+    /// Per-episode runtime in minutes. AL exposes this on `Media.duration`,
+    /// not on the schedule row itself, so it's the same value for every
+    /// episode of a given series. `None` when AL hasn't populated it
+    /// (rare — most listed series have a duration). Caller defaults to
+    /// 24 minutes when emitting `DTEND` on iCal events.
+    pub duration_minutes: Option<i32>,
+    pub title_romaji: String,
+    pub title_english: String,
+    pub title_native: String,
+}
+
+const PER_PAGE: usize = 50;
+
+/// Fetch every airing schedule for `ids` whose `airingAt` falls in
+/// `from..to` (Unix epoch seconds). Returns an empty Vec when `ids`
+/// is empty (no AL request issued). Walks `Page.pageInfo.hasNextPage`
+/// until exhausted; with `PER_PAGE = 50` and AL's 30/min degraded
+/// budget, even a 500-series library (~5 pages worst case) costs
+/// 1/6 of the per-minute budget per refresh.
+///
+/// Negative-AL-id sentinel series (Jikan-fallback rows where
+/// `series.anilist_id = -mal_id`) are caller-filtered, not handled
+/// here — passing a negative id would hit AL with an invalid ID
+/// and return an empty result. The caller in `services::calendar`
+/// applies the `anilist_id > 0` filter, matching the convention
+/// every other AL call site uses.
+pub async fn fetch_airing_schedules(
+    ids: &[i32],
+    from: i64,
+    to: i64,
+) -> Result<Vec<AiringSchedule>, String> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut out: Vec<AiringSchedule> = Vec::new();
+    let mut page = 1;
+    loop {
+        let (mut chunk, has_next) = fetch_page(ids, from, to, page).await?;
+        out.append(&mut chunk);
+        if !has_next {
+            break;
+        }
+        page += 1;
+        // Defensive cap. A 500-series library at perPage=50 with
+        // every series airing in-window would top out at ~5 pages.
+        // 50 pages = 2500 in-window airings, far past anything a
+        // single user has. If we ever hit this, something has
+        // gone wrong with the response (infinite hasNextPage loop)
+        // and we'd rather bail than spend the whole rate budget
+        // on it.
+        if page > 50 {
+            return Err(
+                "AniList airingSchedules pagination exceeded 50 pages — aborting".to_string(),
+            );
+        }
+    }
+    Ok(out)
+}
+
+async fn fetch_page(
+    ids: &[i32],
+    from: i64,
+    to: i64,
+    page: i32,
+) -> Result<(Vec<AiringSchedule>, bool), String> {
+    let query = r#"
+        query ($ids: [Int], $from: Int, $to: Int, $page: Int, $perPage: Int) {
+          Page(page: $page, perPage: $perPage) {
+            pageInfo { hasNextPage }
+            airingSchedules(mediaId_in: $ids, airingAt_greater: $from, airingAt_lesser: $to, sort: TIME) {
+              episode
+              airingAt
+              mediaId
+              media {
+                duration
+                title { romaji english native }
+              }
+            }
+          }
+        }
+    "#;
+    let gql = json!({
+        "query": query,
+        "variables": {
+            "ids": ids,
+            "from": from,
+            "to": to,
+            "page": page,
+            "perPage": PER_PAGE,
+        },
+    });
+
+    throttle_before_anilist_request().await;
+    let resp = match HTTP_CLIENT
+        .post(anilist_api_base())
+        .header("User-Agent", "Ryokan/0.1")
+        .json(&gql)
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            return Err(format!(
+                "AniList unavailable: airingSchedules request failed: {e}"
+            ));
+        }
+    };
+
+    let status = resp.status();
+    record_rate_limit_headers(resp.headers());
+
+    if status == reqwest::StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
+        let retry_after_secs = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.parse::<u64>().ok());
+        set_anilist_cooldown(retry_after_secs, ANILIST_COOLDOWN_DEFAULT);
+        // Use the standard prefix so downstream callers can match on
+        // the failure taxonomy ("AniList rate-limited" / "AniList
+        // unavailable") rather than HTTP codes — same shape every
+        // other AL call site uses.
+        return Err(if status == reqwest::StatusCode::TOO_MANY_REQUESTS {
+            format!(
+                "AniList rate-limited (airingSchedules){}",
+                retry_after_secs
+                    .map(|r| format!(" — retry in {r}s"))
+                    .unwrap_or_default()
+            )
+        } else {
+            format!("AniList unavailable: airingSchedules HTTP {status}")
+        });
+    }
+
+    let body_text = resp
+        .text()
+        .await
+        .map_err(|e| format!("AniList unavailable: read body: {e}"))?;
+    let body: serde_json::Value = serde_json::from_str(&body_text).map_err(|e| {
+        format!(
+            "AniList unavailable: parse JSON ({}): {}",
+            e,
+            body_text.chars().take(200).collect::<String>()
+        )
+    })?;
+
+    if !status.is_success() {
+        // The 429/5xx cooldown branch above handles those statuses;
+        // anything else here is a 4xx that the caller can treat as
+        // unavailable (no cooldown — we don't know the cause).
+        let msg = extract_graphql_error(&body).unwrap_or_else(|| body.to_string());
+        return Err(format!(
+            "AniList unavailable: airingSchedules HTTP {status}: {msg}"
+        ));
+    }
+    if let Some(msg) = extract_graphql_error(&body) {
+        return Err(format!(
+            "AniList unavailable: airingSchedules GraphQL error: {msg}"
+        ));
+    }
+
+    let page_obj = &body["data"]["Page"];
+    let has_next = page_obj["pageInfo"]["hasNextPage"]
+        .as_bool()
+        .unwrap_or(false);
+    let arr = match page_obj["airingSchedules"].as_array() {
+        Some(a) => a,
+        None => {
+            // Schema mismatch — log and return empty for this page so
+            // the caller can still serve a stale-cache or empty
+            // calendar instead of erroring out the whole feed.
+            tracing::warn!(
+                target: "ryokan::anilist::airing",
+                "Page.airingSchedules missing in response — schema mismatch?"
+            );
+            return Ok((Vec::new(), false));
+        }
+    };
+
+    let mut out: Vec<AiringSchedule> = Vec::with_capacity(arr.len());
+    for item in arr {
+        let episode = item["episode"].as_i64().unwrap_or(0) as i32;
+        let airing_at = item["airingAt"].as_i64().unwrap_or(0);
+        let media_id = item["mediaId"].as_i64().unwrap_or(0) as i32;
+        if episode <= 0 || airing_at <= 0 || media_id <= 0 {
+            // Defensive — AL rarely returns missing fields here, but
+            // a partial schedule row is unusable for SUMMARY/UID/DTSTART
+            // emission; skip rather than emit a broken VEVENT.
+            continue;
+        }
+        let duration_minutes = item["media"]["duration"].as_i64().map(|d| d as i32);
+        let title = &item["media"]["title"];
+        let title_romaji = title["romaji"].as_str().unwrap_or("").to_string();
+        let title_english = title["english"].as_str().unwrap_or("").to_string();
+        let title_native = title["native"].as_str().unwrap_or("").to_string();
+        out.push(AiringSchedule {
+            episode,
+            airing_at,
+            media_id,
+            duration_minutes,
+            title_romaji,
+            title_english,
+            title_native,
+        });
+    }
+    Ok((out, has_next))
+}
+
+// Suppress dead-code on the duration-default constant; it'll be
+// referenced once `services::calendar` lands the iCal emitter.
+#[allow(dead_code)]
+const _DEFAULT_DURATION_MINUTES: i32 = 24;

--- a/src/services/anilist/mod.rs
+++ b/src/services/anilist/mod.rs
@@ -7,6 +7,7 @@ use tokio::sync::RwLock;
 
 use crate::services::jikan;
 
+pub mod airing_schedules;
 mod rate_limit;
 #[cfg(any(test, feature = "test-support"))]
 pub use rate_limit::reset_state_for_tests;

--- a/src/services/calendar.rs
+++ b/src/services/calendar.rs
@@ -1,52 +1,50 @@
-//! Calendar data layer (issue #115).
+//! Calendar reader (issues #115 / #116).
 //!
 //! Single source of truth for "what episodes are airing soon"
 //! shared by the iCal feed (`/api/calendar.ics`) and the in-app
-//! calendar page (`/calendar`, issue #116). Both consumers call
-//! [`fetch_upcoming`] with their preferred window; the cache + AL
-//! fetch + DB join happen here exactly once per (id-set, window)
-//! tuple regardless of how many subscribers are polling.
+//! calendar page (`/calendar`). Both consumers call
+//! [`fetch_upcoming`] with their preferred window.
 //!
-//! ## Architecture
+//! ## Architecture (post-refactor)
 //!
-//! Read-through to AniList with a 15-minute server-side cache. No
-//! new persistent state — the AL `Page.airingSchedules` query is
-//! the right shape for this, and persisting per-series next-airing
-//! state would couple iCal freshness to the 12h metadata-refresh
-//! cadence (and miss future weeks).
+//! Reads stamped airings from `episode_airings` joined against
+//! `series` — no AL round-trip on the request path. The
+//! `services::airing_refresh` 12h supervised task is what stamps
+//! the table, and the library add path stamps a single series
+//! inline so a freshly-added series shows up without waiting for
+//! the next tick.
 //!
-//! Cache is keyed by `(sorted_anilist_ids, from, to)`. When the
-//! user adds or removes a series, the id set changes and the next
-//! request misses the cache; a 15-min stale window for "I just
-//! added a series, when will it appear in my calendar?" is
-//! acceptable.
+//! Mirrors Sonarr's `Episode.AirDateUtc` shape: stamp once, serve
+//! from the DB forever (until the next refresh tick). Saves the
+//! per-request AL cost — load-bearing because AL's degraded
+//! airingSchedules budget is 30/min.
+//!
+//! No more in-process cache: the SQL query is a single indexed
+//! range scan against `idx_episode_airings_at`, cheap enough that
+//! the previous 15-min memoization was strictly redundant.
 //!
 //! ## Negative-AL-id blind spot
 //!
 //! Series added via the Jikan/MAL fallback path with no AL mapping
-//! get `series.anilist_id = -mal_id`. We filter `anilist_id > 0`
-//! before the AL query (matching every other AL call site) so
-//! synthetic ids don't leak into AL requests. Documented in the
-//! Settings → Calendar panel so users with MAL-exclusive series
-//! aren't surprised by their absence from the feed.
+//! get `series.anilist_id = -mal_id`. The refresh task's
+//! `anilist_id > 0` filter means these series never get stamped
+//! airings, so they're invisible to the calendar. This matches
+//! every other AL-keyed surface (SeaDex, refresh, etc.) and is
+//! documented in the Settings → Calendar panel.
 //!
 //! ## Auth
 //!
-//! This module is auth-agnostic — it just returns Vec<UpcomingEpisode>.
-//! The iCal handler gates on the `calendar` scoped key
-//! (`require_calendar_scope`); the in-app page gates on the cookie
-//! `require_auth` middleware. Both call this same function.
-
-use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex as StdMutex};
-use std::time::{Duration, Instant};
+//! This module is auth-agnostic — it just returns
+//! `Vec<UpcomingEpisode>`. The iCal handler gates on the
+//! `calendar` scoped key (`require_calendar_scope`); the in-app
+//! page gates on the cookie `require_auth` middleware. Both call
+//! this same function.
 
 use serde::Serialize;
 use sqlx::Row;
 use sqlx::SqlitePool;
 
 use crate::models::config::Config;
-use crate::services::anilist::airing_schedules;
 
 /// Per-episode shape served to both consumers. Title is already
 /// resolved via `Config.title_language` so neither the iCal text
@@ -57,8 +55,8 @@ pub struct UpcomingEpisode {
     /// Ryokan-internal `series.id`. Used to back-link to
     /// `/series/{id}` in iCal events + the calendar page cards.
     pub series_id: i64,
-    /// AL media id. Always positive — negative-id sentinel rows are
-    /// filtered out before the AL query.
+    /// AL media id. Always positive — only positive-AL-id series
+    /// get stamped airings.
     pub anilist_id: i32,
     /// Already resolved per `Config.title_language` with the usual
     /// romaji → english → native fallback so callers don't have to
@@ -68,8 +66,8 @@ pub struct UpcomingEpisode {
     /// Unix epoch seconds (UTC). Both consumers render this in the
     /// user's local timezone client-side.
     pub airing_at: i64,
-    /// AL's `Media.duration` (per-episode runtime in minutes).
-    /// Defaults to 24 — the value most TV anime series use.
+    /// Per-episode runtime in minutes. Defaults to 24 — the value
+    /// most TV anime series use.
     pub duration_minutes: i32,
     /// True when this series is monitored (`monitor_mode != 'none'`).
     /// The `?monitored=true` filter on the iCal endpoint uses this;
@@ -77,76 +75,30 @@ pub struct UpcomingEpisode {
     pub monitored: bool,
     /// `series.cover_url` (AL CDN poster). Used by the in-app
     /// `/calendar` page to render a thumbnail next to each episode
-    /// card; the iCal feed ignores it (calendar clients don't
-    /// render embedded artwork).
+    /// card; the iCal feed ignores it.
     pub cover_url: String,
     /// Lowercased concatenation of every title variant (romaji +
     /// english + native + db-stored). Used by the calendar page's
     /// client-side series-name filter so a user typing "attack on
     /// titan" can match the series even when their `title_language`
     /// is set to romaji or native and the visible `series_title`
-    /// is the Japanese form. Computed server-side once instead of
-    /// having the JS layer normalize per-keystroke.
+    /// is the Japanese form.
     pub search_haystack: String,
 }
 
-/// Default forward window for the iCal feed. The plan doc reserves
-/// a configurable `?days=N` query param; until that wires through,
-/// callers pass `DEFAULT_FORWARD_DAYS * 86400` directly.
+/// Default forward window for the iCal feed. Until the
+/// configurable `?days=N` query param wires through, callers pass
+/// `DEFAULT_FORWARD_DAYS * 86400` directly.
 pub const DEFAULT_FORWARD_DAYS: i64 = 30;
-
-/// Cache TTL. 15 minutes balances "iCal subscribers polling every
-/// 15-60 min get fast responses" against "I just added a series —
-/// when will it show up?" The 30-day forward window plus AL's
-/// upstream cadence makes a tighter TTL pointless.
-const CACHE_TTL: Duration = Duration::from_secs(15 * 60);
-
-/// Width of the cache-key window-bucket. Callers pass `from = now`
-/// (which changes every second), so without bucketing the cache
-/// key would change on every request and the cache would never
-/// hit — even within the TTL window. Snapping `from` and `to` to
-/// the nearest 15-minute boundary makes the key stable for the
-/// whole cache lifetime; users get an at-most-15-min-snapped
-/// window which is negligible at the 7-30 day windows the page
-/// actually serves.
-const CACHE_BUCKET_SECS: i64 = 15 * 60;
-
-fn bucket_floor(ts: i64) -> i64 {
-    ts - ts.rem_euclid(CACHE_BUCKET_SECS)
-}
-
-#[derive(Hash, Eq, PartialEq, Clone)]
-struct CacheKey {
-    /// Sorted so two callers with the same set in different order
-    /// hit the same cache entry.
-    sorted_ids: Vec<i32>,
-    from: i64,
-    to: i64,
-}
-
-#[derive(Clone)]
-struct CacheEntry {
-    fetched_at: Instant,
-    data: Vec<UpcomingEpisode>,
-}
-
-/// Process-wide cache. `StdMutex` (not async) is fine — the lock
-/// is held for HashMap get/insert only, never across an await
-/// point. Same shape SeaDex's lookup cache uses.
-static CACHE: LazyLock<StdMutex<HashMap<CacheKey, CacheEntry>>> =
-    LazyLock::new(|| StdMutex::new(HashMap::new()));
 
 /// Fetch upcoming episodes airing in `from..to` for every monitored
 /// series in the library (or every series, depending on
-/// `monitored_only`). Cache hit returns immediately; cache miss
-/// pulls the AL ids from `series`, calls
-/// [`airing_schedules::fetch_airing_schedules`], joins the result
-/// against `series` to resolve internal ids + monitor state, and
-/// writes the cache.
+/// `monitored_only`). One indexed SQL query against
+/// `episode_airings ⨝ series`; never hits AL on the request path.
 ///
-/// Errors propagate from the AL layer with the "AniList
-/// rate-limited" / "AniList unavailable" prefix taxonomy so the
-/// iCal handler can decide whether to serve a stale cache or 503.
+/// Returns `Ok(Vec)` even when no airings match. Errors only
+/// propagate from the SQL layer — wrapped in the `String` shape
+/// the rest of Ryokan uses end-to-end.
 pub async fn fetch_upcoming(
     db: &SqlitePool,
     config: &Config,
@@ -154,146 +106,90 @@ pub async fn fetch_upcoming(
     to: i64,
     monitored_only: bool,
 ) -> Result<Vec<UpcomingEpisode>, String> {
-    // Snap window endpoints to a 15-minute bucket so the cache key
-    // stabilizes across requests within the same TTL window. Without
-    // this, callers passing `from = chrono::Utc::now().timestamp()`
-    // (which changes every second) would generate a unique key per
-    // request and the cache would effectively never hit. See
-    // `CACHE_BUCKET_SECS` above.
-    let from = bucket_floor(from);
-    let to = bucket_floor(to);
-
-    // Pull the per-row mapping from anilist_id → (series_id, monitor
-    // state, locale-resolved title). One query for both the AL id
-    // list and the post-fetch join.
-    let rows = load_series_index(db, config, monitored_only).await?;
-    if rows.is_empty() {
-        // No monitored (or no positive-AL-id) series — no AL request,
-        // empty result. Don't cache the empty result; a freshly-added
-        // series should appear without waiting for cache expiry.
-        return Ok(Vec::new());
-    }
-
-    let mut sorted_ids: Vec<i32> = rows.iter().map(|r| r.anilist_id).collect();
-    sorted_ids.sort_unstable();
-    let key = CacheKey {
-        sorted_ids: sorted_ids.clone(),
-        from,
-        to,
+    let sql = if monitored_only {
+        BASE_QUERY_MONITORED
+    } else {
+        BASE_QUERY_ALL
     };
+    let rows = sqlx::query(sql)
+        .bind(from)
+        .bind(to)
+        .fetch_all(db)
+        .await
+        .map_err(|e| format!("calendar query: {e}"))?;
 
-    if let Some(cached) = cache_get(&key) {
-        return Ok(cached);
-    }
-
-    // Cache miss — fetch from AL.
-    let schedules = airing_schedules::fetch_airing_schedules(&sorted_ids, from, to).await?;
-    let by_anilist_id: HashMap<i32, &SeriesIndexRow> =
-        rows.iter().map(|r| (r.anilist_id, r)).collect();
-
-    let mut out: Vec<UpcomingEpisode> = Vec::with_capacity(schedules.len());
-    for s in schedules {
-        let Some(row) = by_anilist_id.get(&s.media_id) else {
-            // AL returned a schedule for a media id we didn't ask
-            // about (shouldn't happen; mediaId_in is ID-list-
-            // restricted). Drop silently rather than emit an
-            // unidentifiable VEVENT.
+    let mut out: Vec<UpcomingEpisode> = Vec::with_capacity(rows.len());
+    for r in rows {
+        let series_id: i64 = r.try_get("series_id").unwrap_or(0);
+        let anilist_id: i64 = r.try_get("anilist_id").unwrap_or(0);
+        if series_id <= 0 || anilist_id <= 0 {
             continue;
-        };
-        // Pick a per-call title: prefer the user's preferred
-        // language, fall back through romaji → english → native →
-        // database-stored title to ensure SUMMARY is never empty.
-        let title = pick_title(
+        }
+        let title_db: String = r.try_get("title").unwrap_or_default();
+        let title_romaji: String = r.try_get("title_romaji").unwrap_or_default();
+        let title_english: String = r.try_get("title_english").unwrap_or_default();
+        let title_native: String = r.try_get("title_native").unwrap_or_default();
+        let cover_url: String = r.try_get("cover_url").unwrap_or_default();
+        let monitor_mode: String = r.try_get("monitor_mode").unwrap_or_default();
+        let episode: i32 = r.try_get::<i64, _>("episode").unwrap_or(0) as i32;
+        let airing_at: i64 = r.try_get("airing_at").unwrap_or(0);
+        let duration_minutes: i32 = r.try_get::<i64, _>("duration_minutes").unwrap_or(24) as i32;
+
+        let series_title = pick_title(
             &config.title_language,
-            &s.title_romaji,
-            &s.title_english,
-            &s.title_native,
-            &row.title,
+            &title_romaji,
+            &title_english,
+            &title_native,
+            &title_db,
         );
-        // Every title variant lowercased + space-separated so a
-        // single substring search hits any of them. `db_title` is
-        // included as a fallback for series the user manually
-        // renamed (rare; the AL-fetched titles are usually the
-        // ones a user would type to search).
-        let haystack = [
-            s.title_romaji.as_str(),
-            s.title_english.as_str(),
-            s.title_native.as_str(),
-            row.title.as_str(),
+        let search_haystack = [
+            title_romaji.as_str(),
+            title_english.as_str(),
+            title_native.as_str(),
+            title_db.as_str(),
         ]
         .iter()
         .filter(|t| !t.is_empty())
         .map(|t| t.to_lowercase())
         .collect::<Vec<_>>()
         .join(" ");
+
         out.push(UpcomingEpisode {
-            series_id: row.series_id,
-            anilist_id: s.media_id,
-            series_title: title,
-            episode: s.episode,
-            airing_at: s.airing_at,
-            duration_minutes: s.duration_minutes.unwrap_or(24),
-            monitored: row.monitored,
-            cover_url: row.cover_url.clone(),
-            search_haystack: haystack,
-        });
-    }
-    out.sort_by_key(|e| e.airing_at);
-
-    cache_put(key, out.clone());
-    Ok(out)
-}
-
-struct SeriesIndexRow {
-    series_id: i64,
-    anilist_id: i32,
-    /// Database-stored title. Used as the final fallback if the AL
-    /// row's titles are all empty (shouldn't happen but the
-    /// SUMMARY-must-not-be-empty contract is load-bearing for iCal
-    /// validators).
-    title: String,
-    monitored: bool,
-    cover_url: String,
-}
-
-async fn load_series_index(
-    db: &SqlitePool,
-    _config: &Config,
-    monitored_only: bool,
-) -> Result<Vec<SeriesIndexRow>, String> {
-    let sql = if monitored_only {
-        "SELECT id, anilist_id, title, monitor_mode, cover_url \
-         FROM series \
-         WHERE anilist_id > 0 AND monitor_mode != 'none'"
-    } else {
-        "SELECT id, anilist_id, title, monitor_mode, cover_url \
-         FROM series \
-         WHERE anilist_id > 0"
-    };
-    let rows = sqlx::query(sql)
-        .fetch_all(db)
-        .await
-        .map_err(|e| format!("series index query: {e}"))?;
-    let mut out: Vec<SeriesIndexRow> = Vec::with_capacity(rows.len());
-    for row in rows {
-        let series_id: i64 = row.try_get("id").unwrap_or(0);
-        let anilist_id: i64 = row.try_get("anilist_id").unwrap_or(0);
-        if anilist_id <= 0 || series_id <= 0 {
-            continue;
-        }
-        let title: String = row.try_get("title").unwrap_or_default();
-        let monitor_mode: String = row.try_get("monitor_mode").unwrap_or_default();
-        let cover_url: String = row.try_get("cover_url").unwrap_or_default();
-        out.push(SeriesIndexRow {
             series_id,
             anilist_id: anilist_id as i32,
-            title,
+            series_title,
+            episode,
+            airing_at,
+            duration_minutes,
             monitored: monitor_mode != "none",
             cover_url,
+            search_haystack,
         });
     }
+    // SQL `ORDER BY airing_at ASC` already sorts; redundant Rust
+    // sort kept off the hot path.
     Ok(out)
 }
+
+const BASE_QUERY_ALL: &str = "\
+SELECT s.id AS series_id, s.anilist_id, s.title, s.title_romaji, s.title_english, \
+       s.title_native, s.cover_url, s.monitor_mode, \
+       ea.episode, ea.airing_at, ea.duration_minutes \
+FROM episode_airings ea \
+JOIN series s ON s.id = ea.series_id \
+WHERE s.anilist_id > 0 \
+  AND ea.airing_at >= ? AND ea.airing_at < ? \
+ORDER BY ea.airing_at ASC";
+
+const BASE_QUERY_MONITORED: &str = "\
+SELECT s.id AS series_id, s.anilist_id, s.title, s.title_romaji, s.title_english, \
+       s.title_native, s.cover_url, s.monitor_mode, \
+       ea.episode, ea.airing_at, ea.duration_minutes \
+FROM episode_airings ea \
+JOIN series s ON s.id = ea.series_id \
+WHERE s.anilist_id > 0 AND s.monitor_mode != 'none' \
+  AND ea.airing_at >= ? AND ea.airing_at < ? \
+ORDER BY ea.airing_at ASC";
 
 /// Pick a title respecting `Config.title_language`, falling back
 /// through the other language fields and finally the
@@ -317,70 +213,34 @@ fn pick_title(lang: &str, romaji: &str, english: &str, native: &str, db_title: &
     String::new()
 }
 
-fn cache_get(key: &CacheKey) -> Option<Vec<UpcomingEpisode>> {
-    let mut cache = CACHE.lock().ok()?;
-    let entry = cache.get(key)?;
-    if entry.fetched_at.elapsed() > CACHE_TTL {
-        cache.remove(key);
-        return None;
-    }
-    Some(entry.data.clone())
-}
-
-fn cache_put(key: CacheKey, data: Vec<UpcomingEpisode>) {
-    let Ok(mut cache) = CACHE.lock() else {
-        return;
-    };
-    cache.insert(
-        key,
-        CacheEntry {
-            fetched_at: Instant::now(),
-            data,
-        },
-    );
-    // Lazy cleanup: drop expired entries when we cross a soft
-    // ceiling. Avoids unbounded growth from users polling many
-    // distinct ?days=N windows.
-    if cache.len() > 64 {
-        let now = Instant::now();
-        cache.retain(|_, e| now.duration_since(e.fetched_at) <= CACHE_TTL);
-    }
-}
-
-/// Drop every cache entry. Test-only — used to keep cache state
-/// isolated between tests sharing the process-wide CACHE.
-#[cfg(test)]
-pub(crate) fn reset_cache() {
-    if let Ok(mut cache) = CACHE.lock() {
-        cache.clear();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::models::episode_airings::{self, EpisodeAiring};
 
-    #[test]
-    fn bucket_floor_snaps_to_15_minute_boundaries() {
-        // Pin the cache-key bucketing. A request at 14:07:33 and a
-        // request at 14:08:01 should produce the same bucket (14:00)
-        // so they hit the same cache entry. Regression test for the
-        // bug where every per-second `now()` produced a unique key.
-        let secs_in_15min = 15 * 60;
-        // Choose a timestamp partway through a 15-min window: floor
-        // should round down to the window start.
-        let mid_window = 1_700_000_000_i64 + 7 * 60 + 33; // +07:33 into a window
-        let bucketed = bucket_floor(mid_window);
-        let next = bucket_floor(mid_window + 60); // +1 min later
-        assert_eq!(
-            bucketed, next,
-            "two timestamps in the same 15-min window must bucket to the same value"
-        );
-        // Crossing a 15-min boundary changes the bucket.
-        let crossed = bucket_floor(mid_window + secs_in_15min);
-        assert_ne!(bucketed, crossed);
-        // Bucket value is always a multiple of 15 minutes.
-        assert_eq!(bucketed % secs_in_15min, 0);
+    async fn pool() -> SqlitePool {
+        crate::test_support::in_memory_pool().await
+    }
+
+    async fn add_series(
+        pool: &SqlitePool,
+        anilist_id: i64,
+        title: &str,
+        monitor_mode: &str,
+    ) -> i64 {
+        sqlx::query_scalar::<_, i64>(
+            "INSERT INTO series (anilist_id, title, title_romaji, title_english, title_native, cover_url, monitor_mode) \
+             VALUES (?, ?, ?, ?, ?, '', ?) RETURNING id",
+        )
+        .bind(anilist_id)
+        .bind(title)
+        .bind(title) // romaji
+        .bind("")
+        .bind("")
+        .bind(monitor_mode)
+        .fetch_one(pool)
+        .await
+        .unwrap()
     }
 
     #[test]
@@ -401,75 +261,131 @@ mod tests {
 
     #[test]
     fn pick_title_falls_back_through_languages() {
-        // Preferred is empty; should walk romaji → english → native.
         assert_eq!(
             pick_title("english", "Romaji", "", "Native", "DB"),
             "Romaji"
         );
         assert_eq!(pick_title("english", "", "", "Native", "DB"), "Native");
-        // All language fields empty — final fallback to db title.
         assert_eq!(pick_title("english", "", "", "", "DB"), "DB");
         assert_eq!(pick_title("english", "", "", "", ""), "");
     }
 
     #[tokio::test]
-    async fn empty_series_index_returns_empty_without_al_call() {
-        // Empty DB → no AL request fires (would 401 in test env
-        // anyway since there's no wiremock fixture set up here),
-        // function returns an empty Vec immediately.
-        reset_cache();
-        let pool = crate::test_support::in_memory_pool().await;
+    async fn empty_db_returns_empty_without_error() {
+        let pool = pool().await;
         let cfg = Config::default();
-        let result = fetch_upcoming(&pool, &cfg, 0, 1_000_000, true).await;
-        assert!(result.is_ok());
-        assert!(result.unwrap().is_empty());
+        let out = fetch_upcoming(&pool, &cfg, 0, 1_000_000, true)
+            .await
+            .unwrap();
+        assert!(out.is_empty());
     }
 
     #[tokio::test]
-    async fn negative_anilist_ids_are_filtered_from_index() {
-        reset_cache();
-        let pool = crate::test_support::in_memory_pool().await;
+    async fn read_returns_only_in_window_airings_sorted() {
+        let pool = pool().await;
+        let series_id = add_series(&pool, 1, "Series A", "all").await;
+        episode_airings::upsert_for_series(
+            &pool,
+            series_id,
+            &[
+                EpisodeAiring {
+                    series_id,
+                    episode: 5,
+                    airing_at: 2_000,
+                    duration_minutes: 24,
+                },
+                EpisodeAiring {
+                    series_id,
+                    episode: 3,
+                    airing_at: 1_000,
+                    duration_minutes: 24,
+                },
+                // Out of window — should be excluded.
+                EpisodeAiring {
+                    series_id,
+                    episode: 1,
+                    airing_at: 500,
+                    duration_minutes: 24,
+                },
+            ],
+        )
+        .await
+        .unwrap();
+
+        let cfg = Config::default();
+        let out = fetch_upcoming(&pool, &cfg, 1_000, 3_000, false)
+            .await
+            .unwrap();
+        assert_eq!(out.len(), 2);
+        // Sorted ascending by airing_at.
+        assert_eq!(out[0].episode, 3);
+        assert_eq!(out[1].episode, 5);
+    }
+
+    #[tokio::test]
+    async fn monitored_only_excludes_none_mode_series() {
+        let pool = pool().await;
+        let unmonitored = add_series(&pool, 1, "Off", "none").await;
+        let monitored = add_series(&pool, 2, "On", "all").await;
+        for sid in [unmonitored, monitored] {
+            episode_airings::upsert_for_series(
+                &pool,
+                sid,
+                &[EpisodeAiring {
+                    series_id: sid,
+                    episode: 1,
+                    airing_at: 1_500,
+                    duration_minutes: 24,
+                }],
+            )
+            .await
+            .unwrap();
+        }
+
+        let cfg = Config::default();
+        let with_filter = fetch_upcoming(&pool, &cfg, 0, 5_000, true).await.unwrap();
+        assert_eq!(with_filter.len(), 1);
+        assert_eq!(with_filter[0].series_id, monitored);
+
+        let without_filter = fetch_upcoming(&pool, &cfg, 0, 5_000, false).await.unwrap();
+        assert_eq!(without_filter.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn negative_anilist_id_series_are_invisible() {
+        let pool = pool().await;
+        // Insert a Jikan-fallback series with a negative AL id and
+        // smuggle a stamped airing in (the refresh task wouldn't
+        // normally do this, but the read-side filter should still
+        // reject the row).
         sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'all')")
-            .bind(-12345_i64) // Jikan-fallback negative-id sentinel
-            .bind("MAL-only series")
+            .bind(-12345_i64)
+            .bind("MAL-only")
             .execute(&pool)
             .await
             .unwrap();
-        let rows = load_series_index(&pool, &Config::default(), true)
+        let id: i64 = sqlx::query_scalar("SELECT id FROM series WHERE anilist_id = -12345")
+            .fetch_one(&pool)
             .await
             .unwrap();
+        episode_airings::upsert_for_series(
+            &pool,
+            id,
+            &[EpisodeAiring {
+                series_id: id,
+                episode: 1,
+                airing_at: 1_500,
+                duration_minutes: 24,
+            }],
+        )
+        .await
+        .unwrap();
+
+        let cfg = Config::default();
+        let out = fetch_upcoming(&pool, &cfg, 0, 5_000, false).await.unwrap();
         assert!(
-            rows.is_empty(),
-            "negative-id sentinel rows should be filtered out"
+            out.is_empty(),
+            "negative-AL-id series must not appear in the calendar"
         );
-    }
-
-    #[tokio::test]
-    async fn monitored_only_filters_none_rows() {
-        reset_cache();
-        let pool = crate::test_support::in_memory_pool().await;
-        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'all')")
-            .bind(1_i64)
-            .bind("Watched")
-            .execute(&pool)
-            .await
-            .unwrap();
-        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'none')")
-            .bind(2_i64)
-            .bind("Ignored")
-            .execute(&pool)
-            .await
-            .unwrap();
-
-        let monitored = load_series_index(&pool, &Config::default(), true)
-            .await
-            .unwrap();
-        assert_eq!(monitored.len(), 1);
-        assert_eq!(monitored[0].anilist_id, 1);
-
-        let all = load_series_index(&pool, &Config::default(), false)
-            .await
-            .unwrap();
-        assert_eq!(all.len(), 2);
     }
 }

--- a/src/services/calendar.rs
+++ b/src/services/calendar.rs
@@ -40,7 +40,6 @@
 //! page gates on the cookie `require_auth` middleware. Both call
 //! this same function.
 
-use serde::Serialize;
 use sqlx::Row;
 use sqlx::SqlitePool;
 
@@ -48,9 +47,9 @@ use crate::models::config::Config;
 
 /// Per-episode shape served to both consumers. Title is already
 /// resolved via `Config.title_language` so neither the iCal text
-/// emitter nor the JSON page renderer needs to re-pick from
+/// emitter nor the page renderer needs to re-pick from
 /// romaji/english/native.
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone)]
 pub struct UpcomingEpisode {
     /// Ryokan-internal `series.id`. Used to back-link to
     /// `/series/{id}` in iCal events + the calendar page cards.

--- a/src/services/calendar.rs
+++ b/src/services/calendar.rs
@@ -1,0 +1,475 @@
+//! Calendar data layer (issue #115).
+//!
+//! Single source of truth for "what episodes are airing soon"
+//! shared by the iCal feed (`/api/calendar.ics`) and the in-app
+//! calendar page (`/calendar`, issue #116). Both consumers call
+//! [`fetch_upcoming`] with their preferred window; the cache + AL
+//! fetch + DB join happen here exactly once per (id-set, window)
+//! tuple regardless of how many subscribers are polling.
+//!
+//! ## Architecture
+//!
+//! Read-through to AniList with a 15-minute server-side cache. No
+//! new persistent state — the AL `Page.airingSchedules` query is
+//! the right shape for this, and persisting per-series next-airing
+//! state would couple iCal freshness to the 12h metadata-refresh
+//! cadence (and miss future weeks).
+//!
+//! Cache is keyed by `(sorted_anilist_ids, from, to)`. When the
+//! user adds or removes a series, the id set changes and the next
+//! request misses the cache; a 15-min stale window for "I just
+//! added a series, when will it appear in my calendar?" is
+//! acceptable.
+//!
+//! ## Negative-AL-id blind spot
+//!
+//! Series added via the Jikan/MAL fallback path with no AL mapping
+//! get `series.anilist_id = -mal_id`. We filter `anilist_id > 0`
+//! before the AL query (matching every other AL call site) so
+//! synthetic ids don't leak into AL requests. Documented in the
+//! Settings → Calendar panel so users with MAL-exclusive series
+//! aren't surprised by their absence from the feed.
+//!
+//! ## Auth
+//!
+//! This module is auth-agnostic — it just returns Vec<UpcomingEpisode>.
+//! The iCal handler gates on the `calendar` scoped key
+//! (`require_calendar_scope`); the in-app page gates on the cookie
+//! `require_auth` middleware. Both call this same function.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use sqlx::Row;
+use sqlx::SqlitePool;
+
+use crate::models::config::Config;
+use crate::services::anilist::airing_schedules;
+
+/// Per-episode shape served to both consumers. Title is already
+/// resolved via `Config.title_language` so neither the iCal text
+/// emitter nor the JSON page renderer needs to re-pick from
+/// romaji/english/native.
+#[derive(Debug, Clone, Serialize)]
+pub struct UpcomingEpisode {
+    /// Ryokan-internal `series.id`. Used to back-link to
+    /// `/series/{id}` in iCal events + the calendar page cards.
+    pub series_id: i64,
+    /// AL media id. Always positive — negative-id sentinel rows are
+    /// filtered out before the AL query.
+    pub anilist_id: i32,
+    /// Already resolved per `Config.title_language` with the usual
+    /// romaji → english → native fallback so callers don't have to
+    /// pick.
+    pub series_title: String,
+    pub episode: i32,
+    /// Unix epoch seconds (UTC). Both consumers render this in the
+    /// user's local timezone client-side.
+    pub airing_at: i64,
+    /// AL's `Media.duration` (per-episode runtime in minutes).
+    /// Defaults to 24 — the value most TV anime series use.
+    pub duration_minutes: i32,
+    /// True when this series is monitored (`monitor_mode != 'none'`).
+    /// The `?monitored=true` filter on the iCal endpoint uses this;
+    /// the calendar page renders it as a per-row badge.
+    pub monitored: bool,
+    /// `series.cover_url` (AL CDN poster). Used by the in-app
+    /// `/calendar` page to render a thumbnail next to each episode
+    /// card; the iCal feed ignores it (calendar clients don't
+    /// render embedded artwork).
+    pub cover_url: String,
+    /// Lowercased concatenation of every title variant (romaji +
+    /// english + native + db-stored). Used by the calendar page's
+    /// client-side series-name filter so a user typing "attack on
+    /// titan" can match the series even when their `title_language`
+    /// is set to romaji or native and the visible `series_title`
+    /// is the Japanese form. Computed server-side once instead of
+    /// having the JS layer normalize per-keystroke.
+    pub search_haystack: String,
+}
+
+/// Default forward window for the iCal feed. The plan doc reserves
+/// a configurable `?days=N` query param; until that wires through,
+/// callers pass `DEFAULT_FORWARD_DAYS * 86400` directly.
+pub const DEFAULT_FORWARD_DAYS: i64 = 30;
+
+/// Cache TTL. 15 minutes balances "iCal subscribers polling every
+/// 15-60 min get fast responses" against "I just added a series —
+/// when will it show up?" The 30-day forward window plus AL's
+/// upstream cadence makes a tighter TTL pointless.
+const CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+
+/// Width of the cache-key window-bucket. Callers pass `from = now`
+/// (which changes every second), so without bucketing the cache
+/// key would change on every request and the cache would never
+/// hit — even within the TTL window. Snapping `from` and `to` to
+/// the nearest 15-minute boundary makes the key stable for the
+/// whole cache lifetime; users get an at-most-15-min-snapped
+/// window which is negligible at the 7-30 day windows the page
+/// actually serves.
+const CACHE_BUCKET_SECS: i64 = 15 * 60;
+
+fn bucket_floor(ts: i64) -> i64 {
+    ts - ts.rem_euclid(CACHE_BUCKET_SECS)
+}
+
+#[derive(Hash, Eq, PartialEq, Clone)]
+struct CacheKey {
+    /// Sorted so two callers with the same set in different order
+    /// hit the same cache entry.
+    sorted_ids: Vec<i32>,
+    from: i64,
+    to: i64,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    fetched_at: Instant,
+    data: Vec<UpcomingEpisode>,
+}
+
+/// Process-wide cache. `StdMutex` (not async) is fine — the lock
+/// is held for HashMap get/insert only, never across an await
+/// point. Same shape SeaDex's lookup cache uses.
+static CACHE: LazyLock<StdMutex<HashMap<CacheKey, CacheEntry>>> =
+    LazyLock::new(|| StdMutex::new(HashMap::new()));
+
+/// Fetch upcoming episodes airing in `from..to` for every monitored
+/// series in the library (or every series, depending on
+/// `monitored_only`). Cache hit returns immediately; cache miss
+/// pulls the AL ids from `series`, calls
+/// [`airing_schedules::fetch_airing_schedules`], joins the result
+/// against `series` to resolve internal ids + monitor state, and
+/// writes the cache.
+///
+/// Errors propagate from the AL layer with the "AniList
+/// rate-limited" / "AniList unavailable" prefix taxonomy so the
+/// iCal handler can decide whether to serve a stale cache or 503.
+pub async fn fetch_upcoming(
+    db: &SqlitePool,
+    config: &Config,
+    from: i64,
+    to: i64,
+    monitored_only: bool,
+) -> Result<Vec<UpcomingEpisode>, String> {
+    // Snap window endpoints to a 15-minute bucket so the cache key
+    // stabilizes across requests within the same TTL window. Without
+    // this, callers passing `from = chrono::Utc::now().timestamp()`
+    // (which changes every second) would generate a unique key per
+    // request and the cache would effectively never hit. See
+    // `CACHE_BUCKET_SECS` above.
+    let from = bucket_floor(from);
+    let to = bucket_floor(to);
+
+    // Pull the per-row mapping from anilist_id → (series_id, monitor
+    // state, locale-resolved title). One query for both the AL id
+    // list and the post-fetch join.
+    let rows = load_series_index(db, config, monitored_only).await?;
+    if rows.is_empty() {
+        // No monitored (or no positive-AL-id) series — no AL request,
+        // empty result. Don't cache the empty result; a freshly-added
+        // series should appear without waiting for cache expiry.
+        return Ok(Vec::new());
+    }
+
+    let mut sorted_ids: Vec<i32> = rows.iter().map(|r| r.anilist_id).collect();
+    sorted_ids.sort_unstable();
+    let key = CacheKey {
+        sorted_ids: sorted_ids.clone(),
+        from,
+        to,
+    };
+
+    if let Some(cached) = cache_get(&key) {
+        return Ok(cached);
+    }
+
+    // Cache miss — fetch from AL.
+    let schedules = airing_schedules::fetch_airing_schedules(&sorted_ids, from, to).await?;
+    let by_anilist_id: HashMap<i32, &SeriesIndexRow> =
+        rows.iter().map(|r| (r.anilist_id, r)).collect();
+
+    let mut out: Vec<UpcomingEpisode> = Vec::with_capacity(schedules.len());
+    for s in schedules {
+        let Some(row) = by_anilist_id.get(&s.media_id) else {
+            // AL returned a schedule for a media id we didn't ask
+            // about (shouldn't happen; mediaId_in is ID-list-
+            // restricted). Drop silently rather than emit an
+            // unidentifiable VEVENT.
+            continue;
+        };
+        // Pick a per-call title: prefer the user's preferred
+        // language, fall back through romaji → english → native →
+        // database-stored title to ensure SUMMARY is never empty.
+        let title = pick_title(
+            &config.title_language,
+            &s.title_romaji,
+            &s.title_english,
+            &s.title_native,
+            &row.title,
+        );
+        // Every title variant lowercased + space-separated so a
+        // single substring search hits any of them. `db_title` is
+        // included as a fallback for series the user manually
+        // renamed (rare; the AL-fetched titles are usually the
+        // ones a user would type to search).
+        let haystack = [
+            s.title_romaji.as_str(),
+            s.title_english.as_str(),
+            s.title_native.as_str(),
+            row.title.as_str(),
+        ]
+        .iter()
+        .filter(|t| !t.is_empty())
+        .map(|t| t.to_lowercase())
+        .collect::<Vec<_>>()
+        .join(" ");
+        out.push(UpcomingEpisode {
+            series_id: row.series_id,
+            anilist_id: s.media_id,
+            series_title: title,
+            episode: s.episode,
+            airing_at: s.airing_at,
+            duration_minutes: s.duration_minutes.unwrap_or(24),
+            monitored: row.monitored,
+            cover_url: row.cover_url.clone(),
+            search_haystack: haystack,
+        });
+    }
+    out.sort_by_key(|e| e.airing_at);
+
+    cache_put(key, out.clone());
+    Ok(out)
+}
+
+struct SeriesIndexRow {
+    series_id: i64,
+    anilist_id: i32,
+    /// Database-stored title. Used as the final fallback if the AL
+    /// row's titles are all empty (shouldn't happen but the
+    /// SUMMARY-must-not-be-empty contract is load-bearing for iCal
+    /// validators).
+    title: String,
+    monitored: bool,
+    cover_url: String,
+}
+
+async fn load_series_index(
+    db: &SqlitePool,
+    _config: &Config,
+    monitored_only: bool,
+) -> Result<Vec<SeriesIndexRow>, String> {
+    let sql = if monitored_only {
+        "SELECT id, anilist_id, title, monitor_mode, cover_url \
+         FROM series \
+         WHERE anilist_id > 0 AND monitor_mode != 'none'"
+    } else {
+        "SELECT id, anilist_id, title, monitor_mode, cover_url \
+         FROM series \
+         WHERE anilist_id > 0"
+    };
+    let rows = sqlx::query(sql)
+        .fetch_all(db)
+        .await
+        .map_err(|e| format!("series index query: {e}"))?;
+    let mut out: Vec<SeriesIndexRow> = Vec::with_capacity(rows.len());
+    for row in rows {
+        let series_id: i64 = row.try_get("id").unwrap_or(0);
+        let anilist_id: i64 = row.try_get("anilist_id").unwrap_or(0);
+        if anilist_id <= 0 || series_id <= 0 {
+            continue;
+        }
+        let title: String = row.try_get("title").unwrap_or_default();
+        let monitor_mode: String = row.try_get("monitor_mode").unwrap_or_default();
+        let cover_url: String = row.try_get("cover_url").unwrap_or_default();
+        out.push(SeriesIndexRow {
+            series_id,
+            anilist_id: anilist_id as i32,
+            title,
+            monitored: monitor_mode != "none",
+            cover_url,
+        });
+    }
+    Ok(out)
+}
+
+/// Pick a title respecting `Config.title_language`, falling back
+/// through the other language fields and finally the
+/// database-stored title. Mirrors the per-series-page title
+/// resolution shape so what the user sees in their library matches
+/// what they see in their calendar.
+fn pick_title(lang: &str, romaji: &str, english: &str, native: &str, db_title: &str) -> String {
+    let preferred = match lang {
+        "english" => english,
+        "native" => native,
+        _ => romaji,
+    };
+    if !preferred.is_empty() {
+        return preferred.to_string();
+    }
+    for candidate in [romaji, english, native, db_title] {
+        if !candidate.is_empty() {
+            return candidate.to_string();
+        }
+    }
+    String::new()
+}
+
+fn cache_get(key: &CacheKey) -> Option<Vec<UpcomingEpisode>> {
+    let mut cache = CACHE.lock().ok()?;
+    let entry = cache.get(key)?;
+    if entry.fetched_at.elapsed() > CACHE_TTL {
+        cache.remove(key);
+        return None;
+    }
+    Some(entry.data.clone())
+}
+
+fn cache_put(key: CacheKey, data: Vec<UpcomingEpisode>) {
+    let Ok(mut cache) = CACHE.lock() else {
+        return;
+    };
+    cache.insert(
+        key,
+        CacheEntry {
+            fetched_at: Instant::now(),
+            data,
+        },
+    );
+    // Lazy cleanup: drop expired entries when we cross a soft
+    // ceiling. Avoids unbounded growth from users polling many
+    // distinct ?days=N windows.
+    if cache.len() > 64 {
+        let now = Instant::now();
+        cache.retain(|_, e| now.duration_since(e.fetched_at) <= CACHE_TTL);
+    }
+}
+
+/// Drop every cache entry. Test-only — used to keep cache state
+/// isolated between tests sharing the process-wide CACHE.
+#[cfg(test)]
+pub(crate) fn reset_cache() {
+    if let Ok(mut cache) = CACHE.lock() {
+        cache.clear();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bucket_floor_snaps_to_15_minute_boundaries() {
+        // Pin the cache-key bucketing. A request at 14:07:33 and a
+        // request at 14:08:01 should produce the same bucket (14:00)
+        // so they hit the same cache entry. Regression test for the
+        // bug where every per-second `now()` produced a unique key.
+        let secs_in_15min = 15 * 60;
+        // Choose a timestamp partway through a 15-min window: floor
+        // should round down to the window start.
+        let mid_window = 1_700_000_000_i64 + 7 * 60 + 33; // +07:33 into a window
+        let bucketed = bucket_floor(mid_window);
+        let next = bucket_floor(mid_window + 60); // +1 min later
+        assert_eq!(
+            bucketed, next,
+            "two timestamps in the same 15-min window must bucket to the same value"
+        );
+        // Crossing a 15-min boundary changes the bucket.
+        let crossed = bucket_floor(mid_window + secs_in_15min);
+        assert_ne!(bucketed, crossed);
+        // Bucket value is always a multiple of 15 minutes.
+        assert_eq!(bucketed % secs_in_15min, 0);
+    }
+
+    #[test]
+    fn pick_title_prefers_user_language() {
+        assert_eq!(
+            pick_title("english", "Romaji", "English", "Native", "DB"),
+            "English"
+        );
+        assert_eq!(
+            pick_title("native", "Romaji", "English", "Native", "DB"),
+            "Native"
+        );
+        assert_eq!(
+            pick_title("romaji", "Romaji", "English", "Native", "DB"),
+            "Romaji"
+        );
+    }
+
+    #[test]
+    fn pick_title_falls_back_through_languages() {
+        // Preferred is empty; should walk romaji → english → native.
+        assert_eq!(
+            pick_title("english", "Romaji", "", "Native", "DB"),
+            "Romaji"
+        );
+        assert_eq!(pick_title("english", "", "", "Native", "DB"), "Native");
+        // All language fields empty — final fallback to db title.
+        assert_eq!(pick_title("english", "", "", "", "DB"), "DB");
+        assert_eq!(pick_title("english", "", "", "", ""), "");
+    }
+
+    #[tokio::test]
+    async fn empty_series_index_returns_empty_without_al_call() {
+        // Empty DB → no AL request fires (would 401 in test env
+        // anyway since there's no wiremock fixture set up here),
+        // function returns an empty Vec immediately.
+        reset_cache();
+        let pool = crate::test_support::in_memory_pool().await;
+        let cfg = Config::default();
+        let result = fetch_upcoming(&pool, &cfg, 0, 1_000_000, true).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn negative_anilist_ids_are_filtered_from_index() {
+        reset_cache();
+        let pool = crate::test_support::in_memory_pool().await;
+        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'all')")
+            .bind(-12345_i64) // Jikan-fallback negative-id sentinel
+            .bind("MAL-only series")
+            .execute(&pool)
+            .await
+            .unwrap();
+        let rows = load_series_index(&pool, &Config::default(), true)
+            .await
+            .unwrap();
+        assert!(
+            rows.is_empty(),
+            "negative-id sentinel rows should be filtered out"
+        );
+    }
+
+    #[tokio::test]
+    async fn monitored_only_filters_none_rows() {
+        reset_cache();
+        let pool = crate::test_support::in_memory_pool().await;
+        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'all')")
+            .bind(1_i64)
+            .bind("Watched")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO series (anilist_id, title, monitor_mode) VALUES (?, ?, 'none')")
+            .bind(2_i64)
+            .bind("Ignored")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let monitored = load_series_index(&pool, &Config::default(), true)
+            .await
+            .unwrap();
+        assert_eq!(monitored.len(), 1);
+        assert_eq!(monitored[0].anilist_id, 1);
+
+        let all = load_series_index(&pool, &Config::default(), false)
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 2);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
+pub mod airing_refresh;
 pub mod anilist;
 pub mod calendar;
 pub mod crypto;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod anilist;
+pub mod calendar;
 pub mod crypto;
 pub mod download_client;
 pub mod external_sync;

--- a/static/css/pages/calendar.css
+++ b/static/css/pages/calendar.css
@@ -291,6 +291,16 @@
     background: rgba(108, 112, 134, 0.18);
 }
 
+/* "Premiere" — first episode of a Ryokan series. Each anime
+   season is its own series here, so this fires for E1 of any
+   new cour, not just brand-new shows. Accent-coloured to draw
+   the eye but not louder than monitored/unmon since premieres
+   are common. */
+.calendar-episode-badge-premiere {
+    color: var(--accent);
+    background: rgba(168, 124, 255, 0.16);
+}
+
 .calendar-empty {
     padding: 48px 24px;
     text-align: center;
@@ -299,6 +309,202 @@
 
 .calendar-empty p {
     margin: 0 0 8px;
+}
+
+/* ── Month-grid view (range=month) ───────────────────────────
+   Sun→Sat 7-column rectangle. Each cell is a square-ish slot
+   with the day number top-right and stacked episode pills
+   beneath. Out-of-month cells stay rendered (faded) so each
+   week is a clean row. */
+
+.calendar-month {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.calendar-month-title {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--text-bright);
+    margin: 0 0 4px;
+    letter-spacing: 0.01em;
+}
+
+.calendar-month-dow {
+    display: grid;
+    /* `minmax(0, 1fr)` instead of bare `1fr` — bare `1fr` lets a
+       column grow past its share when a child has a min content
+       width (the nowrap pill title), making columns wildly
+       uneven. `minmax(0, 1fr)` caps the lower bound at 0 so the
+       7 columns stay equal. */
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1px;
+    text-transform: uppercase;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--text-dim);
+}
+
+.calendar-month-dow span {
+    padding: 4px 8px;
+}
+
+.calendar-month-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    gap: 1px;
+    background: var(--border);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    overflow: hidden;
+}
+
+.calendar-month-cell {
+    background: var(--bg-card);
+    min-height: 120px;
+    padding: 6px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    position: relative;
+    transition: background 0.12s;
+    /* Same min-width-0 escape hatch as the column track — without
+       this, a wide pill child propagates its min-content width
+       up and overrides the grid track's `minmax(0, 1fr)`. */
+    min-width: 0;
+}
+
+.calendar-month-cell-other {
+    background: var(--bg);
+    color: var(--text-dim);
+}
+
+.calendar-month-cell-other .calendar-month-cell-num {
+    color: var(--text-dim);
+    opacity: 0.6;
+}
+
+.calendar-month-cell-num {
+    align-self: flex-end;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    line-height: 1;
+}
+
+.calendar-month-cell-today {
+    background: var(--bg-elevated);
+    box-shadow: inset 0 2px 0 var(--accent);
+}
+
+.calendar-month-cell-today .calendar-month-cell-num {
+    color: var(--accent);
+    font-weight: 700;
+}
+
+.calendar-month-cell-eps {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    overflow: hidden;
+}
+
+.calendar-month-pill {
+    display: flex;
+    align-items: baseline;
+    gap: 6px;
+    padding: 3px 6px;
+    border-radius: 4px;
+    font-size: 11px;
+    line-height: 1.3;
+    text-decoration: none;
+    color: var(--text);
+    background: var(--bg-elevated);
+    border-left: 3px solid var(--text-dim);
+    overflow: hidden;
+    transition: background 0.12s;
+    /* Min-width-0 on the flex container so the title's nowrap
+       can't push the pill (and its grid cell) past its share. */
+    min-width: 0;
+}
+
+.calendar-month-pill:hover {
+    background: var(--bg);
+}
+
+.calendar-month-pill-monitored {
+    border-left-color: var(--green, #a6e3a1);
+}
+
+.calendar-month-pill-unmon {
+    border-left-color: var(--text-dim);
+    opacity: 0.78;
+}
+
+/* Premiere pill — accent-coloured left border (overrides
+   monitored/unmon) + a small ★ glyph before the title. The
+   border-left wins because the class is appended after the
+   monitored/unmon class in the template. */
+.calendar-month-pill-premiere {
+    border-left-color: var(--accent);
+    /* Restore full opacity even when the underlying state is
+       unmonitored — premieres are notable enough that they
+       shouldn't be dimmed. */
+    opacity: 1;
+}
+
+.calendar-month-pill-prem-mark {
+    flex-shrink: 0;
+    color: var(--accent);
+    font-size: 10px;
+    line-height: 1;
+    /* Center the glyph against baseline-aligned siblings. */
+    align-self: center;
+}
+
+.calendar-month-pill-time {
+    flex-shrink: 0;
+    font-variant-numeric: tabular-nums;
+    font-size: 10px;
+    color: var(--text-dim);
+    min-width: 36px;
+}
+
+.calendar-month-pill-title {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: 500;
+    /* Required for `text-overflow: ellipsis` to actually engage
+       inside a flex item; without it the item's min-content
+       width = full text width and there's nothing to truncate. */
+    min-width: 0;
+}
+
+.calendar-month-pill-ep {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--accent);
+    font-weight: 600;
+}
+
+@media (max-width: 900px) {
+    .calendar-month-cell {
+        min-height: 90px;
+        padding: 4px;
+    }
+    .calendar-month-pill {
+        gap: 4px;
+        padding: 2px 4px;
+    }
+    .calendar-month-pill-time {
+        display: none;
+    }
 }
 
 @media (max-width: 640px) {
@@ -323,5 +529,45 @@
     .calendar-episode-cover {
         width: 40px;
         height: 56px;
+    }
+
+    /* Month grid on phones — the 7-column rectangle is too
+       cramped to read. Collapse to a single-column flow that
+       skips empty + out-of-month cells; effectively turns the
+       grid into a date-grouped list while keeping the same
+       day_key markup so the JS today-highlight + filters work
+       unchanged. */
+    .calendar-month-dow {
+        display: none;
+    }
+    .calendar-month-grid {
+        grid-template-columns: 1fr;
+        gap: 0;
+        background: transparent;
+        border: 1px solid var(--border);
+        border-radius: var(--radius);
+    }
+    .calendar-month-cell {
+        min-height: 0;
+        border-bottom: 1px solid var(--border);
+    }
+    .calendar-month-cell:last-child {
+        border-bottom: none;
+    }
+    .calendar-month-cell:has(.calendar-month-cell-eps) .calendar-month-cell-num {
+        align-self: flex-start;
+        color: var(--accent);
+        font-size: 11px;
+    }
+    .calendar-month-cell-other,
+    .calendar-month-cell:not(:has(.calendar-month-cell-eps)) {
+        display: none;
+    }
+    .calendar-month-pill {
+        font-size: 12px;
+        padding: 6px 8px;
+    }
+    .calendar-month-pill-time {
+        display: inline;
     }
 }

--- a/static/css/pages/calendar.css
+++ b/static/css/pages/calendar.css
@@ -1,0 +1,327 @@
+/* /calendar page (issue #116). Day-grouped episode list with
+   sticky day headers; range tabs + monitored-only filter at
+   the top; "iCal Link" button in the page header that opens a
+   subscription-URL modal (Sonarr-style, no inline section). */
+
+.calendar-page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.calendar-ical-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    font-weight: 500;
+}
+
+.calendar-ical-btn svg {
+    flex-shrink: 0;
+}
+
+.calendar-toolbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.calendar-range-tabs {
+    display: inline-flex;
+    gap: 2px;
+    background: var(--bg-elevated);
+    padding: 3px;
+    border-radius: 8px;
+    border: 1px solid var(--border);
+}
+
+.calendar-range-tab {
+    padding: 6px 12px;
+    color: var(--text-dim);
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 6px;
+    transition: color 0.15s, background 0.15s;
+}
+
+.calendar-range-tab:hover {
+    color: var(--text);
+}
+
+.calendar-range-tab.active {
+    color: var(--accent);
+    background: var(--bg-card);
+}
+
+/* Filters row — search input + per-mode toggle pills sit to the
+   right of the range tabs. On mobile they stack via the existing
+   .calendar-toolbar @media flex-direction: column. */
+.calendar-filters {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.calendar-series-search {
+    width: 220px;
+    height: 36px;
+    padding: 0 12px;
+    background: var(--bg-elevated);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text);
+    font-size: 13px;
+    font-family: inherit;
+    transition: border-color 0.15s;
+}
+
+.calendar-series-search:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.calendar-series-search::placeholder {
+    color: var(--text-dim);
+}
+
+/* Shared shape for the per-mode checkboxes (premieres-only,
+   monitored-only). Inline label that reads as a pill of small
+   text + checkbox so it doesn't compete visually with the search
+   input. */
+.calendar-toggle-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-dim);
+    font-size: 13px;
+    cursor: pointer;
+    user-select: none;
+}
+
+/* Backwards-compat: the original `.calendar-monitored-filter`
+   class is still referenced by tests / older snapshots if we
+   ever pick it up, but new markup uses `.calendar-toggle-filter`
+   for the same shape. */
+.calendar-monitored-filter {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: var(--text-dim);
+    font-size: 13px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.calendar-list {
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.calendar-day {
+    /* Soft-card shape so each day reads as a chunk; no heavy
+       border, just a faint surface tint. */
+}
+
+.calendar-day-label {
+    /* Sticky so the day label stays visible while scrolling
+       through a long week. Top offset clears the fixed topbar
+       (56px) plus a gap. */
+    position: sticky;
+    top: 64px;
+    z-index: 5;
+    margin: 0 0 12px;
+    padding: 6px 0;
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--accent);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    background: var(--bg);
+    border-bottom: 1px solid var(--border);
+    /* Layout for the date label + episode count pill on the
+       right end of the row. */
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+}
+
+.calendar-day-label-text {
+    /* Plain wrapper so the parent's flex layout positions the
+       text + count predictably. */
+}
+
+.calendar-day-label-count {
+    font-size: 11px;
+    font-weight: 500;
+    color: var(--text-dim);
+    text-transform: none;
+    letter-spacing: 0.02em;
+    font-variant-numeric: tabular-nums;
+}
+
+/* Today highlight — accent left border + brighter label color so
+   the user's eye lands on today even mid-week. The `.calendar-day`
+   gets a tinted left strip via border-left. */
+.calendar-day-today .calendar-day-label-text::before {
+    content: 'Today · ';
+    color: var(--accent);
+    font-weight: 700;
+}
+
+.calendar-day-today {
+    border-left: 3px solid var(--accent);
+    padding-left: 12px;
+    margin-left: -15px;
+}
+
+/* Hidden-by-filter sections + episodes — `display: none` so the
+   container's flex/grid doesn't reserve their space. */
+.calendar-day-hidden,
+.calendar-episode-hidden {
+    display: none;
+}
+
+.calendar-day-episodes {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.calendar-episode {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg);
+    transition: border-color 0.15s, transform 0.1s ease-out;
+}
+
+.calendar-episode:hover {
+    border-color: var(--border-accent, var(--accent));
+}
+
+.calendar-episode-link {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    padding: 12px 14px;
+    color: var(--text);
+    text-decoration: none;
+}
+
+.calendar-episode-cover {
+    flex-shrink: 0;
+    width: 48px;
+    height: 68px;
+    border-radius: 4px;
+    object-fit: cover;
+    background: var(--bg-elevated);
+}
+
+.calendar-episode-cover-placeholder {
+    background: linear-gradient(135deg, var(--bg-elevated), var(--bg-card));
+    border: 1px solid var(--border);
+}
+
+.calendar-episode-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    min-width: 0;
+    flex: 1;
+}
+
+.calendar-episode-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--text-bright);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.calendar-episode-sub {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    color: var(--text-dim);
+    flex-wrap: wrap;
+}
+
+.calendar-episode-num {
+    font-family: var(--font-mono);
+    font-weight: 600;
+    color: var(--accent);
+}
+
+.calendar-episode-time {
+    font-variant-numeric: tabular-nums;
+}
+
+.calendar-episode-badge {
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.calendar-episode-badge-monitored {
+    color: var(--green, #a6e3a1);
+    background: rgba(166, 227, 161, 0.18);
+}
+
+.calendar-episode-badge-unmon {
+    color: var(--text-dim);
+    background: rgba(108, 112, 134, 0.18);
+}
+
+.calendar-empty {
+    padding: 48px 24px;
+    text-align: center;
+    color: var(--text-dim);
+}
+
+.calendar-empty p {
+    margin: 0 0 8px;
+}
+
+@media (max-width: 640px) {
+    .calendar-toolbar {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    .calendar-range-tabs {
+        justify-content: stretch;
+    }
+    .calendar-range-tab {
+        flex: 1 1 auto;
+        text-align: center;
+    }
+    .calendar-day-label {
+        top: 0;
+    }
+    .calendar-episode-link {
+        gap: 10px;
+        padding: 10px 12px;
+    }
+    .calendar-episode-cover {
+        width: 40px;
+        height: 56px;
+    }
+}

--- a/static/css/topbar.css
+++ b/static/css/topbar.css
@@ -89,6 +89,31 @@
     flex-shrink: 0;
 }
 
+/* Issue #116 — Calendar nav entry shape. Two variants:
+   - `.nav-calendar-desktop`: regular labeled link in the topbar
+     between Library and bulk-select. Always rendered; hidden on
+     mobile via the `.nav-links > *:not(...)` filter below.
+   - `.nav-calendar-mobile`: icon-only library-page-only entry,
+     whitelisted through the mobile filter so it shows up next to
+     the bulk-select toggle on mobile. Hidden on desktop. */
+.nav-calendar-mobile {
+    display: none;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    color: var(--text-dim);
+    border-radius: var(--radius);
+    transition: color 0.15s, background 0.15s;
+}
+.nav-calendar-mobile:hover {
+    color: var(--text);
+    background: var(--bg-elevated);
+}
+.nav-calendar-mobile svg {
+    flex-shrink: 0;
+}
+
 @media (max-width: 640px) {
     /* Keep .nav-links flexed on mobile but hide every child except
        (a) the mobile logout icon and (b) the bulk-select toggle on
@@ -100,10 +125,13 @@
         gap: 6px;
         align-items: center;
     }
-    .nav-links > *:not(.nav-logout-mobile):not(.bulk-select-toggle) {
+    .nav-links > *:not(.nav-logout-mobile):not(.bulk-select-toggle):not(.nav-calendar-mobile) {
         display: none;
     }
     .nav-logout-mobile {
+        display: inline-flex;
+    }
+    .nav-calendar-mobile {
         display: inline-flex;
     }
     .mobile-tabbar {

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -1,0 +1,258 @@
+// /calendar page lifecycle (issue #116). HTMX-driven swap:
+//
+//   1. Range tabs (this week / next week / month) carry hx-get
+//      against the same /calendar URL. The handler branches on
+//      HxRequest and returns the partials/calendar/list.html
+//      partial, which htmx swaps into #calendar-list. No JS
+//      involvement needed here — this file only re-applies post-
+//      swap hydrators (time, today-highlight, local filters).
+//
+//   2. "Monitored only" toggle uses htmx.ajax() to fetch the
+//      same partial with the new query string, keeping the URL
+//      bar honest via hx-push-url semantics.
+//
+//   3. iCal subscribe modal opens on the page-header button and
+//      composes the subscription URL by fetching the picked
+//      key's plaintext via /api/api-keys/{id}/reveal (cookie-auth
+//      gated same as Settings).
+//
+// `var` at module scope per CLAUDE.md hx-boost re-execution rule.
+
+(function () {
+    if (!document.getElementById('calendar-list')) return;
+
+    function activeRange() {
+        var t = document.querySelector('.calendar-range-tab.active');
+        return t ? t.dataset.range : 'this_week';
+    }
+
+    function monitoredOnly() {
+        var cb = document.getElementById('calendar-monitored-toggle');
+        return cb ? cb.checked : false;
+    }
+
+    function fmtTime(unixTs) {
+        try {
+            var d = new Date(unixTs * 1000);
+            return d.toLocaleTimeString(undefined, {
+                hour: 'numeric',
+                minute: '2-digit',
+            });
+        } catch (_) {
+            return '';
+        }
+    }
+
+    function calendarUrl() {
+        var url = '/calendar?range=' + encodeURIComponent(activeRange());
+        if (monitoredOnly()) url += '&monitored=true';
+        return url;
+    }
+
+    // Patch each tab's `href` + `hx-get` to carry the current
+    // monitored-only state forward, so toggling monitored then
+    // clicking a range doesn't reset it.
+    function syncRangeTabHrefs() {
+        document.querySelectorAll('.calendar-range-tab').forEach(function (a) {
+            var url = '/calendar?range=' + encodeURIComponent(a.dataset.range);
+            if (monitoredOnly()) url += '&monitored=true';
+            a.setAttribute('href', url);
+            a.setAttribute('hx-get', url);
+        });
+    }
+
+    // ── Monitored-only toggle (HTMX swap) ───────────────────────
+    var monToggle = document.getElementById('calendar-monitored-toggle');
+    if (monToggle && window.htmx) {
+        monToggle.addEventListener('change', function () {
+            syncRangeTabHrefs();
+            // htmx.ajax with target+swap mirrors what hx-get would
+            // do declaratively, plus pushUrl for back/forward.
+            window.htmx.ajax('GET', calendarUrl(), {
+                target: '#calendar-list',
+                swap: 'innerHTML',
+                pushUrl: true,
+            });
+        });
+    }
+
+    // ── iCal subscribe modal ────────────────────────────────────
+
+    var icalBtn = document.getElementById('calendar-ical-btn');
+    var modal = document.getElementById('calendar-subscribe-modal');
+    var keyPicker = document.getElementById('calendar-subscribe-key');
+    var urlInput = document.getElementById('calendar-subscribe-url');
+    var copyBtn = document.getElementById('calendar-subscribe-copy-btn');
+    var copyConfirm = document.getElementById('calendar-subscribe-copy-confirm');
+
+    function refreshSubscribeUrl() {
+        if (!keyPicker || !urlInput) return;
+        var keyId = keyPicker.value;
+        if (!keyId) {
+            urlInput.value = '';
+            return;
+        }
+        urlInput.value = 'Loading...';
+        fetch('/api/api-keys/' + keyId + '/reveal', { credentials: 'same-origin' })
+            .then(function (r) {
+                if (!r.ok) throw new Error('reveal failed');
+                return r.json();
+            })
+            .then(function (data) {
+                if (!data || !data.plaintext) {
+                    urlInput.value = '(failed to load key)';
+                    return;
+                }
+                urlInput.value = window.location.origin
+                    + '/api/calendar.ics?apikey='
+                    + encodeURIComponent(data.plaintext);
+            })
+            .catch(function () {
+                urlInput.value = '(failed to load key)';
+            });
+    }
+
+    if (icalBtn && modal) {
+        icalBtn.addEventListener('click', function () {
+            modal.style.display = 'flex';
+            refreshSubscribeUrl();
+        });
+    }
+    if (keyPicker) keyPicker.addEventListener('change', refreshSubscribeUrl);
+
+    document.querySelectorAll('[data-modal-close="calendar-subscribe-modal"]').forEach(function (el) {
+        el.addEventListener('click', function () {
+            if (modal) modal.style.display = 'none';
+        });
+    });
+    if (modal) {
+        modal.addEventListener('click', function (ev) {
+            if (ev.target === modal) modal.style.display = 'none';
+        });
+    }
+
+    if (copyBtn && urlInput) {
+        copyBtn.addEventListener('click', function () {
+            if (!urlInput.value || urlInput.value.startsWith('(')) return;
+            navigator.clipboard.writeText(urlInput.value).then(function () {
+                if (copyConfirm) {
+                    copyConfirm.hidden = false;
+                    setTimeout(function () { copyConfirm.hidden = true; }, 2000);
+                }
+            }, function () {
+                urlInput.select();
+                urlInput.setSelectionRange(0, 99999);
+            });
+        });
+    }
+
+    // ── Per-cell time hydration ─────────────────────────────────
+    // Server renders `·` as a placeholder; we hydrate to the
+    // user's local-time format on first paint and after every
+    // HTMX swap.
+    function hydrateTimes(root) {
+        (root || document).querySelectorAll('.calendar-episode-time[data-airing-at]').forEach(function (el) {
+            var ts = parseInt(el.dataset.airingAt, 10);
+            if (ts > 0) el.textContent = fmtTime(ts);
+        });
+    }
+
+    // ── Today highlight + scroll-to-today ───────────────────────
+    function applyTodayHighlight(root) {
+        var now = Math.floor(Date.now() / 1000);
+        var todayUtcMidnight = now - (((now % 86400) + 86400) % 86400);
+        var todayEl = null;
+        (root || document).querySelectorAll('.calendar-day').forEach(function (el) {
+            var dk = parseInt(el.dataset.dayKey, 10);
+            var isToday = dk === todayUtcMidnight;
+            el.classList.toggle('calendar-day-today', isToday);
+            if (isToday) todayEl = el;
+        });
+        return todayEl;
+    }
+
+    function maybeScrollToToday(todayEl) {
+        if (!todayEl || typeof todayEl.scrollIntoView !== 'function') return;
+        // Defer to next frame so layout has settled.
+        requestAnimationFrame(function () {
+            todayEl.scrollIntoView({ behavior: 'auto', block: 'start' });
+            window.scrollBy({ top: -68, left: 0, behavior: 'auto' });
+        });
+    }
+
+    // ── Local filters: series-name search + premieres-only ──────
+    var seriesSearchInput = document.getElementById('calendar-series-search');
+    var premieresToggle = document.getElementById('calendar-premieres-toggle');
+
+    function applyLocalFilters(root) {
+        var query = seriesSearchInput ? seriesSearchInput.value.trim().toLowerCase() : '';
+        var premieresOnly = premieresToggle ? premieresToggle.checked : false;
+
+        (root || document).querySelectorAll('.calendar-day').forEach(function (day) {
+            var visibleCount = 0;
+            day.querySelectorAll('.calendar-episode').forEach(function (ep) {
+                var name = ep.dataset.seriesName || '';
+                var epNum = parseInt(ep.dataset.episode, 10) || 0;
+                var matches = (!query || name.indexOf(query) !== -1)
+                    && (!premieresOnly || epNum === 1);
+                ep.classList.toggle('calendar-episode-hidden', !matches);
+                if (matches) visibleCount++;
+            });
+            day.classList.toggle('calendar-day-hidden', visibleCount === 0);
+            var countEl = day.querySelector('.calendar-day-label-count');
+            if (countEl) {
+                var totalEps = day.querySelectorAll('.calendar-episode').length;
+                if (visibleCount < totalEps) {
+                    countEl.textContent = visibleCount + ' / ' + totalEps + ' eps';
+                } else {
+                    countEl.textContent = totalEps + (totalEps === 1 ? ' ep' : ' eps');
+                }
+            }
+        });
+    }
+
+    if (seriesSearchInput) {
+        seriesSearchInput.addEventListener('input', function () { applyLocalFilters(); });
+    }
+    if (premieresToggle) {
+        premieresToggle.addEventListener('change', function () { applyLocalFilters(); });
+    }
+
+    // Initial paint hydrators + first scroll-to-today.
+    hydrateTimes();
+    var initialToday = applyTodayHighlight();
+    applyLocalFilters();
+    maybeScrollToToday(initialToday);
+
+    // ── Re-hydrate after every HTMX swap of #calendar-list ──────
+    // The handler returns the same partial used for the initial
+    // render, but the DOM nodes are fresh — so the timestamps,
+    // today-highlight, and local filters all need re-applying.
+    // Listen on the list container; the event bubbles up but we
+    // scope to swaps that actually replaced our region.
+    var listEl = document.getElementById('calendar-list');
+    if (listEl) {
+        listEl.addEventListener('htmx:afterSwap', function (ev) {
+            if (!ev || !ev.target) return;
+            // The target on a swap settle is the swapped element
+            // itself. Re-run the hydrators against the current
+            // list root so we don't pick up stale handles.
+            var root = document.getElementById('calendar-list') || document;
+            hydrateTimes(root);
+            applyTodayHighlight(root);
+            applyLocalFilters(root);
+            // Active-tab class follows hx-push-url'd state. htmx
+            // doesn't update the `.active` class on swap, so we
+            // resync from the URL.
+            try {
+                var url = new URL(window.location.href);
+                var range = url.searchParams.get('range') || 'this_week';
+                document.querySelectorAll('.calendar-range-tab').forEach(function (a) {
+                    var on = a.dataset.range === range;
+                    a.classList.toggle('active', on);
+                    a.setAttribute('aria-selected', on ? 'true' : 'false');
+                });
+            } catch (_) {}
+        });
+    }
+})();

--- a/static/js/calendar.js
+++ b/static/js/calendar.js
@@ -147,32 +147,49 @@
     }
 
     // ── Per-cell time hydration ─────────────────────────────────
-    // Server renders `·` as a placeholder; we hydrate to the
-    // user's local-time format on first paint and after every
+    // Server renders `·` as a placeholder for both the list view
+    // (`.calendar-episode-time`) and the grid view's pills
+    // (`.calendar-month-pill-time`). We hydrate both shapes to
+    // the user's local-time format on first paint and after every
     // HTMX swap.
     function hydrateTimes(root) {
-        (root || document).querySelectorAll('.calendar-episode-time[data-airing-at]').forEach(function (el) {
+        var sel = '.calendar-episode-time[data-airing-at], .calendar-month-pill-time[data-airing-at]';
+        (root || document).querySelectorAll(sel).forEach(function (el) {
             var ts = parseInt(el.dataset.airingAt, 10);
             if (ts > 0) el.textContent = fmtTime(ts);
         });
     }
 
     // ── Today highlight + scroll-to-today ───────────────────────
+    // Both views key by `data-day-key` (UTC midnight). List view
+    // gets `.calendar-day-today`; grid view gets
+    // `.calendar-month-cell-today`. Server-side render already
+    // sets `is_today` on the right cell, so this is mainly the
+    // post-swap re-apply.
     function applyTodayHighlight(root) {
         var now = Math.floor(Date.now() / 1000);
         var todayUtcMidnight = now - (((now % 86400) + 86400) % 86400);
         var todayEl = null;
-        (root || document).querySelectorAll('.calendar-day').forEach(function (el) {
+        (root || document).querySelectorAll('.calendar-day, .calendar-month-cell').forEach(function (el) {
             var dk = parseInt(el.dataset.dayKey, 10);
             var isToday = dk === todayUtcMidnight;
-            el.classList.toggle('calendar-day-today', isToday);
-            if (isToday) todayEl = el;
+            if (el.classList.contains('calendar-day')) {
+                el.classList.toggle('calendar-day-today', isToday);
+            } else {
+                el.classList.toggle('calendar-month-cell-today', isToday);
+            }
+            if (isToday && !todayEl) todayEl = el;
         });
         return todayEl;
     }
 
     function maybeScrollToToday(todayEl) {
         if (!todayEl || typeof todayEl.scrollIntoView !== 'function') return;
+        // Skip auto-scroll in grid view — the full month fits
+        // roughly one screen, and jumping to today's cell mid-grid
+        // hides the leading weeks. List view benefits from the
+        // jump because the day-grouped flow can be long.
+        if (todayEl.classList.contains('calendar-month-cell')) return;
         // Defer to next frame so layout has settled.
         requestAnimationFrame(function () {
             todayEl.scrollIntoView({ behavior: 'auto', block: 'start' });
@@ -180,21 +197,21 @@
         });
     }
 
-    // ── Local filters: series-name search + premieres-only ──────
+    // ── Local filter: series-name search ────────────────────────
+    // Premiere status is now a passive visual indicator (badge in
+    // list view, ★ + accent border in grid view), not a filter.
     var seriesSearchInput = document.getElementById('calendar-series-search');
-    var premieresToggle = document.getElementById('calendar-premieres-toggle');
 
     function applyLocalFilters(root) {
         var query = seriesSearchInput ? seriesSearchInput.value.trim().toLowerCase() : '';
-        var premieresOnly = premieresToggle ? premieresToggle.checked : false;
+        var scope = root || document;
 
-        (root || document).querySelectorAll('.calendar-day').forEach(function (day) {
+        // List view — day-grouped sections.
+        scope.querySelectorAll('.calendar-day').forEach(function (day) {
             var visibleCount = 0;
             day.querySelectorAll('.calendar-episode').forEach(function (ep) {
                 var name = ep.dataset.seriesName || '';
-                var epNum = parseInt(ep.dataset.episode, 10) || 0;
-                var matches = (!query || name.indexOf(query) !== -1)
-                    && (!premieresOnly || epNum === 1);
+                var matches = !query || name.indexOf(query) !== -1;
                 ep.classList.toggle('calendar-episode-hidden', !matches);
                 if (matches) visibleCount++;
             });
@@ -209,13 +226,19 @@
                 }
             }
         });
+
+        // Grid view — filter pills per cell. Cells stay in place
+        // (hiding them would break the 7-column rectangle); only
+        // non-matching pills get hidden.
+        scope.querySelectorAll('.calendar-month-pill').forEach(function (pill) {
+            var name = pill.dataset.seriesName || '';
+            var matches = !query || name.indexOf(query) !== -1;
+            pill.classList.toggle('calendar-episode-hidden', !matches);
+        });
     }
 
     if (seriesSearchInput) {
         seriesSearchInput.addEventListener('input', function () { applyLocalFilters(); });
-    }
-    if (premieresToggle) {
-        premieresToggle.addEventListener('change', function () { applyLocalFilters(); });
     }
 
     // Initial paint hydrators + first scroll-to-today.

--- a/static/js/system.js
+++ b/static/js/system.js
@@ -246,6 +246,7 @@ function forceRunTask(btn, taskKey) {
     const endpoints = {
         rss_sync: '/api/rss/sync',
         metadata_refresh: '/api/tasks/metadata-refresh',
+        airing_refresh: '/api/tasks/airing-refresh',
         // The rebuild handler `api_rebuild_cached_metadata` writes a
         // `metadata_rebuild` scheduled-tasks row, so once the user has
         // ever clicked Rebuild on the Debug tab the task shows up in

--- a/templates/base.html
+++ b/templates/base.html
@@ -68,6 +68,7 @@
        `.indexer-*`, `.cf-*`, `.ep-*`, etc.) that cross-page rule
        collision is not a concern. #}
     <link rel="stylesheet" href="/static/css/pages/auth.css">
+    <link rel="stylesheet" href="/static/css/pages/calendar.css">
     <link rel="stylesheet" href="/static/css/pages/downloads.css">
     <link rel="stylesheet" href="/static/css/pages/grab_picker.css">
     <link rel="stylesheet" href="/static/css/pages/index.css">
@@ -158,6 +159,27 @@
                 </svg>
                 <span class="bulk-select-toggle-label">Select</span>
             </button>
+            {% endif %}
+            {# Issue #116 — Calendar entry. Desktop variant always
+               visible in the topbar; the library-only mobile-icon
+               variant lives in the library-only block below so
+               mobile users still reach /calendar from the library
+               page without burning a mobile-tabbar slot. #}
+            <a href="/calendar" class="nav-calendar-desktop {% if page == "calendar" %}active{% endif %}">Calendar</a>
+            {% if page == "library" %}
+            {# Mobile-only icon Calendar — same library-page-only
+               whitelist pattern as bulk-select. Desktop hides this
+               via the mobile filter (nav-links > *:not(...)) but
+               on mobile (where nav-links is forced visible only
+               for whitelisted children), this icon shows up. #}
+            <a href="/calendar" class="nav-action nav-calendar-mobile" aria-label="Calendar" title="Calendar">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <rect x="3" y="4" width="18" height="18" rx="2"/>
+                    <path d="M16 2v4"/>
+                    <path d="M8 2v4"/>
+                    <path d="M3 10h18"/>
+                </svg>
+            </a>
             {% endif %}
             <a href="/search" class="{% if page == "search" %}active{% endif %}">Search</a>
             <a href="/downloads" class="{% if page == "downloads" %}active{% endif %}">Downloads</a>

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -71,11 +71,6 @@
                aria-label="Filter by series name"
                autocomplete="off">
 
-        <label class="calendar-toggle-filter" title="Show only first episodes (S01E01)">
-            <input type="checkbox" id="calendar-premieres-toggle">
-            <span>Premieres only</span>
-        </label>
-
         <label class="calendar-toggle-filter">
             <input type="checkbox"
                    id="calendar-monitored-toggle"
@@ -85,11 +80,18 @@
     </div>
 </div>
 
-{# Day-grouped episode list. Each day is a sticky header followed
-   by its episode rows; the JS layer re-renders this region in
-   place when range/filter change. #}
-<div class="calendar-list" id="calendar-list">
+{# Body container — `#calendar-list` is the HTMX swap target for
+   range tab clicks + the monitored-only toggle. The handler
+   branches on view_mode and returns either the day-grouped list
+   partial (week ranges) or the calendar-month grid (month range).
+   Keeping both paths anchored at the same target means the JS
+   afterSwap hook hydrates whichever shape just landed. #}
+<div class="calendar-list" id="calendar-list" data-view-mode="{{ view_mode }}">
+{% if view_mode == "grid" %}
+{%~ include "partials/calendar/grid.html" ~%}
+{% else %}
 {%~ include "partials/calendar/list.html" ~%}
+{% endif %}
 </div>
 
 {# Subscribe modal — opened by the "iCal Link" button in the

--- a/templates/calendar.html
+++ b/templates/calendar.html
@@ -1,0 +1,163 @@
+{% extends "base.html" %}
+{# Per-page CSS now bundled in base.html — see comment there. #}
+
+{% block title %} - Calendar{% endblock %}
+
+{% block content %}
+<div class="page-header calendar-page-header">
+    <h2>Calendar</h2>
+    {# Sonarr-style "iCal Link" icon button. Opens a modal with the
+       subscription URL helper. Hidden when no calendar-scoped key
+       exists (the create-key prompt lives inside the modal anyway,
+       but if the user has zero keys total there's nothing to
+       compose, so the button just routes them to the API Keys
+       tab). #}
+    <button type="button"
+            class="btn btn-ghost calendar-ical-btn"
+            id="calendar-ical-btn"
+            title="Get the iCal subscription URL for this calendar"
+            aria-label="iCal Link">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4"/><path d="M8 2v4"/><path d="M3 10h18"/></svg>
+        <span>iCal Link</span>
+    </button>
+</div>
+
+<div class="calendar-toolbar">
+    {# HTMX-driven range toggle. Each tab's hx-get fetches the
+       partial (handler branches on HxRequest) and swaps it into
+       #calendar-list. `hx-push-url=true` keeps the URL bar and
+       browser-history honest so back/forward and paste-link both
+       work. The bare `href` is the no-JS fallback; same URL,
+       triggers a full-page nav. #}
+    <div class="calendar-range-tabs" role="tablist" aria-label="Calendar range">
+        <a href="/calendar?range=this_week{% if monitored_only %}&monitored=true{% endif %}"
+           hx-get="/calendar?range=this_week{% if monitored_only %}&monitored=true{% endif %}"
+           hx-target="#calendar-list"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="calendar-range-tab {% if range == "this_week" %}active{% endif %}"
+           role="tab"
+           data-range="this_week"
+           aria-selected="{% if range == "this_week" %}true{% else %}false{% endif %}">This week</a>
+        <a href="/calendar?range=next_week{% if monitored_only %}&monitored=true{% endif %}"
+           hx-get="/calendar?range=next_week{% if monitored_only %}&monitored=true{% endif %}"
+           hx-target="#calendar-list"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="calendar-range-tab {% if range == "next_week" %}active{% endif %}"
+           role="tab"
+           data-range="next_week"
+           aria-selected="{% if range == "next_week" %}true{% else %}false{% endif %}">Next week</a>
+        <a href="/calendar?range=month{% if monitored_only %}&monitored=true{% endif %}"
+           hx-get="/calendar?range=month{% if monitored_only %}&monitored=true{% endif %}"
+           hx-target="#calendar-list"
+           hx-swap="innerHTML"
+           hx-push-url="true"
+           class="calendar-range-tab {% if range == "month" %}active{% endif %}"
+           role="tab"
+           data-range="month"
+           aria-selected="{% if range == "month" %}true{% else %}false{% endif %}">This month</a>
+    </div>
+
+    <div class="calendar-filters">
+        {# Sonarr-shaped local search: filters the already-rendered
+           card list in place rather than refetching, so typing
+           feels instant. JS in calendar.js wires the input to a
+           class-toggle on each .calendar-episode. #}
+        <input type="search"
+               id="calendar-series-search"
+               class="calendar-series-search"
+               placeholder="Filter by series…"
+               aria-label="Filter by series name"
+               autocomplete="off">
+
+        <label class="calendar-toggle-filter" title="Show only first episodes (S01E01)">
+            <input type="checkbox" id="calendar-premieres-toggle">
+            <span>Premieres only</span>
+        </label>
+
+        <label class="calendar-toggle-filter">
+            <input type="checkbox"
+                   id="calendar-monitored-toggle"
+                   {% if monitored_only %}checked{% endif %}>
+            <span>Monitored only</span>
+        </label>
+    </div>
+</div>
+
+{# Day-grouped episode list. Each day is a sticky header followed
+   by its episode rows; the JS layer re-renders this region in
+   place when range/filter change. #}
+<div class="calendar-list" id="calendar-list">
+{%~ include "partials/calendar/list.html" ~%}
+</div>
+
+{# Subscribe modal — opened by the "iCal Link" button in the
+   page header. Sonarr-style: the URL helper is one click away
+   from the calendar surface but doesn't take vertical space on
+   the page when not needed. #}
+<div class="modal-backdrop" id="calendar-subscribe-modal" style="display:none"
+     role="dialog" aria-modal="true" aria-labelledby="calendar-subscribe-modal-title">
+    <div class="modal" style="max-width: 560px">
+        <div class="modal-header">
+            <h3 id="calendar-subscribe-modal-title">iCal subscription</h3>
+            <button class="btn-icon" type="button" data-modal-close="calendar-subscribe-modal" aria-label="Close">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+        </div>
+        <div class="api-keys-form" style="padding: 4px 0 12px">
+            {% if calendar_keys.is_empty() %}
+            <div class="api-keys-form-row">
+                <p class="form-hint">
+                    No <code>calendar</code>-scoped API keys configured. Create one on the
+                    <a class="link-accent" href="/settings?tab=api_keys">API Keys tab</a>
+                    to subscribe.
+                </p>
+            </div>
+            {% else %}
+            <div class="api-keys-form-row">
+                <label for="calendar-subscribe-key" class="api-keys-form-label">API key</label>
+                <select id="calendar-subscribe-key" class="api-keys-form-input">
+                    {% for key in calendar_keys %}
+                    <option value="{{ key.id }}">{{ key.name }}</option>
+                    {% endfor %}
+                </select>
+                <p class="api-keys-form-hint">
+                    The key's plaintext is embedded in the URL below; treat the URL as a secret.
+                </p>
+            </div>
+            <div class="api-keys-form-row">
+                <label for="calendar-subscribe-url" class="api-keys-form-label">Subscription URL</label>
+                <div class="api-keys-reveal-key-row">
+                    <input type="text"
+                           id="calendar-subscribe-url"
+                           class="api-keys-reveal-key"
+                           readonly
+                           aria-label="iCal subscription URL"
+                           value="Loading...">
+                    <button type="button"
+                            class="btn btn-secondary api-keys-reveal-copy-btn"
+                            id="calendar-subscribe-copy-btn">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="9" y="9" width="13" height="13" rx="2" ry="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>
+                        <span>Copy</span>
+                    </button>
+                </div>
+                <p class="api-keys-reveal-copy-confirm" id="calendar-subscribe-copy-confirm" hidden>
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polyline points="20 6 9 17 4 12"/></svg>
+                    Copied to clipboard.
+                </p>
+                <p class="api-keys-form-hint">
+                    Paste this URL into Google Calendar (Other calendars → + → From URL), Apple Calendar (File → New Calendar Subscription), or Thunderbird (New Calendar → On the Network → iCalendar).
+                </p>
+                <p class="api-keys-form-hint">
+                    Append <code>?monitored=true</code> for monitored only, or <code>?days=N</code> to change the window (capped at 90).
+                </p>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+</div>
+
+{% endblock %}
+
+{% block page_js %}<script src="/static/js/calendar.js" defer></script>{% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -82,11 +82,6 @@
                 <a class="btn btn-pill library-filter-clear library-filter-clear-hidden" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}" tabindex="-1" aria-hidden="true">Clear</a>
                 {% endif %}
             </form>
-            {# Reserved width pushes the right group's left edge back
-               toward where it sat before the Needs Review button
-               was removed. Successively trimmed as the row grew —
-               first for the always-reserved Clear slot, then for
-               the height-matched (and so wider) dropdowns + search. #}
             <button class="btn btn-primary" style="margin-left: 32px;" onclick="openAddModal()">+ Add Series</button>
         </div>
     </div>

--- a/templates/partials/calendar/grid.html
+++ b/templates/partials/calendar/grid.html
@@ -1,0 +1,61 @@
+{# Calendar month-grid partial (issue #116). Renders the Sun→Sat
+   month grid inside `#calendar-list`. Returned by the
+   `handlers::calendar::page` handler when `view_mode == "grid"`
+   (range=month) and the request carries `HX-Request: true` but
+   not `HX-Boosted: true`. The full page handler embeds it
+   directly into templates/calendar.html. The two render paths
+   share this partial so HTMX swaps and full page loads produce
+   identical markup. #}
+{% if month_grid.weeks.is_empty() %}
+<div class="calendar-empty">
+    {% if library_is_empty %}
+    <p>You don't have any series in your library yet.</p>
+    <p><a class="link-accent" href="/">Go to the library</a> to add some.</p>
+    {% else %}
+    <p>No episodes airing this month.</p>
+    {% endif %}
+</div>
+{% else %}
+<div class="calendar-month">
+    <div class="calendar-month-title">{{ month_grid.month_label }}</div>
+    <div class="calendar-month-dow" aria-hidden="true">
+        <span>Sun</span><span>Mon</span><span>Tue</span><span>Wed</span><span>Thu</span><span>Fri</span><span>Sat</span>
+    </div>
+    <div class="calendar-month-grid" role="grid" aria-label="Calendar grid for {{ month_grid.month_label }}">
+        {% for week in month_grid.weeks %}
+        {% for cell in week %}
+        <div class="calendar-month-cell{% if !cell.is_in_current_month %} calendar-month-cell-other{% endif %}{% if cell.is_today %} calendar-month-cell-today{% endif %}"
+             data-day-key="{{ cell.day_key }}"
+             role="gridcell">
+            <div class="calendar-month-cell-num">{{ cell.day_number }}</div>
+            {% if !cell.episodes.is_empty() %}
+            <div class="calendar-month-cell-eps">
+                {% for ep in cell.episodes %}
+                {# Episode label drops the season prefix — each
+                   anime "season" is its own Ryokan series with its
+                   own E1..EN numbering, so a literal `S01` is
+                   meaningless (and misleading when the title
+                   already says "4th Season"). #}
+                <a class="calendar-month-pill{% if ep.monitored %} calendar-month-pill-monitored{% else %} calendar-month-pill-unmon{% endif %}{% if ep.episode == 1 %} calendar-month-pill-premiere{% endif %}"
+                   href="/series/{{ ep.series_id }}"
+                   data-airing-at="{{ ep.airing_at }}"
+                   data-series-name="{{ ep.search_haystack }}"
+                   data-episode="{{ ep.episode }}"
+                   data-monitored="{% if ep.monitored %}1{% else %}0{% endif %}"
+                   title="{{ ep.series_title }}{% if ep.episode == 1 %} · Premiere{% endif %} · Episode {{ ep.episode }}">
+                    <span class="calendar-month-pill-time" data-airing-at="{{ ep.airing_at }}">·</span>
+                    {% if ep.episode == 1 %}
+                    <span class="calendar-month-pill-prem-mark" aria-label="Premiere" title="Premiere">★</span>
+                    {% endif %}
+                    <span class="calendar-month-pill-title">{{ ep.series_title }}</span>
+                    <span class="calendar-month-pill-ep">E{% if ep.episode < 10 %}0{% endif %}{{ ep.episode }}</span>
+                </a>
+                {% endfor %}
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+        {% endfor %}
+    </div>
+</div>
+{% endif %}

--- a/templates/partials/calendar/list.html
+++ b/templates/partials/calendar/list.html
@@ -38,8 +38,16 @@
                 <div class="calendar-episode-meta">
                     <div class="calendar-episode-title">{{ ep.series_title }}</div>
                     <div class="calendar-episode-sub">
-                        <span class="calendar-episode-num">S01E{% if ep.episode < 10 %}0{% endif %}{{ ep.episode }}</span>
+                        {# Drop the `S01` prefix; each anime
+                           season is its own Ryokan series with
+                           its own E1..EN numbering, so a literal
+                           `S01` reads as wrong when the title
+                           already names the season. #}
+                        <span class="calendar-episode-num">E{% if ep.episode < 10 %}0{% endif %}{{ ep.episode }}</span>
                         <span class="calendar-episode-time" data-airing-at="{{ ep.airing_at }}">·</span>
+                        {% if ep.episode == 1 %}
+                        <span class="calendar-episode-badge calendar-episode-badge-premiere" title="First episode of this series">Premiere</span>
+                        {% endif %}
                         {% if ep.monitored %}
                         <span class="calendar-episode-badge calendar-episode-badge-monitored">Monitored</span>
                         {% else %}

--- a/templates/partials/calendar/list.html
+++ b/templates/partials/calendar/list.html
@@ -1,0 +1,56 @@
+{# Calendar list partial (issue #116). Renders the day-grouped
+   episode list inside `#calendar-list`. Returned by the
+   `handlers::calendar::page` handler when the request carries
+   `HX-Request: true`; the full page handler embeds it directly
+   into templates/calendar.html. The two render paths share this
+   partial so HTMX swaps and full page loads produce identical
+   markup. #}
+{% if day_buckets.is_empty() %}
+<div class="calendar-empty">
+    {% if library_is_empty %}
+    <p>You don't have any series in your library yet.</p>
+    <p><a class="link-accent" href="/">Go to the library</a> to add some.</p>
+    {% else %}
+    <p>No episodes airing in this range.</p>
+    <p class="form-hint">Try expanding the range or turning off the monitored-only filter.</p>
+    {% endif %}
+</div>
+{% else %}
+{% for bucket in day_buckets %}
+<section class="calendar-day" data-day-key="{{ bucket.day_key }}">
+    <h3 class="calendar-day-label">
+        <span class="calendar-day-label-text">{{ bucket.label }}</span>
+        <span class="calendar-day-label-count">{{ bucket.episodes.len() }}{% if bucket.episodes.len() == 1 %} ep{% else %} eps{% endif %}</span>
+    </h3>
+    <ul class="calendar-day-episodes">
+        {% for ep in bucket.episodes %}
+        <li class="calendar-episode"
+            data-airing-at="{{ ep.airing_at }}"
+            data-series-name="{{ ep.search_haystack }}"
+            data-episode="{{ ep.episode }}"
+            data-monitored="{% if ep.monitored %}1{% else %}0{% endif %}">
+            <a class="calendar-episode-link" href="/series/{{ ep.series_id }}">
+                {% if !ep.cover_url.is_empty() %}
+                <img class="calendar-episode-cover" src="{{ ep.cover_url }}" alt="" loading="lazy">
+                {% else %}
+                <div class="calendar-episode-cover calendar-episode-cover-placeholder" aria-hidden="true"></div>
+                {% endif %}
+                <div class="calendar-episode-meta">
+                    <div class="calendar-episode-title">{{ ep.series_title }}</div>
+                    <div class="calendar-episode-sub">
+                        <span class="calendar-episode-num">S01E{% if ep.episode < 10 %}0{% endif %}{{ ep.episode }}</span>
+                        <span class="calendar-episode-time" data-airing-at="{{ ep.airing_at }}">·</span>
+                        {% if ep.monitored %}
+                        <span class="calendar-episode-badge calendar-episode-badge-monitored">Monitored</span>
+                        {% else %}
+                        <span class="calendar-episode-badge calendar-episode-badge-unmon">Not monitored</span>
+                        {% endif %}
+                    </div>
+                </div>
+            </a>
+        </li>
+        {% endfor %}
+    </ul>
+</section>
+{% endfor %}
+{% endif %}

--- a/templates/partials/settings/api_keys.html
+++ b/templates/partials/settings/api_keys.html
@@ -8,6 +8,14 @@
    without a round-trip page reload. JS lives in
    `static/js/settings.js` under the api-keys section. #}
 <div class="api-keys-tab" id="api-keys-tab">
+    {# Per-tab toast — see settings.html comment for the rationale. #}
+    {% if let Some(msg) = message %}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="API Keys">{{ msg }}</div>
+    {% endif %}
+    {% if let Some(err) = error %}
+    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="API Keys">{{ err }}</div>
+    {% endif %}
+
     <div class="api-keys-section-header">
         <div>
             <h3 class="settings-section-title">API Keys</h3>

--- a/templates/partials/settings/custom_formats.html
+++ b/templates/partials/settings/custom_formats.html
@@ -1,3 +1,14 @@
+    {# Per-tab toast. Page-level alert was dropped from
+       settings.html so every tab anchors its alerts inside
+       `.tabbed-content` rather than spanning the breakout
+       `.tabbed-page` width across the sidebar. #}
+    {% if let Some(msg) = message %}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Custom Formats">{{ msg }}</div>
+    {% endif %}
+    {% if let Some(err) = error %}
+    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Custom Formats">{{ err }}</div>
+    {% endif %}
+
     <p class="cf-section-desc" style="max-width: 820px; margin-bottom: 20px;">
         Sonarr v4-compatible Custom Formats. Every matching spec contributes its score to the release total during auto-search. Paste JSON exports from Sonarr or <a href="https://trash-guides.info" target="_blank" rel="noopener">Trash Guides</a>, or build your own from scratch.
     </p>

--- a/templates/partials/settings/download_clients.html
+++ b/templates/partials/settings/download_clients.html
@@ -5,6 +5,14 @@
    the bulk form because per-row delete forms can't nest inside
    the bulk POST). #}
 <div class="dc-page">
+    {# Per-tab toast — see settings.html comment for the rationale. #}
+    {% if let Some(msg) = message %}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Download Clients">{{ msg }}</div>
+    {% endif %}
+    {% if let Some(err) = error %}
+    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Download Clients">{{ err }}</div>
+    {% endif %}
+
     <p class="form-hint" style="margin-bottom: 16px;">
         Ryokan can route grabs to multiple download clients. Pin a specific client to an indexer on the
         <a href="/settings?tab=indexers" class="link-accent">Indexers</a> tab; the built-in Nyaa search uses the dropdown there too.

--- a/templates/partials/settings/groups.html
+++ b/templates/partials/settings/groups.html
@@ -1,3 +1,11 @@
+    {# Per-tab toast — see settings.html comment for the rationale. #}
+    {% if let Some(msg) = message %}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Release Groups">{{ msg }}</div>
+    {% endif %}
+    {% if let Some(err) = error %}
+    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Release Groups">{{ err }}</div>
+    {% endif %}
+
     <fieldset>
         <legend>Release Group Source Map</legend>
         <p class="form-hint">Maps release groups to their known source. Used by Layer 3 of the classification pipeline when the filename alone doesn't carry source keywords (e.g. SubsPlease is WEB, VCB-Studio is BD). Seeded rows are restored on startup; user-edited rows are preserved.</p>

--- a/templates/partials/settings/indexers.html
+++ b/templates/partials/settings/indexers.html
@@ -1,3 +1,11 @@
+    {# Per-tab toast — see settings.html comment for the rationale. #}
+    {% if let Some(msg) = message %}
+    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Indexers">{{ msg }}</div>
+    {% endif %}
+    {% if let Some(err) = error %}
+    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Indexers">{{ err }}</div>
+    {% endif %}
+
     {# Indexers fieldset — owned by the section partial so a
        successful HTMX upsert/delete can re-render the whole thing
        (catalog grid + existing-indexer cards + modal) in one swap.

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -165,6 +165,7 @@
 </div>
 {% endif %}
 
+
 </div>{# /.tabbed-content #}
 </div>{# /.tabbed-layout #}
 </div>{# /.tabbed-page #}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -14,16 +14,15 @@
     <h2>Settings</h2>
 </div>
 
-{% if let Some(msg) = message %}
-    {# Auto-escape — never |safe. msg can come from `?msg=` query string
-       (settings_page) and from POST notice strings (settings_submit, which
-       interpolates user-controlled fields like media_root into format!()).
-       Either path is reflected/stored XSS without escaping. #}
-    <div class="alert alert-success" data-ryokan-toast="success" data-ryokan-toast-title="Settings saved">{{ msg }}</div>
-{% endif %}
-{% if let Some(err) = error %}
-    <div class="alert alert-error" data-ryokan-toast="error" data-ryokan-toast-title="Settings error">{{ err }}</div>
-{% endif %}
+{# Toast/alert rendering is per-tab partial, not page-level.
+   Page-level placement spans the viewport-breakout `.tabbed-page`
+   width — it visually overlaps the sidebar column on a desktop
+   layout. Each partial owns its own `{% if let Some(msg) %}…`
+   block at its top so the alert lands inside `.tabbed-content`'s
+   centered column, matching the *_form.html partials that
+   already do this (integrations / quality / general). XSS escaping
+   is unchanged — the partials use `{{ msg }}` (auto-escape), never
+   `|safe`. #}
 
 <div class="tabbed-layout">
 <nav class="tabbed-sidebar" aria-label="Settings sections">
@@ -68,13 +67,13 @@
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
         <span>Release Groups</span>
     </a>
-    <a href="/settings?tab=general" class="tabbed-side-tab {% if tab == "general" %}active{% endif %}">
-        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
-        <span>General</span>
-    </a>
     <a href="/settings?tab=api_keys" class="tabbed-side-tab {% if tab == "api_keys" %}active{% endif %}">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="8" cy="15" r="4"/><path d="M10.85 12.15 19 4"/><path d="m18 5 2 2"/><path d="m15 8 2 2"/></svg>
         <span>API Keys</span>
+    </a>
+    <a href="/settings?tab=general" class="tabbed-side-tab {% if tab == "general" %}active{% endif %}">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" y1="21" x2="4" y2="14"/><line x1="4" y1="10" x2="4" y2="3"/><line x1="12" y1="21" x2="12" y2="12"/><line x1="12" y1="8" x2="12" y2="3"/><line x1="20" y1="21" x2="20" y2="16"/><line x1="20" y1="12" x2="20" y2="3"/><line x1="1" y1="14" x2="7" y2="14"/><line x1="9" y1="8" x2="15" y2="8"/><line x1="17" y1="16" x2="23" y2="16"/></svg>
+        <span>General</span>
     </a>
 </nav>
 <div class="tabbed-content">


### PR DESCRIPTION
## Summary

Closes #115 (iCal subscription feed) and #116 (in-app calendar page).

## What lands

**iCal feed** at `GET /api/calendar.ics`, gated by the `calendar`-scoped API key from #114. Hand-rolled RFC-5545 output with `ETag` + `Cache-Control: public, max-age=600`; conditional GET supported. Configurable via `?days=N` (capped at 90) and `?monitored=true`. Subscribed via Apple Calendar / Google Calendar / Thunderbird with the URL helper exposed in the in-app page header.

**In-app `/calendar` page** with two views:
- List view (this week / next week) — day-grouped sticky-header sections with cover thumbnails and episode badges.
- Grid view (this month) — Sun→Sat 6-week calendar grid with stacked episode pills per day. Mobile collapses to a single-column flow.

Topbar nav slot sits between Library and Search on desktop; mobile gets an icon-only entry on the library page next to bulk-select. Range tabs and the monitored-only toggle drive HTMX swaps via `hx-get` + `hx-push-url` so back/forward and paste-link both work; bare `href` is the no-JS fallback.

**Local-DB air-date stamping** (Sonarr-style). New `episode_airings` table + 12h `airing_refresh` supervised task pulls AL `Page.airingSchedules` for every positive-AL-id series and stamps the result; the calendar reader joins this against `series` instead of round-tripping to AL per-request, preserving AL's 30/min degraded budget. Library add-flow stamps inline so freshly-added series show up without waiting for the next 12h tick. Manual run endpoint at `POST /api/tasks/airing-refresh`.

**Smaller polish in the same epic**:
- Premieres are passive markers (badge in list, accent border + star in grid) instead of a filter toggle.
- S01 prefix dropped from in-app and iCal surfaces because each anime season is its own Ryokan series with E1..EN numbering.
- HTMX boost vs explicit-swap branching so topbar boosted nav still gets the full page chrome.
- Per-tab toast layout fix on Settings — Custom Formats, Download Clients, Indexers, Release Groups, API Keys tabs no longer span the sidebar with their save toast.
- Settings sidebar reorder — API Keys above General.

## Test plan

- [x] `cargo nextest run --features test-support` passes (calendar suite at 26 tests, settings at 125)
- [x] `cargo fmt --all -- --check` and `cargo clippy --workspace --all-targets --features test-support -- -D warnings` clean
- [x] Manual: `/calendar` renders list (week ranges) and grid (month range)
- [x] Manual: monitored-only toggle round-trips through HTMX swap
- [x] Manual: range-tab clicks update URL via `hx-push-url`; back/forward + paste-link both work
- [x] Manual: iCal feed importable into Apple Calendar via the in-app subscribe modal
- [x] Manual: System → Tasks shows the `airing_refresh` row + Run-now works
- [x] Manual: Save toast on each Settings tab now lands inside `.tabbed-content`