### PR TITLE
Merge dev -> main: dependency + lockfile bumps resolving four RUSTSEC advisories

### DIFF
--- a/.github/workflows/cargo-audit.yml
+++ b/.github/workflows/cargo-audit.yml
@@ -39,7 +39,7 @@ jobs:
     # 10 min is generous headroom against an advisory-DB clone hang.
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: rustsec/audit-check@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,7 +59,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,7 +38,7 @@ jobs:
           echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/license-notices.yml
+++ b/.github/workflows/license-notices.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           # Need the full token so the auto-commit push back to `dev`
           # uses the workflow's own credentials. The default

--- a/.github/workflows/mutants-weekly.yml
+++ b/.github/workflows/mutants-weekly.yml
@@ -71,7 +71,7 @@ jobs:
       # nothing and the script handles the missing-baseline case.
       - name: Restore previous baseline
         id: restore-baseline
-        uses: actions/cache/restore@v5
+        uses: actions/cache/restore@v6
         with:
           path: mutants.baseline.json
           key: mutants-baseline-v1-
@@ -136,7 +136,7 @@ jobs:
       # cache entries after 7 days of no access.
       - name: Save baseline for next run
         if: always()
-        uses: actions/cache/save@v5
+        uses: actions/cache/save@v6
         with:
           path: mutants.baseline.json
           key: mutants-baseline-v1-${{ github.run_id }}

--- a/.github/workflows/mutants-weekly.yml
+++ b/.github/workflows/mutants-weekly.yml
@@ -44,7 +44,7 @@ jobs:
     # slow link or flaky wiremock binding.
     timeout-minutes: 360
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
     # eating the runner) before it burns hours of runner minutes.
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
@@ -94,7 +94,7 @@ jobs:
     # hung dep download.
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@1.95.0
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,9 +89,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1215,11 +1215,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1229,11 +1227,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2260,15 +2260,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2369,6 +2370,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "rand_xorshift"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,14 +50,13 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "ammonia"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e913097e1a2124b46746c980134e8c954bc17a6a59bb3fde96f088d126dde6"
+checksum = "68b9d3370580a12f4b7a10fdcc18b28942c083ba570e3d954fe59d10951b85a2"
 dependencies = [
- "cssparser 0.35.0",
- "html5ever 0.35.0",
+ "cssparser",
+ "html5ever",
  "maplit",
- "tendril 0.4.3",
  "url",
 ]
 
@@ -323,9 +322,9 @@ dependencies = [
 
 [[package]]
 name = "bcrypt"
-version = "0.19.1"
+version = "0.19.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24ae5479c93d3720e4c1dbd6b945b97457c50cb672781104768190371df1a905"
+checksum = "7f3c067aa24dd4ed5c79cf222a38f260c8f23d3b82a062fba3f28c6fe563b753"
 dependencies = [
  "base64",
  "blowfish",
@@ -492,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -747,38 +746,15 @@ dependencies = [
 
 [[package]]
 name = "cssparser"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e901edd733a1472f944a45116df3f846f54d37e67e68640ac8bb69689aca2aa"
-dependencies = [
- "cssparser-macros 0.6.1",
- "dtoa-short",
- "itoa",
- "phf 0.11.3",
- "smallvec",
-]
-
-[[package]]
-name = "cssparser"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9cdaae01d5ed7882b04d795e7f752f46ff52d2fa3b50a20d28c464510bba98"
 dependencies = [
- "cssparser-macros 0.7.0",
+ "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.13.1",
+ "phf",
  "smallvec",
-]
-
-[[package]]
-name = "cssparser-macros"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
-dependencies = [
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1096,16 +1072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
-name = "futf"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df420e2e84819663797d1ec6544b13c5be84629e7bb00dc960d6917db2987843"
-dependencies = [
- "mac",
- "new_debug_unreachable",
-]
-
-[[package]]
 name = "futures"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1368,23 +1334,12 @@ dependencies = [
 
 [[package]]
 name = "html5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55d958c2f74b664487a2035fe1dadb032c48718a03b63f3ab0b8537db8549ed4"
-dependencies = [
- "log",
- "markup5ever 0.35.0",
- "match_token",
-]
-
-[[package]]
-name = "html5ever"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46a1761807faccc9a19e86944bbf40610014066306f96edcdedc2fb714bcb7b8"
 dependencies = [
  "log",
- "markup5ever 0.39.0",
+ "markup5ever",
 ]
 
 [[package]]
@@ -1761,9 +1716,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",
@@ -1931,27 +1886,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
-name = "mac"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "markup5ever"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "311fe69c934650f8f19652b3946075f0fc41ad8757dbb68f1ca14e7900ecc1c3"
-dependencies = [
- "log",
- "tendril 0.4.3",
- "web_atoms 0.1.3",
-]
 
 [[package]]
 name = "markup5ever"
@@ -1960,19 +1898,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7122d987ec5f704ee56f6e5b41a7d93722e9aae27ae07cafa4036c4d3f9757de"
 dependencies = [
  "log",
- "tendril 0.5.0",
- "web_atoms 0.2.4",
-]
-
-[[package]]
-name = "match_token"
-version = "0.35.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "tendril",
+ "web_atoms",
 ]
 
 [[package]]
@@ -2138,33 +2065,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
-dependencies = [
- "phf_macros 0.11.3",
- "phf_shared 0.11.3",
-]
-
-[[package]]
-name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros 0.13.1",
- "phf_shared 0.13.1",
+ "phf_macros",
+ "phf_shared",
  "serde",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2173,18 +2080,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
-dependencies = [
- "phf_shared 0.11.3",
- "rand 0.8.6",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2194,20 +2091,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared 0.13.1",
-]
-
-[[package]]
-name = "phf_macros"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
- "syn",
+ "phf_shared",
 ]
 
 [[package]]
@@ -2216,20 +2100,11 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -2439,15 +2314,6 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
-
-[[package]]
-name = "rand"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
-dependencies = [
- "rand_core 0.6.4",
-]
 
 [[package]]
 name = "rand"
@@ -2887,13 +2753,13 @@ version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bdd0be4d296f048bfb06dd01bbc80ef789ddd2e55583e8d2e6b804942abfabc2"
 dependencies = [
- "cssparser 0.37.0",
+ "cssparser",
  "ego-tree",
  "getopts",
- "html5ever 0.39.0",
+ "html5ever",
  "precomputed-hash",
  "selectors",
- "tendril 0.5.0",
+ "tendril",
 ]
 
 [[package]]
@@ -2926,12 +2792,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
  "bitflags",
- "cssparser 0.37.0",
+ "cssparser",
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf 0.13.1",
- "phf_codegen 0.13.1",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
  "servo_arc",
@@ -3311,39 +3177,14 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
-dependencies = [
- "new_debug_unreachable",
- "parking_lot",
- "phf_shared 0.11.3",
- "precomputed-hash",
- "serde",
-]
-
-[[package]]
-name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared 0.13.1",
+ "phf_shared",
  "precomputed-hash",
-]
-
-[[package]]
-name = "string_cache_codegen"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
-dependencies = [
- "phf_generator 0.11.3",
- "phf_shared 0.11.3",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -3352,8 +3193,8 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.13.1",
- "phf_shared 0.13.1",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -3438,17 +3279,6 @@ dependencies = [
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tendril"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d24a120c5fc464a3458240ee02c299ebcb9d67b5249c8848b09d639dca8d7bb0"
-dependencies = [
- "futf",
- "mac",
- "utf-8",
 ]
 
 [[package]]
@@ -4118,26 +3948,14 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ffde1dc01240bdf9992e3205668b235e59421fd085e8a317ed98da0178d414"
-dependencies = [
- "phf 0.11.3",
- "phf_codegen 0.11.3",
- "string_cache 0.8.9",
- "string_cache_codegen 0.5.4",
-]
-
-[[package]]
-name = "web_atoms"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf 0.13.1",
- "phf_codegen 0.13.1",
- "string_cache 0.9.0",
- "string_cache_codegen 0.6.1",
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "cmov"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "combine"

--- a/licenses/THIRD_PARTY_LICENSES.html
+++ b/licenses/THIRD_PARTY_LICENSES.html
@@ -490,7 +490,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.3</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">ctutils 0.4.2</a></li>
                     <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode 1.0.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>

--- a/licenses/THIRD_PARTY_LICENSES.html
+++ b/licenses/THIRD_PARTY_LICENSES.html
@@ -53,12 +53,12 @@
     
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (285)</li>
-            <li><a href="#MIT">MIT License</a> (76)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (275)</li>
+            <li><a href="#MIT">MIT License</a> (71)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (9)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (8)</li>
             <li><a href="#ISC">ISC License</a> (6)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (6)</li>
             <li><a href="#Zlib">zlib License</a> (2)</li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (1)</li>
             <li><a href="#GPL-3.0-or-later">GNU General Public License v3.0 or later</a> (1)</li>
@@ -2818,7 +2818,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-ammonia/ammonia ">ammonia 4.1.2</a></li>
+                    <li><a href=" https://github.com/rust-ammonia/ammonia ">ammonia 4.1.3</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
@@ -5583,7 +5583,6 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
-                    <li><a href=" https://github.com/servo/futf ">futf 0.1.5</a></li>
                     <li><a href=" https://github.com/async-rs/futures-timer ">futures-timer 3.0.3</a></li>
                     <li><a href=" https://github.com/rust-lang/getopts ">getopts 0.2.24</a></li>
                     <li><a href=" https://github.com/rust-lang/glob ">glob 0.3.3</a></li>
@@ -5591,14 +5590,13 @@ limitations under the License.
                     <li><a href=" https://github.com/rust-lang/hashbrown ">hashbrown 0.17.0</a></li>
                     <li><a href=" https://github.com/withoutboats/heck ">heck 0.5.0</a></li>
                     <li><a href=" https://github.com/hermit-os/hermit-rs ">hermit-abi 0.5.2</a></li>
-                    <li><a href=" https://github.com/servo/html5ever ">html5ever 0.35.0</a></li>
                     <li><a href=" https://github.com/servo/html5ever ">html5ever 0.39.0</a></li>
                     <li><a href=" https://github.com/seanmonstar/httparse ">httparse 1.10.1</a></li>
                     <li><a href=" https://github.com/rustls/hyper-rustls ">hyper-rustls 0.27.9</a></li>
                     <li><a href=" https://github.com/servo/rust-url/ ">idna 1.1.0</a></li>
                     <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
                     <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.14.0</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/insta ">insta 1.47.2</a></li>
+                    <li><a href=" https://github.com/mitsuhiko/insta ">insta 1.48.0</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.21.1</a></li>
                     <li><a href=" https://github.com/rust-lang/jobserver-rs ">jobserver 0.1.34</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.95</a></li>
@@ -5607,7 +5605,6 @@ limitations under the License.
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
                     <li><a href=" https://github.com/bluss/maplit ">maplit 1.0.2</a></li>
-                    <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.35.0</a></li>
                     <li><a href=" https://github.com/servo/html5ever ">markup5ever 0.39.0</a></li>
                     <li><a href=" https://github.com/hyperium/mime ">mime 0.3.17</a></li>
                     <li><a href=" https://github.com/rust-num/num-traits ">num-traits 0.2.19</a></li>
@@ -5640,14 +5637,11 @@ limitations under the License.
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
-                    <li><a href=" https://github.com/servo/string-cache ">string_cache 0.8.9</a></li>
                     <li><a href=" https://github.com/servo/string-cache ">string_cache 0.9.0</a></li>
-                    <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.5.4</a></li>
                     <li><a href=" https://github.com/servo/string-cache ">string_cache_codegen 0.6.1</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
-                    <li><a href=" https://github.com/servo/tendril ">tendril 0.4.3</a></li>
                     <li><a href=" https://github.com/servo/html5ever ">tendril 0.5.0</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
@@ -5663,7 +5657,6 @@ limitations under the License.
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.118</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.118</a></li>
                     <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.95</a></li>
-                    <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.1.3</a></li>
                     <li><a href=" https://github.com/servo/html5ever ">web_atoms 0.2.4</a></li>
                     <li><a href=" https://github.com/LukeMathWalker/wiremock-rs ">wiremock 0.6.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
@@ -8208,8 +8201,6 @@ limitations under the License.
                     <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.185</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
-                    <li><a href=" https://github.com/reem/rust-mac.git ">mac 0.1.1</a></li>
-                    <li><a href=" https://github.com/servo/html5ever ">match_token 0.35.0</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.1</a></li>
                     <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
@@ -8218,7 +8209,6 @@ limitations under the License.
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.10.1</a></li>
-                    <li><a href=" https://github.com/rust-random/rand ">rand 0.8.6</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.9.4</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xorshift 0.4.0</a></li>
@@ -8332,7 +8322,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.45</a></li>
                 </ul>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -10706,15 +10696,10 @@ licences; see files named LICENSE.*.txt for details.</pre>
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.11.3</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf 0.13.1</a></li>
-                    <li><a href=" https://github.com/rust-phf/rust-phf ">phf_codegen 0.11.3</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_codegen 0.13.1</a></li>
-                    <li><a href=" https://github.com/rust-phf/rust-phf ">phf_generator 0.11.3</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_generator 0.13.1</a></li>
-                    <li><a href=" https://github.com/rust-phf/rust-phf ">phf_macros 0.11.3</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_macros 0.13.1</a></li>
-                    <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.11.3</a></li>
                     <li><a href=" https://github.com/rust-phf/rust-phf ">phf_shared 0.13.1</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -10957,7 +10942,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/Keats/rust-bcrypt ">bcrypt 0.19.1</a></li>
+                    <li><a href=" https://github.com/Keats/rust-bcrypt ">bcrypt 0.19.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -11483,9 +11468,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/servo/rust-cssparser ">cssparser-macros 0.6.1</a></li>
                     <li><a href=" https://github.com/servo/rust-cssparser ">cssparser-macros 0.7.0</a></li>
-                    <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.35.0</a></li>
                     <li><a href=" https://github.com/servo/rust-cssparser ">cssparser 0.37.0</a></li>
                 </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0


### PR DESCRIPTION
Rolls up the maintenance work on dev:

- bcrypt 0.19.1 -> 0.19.2 (PR #181) — RUSTSEC-2026-0199 panic on non-ASCII hash input. Closes #183
- ammonia 4.1.2 -> 4.1.3 (PR #181) — RUSTSEC-2026-0193 mXSS via annotation-xml. Closes #182
- anyhow 1.0.102 -> 1.0.103 (lockfile-only) — RUSTSEC-2026-0190. Closes #184
- quinn-proto 0.11.14 -> 0.11.16 (lockfile-only) — RUSTSEC-2026-0185. Closes #180
- chrono 0.4.45, insta bump (PR #181), cmov 0.5.4 (lockfile-only)
- actions/cache v6 (PR #179), actions/checkout v7 (PR #178)
- THIRD_PARTY_LICENSES.html regens

Note: anyhow and quinn-proto are phantom lockfile entries — neither is compiled into Ryokan (`cargo tree -i` finds no path even with `--target all -e all`), so those two bumps are audit noise reduction rather than runtime fixes.

Full suite green locally at the final lockfile state: 2548 passed, 24 skipped. `cargo fmt --all -- --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)