### PR TITLE
UI polish: layout fixes, Unaired/Missing split, library page redesign

### DIFF
--- a/src/handlers/downloads.rs
+++ b/src/handlers/downloads.rs
@@ -139,6 +139,20 @@ pub struct DownloadsQuery {
     tab: Option<String>,
 }
 
+/// User-facing label for a `download_clients.kind` value. Matches the
+/// option labels in the Settings → Download Clients add/edit forms so
+/// error copy and the form speak the same names.
+fn client_kind_display(kind: &str) -> &'static str {
+    match kind {
+        "qbittorrent" => "qBittorrent",
+        "deluge" => "Deluge",
+        "transmission" => "Transmission",
+        "rtorrent" => "rTorrent",
+        "sabnzbd" => "SABnzbd",
+        _ => "download client",
+    }
+}
+
 fn normalize_tab(tab: Option<String>) -> String {
     match tab.as_deref() {
         Some("history") => "history".to_string(),
@@ -170,14 +184,17 @@ pub async fn downloads_page(
         // whole tab — it logs and the other clients still render.
         let pool = state.download_clients.read().await.clone();
         if pool.clients.is_empty() {
-            (Vec::new(), "Download client is not configured.".to_string())
+            (
+                Vec::new(),
+                "No download client is configured. Add one under Settings → Download Clients to see its queue here.".to_string(),
+            )
         } else {
             let mut torrents: Vec<crate::services::download_client::DownloadItem> = Vec::new();
-            let mut errors: Vec<String> = Vec::new();
+            let mut errors: Vec<(i64, String)> = Vec::new();
             for (id, c) in pool.clients.iter() {
                 match c.list_scoped().await {
                     Ok(mut items) => torrents.append(&mut items),
-                    Err(e) => errors.push(format!("client #{}: {}", id, e)),
+                    Err(e) => errors.push((*id, e)),
                 }
             }
             let is_downloading = |k: DownloadItemState| {
@@ -202,7 +219,53 @@ pub async fn downloads_page(
             let error_msg = if errors.is_empty() {
                 String::new()
             } else {
-                format!("Could not load queue from: {}", errors.join("; "))
+                // Interface-voice summary: identify the failing
+                // client(s) by configured name AND kind — with a
+                // multi-client pool a bare row name like "qbit" is
+                // ambiguous — and say whether the rest of the queue
+                // still rendered. The raw transport error (reqwest
+                // URL, connect detail) goes to the DB log instead of
+                // the page; it's diagnostic material, not direction.
+                let rows = crate::models::download_clients::list_all(&state.db)
+                    .await
+                    .unwrap_or_default();
+                let describe = |id: i64| {
+                    rows.iter()
+                        .find(|r| r.id == id)
+                        .map(|r| format!("\"{}\" ({})", r.name, client_kind_display(&r.kind)))
+                        .unwrap_or_else(|| format!("download client #{}", id))
+                };
+                let detail = errors
+                    .iter()
+                    .map(|(id, e)| format!("{}: {}", describe(*id), e))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                crate::services::logger::warn(
+                    &state.db,
+                    crate::models::log::LogCategory::DownloadClient,
+                    "Queue load failed for one or more download clients",
+                    &detail,
+                )
+                .await;
+                let names = errors
+                    .iter()
+                    .map(|(id, _)| describe(*id))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                let lead = if errors.len() == 1 {
+                    format!("Can't reach the download client {}.", names)
+                } else {
+                    format!("Can't reach {} download clients: {}.", errors.len(), names)
+                };
+                let partial = if errors.len() < pool.clients.len() {
+                    " Queues from the other clients are still shown."
+                } else {
+                    ""
+                };
+                format!(
+                    "{}{} Check the connection details under Settings → Download Clients; the full error is in System → Logs.",
+                    lead, partial
+                )
             };
             (views, error_msg)
         }

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -204,6 +204,15 @@ pub struct Episode {
     pub filename: String,
     pub can_auto_search: bool,
     pub monitored: bool,
+    /// True when the episode has no file AND hasn't aired yet: its
+    /// air date parses to a future date, or the air date is unknown
+    /// while the series is still airing/upcoming (anything but
+    /// FINISHED / FINISHED_AIRING / CANCELLED). Splits the no-file
+    /// display state in two: "Missing" (red, actionable — the episode
+    /// aired and we don't have it) vs "Unaired" (neutral — nothing is
+    /// wrong, there's just nothing to grab yet). Mirrors Sonarr's
+    /// Missing-vs-Unaired episode split.
+    pub unaired: bool,
     /// Phase 4 classification columns — exposed to the template so the
     /// manual override picker can pre-select the current values. The
     /// override dropdown's composite key (e.g. "bluray_remux", "web",

--- a/src/handlers/library/mod.rs
+++ b/src/handlers/library/mod.rs
@@ -12,11 +12,40 @@ pub mod pages;
 pub mod reconcile;
 pub mod search;
 
+/// Per-card completeness summary for the library grid's status bar.
+/// Answers exactly one question — "do I have what's aired?" — in
+/// three states, reusing the episode table's color vocabulary
+/// (green complete / red missing-and-actionable / accent in-flight).
+/// Airing status deliberately isn't encoded here: the card's
+/// RELEASING/FINISHED text chip already carries it.
+#[derive(Debug, Clone, Default)]
+pub struct CardProgress {
+    /// `complete` | `missing` | `downloading` | `idle` (nothing
+    /// aired yet, or the series has no episode data at all).
+    pub state: String,
+    /// Distinct episodes on disk or with a completed grab tag.
+    pub downloaded: i64,
+    /// Episodes aired so far (cached air dates <= today), falling
+    /// back to the total episode count when no air dates are cached
+    /// (honest fallback for Jikan-added series with sparse data).
+    pub aired: i64,
+    /// Fill percentage, `downloaded / aired` clamped to 0..=100.
+    pub pct: i64,
+    /// False when `monitor_mode == "none"` — the bar renders dimmed:
+    /// "I'm ignoring this" is a modifier, not a fourth color.
+    pub monitored: bool,
+    /// Pre-built tooltip text for the bar.
+    pub label: String,
+}
+
 #[derive(Template)]
 #[template(path = "index.html")]
 struct IndexTemplate {
     page: String,
-    library: Vec<series::Series>,
+    /// One entry per rendered card: the series plus its completeness
+    /// summary. Tupled (rather than a wrapper struct) so the card
+    /// template's dense `s.*` field references stay untouched.
+    cards: Vec<(series::Series, CardProgress)>,
     title_language: String,
     /// #62 — the linked external account's `score_format`,
     /// used by `Series::user_score_display(...)` to render per-row
@@ -24,24 +53,41 @@ struct IndexTemplate {
     /// which case `user_score_display` always returns `None` and
     /// the template renders no badge.
     score_format: String,
-    /// #62 — distinct AL custom-list names across the whole
-    /// library. Powers the filter-dropdown next to the search box.
+    /// #62 — AL custom-list names with member counts, across the
+    /// whole library. Powers the scope-chip row under the title.
     /// Empty when no memberships have synced yet, in which case the
-    /// template hides the dropdown entirely.
-    custom_list_names: Vec<String>,
+    /// template hides the chip row's list entries (the "All" chip
+    /// alone would be noise).
+    list_counts: Vec<(String, i64)>,
     /// Currently-active filter value from `?list=<name>`. Empty
     /// means "no filter, show everything." The handler has already
-    /// applied the filter to `library`; this field drives the
-    /// dropdown's selected-option state on render.
+    /// applied the filter to `library`; this field drives which
+    /// chip renders as active.
     custom_list_filter: String,
     /// Currently-active library search query from `?search=<text>`.
     /// Echoed back so the input's `value` persists across
     /// navigations.
     search_query: String,
-    /// #62 — `recent` (default) or `score`. The handler has
-    /// already applied the sort to `library`; this field drives the
-    /// dropdown's selected-option state.
+    /// Canonical sort value (`recent` / `oldest` / `title_asc` /
+    /// `title_desc` / `score` / `score_asc`). The handler has
+    /// already applied it to `library`; chips carry it through
+    /// their hrefs so switching scope keeps the ordering.
     sort_value: String,
+    /// Sort UI decomposition of `sort_value`: which key the select
+    /// shows (`recent` / `title` / `score`)...
+    sort_key: String,
+    /// ...and whether the direction toggle points descending. The
+    /// key+direction pair recomposes to the canonical value in
+    /// static/js/index.js (librarySortNavigate).
+    sort_desc: bool,
+    /// Whole-library size, computed before any filter is applied —
+    /// the identity row describes the collection, not the current
+    /// view (chips carry the per-scope counts).
+    total_count: usize,
+    /// How many of those are currently airing (AL `RELEASING` /
+    /// MAL `CURRENTLY_AIRING`). Renders as "· N airing" next to the
+    /// total; hidden at zero.
+    airing_count: usize,
 }
 
 #[derive(Template)]

--- a/src/handlers/library/pages/mod.rs
+++ b/src/handlers/library/pages/mod.rs
@@ -85,10 +85,19 @@ pub async fn index(
         .map(|a| a.score_format)
         .unwrap_or_default();
 
-    // #62 — populate the filter dropdown + apply the active
-    // filter. Distinct list names are alphabetized; empty result
-    // means no memberships synced yet (template hides the dropdown).
-    let custom_list_names = crate::models::series_custom_lists::distinct_list_names(&state.db)
+    // Whole-library counts for the identity row, captured BEFORE any
+    // filter mutates `library` — "31 series · 2 airing" describes the
+    // collection; the chips carry the per-scope counts.
+    let total_count = library.len();
+    let airing_count = library
+        .iter()
+        .filter(|s| matches!(s.status.as_str(), "RELEASING" | "CURRENTLY_AIRING"))
+        .count();
+
+    // #62 — populate the scope-chip row + apply the active
+    // filter. Names+counts are alphabetized; empty result means no
+    // memberships synced yet (template hides the list chips).
+    let list_counts = crate::models::series_custom_lists::list_counts(&state.db)
         .await
         .unwrap_or_default();
     let custom_list_filter = q.list.unwrap_or_default();
@@ -206,17 +215,143 @@ pub async fn index(
         _ => "recent".to_string(),
     };
 
+    // Decompose the canonical sort value into the key+direction pair
+    // the two-part sort control renders. Recomposition happens in
+    // static/js/index.js (librarySortNavigate); the canonical values
+    // in the URL and handler are unchanged.
+    let (sort_key, sort_desc) = match sort_value.as_str() {
+        "oldest" => ("recent", false),
+        "title_asc" => ("title", false),
+        "title_desc" => ("title", true),
+        "score" => ("score", true),
+        "score_asc" => ("score", false),
+        _ => ("recent", true),
+    };
+
+    // Per-card completeness summaries ("do I have what's aired?").
+    // Three sources, each one round-trip and proportional to the
+    // library: a batched folder scan (single spawn_blocking hop), the
+    // aired-count GROUP BY, and the active-tag-state slice. Computed
+    // AFTER filter + sort so only rendered cards pay for it.
+    let media_root = cfg
+        .as_ref()
+        .map(|c| c.media_root.clone())
+        .unwrap_or_default();
+    let folder_list: Vec<(i64, String)> = library
+        .iter()
+        .map(|s| (s.id, s.folder_name.clone()))
+        .collect();
+    let (disk_map, aired_map, tag_rows) = tokio::join!(
+        media::scan_series_folders_batch(&media_root, folder_list),
+        local_metadata::aired_episode_counts(&state.db),
+        episode_tags::active_states_all_series(&state.db),
+    );
+    let aired_map = aired_map.unwrap_or_default();
+    let mut completed_by_series: HashMap<i64, std::collections::HashSet<i32>> = HashMap::new();
+    let mut downloading_series: std::collections::HashSet<i64> = std::collections::HashSet::new();
+    for (sid, ep, tag_state) in tag_rows.unwrap_or_default() {
+        if tag_state == "grabbed" {
+            downloading_series.insert(sid);
+        } else {
+            completed_by_series.entry(sid).or_default().insert(ep);
+        }
+    }
+    let cards: Vec<(series::Series, super::CardProgress)> = library
+        .into_iter()
+        .map(|s| {
+            let total = i64::from(s.episodes.unwrap_or(0));
+            // Downloaded = distinct episode numbers on disk or with a
+            // completed grab tag — same union the series page's
+            // `downloaded` flag uses. The season filter mirrors
+            // build_episodes: with a known episode count, only
+            // season-1 / unseasoned files belong to the main list.
+            let mut have: std::collections::HashSet<i32> = std::collections::HashSet::new();
+            if let Some(files) = disk_map.get(&s.id) {
+                for f in files {
+                    if f.episode_number <= 0 {
+                        continue;
+                    }
+                    if total > 0 && matches!(f.season_number, Some(n) if n != 1) {
+                        continue;
+                    }
+                    have.insert(f.episode_number);
+                }
+            }
+            if let Some(eps) = completed_by_series.get(&s.id) {
+                have.extend(eps);
+            }
+            let downloaded = have.len() as i64;
+            let aired = match aired_map.get(&s.id) {
+                Some(&n) if n > 0 => n,
+                // No cached air dates. NOT_YET_RELEASED genuinely has
+                // nothing aired; everything else counts against the
+                // total (exact for FINISHED, honest degradation for
+                // releasing series with sparse Jikan-fallback data).
+                _ if s.status == "NOT_YET_RELEASED" => 0,
+                _ => total,
+            };
+            let downloading = downloading_series.contains(&s.id);
+            let pct = if aired > 0 {
+                (downloaded * 100 / aired).clamp(0, 100)
+            } else {
+                0
+            };
+            // While downloading, guarantee a visible sliver even at
+            // zero on-disk episodes — an invisible "in flight" state
+            // defeats the point of the bar.
+            let pct = if downloading { pct.max(6) } else { pct };
+            let (card_state, label) = if downloading {
+                if aired > 0 {
+                    (
+                        "downloading",
+                        format!(
+                            "Downloading; {} of {} aired episodes on disk",
+                            downloaded, aired
+                        ),
+                    )
+                } else {
+                    ("downloading", "Downloading".to_string())
+                }
+            } else if aired == 0 {
+                ("idle", "Nothing aired yet".to_string())
+            } else if downloaded >= aired {
+                (
+                    "complete",
+                    format!("All {} aired episodes downloaded", aired),
+                )
+            } else {
+                (
+                    "missing",
+                    format!("{} of {} aired episodes downloaded", downloaded, aired),
+                )
+            };
+            let progress = super::CardProgress {
+                state: card_state.to_string(),
+                downloaded,
+                aired,
+                pct,
+                monitored: s.monitor_mode != "none",
+                label,
+            };
+            (s, progress)
+        })
+        .collect();
+
     let template = IndexTemplate {
         page: "library".to_string(),
-        library,
+        cards,
         title_language: cfg
             .map(|c| c.title_language)
             .unwrap_or_else(|| "english".to_string()),
         score_format,
-        custom_list_names,
+        list_counts,
         custom_list_filter,
         search_query,
         sort_value,
+        sort_key: sort_key.to_string(),
+        sort_desc,
+        total_count,
+        airing_count,
     };
     Html(template.render().unwrap_or_default())
 }

--- a/src/handlers/library/pages/mod.rs
+++ b/src/handlers/library/pages/mod.rs
@@ -787,6 +787,10 @@ pub(super) async fn build_episodes(
     let mut total_size: u64 = 0;
     let mut monitored_count = 0i32;
 
+    // For the unaired-vs-missing split below. Date-only, UTC: provider
+    // air dates are calendar dates, not timestamps.
+    let today = chrono::Utc::now().date_naive();
+
     for ep_num in 1..=ep_count.max(0) {
         let disk_match = disk_files.iter().find(|f| {
             if let Some(s) = f.season_number {
@@ -957,6 +961,22 @@ pub(super) async fn build_episodes(
         if downloaded {
             downloaded_count += 1;
         }
+        // Unaired-vs-missing split (display only). Date-only compare:
+        // an episode whose air date is today counts as aired. Unknown
+        // air date defers to the series status — a still-airing or
+        // upcoming series usually lacks dates for episodes providers
+        // haven't seen yet, while a finished series with missing dates
+        // has certainly aired everything. `quality_state.is_empty()`
+        // keeps failed grabs red: a failed grab on an unaired episode
+        // means someone grabbed a release for it, so "actionable" is
+        // the right read.
+        let unaired = !downloaded
+            && quality_state.is_empty()
+            && match chrono::NaiveDate::parse_from_str(ep_aired.get(..10).unwrap_or(""), "%Y-%m-%d")
+            {
+                Ok(d) => d > today,
+                Err(_) => !detail.is_finished(),
+            };
         episodes.push(Episode {
             number: ep_num,
             title: ep_title,
@@ -973,6 +993,7 @@ pub(super) async fn build_episodes(
             filename,
             can_auto_search: is_tracked,
             monitored,
+            unaired,
             class_source,
             class_resolution,
             class_is_remux,
@@ -1067,6 +1088,8 @@ pub(super) async fn build_episodes(
             filename: f.filename.clone(),
             can_auto_search: is_tracked,
             monitored,
+            // On disk by definition in this pass, so never unaired.
+            unaired: false,
             class_source,
             class_resolution,
             class_is_remux,
@@ -1121,6 +1144,9 @@ pub(super) async fn build_episodes(
                 filename: String::new(),
                 can_auto_search: is_tracked,
                 monitored,
+                // Has a grab tag by definition in this pass (grabbed or
+                // completed), so the unaired display state never applies.
+                unaired: false,
                 class_source: tag.source.clone(),
                 class_resolution: tag.resolution.clone(),
                 class_is_remux: tag.is_remux,

--- a/src/handlers/library/search/interactive.rs
+++ b/src/handlers/library/search/interactive.rs
@@ -65,6 +65,10 @@ pub(super) struct InteractiveSearchTablePartial {
     /// found."; batch shows "No batch releases found." — matches the
     /// pre-migration JS copy verbatim.
     empty_message: &'static str,
+    /// Direction line under the lead — what to try next, in the same
+    /// voice as the calendar's empty state. An empty result with no
+    /// next step is a dead end.
+    empty_hint: &'static str,
 }
 
 fn build_interactive_search_partial(
@@ -95,15 +99,22 @@ fn build_interactive_search_partial(
             }
         })
         .collect();
-    let empty_message = if grab_episode_number.is_some() {
-        "No results found."
+    let (empty_message, empty_hint) = if grab_episode_number.is_some() {
+        (
+            "No results found.",
+            "Recent episodes can take a while to appear on indexers. A batch search may find a season pack that includes this episode; if the series uses unusual release naming, set a search override on this page.",
+        )
     } else {
-        "No batch releases found."
+        (
+            "No batch releases found.",
+            "Batches usually appear after a season finishes airing. Per-episode searches may still find individual releases.",
+        )
     };
     InteractiveSearchTablePartial {
         rows,
         grab_episode_number,
         empty_message,
+        empty_hint,
     }
 }
 

--- a/src/models/episode_tags.rs
+++ b/src/models/episode_tags.rs
@@ -325,6 +325,24 @@ pub async fn get_for_series(
     Ok(rows.into_iter().map(|t| (t.episode_number, t)).collect())
 }
 
+/// Library-wide slice of active tag states for the index page's
+/// per-card completeness bars: every (series_id, episode_number,
+/// state) row whose state is 'completed' (counts toward downloaded,
+/// unioned with on-disk files) or 'grabbed' (flips the card into the
+/// downloading state). Failed tags are irrelevant to the bar — a
+/// failed grab leaves the episode missing — so they're filtered
+/// server-side to keep the row count proportional to the library.
+pub async fn active_states_all_series(
+    db: &SqlitePool,
+) -> Result<Vec<(i64, i32, String)>, sqlx::Error> {
+    sqlx::query_as::<_, (i64, i32, String)>(
+        "SELECT series_id, episode_number, state FROM episode_quality_tags
+         WHERE state IN ('completed', 'grabbed')",
+    )
+    .fetch_all(db)
+    .await
+}
+
 /// Get grab history for a specific episode, newest first. No LIMIT — the
 /// modal UI scrolls past the first 10 entries, and there are no known
 /// series with enough grabs for an unbounded SELECT to be a problem.

--- a/src/models/local_metadata.rs
+++ b/src/models/local_metadata.rs
@@ -558,6 +558,32 @@ pub async fn get_episode_map_for_provider(
     get_episode_table(db, "provider_episode_metadata", "provider_id", provider_id).await
 }
 
+/// Per-series count of episodes that have aired, judged by the cached
+/// air-date strings: a parseable leading `YYYY-MM-DD` that's today or
+/// earlier. Powers the library cards' completeness bars ("do I have
+/// what's aired?"), so the denominator must exclude unaired episodes
+/// or a releasing series would read as perpetually incomplete.
+/// Notes on the WHERE shape:
+/// - `episode_number >= 1` skips the negative-cache sentinel row
+///   (episode 0) the Jikan/Kitsu fallback writes.
+/// - `length(aired) >= 10` skips the unknown markers ('' and '-').
+/// - The substr comparison is lexicographic, which is chronological
+///   for ISO dates; `date('now')` renders as `YYYY-MM-DD` in UTC —
+///   same date-only, UTC semantics as the series page's
+///   unaired-vs-missing split.
+pub async fn aired_episode_counts(db: &SqlitePool) -> Result<HashMap<i64, i64>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (i64, i64)>(
+        "SELECT series_id, COUNT(*) FROM series_episode_metadata
+         WHERE episode_number >= 1
+           AND length(aired) >= 10
+           AND substr(aired, 1, 10) <= date('now')
+         GROUP BY series_id",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows.into_iter().collect())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/models/series_custom_lists.rs
+++ b/src/models/series_custom_lists.rs
@@ -118,6 +118,20 @@ pub async fn distinct_list_names(db: &SqlitePool) -> Result<Vec<String>, sqlx::E
     Ok(rows)
 }
 
+/// Distinct list names with their member counts, alphabetized. Powers
+/// the library page's scope-chip row (each chip renders "Name (N)").
+/// Membership rows FK onto `series(id)` with ON DELETE CASCADE, so
+/// counts always reflect series actually present in the library.
+pub async fn list_counts(db: &SqlitePool) -> Result<Vec<(String, i64)>, sqlx::Error> {
+    let rows = sqlx::query_as::<_, (String, i64)>(
+        "SELECT list_name, COUNT(DISTINCT series_id) FROM series_custom_lists
+         GROUP BY list_name ORDER BY list_name COLLATE NOCASE",
+    )
+    .fetch_all(db)
+    .await?;
+    Ok(rows)
+}
+
 /// Drop every membership row for the given provider. Used on
 /// account unlink so the library filter dropdown stops showing list
 /// names that came from an account the user no longer has linked

--- a/src/services/media.rs
+++ b/src/services/media.rs
@@ -133,6 +133,30 @@ pub async fn scan_series_folder(media_root: &str, folder_name: &str) -> Vec<Epis
         .unwrap_or_default()
 }
 
+/// Batch variant of `scan_series_folder` for the library index's
+/// per-card completeness bars: one `spawn_blocking` hop for the whole
+/// library instead of one per series. Each entry is (series_id,
+/// folder_name); the result maps series_id to that folder's files.
+/// A readdir per series is cheap (single-digit ms for a whole
+/// library on local disk), but N spawn_blocking hops wouldn't be.
+pub async fn scan_series_folders_batch(
+    media_root: &str,
+    folders: Vec<(i64, String)>,
+) -> std::collections::HashMap<i64, Vec<EpisodeFile>> {
+    if media_root.is_empty() || folders.is_empty() {
+        return std::collections::HashMap::new();
+    }
+    let media_root = media_root.to_string();
+    tokio::task::spawn_blocking(move || {
+        folders
+            .into_iter()
+            .map(|(id, folder)| (id, scan_series_folder_blocking(&media_root, &folder)))
+            .collect()
+    })
+    .await
+    .unwrap_or_default()
+}
+
 fn scan_series_folder_blocking(media_root: &str, folder_name: &str) -> Vec<EpisodeFile> {
     let series_path = Path::new(media_root).join(folder_name);
     if !series_path.is_dir() {

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -159,6 +159,24 @@
     visibility: hidden;
 }
 
+/* Absorb the scrollbar-width error inherent to the two viewport-
+ * breakout shapes (`.detail-banner` on series pages, `.tabbed-page`
+ * on Settings/System): `100vw` includes the vertical scrollbar, so
+ * a full-bleed box's right edge lands ~8px past the client area and
+ * mints a horizontal scrollbar on every page tall enough to scroll.
+ * `clip` (not `hidden`) crops that overhang without creating a
+ * scroll container, so sticky positioning inside the page keeps
+ * working. Both elements need it: on `html` alone the value
+ * propagates to the viewport as `hidden`, which drops the scrollbar
+ * but leaves the page programmatically scrollable (focus jumps and
+ * find-in-page could still shift it sideways); adding `body` clips
+ * the overhang at the source so the scrollable-overflow region is
+ * truly empty. The mobile media query below predates this rule and
+ * keeps its stronger `hidden` form. */
+html, body {
+    overflow-x: clip;
+}
+
 body {
     background: var(--bg);
     color: var(--text);

--- a/static/css/pages/index.css
+++ b/static/css/pages/index.css
@@ -1,16 +1,166 @@
 /* pages/index.css — auto-split from style.css. */
 
-/* Library page header overrides. Scoped to .library-header-row so
-   other pages keep their existing flex-start (page-desc-under-h2)
-   shape. We want the "Anime Library" title vertically centered on
-   the same baseline as the filter controls and Add Series button to
-   its right, since the page-desc is gone and there's nothing for
-   the second-line alignment to anchor to. */
-.library-header-row {
+/* ── Library header: two rows split by role ─────────────────────────
+   Row 1 (identity + primary): title + collection counts | search |
+   + Add Series. Row 2 (scope + presentation): custom-list chips |
+   sort key + direction | Select. Each row has exactly one flexible
+   element (row 1: the search input shrinks; row 2: the chip strip
+   scrolls), so the layout is the same shape at every viewport width
+   instead of wrapping controls into ambiguous positions. */
+
+.library-identity-row {
+    display: flex;
     align-items: center;
+    gap: 12px;
 }
-.library-header-row h2 {
+
+.library-title-group {
+    display: flex;
+    align-items: baseline;
+    gap: 12px;
+    flex-shrink: 0;
+}
+
+.library-title-group h2 {
     margin-bottom: 0;
+    white-space: nowrap;
+}
+
+.library-count {
+    color: var(--text-dim);
+    font-size: 13px;
+    white-space: nowrap;
+}
+
+/* Squeeze band between the mobile stack (<=640, where the title gets
+   a full-width row and the count fits fine) and ~760px: the count is
+   the one element in row 1 with no graceful shrink story (truncating
+   "1 airing" mid-word reads as a bug), and it's ambient info — so it
+   yields first. Everything else in the row has a shrink/wrap plan. */
+@media (min-width: 641px) and (max-width: 760px) {
+    .library-count {
+        display: none;
+    }
+}
+
+.library-search-form {
+    display: flex;
+    justify-content: flex-end;
+    flex: 1 1 auto;
+    min-width: 0;
+    margin-left: auto;
+}
+
+.library-add-btn {
+    flex-shrink: 0;
+}
+
+.library-scope-row {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    margin-top: 14px;
+}
+
+.library-chips-spacer {
+    flex: 1 1 auto;
+}
+
+/* Chip strip: single line, horizontal scroll as the overflow story.
+   Scrollbar hidden — the cut-off chip edge is the affordance, and
+   the strip is mouse-wheel / touch scrollable. */
+.library-chips {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    min-width: 0;
+    overflow-x: auto;
+    scrollbar-width: none;
+    /* Breathing room so focus rings don't get clipped by the
+       scroll container. */
+    padding: 2px;
+    margin: -2px;
+}
+
+.library-chips::-webkit-scrollbar {
+    display: none;
+}
+
+.library-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 12px;
+    border: 1px solid var(--border);
+    /* Same rounded-square radius as the buttons in both header rows;
+       a pill shape read as a different control family. */
+    border-radius: var(--radius);
+    background: transparent;
+    color: var(--text-dim);
+    font-size: 13px;
+    font-weight: 500;
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color 0.15s, border-color 0.15s, background 0.15s;
+}
+
+.library-chip:hover {
+    color: var(--text);
+    border-color: var(--border-accent);
+}
+
+.library-chip.active {
+    color: var(--accent);
+    border-color: rgba(203, 166, 247, 0.45);
+    background: rgba(203, 166, 247, 0.08);
+}
+
+.library-chip-count {
+    font-size: 11px;
+    color: var(--text-dim);
+    opacity: 0.8;
+}
+
+.library-chip.active .library-chip-count {
+    color: var(--accent);
+}
+
+.library-scope-tools {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+    margin-left: auto;
+}
+
+/* Direction toggle: square button matching the sort select's height.
+   The arrow SVG points down (descending); ascending rotates it. */
+.library-sort-dir {
+    box-sizing: border-box;
+    height: 34px;
+    width: 34px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    color: var(--text-dim);
+    cursor: pointer;
+    transition: color 0.15s, border-color 0.15s;
+}
+
+.library-sort-dir:hover {
+    color: var(--text);
+    border-color: var(--border-accent);
+}
+
+.library-sort-dir-icon {
+    transition: transform 0.15s;
+}
+
+.library-sort-dir[data-desc="false"] .library-sort-dir-icon {
+    transform: rotate(180deg);
 }
 
 .btn-pill {
@@ -60,18 +210,13 @@
     color: var(--text);
     font-size: 13px;
     font-family: var(--font-body);
-    width: 220px;
-    min-width: 180px;
+    /* Row 1's single flexible element: 300px when space allows,
+       shrinking to 150px before anything else in the row moves. */
+    width: 100%;
+    max-width: 300px;
+    min-width: 150px;
     appearance: textfield;
     -webkit-appearance: textfield;
-}
-
-/* When the custom-list dropdown is absent (no AL account linked yet
-   or freshly unlinked), the search input absorbs that slot's
-   footprint so the row doesn't visibly contract. 220px (own width)
-   + 180px (list dropdown) + 6px (flex gap) = 406px. */
-.library-search-input.library-search-input-wide {
-    width: 406px;
 }
 
 .library-search-input::placeholder {
@@ -83,53 +228,23 @@
     border-color: var(--accent);
 }
 
-/* Scoped overrides on the page-header filter row so the dropdowns
-   and Clear pill share the search input's exact height. Underlying
-   .folder-select / .btn-pill rules stay untouched so other pages
-   keep their tighter sizing. */
-.library-filter-form .folder-select {
+/* Sort key select: compact, secondary sizing (34px vs the search
+   input's 42px) — row 2 is quiet tooling, not the primary controls.
+   Scoped so other pages' .folder-select sizing stays untouched. */
+.library-scope-tools .folder-select {
     box-sizing: border-box;
-    height: 42px;
-    width: 180px;
+    height: 34px;
     padding: 0 28px 0 12px;
     font-size: 13px;
+    width: auto;
 }
 
-.library-filter-form .library-filter-clear {
+/* Select toggle matches the row's compact height. */
+.library-scope-tools .bulk-select-toggle {
     box-sizing: border-box;
-    height: 42px;
+    height: 34px;
     padding: 0 14px;
     font-size: 13px;
-    display: inline-flex;
-    align-items: center;
-}
-
-/* "Clear" link styled as a quiet pill; only renders when at least
-   one filter is active. */
-.library-filter-clear {
-    background: transparent;
-    color: var(--text-dim);
-    border: 1px solid var(--border-subtle);
-    padding: 4px 12px;
-    font-size: 12px;
-    border-radius: 999px;
-    text-decoration: none;
-    transition: color 0.15s, border-color 0.15s;
-}
-
-.library-filter-clear:hover {
-    color: var(--accent);
-    border-color: rgba(203, 166, 247, 0.45);
-}
-
-/* Reserve the Clear button's layout slot when no filter is active
-   so the row doesn't shift sideways the moment the user types into
-   the search box. visibility:hidden keeps the box (and the flex
-   gap) in place; pointer-events:none + the template's tabindex=-1
-   keep it out of mouse and keyboard focus. */
-.library-filter-clear-hidden {
-    visibility: hidden;
-    pointer-events: none;
 }
 
 @media (max-width: 640px) {
@@ -169,6 +284,84 @@
     aspect-ratio: 2/3;
     overflow: hidden;
     background: var(--bg-elevated);
+}
+
+/* ── Card completeness bar ──────────────────────────────────────────
+   Thin strip on the poster's bottom edge answering one question:
+   "do I have what's aired?" Fill = downloaded / aired. Three states
+   + one modifier:
+   - complete: full green fill on the neutral track.
+   - missing: green fill for what's on disk, red track for the gap
+     (red = actionable, same as the episode table's Missing).
+   - downloading: accent fill with a soft pulse.
+   - unmonitored (modifier): whole bar dimmed; "ignoring this" is
+     not a fourth color.
+   The idle state (nothing aired yet) is just the neutral track.
+   The numeric N/M chip in the card meta is the colorblind-safe
+   fallback for the missing state. */
+.card-progress {
+    /* Saturated signal variants, deliberately NOT the theme's pastel
+       --green/--red: those are tuned for text on dark and wash out
+       as a 5px strip. A status bar is signage — it gets traffic-light
+       saturation, scoped here so the rest of the page keeps the
+       muted palette. */
+    --bar-green: #2fce5f;
+    --bar-red: #e5484d;
+    --bar-accent: #a06cf5;
+    display: block;
+    height: 4px;
+    background: rgba(255, 255, 255, 0.1);
+}
+
+.card-progress-fill {
+    height: 100%;
+    width: 0;
+    background: var(--bar-green);
+}
+
+.card-progress-missing {
+    background: var(--bar-red);
+}
+
+/* Downloading: the whole strip goes mauve — dim track + solid fill —
+   and pulses. A bare 6% fill sliver was invisible at a glance, and
+   "something is in flight" matters more than the exact fraction here
+   (the tooltip and the series page carry the numbers). */
+.card-progress-downloading {
+    background: rgba(160, 108, 245, 0.35);
+}
+
+.card-progress-downloading .card-progress-fill {
+    background: var(--bar-accent);
+    animation: card-progress-pulse 1.8s ease-in-out infinite;
+}
+
+/* Unmonitored modifier: currently no visual distinction (opacity 1).
+   Earlier dim attempts (0.35, then 0.6) washed the whole grid out on
+   libraries where import prefs leave every series monitor_mode='none'.
+   The class stays on the element so a future distinction (or a
+   user-side custom CSS tweak) has a hook to target. */
+.card-progress-unmonitored {
+    opacity: 1;
+}
+
+@keyframes card-progress-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.45; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .card-progress-downloading .card-progress-fill {
+        animation: none;
+    }
+}
+
+/* Numeric have/aired readout, rendered only in the missing state.
+   Same tag shape as its FINISHED/eps neighbors, tinted with the
+   bar's red so the two surfaces read as one signal. */
+.tag-progress-missing {
+    color: var(--red);
+    background: rgba(211, 125, 125, 0.12);
 }
 
 /* Hover vignette — bottom band only. One linear gradient fading up
@@ -534,49 +727,31 @@
     border-color: var(--accent);
 }
 
-/* "Select" toggle button in the topbar (base.html nav-links). Lives
-   here rather than in the page filter row so it sits in the
-   persistent topbar — the same place Sonarr surfaces its "Select
-   Series" page-mode toggle. Conditionally rendered only when
-   `page == "library"`; on other pages the button is not in the
-   DOM at all (so toggleBulkSelectMode() can't be invoked from
-   pages that don't load index.js).
-   Sizing matches `.nav-links a` exactly (same padding, same
-   font-size, no border) so the button height aligns with the
-   surrounding nav-link anchors. The active state (mode on) inverts
-   to a mauve fill for constant visual confirmation that mode is on. */
-.nav-action.bulk-select-toggle {
+/* "Select" toggle button in the library toolbar (templates/
+   index.html, next to "+ Add Series"). It used to live in the
+   topbar's nav-links, but a library-only button in persistent
+   chrome shifted every nav item's position between library and
+   non-library pages, which hx-boost's instant swaps made very
+   visible. Base look comes from `.btn.btn-secondary`; this block
+   only adds the icon layout and the mode-on state. The active
+   state (mode on) inverts to a mauve fill for constant visual
+   confirmation, and the label swaps to "Cancel" (index.js). */
+.bulk-select-toggle {
     display: inline-flex;
     align-items: center;
     gap: 6px;
-    background: transparent;
-    color: var(--text-dim);
-    padding: 6px 14px;
-    border: none;
-    border-radius: var(--radius);
-    /* Match `.nav-links a` exactly: 14px font, body-inherited line-
-       height (1.6 from base.css's `body`). The default UA stylesheet
-       on <button> sets `line-height: normal` which renders shorter
-       than the surrounding anchors, so we restate explicitly. */
-    font-size: 14px;
-    font-weight: 500;
-    font-family: inherit;
-    line-height: 1.6;
-    cursor: pointer;
-    transition: color 0.15s, background 0.15s, transform 0.1s;
 }
-.nav-action.bulk-select-toggle:hover {
-    color: var(--text);
-    background: var(--bg-elevated);
-}
-.nav-action.bulk-select-toggle.active {
+.bulk-select-toggle.active,
+.bulk-select-toggle.active:hover {
     background: var(--accent);
+    border-color: var(--accent);
     color: var(--bg);
 }
-.nav-action.bulk-select-toggle.active:hover {
+.bulk-select-toggle.active:hover {
     background: var(--accent-hover);
+    border-color: var(--accent-hover);
 }
-.nav-action.bulk-select-toggle:active {
+.bulk-select-toggle:active {
     transform: scale(0.97);
 }
 .bulk-select-toggle-icon {
@@ -591,61 +766,49 @@
     flex-shrink: 0;
 }
 
-/* Library header on mobile: stack vertically. The default
-   page-header-row is a flex row with the title on the left and
-   filter controls + Add Series on the right; below --bp-phone the
-   right side wraps awkwardly (title squeezed onto two lines, +Add
-   Series orphaned in the middle of the row). Stacking gives each
-   slot its own row so the layout reads top-to-bottom: title,
-   search + filters, Add Series. */
+/* Library header on mobile: the identity row wraps into three rows
+   (title + counts / full-width search / full-width Add Series), and
+   the scope row wraps into chips-strip-then-tools. The chip strip
+   keeps its horizontal scroll — same affordance as the bottom
+   tabbar. */
 @media (max-width: 640px) {
-    .library-header-row {
-        flex-direction: column;
-        align-items: stretch;
-        gap: 12px;
-    }
-    .library-header-row h2 {
-        margin: 0;
-    }
-    /* Right-side wrapper: the filter form + Add Series share a
-       container <div> in the template. Let it flex-wrap so its
-       children stack cleanly. */
-    .library-header-row > div:last-child {
-        display: flex;
-        flex-direction: column;
-        gap: 8px;
-        align-items: stretch;
-    }
-    .library-filter-form {
+    .library-identity-row {
         flex-wrap: wrap;
-        width: 100%;
-        gap: 8px;
+        gap: 10px;
     }
-    /* Search input goes full-width. The wide variant (no list
-       dropdown) was already 100% via the `width: 406px` rule
-       hitting the viewport cap; standardize. */
-    .library-filter-form .library-search-input,
-    .library-filter-form .library-search-input.library-search-input-wide {
+    .library-title-group {
         width: 100%;
-        min-width: 0;
     }
-    /* Each form control gets its own full-width row on mobile:
-       custom-list filter, search box, sort dropdown, Clear pill all
-       stack vertically. Sharing rows looked uneven (50/50 selects
-       collapsed unequally based on content width). Full-width is
-       cleaner and matches the +Add Series button's full-width row
-       below them. */
-    .library-filter-form .folder-select {
+    .library-search-form {
         flex: 1 1 100%;
-        width: 100%;
-        min-width: 0;
+        margin-left: 0;
     }
-    /* Add Series button breaks to full-width with no left margin
-       (the original 32px sat next to the filters; on mobile it
-       just creates a misalignment). */
-    .library-header-row .btn-primary {
-        margin-left: 0 !important;
+    .library-search-input {
+        max-width: none;
+    }
+    .library-add-btn {
+        flex: 1 1 100%;
+    }
+    .library-scope-row {
+        flex-wrap: wrap;
+        gap: 10px;
+    }
+    .library-chips {
+        flex: 1 1 100%;
+    }
+    .library-chips-spacer {
+        display: none;
+    }
+    .library-scope-tools {
         width: 100%;
+        margin-left: 0;
+    }
+    .library-scope-tools .folder-select {
+        flex: 1 1 auto;
+        width: auto;
+    }
+    .library-scope-tools .bulk-select-toggle {
+        flex-shrink: 0;
     }
 }
 

--- a/static/css/pages/series.css
+++ b/static/css/pages/series.css
@@ -496,6 +496,11 @@
 
 .ep-missing { color: var(--red); opacity: 0.5; }
 
+/* Unaired (no file, air date in the future or unknown on a still-
+   airing series): deliberately neutral. Red is reserved for
+   aired-but-absent episodes, where "go grab it" is a real action. */
+.ep-unaired { color: var(--text-dim); opacity: 0.5; }
+
 .ep-row-have .ep-col-num { color: var(--text); }
 
 .ep-title-name {
@@ -513,6 +518,12 @@
     font-size: 11px;
     color: var(--red);
     opacity: 0.6;
+}
+
+.ep-unaired-label {
+    font-size: 11px;
+    color: var(--text-dim);
+    opacity: 0.8;
 }
 
 @media (max-width: 640px) {
@@ -1153,6 +1164,16 @@
     text-align: center;
     color: var(--text-dim);
     padding: 32px;
+}
+
+.isearch-empty-hint {
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--text-dim);
+    opacity: 0.75;
+    max-width: 520px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 /* Inline save-status pill returned by the HTMX-aware

--- a/static/css/pages/settings.css
+++ b/static/css/pages/settings.css
@@ -59,19 +59,25 @@ fieldset legend {
        left edge to the viewport-left. More robust than the prior
        `margin-left: calc(50% - 50vw)` shape, which depended on the
        parent's content-box width matching the rendered width
-       (broke when `.content`'s padding wasn't accounted for). */
-    width: 100vw;
+       (broke when `.content`'s padding wasn't accounted for).
+
+       The 1564px cap = 200 sidebar + 32 gap + 1052 content + 32 gap
+       + 200 phantom + 48 padding. Below the cap this behaves exactly
+       like the plain breakout; above it the whole unit centers so an
+       ultrawide monitor doesn't strand the sidebar at the far-left
+       edge, meters away from the content it controls. The margin
+       mirrors the width via max() (both negative, so max() picks the
+       smaller magnitude once the cap engages).
+
+       100vw includes the vertical scrollbar, so the uncapped shape
+       overhangs the client area by scrollbar-width; `html
+       { overflow-x: clip }` in base.css crops that overhang. */
+    width: min(100vw, 1564px);
     position: relative;
     left: 50%;
-    margin-left: -50vw;
+    margin-left: max(-50vw, -782px);
     padding-left: 24px;
     padding-right: 24px;
-    /* `.content` doesn't set overflow-x, so the negative margin
-       won't trigger horizontal scroll; the body's natural shape
-       already excludes overflow there. If a future change adds
-       overflow-x: hidden to body or `.content` and clips this
-       breakout, the fix is to lift overflow-x off them, not to
-       roll back this rule. */
 }
 
 .tabbed-page-header {

--- a/static/css/topbar.css
+++ b/static/css/topbar.css
@@ -59,6 +59,30 @@
     font-size: 14px;
     font-weight: 500;
     transition: color 0.15s, background 0.15s;
+    white-space: nowrap;
+}
+
+/* The 641-900px band: too narrow for the full-size nav (7 links at
+   14px/14px-padding overflow the right edge and clip Logout off the
+   viewport entirely), too wide for the mobile tabbar takeover at
+   640px. Compress instead of clipping: drop the Latin half of the
+   brand (the kanji mark stands alone), tighten link padding + gap,
+   and step the font down a notch. Verified to fit all seven links
+   at 641px. */
+@media (max-width: 900px) and (min-width: 641px) {
+    .nav {
+        padding: 0 12px;
+    }
+    .nav-brand .brand-latin {
+        display: none;
+    }
+    .nav-links {
+        gap: 2px;
+    }
+    .nav-links a {
+        padding: 6px 8px;
+        font-size: 13px;
+    }
 }
 
 .nav-links a:hover { color: var(--text); background: var(--bg-elevated); }
@@ -116,16 +140,18 @@
 
 @media (max-width: 640px) {
     /* Keep .nav-links flexed on mobile but hide every child except
-       (a) the mobile logout icon and (b) the bulk-select toggle on
-       the library page. Primary nav lives in the bottom
-       mobile-tabbar; the topbar's right slot is reserved for
-       page-mode actions (Select) and account actions (Logout). */
+       the mobile logout and calendar icons. Primary nav lives in
+       the bottom mobile-tabbar; the topbar's right slot is reserved
+       for account actions (Logout) and the calendar shortcut. The
+       bulk-select toggle used to be whitelisted here too; it now
+       lives in the library toolbar (templates/index.html) instead
+       of the topbar. */
     .nav-links {
         display: flex;
         gap: 6px;
         align-items: center;
     }
-    .nav-links > *:not(.nav-logout-mobile):not(.bulk-select-toggle):not(.nav-calendar-mobile) {
+    .nav-links > *:not(.nav-logout-mobile):not(.nav-calendar-mobile) {
         display: none;
     }
     .nav-logout-mobile {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -26,6 +26,45 @@ function liveLibrarySearch(input) {
     }, 250);
 }
 
+// ── Two-part sort control (key select + direction toggle) ─────────
+//
+// The header renders sort as a key ('recent' / 'title' / 'score')
+// plus a direction arrow; the server and URL keep the canonical
+// six-value ?sort= vocabulary. This recomposes and navigates,
+// preserving ?list= (scope) and the live search text.
+function librarySortNavigate(sortValue) {
+    var url = new URL(window.location.href);
+    if (sortValue === 'recent') url.searchParams.delete('sort');
+    else url.searchParams.set('sort', sortValue);
+    // The search input's live value may be newer than the URL param
+    // (liveLibrarySearch debounces its replaceState by 250ms).
+    var search = document.getElementById('library-search');
+    var q = search ? search.value.trim() : '';
+    if (q) url.searchParams.set('search', q);
+    else url.searchParams.delete('search');
+    window.location.assign(url);
+}
+
+// Picking a key applies that key's default direction — newest first,
+// A to Z, highest score first — matching the select's option values.
+function librarySortKeyChanged(sel) {
+    var defaults = { recent: 'recent', title: 'title_asc', score: 'score' };
+    librarySortNavigate(defaults[sel.value] || 'recent');
+}
+
+// The arrow flips direction within the current key.
+function librarySortDirToggled(btn) {
+    var keySel = document.getElementById('library-sort-key');
+    var key = keySel ? keySel.value : 'recent';
+    var wasDesc = btn.dataset.desc === 'true';
+    var composed = {
+        recent: wasDesc ? 'oldest' : 'recent',
+        title: wasDesc ? 'title_asc' : 'title_desc',
+        score: wasDesc ? 'score_asc' : 'score',
+    };
+    librarySortNavigate(composed[key] || 'recent');
+}
+
 function _liveLibrarySearchImmediate(input) {
     const q = (input.value || '').trim().toLowerCase();
     const grid = document.getElementById('library-grid');
@@ -56,22 +95,6 @@ function _liveLibrarySearchImmediate(input) {
     if (q) url.searchParams.set('search', q);
     else url.searchParams.delete('search');
     window.history.replaceState(null, '', url);
-
-    // Clear button visibility: track whether *any* filter is active,
-    // not just search. The list filter is reflected in the URL.
-    const hasListFilter = !!url.searchParams.get('list');
-    const clear = document.querySelector('.library-filter-clear');
-    if (clear) {
-        const anyActive = !!q || hasListFilter;
-        clear.classList.toggle('library-filter-clear-hidden', !anyActive);
-        if (anyActive) {
-            clear.removeAttribute('aria-hidden');
-            clear.removeAttribute('tabindex');
-        } else {
-            clear.setAttribute('aria-hidden', 'true');
-            clear.setAttribute('tabindex', '-1');
-        }
-    }
 
     // No-matches inline empty state. Built once and toggled — avoids
     // navigation while still telling the user their query found
@@ -586,6 +609,24 @@ if (!window.__ryokanBulkSelectInit) {
         if (!id) return;
         toggleSeriesSelectById(id);
     }, true);
+
+    // "/" focuses the library search from anywhere on the page —
+    // the same muscle memory as Nyaa, GitHub, and the *arr stack.
+    // Skipped while typing in any field so a literal slash still
+    // works there, and no-ops on non-library pages (the input isn't
+    // in the DOM). Document-level for the same hx-boost-survival
+    // reason as the listeners above.
+    document.addEventListener('keydown', function (ev) {
+        if (ev.key !== '/' || ev.ctrlKey || ev.metaKey || ev.altKey) return;
+        var el = document.activeElement;
+        if (el && (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA' ||
+                   el.tagName === 'SELECT' || el.isContentEditable)) return;
+        var search = document.getElementById('library-search');
+        if (!search) return;
+        ev.preventDefault();
+        search.focus();
+        search.select();
+    });
 
     // Esc: exits the bulk delete modal first if open, then bulk
     // monitor modal, then selecting mode (clears selection on the

--- a/static/js/search.js
+++ b/static/js/search.js
@@ -579,7 +579,7 @@ function renderScoreBreakdown(r) {
             </li>`;
         }).join('');
         inner = `<ul>${lis}</ul>
-            <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page — open the series page's interactive search for the full breakdown.</div>`;
+            <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page; open the series page's interactive search for the full breakdown.</div>`;
     }
     return `<div class="score-components">
         <div class="score-components-title">Base score breakdown</div>

--- a/static/js/series.js
+++ b/static/js/series.js
@@ -17,6 +17,7 @@ function updateEpisodeRow(epNum, state, group) {
         if (!numCell || parseInt(numCell.textContent.trim()) !== epNum) continue;
 
         if (state === 'grabbed') {
+            row.classList.remove('ep-row-missing', 'ep-row-unaired');
             row.classList.add('ep-row-queued');
             const qualityCell = row.querySelector('.ep-col-quality');
             if (qualityCell) {
@@ -36,14 +37,21 @@ function updateEpisodeRow(epNum, state, group) {
             // refresh arrived — hence the "cancel one visually cancels
             // all" / "stuck queued" marker.
             row.classList.remove('ep-row-have', 'ep-row-queued');
-            row.classList.add('ep-row-missing');
+            // A cancelled grab on a not-yet-aired episode goes back to
+            // the neutral Unaired state, not red Missing. The row's
+            // data-unaired attribute mirrors Episode.unaired (stamped
+            // server-side and kept fresh by syncEpisodeDataset).
+            var wasUnaired = row.dataset.unaired === 'true';
+            row.classList.add(wasUnaired ? 'ep-row-unaired' : 'ep-row-missing');
             const statusCell = row.querySelector('.ep-col-status');
             if (statusCell) {
-                statusCell.innerHTML = '<span class="ep-status-icon ep-missing" title="Missing"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg></span>';
+                statusCell.innerHTML = wasUnaired ? STATUS_ICON_UNAIRED : STATUS_ICON_MISSING;
             }
             const qualityCell = row.querySelector('.ep-col-quality');
             if (qualityCell) {
-                qualityCell.innerHTML = '<span class="ep-missing-label">Missing</span>';
+                qualityCell.innerHTML = wasUnaired
+                    ? '<span class="ep-unaired-label">Unaired</span>'
+                    : '<span class="ep-missing-label">Missing</span>';
                 // Drop the cached `originalHtml` stash so future
                 // showings of a progress bar on this row don't restore
                 // the stale queued HTML.
@@ -257,6 +265,7 @@ var dlPoll = (window.__ryokanSeriesDlPoll = window.__ryokanSeriesDlPoll || {
 
 var STATUS_ICON_HAVE = '<span class="ep-status-icon ep-have" title="On disk"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>';
 var STATUS_ICON_MISSING = '<span class="ep-status-icon ep-missing" title="Missing"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/></svg></span>';
+var STATUS_ICON_UNAIRED = '<span class="ep-status-icon ep-unaired" title="Unaired"><svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg></span>';
 var DL_PROGRESS_HTML_ZERO = '<div class="dl-progress-wrap"><div class="dl-progress-bar"><div class="dl-progress-fill" style="width:0%"></div></div><span class="dl-progress-text">0.0%</span></div>';
 
 // Sync the episode table with the server's authoritative state.
@@ -326,6 +335,11 @@ function refreshEpisodeRows(options) {
 // every patch call regardless of force/showingProgress gating
 // because the dataset is read on demand, not on every poll tick.
 function syncEpisodeDataset(row, ep) {
+    // Keep the row's unaired marker fresh so optimistic patches
+    // (updateEpisodeRow's 'deleted' flip) restore the right state.
+    if (typeof ep.unaired === 'boolean') {
+        row.dataset.unaired = ep.unaired ? 'true' : 'false';
+    }
     const titleBtn = row.querySelector('.ep-title-btn');
     if (!titleBtn) return;
     if (typeof ep.size_display === 'string') {
@@ -386,7 +400,7 @@ function patchEpisodeRows(episodes, force) {
         const statusCell = row.querySelector('.ep-col-status');
 
         if (ep.on_disk) {
-            row.classList.remove('ep-row-missing', 'ep-row-queued');
+            row.classList.remove('ep-row-missing', 'ep-row-unaired', 'ep-row-queued');
             row.classList.add('ep-row-have');
             if (statusCell) statusCell.innerHTML = STATUS_ICON_HAVE;
             const quality = ep.quality || 'UNKNOWN';
@@ -396,7 +410,7 @@ function patchEpisodeRows(episodes, force) {
             // Episode was just grabbed (or is still queued). Show a 0%
             // progress bar — the poller will update it once the
             // download client reports real progress.
-            row.classList.remove('ep-row-have', 'ep-row-missing');
+            row.classList.remove('ep-row-have', 'ep-row-missing', 'ep-row-unaired');
             row.classList.add('ep-row-queued');
             if (!showingProgress) {
                 if (!qualityCell.dataset.originalHtml) {
@@ -413,13 +427,15 @@ function patchEpisodeRows(episodes, force) {
             // even though on_disk is false. Without this branch, a
             // completed row falls through to the missing fallback below
             // and flashes back to "Missing" mid-poll.
-            row.classList.remove('ep-row-missing', 'ep-row-queued');
+            row.classList.remove('ep-row-missing', 'ep-row-unaired', 'ep-row-queued');
             row.classList.add('ep-row-have');
             if (statusCell) statusCell.innerHTML = STATUS_ICON_HAVE;
             qualityCell.innerHTML = `<span class="tag tag-quality">${escHtml(ep.quality || 'UNKNOWN')}</span>`;
             delete qualityCell.dataset.originalHtml;
         } else if (ep.quality_state === 'failed') {
-            row.classList.remove('ep-row-queued', 'ep-row-have');
+            // Failed stays red even on an unaired episode — a grab
+            // existed for it, so there's something to act on.
+            row.classList.remove('ep-row-queued', 'ep-row-have', 'ep-row-unaired');
             row.classList.add('ep-row-missing');
             if (statusCell) statusCell.innerHTML = STATUS_ICON_MISSING;
             qualityCell.innerHTML = `<span class="tag tag-quality-failed">${escHtml(ep.quality || '')} ✗</span>`;
@@ -436,9 +452,20 @@ function patchEpisodeRows(episodes, force) {
             // is the bug the user reports as "stays at 0% after
             // deleting in qBit / on the downloads page."
             row.classList.remove('ep-row-have', 'ep-row-queued');
-            row.classList.add('ep-row-missing');
-            if (statusCell) statusCell.innerHTML = STATUS_ICON_MISSING;
-            qualityCell.innerHTML = '<span class="ep-missing-label">Missing</span>';
+            // Unaired-vs-missing split mirrors the server template:
+            // neutral state for episodes that haven't aired yet, red
+            // Missing for aired-but-absent.
+            if (ep.unaired) {
+                row.classList.remove('ep-row-missing');
+                row.classList.add('ep-row-unaired');
+                if (statusCell) statusCell.innerHTML = STATUS_ICON_UNAIRED;
+                qualityCell.innerHTML = '<span class="ep-unaired-label">Unaired</span>';
+            } else {
+                row.classList.remove('ep-row-unaired');
+                row.classList.add('ep-row-missing');
+                if (statusCell) statusCell.innerHTML = STATUS_ICON_MISSING;
+                qualityCell.innerHTML = '<span class="ep-missing-label">Missing</span>';
+            }
             delete qualityCell.dataset.originalHtml;
         }
     }

--- a/static/js/series_config.js
+++ b/static/js/series_config.js
@@ -74,7 +74,8 @@ function openManualOverride(epNumber, currentSource, currentResolution, isRemux,
     const srcSelect = document.getElementById('override-source');
     const resSelect = document.getElementById('override-resolution');
     const status = document.getElementById('override-status');
-    if (title) title.textContent = `Override classification — Episode ${epNumber}`;
+    // ASCII separator: house style bans em dashes in user-facing text.
+    if (title) title.textContent = `Override classification: Episode ${epNumber}`;
     if (srcSelect) {
         const key = overrideKeyFromClassification(currentSource, isRemux, isBdmv, webKind);
         srcSelect.value = OVERRIDE_SOURCE_MAP[key] ? key : 'bluray';

--- a/static/js/series_episode_actions.js
+++ b/static/js/series_episode_actions.js
@@ -35,14 +35,14 @@ function toggleMonitorAll(dbId, currentlyAllMonitored) {
         document.querySelectorAll('.ep-mon-btn').forEach(monBtn => {
             monBtn.textContent = newState ? 'Yes' : 'No';
             monBtn.className = 'ep-mon-btn ' + (newState ? 'ep-mon-yes' : 'ep-mon-no');
-            monBtn.title = newState ? 'Monitored — click to unmonitor' : 'Not monitored — click to monitor';
+            monBtn.title = newState ? 'Monitored; click to unmonitor' : 'Not monitored; click to monitor';
         });
         // Update the monitor-all button
         if (btn) {
             btn.disabled = false;
             btn.classList.toggle('is-active', newState);
             btn.onclick = function() { toggleMonitorAll(dbId, newState); };
-            btn.title = newState ? 'All monitored — click to unmonitor all' : 'Click to monitor all episodes';
+            btn.title = newState ? 'All monitored; click to unmonitor all' : 'Click to monitor all episodes';
             btn.innerHTML = newState
                 ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>'
                 : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M19 21l-7-5-7 5V5a2 2 0 012-2h10a2 2 0 012 2z"/></svg>';

--- a/static/js/series_interactive_search.js
+++ b/static/js/series_interactive_search.js
@@ -162,7 +162,8 @@ function openInteractiveSearch(epNum, btn) {
     const modal = document.getElementById('isearch-modal');
     const titleEl = document.getElementById('isearch-title');
     const body = document.getElementById('isearch-body');
-    titleEl.textContent = `Interactive Search — Episode ${epNum}`;
+    // ASCII separator: house style bans em dashes in user-facing text.
+    titleEl.textContent = `Interactive Search: Episode ${epNum}`;
     body.innerHTML = '<div class="isearch-loading"><span class="isearch-loading-spinner" aria-hidden="true"></span><span>Searching indexers for episode ' + epNum + '</span></div>';
     modal.style.display = 'flex';
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -803,7 +803,7 @@ async function runCfTest() {
         const parsed = data.parsed || {};
         const rows = [];
         rows.push('<p class="form-hint" style="margin-bottom:8px">Parsed: source=<code>' + esc(parsed.source || 'Unknown') + '</code>, resolution=<code>' + esc(parsed.resolution || 'Unknown') + '</code>, group=<code>' + esc(parsed.group || '(none)') + '</code>' + (parsed.is_remux ? ', <code>remux</code>' : '') + (parsed.is_bdmv ? ', <code>BDMV</code>' : '') + '</p>');
-        rows.push('<p><strong>Total score: ' + Number(data.total_score) + '</strong> — <span class="form-hint">' + Number(data.matched.length) + ' matched, ' + Number(data.not_matched.length) + ' not matched</span></p>');
+        rows.push('<p><strong>Total score: ' + Number(data.total_score) + '</strong> · <span class="form-hint">' + Number(data.matched.length) + ' matched, ' + Number(data.not_matched.length) + ' not matched</span></p>');
         if (data.matched.length > 0) {
             rows.push('<div class="settings-subheading">Matched</div>');
             rows.push('<ul style="list-style:none;padding:0;margin:0 0 12px 0">');
@@ -1226,7 +1226,7 @@ function openExternalAccountPasteModal(provider) {
                 <div class="form-group">
                     <label for="ext-accounts-paste-state">State</label>
                     <input id="ext-accounts-paste-state" type="text" style="width:100%;font-family:monospace;font-size:12px">
-                    <span class="form-hint">CSRF nonce — required. Both fields appear on the callback page.</span>
+                    <span class="form-hint">CSRF nonce; required. Both fields appear on the callback page.</span>
                 </div>
                 <div id="ext-accounts-paste-error" class="form-hint" style="color:var(--red);display:none"></div>
                 <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:12px">

--- a/templates/base.html
+++ b/templates/base.html
@@ -142,23 +142,13 @@
         <a href="/" class="nav-brand"><span class="brand-kanji">旅館</span><span class="brand-latin">Ryokan</span></a>
         <div class="nav-links">
             <a href="/" class="{% if page == "library" %}active{% endif %}">Library</a>
-            {# Bulk-select toggle. Library-only — hidden on every other
-               page since it acts on the library card grid. Lives
-               immediately after the Library link so the affordance
-               sits at the natural read-order start of the nav.
-               Library page only; on every other page the button is not
-               in the DOM at all and toggleBulkSelectMode() (defined
-               in index.js) is undefined since index.js doesn't load
-               either. #}
-            {% if page == "library" %}
-            <button type="button" id="bulk-select-toggle" class="nav-action bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
-                <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <polyline points="9 11 12 14 22 4"/>
-                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
-                </svg>
-                <span class="bulk-select-toggle-label">Select</span>
-            </button>
-            {% endif %}
+            {# The bulk-select toggle used to live here (library-only,
+               after the Library link). It moved into the library
+               toolbar next to "+ Add Series" (templates/index.html)
+               so the topbar's item positions stay identical on every
+               page — a page-scoped action in persistent chrome made
+               the whole nav shift left/right between library and
+               non-library pages under hx-boost's instant swaps. #}
             {# Issue #116 — Calendar entry. Desktop variant always
                visible in the topbar; the library-only mobile-icon
                variant lives in the library-only block below so

--- a/templates/downloads.html
+++ b/templates/downloads.html
@@ -31,7 +31,7 @@
         {% else if queue.is_empty() %}
         <div class="logs-empty">
             <p>No active downloads.</p>
-            <p class="form-hint">New grabs land here automatically — via RSS, auto-search, or a manual grab from the Search tab.</p>
+            <p class="form-hint">New grabs land here automatically; via RSS, auto-search, or a manual grab from the Search tab.</p>
         </div>
         {% else %}
         <div class="rss-table-wrap"><table class="rss-table"><thead><tr>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,90 +4,103 @@
 {% block title %} - Library{% endblock %}
 
 {% block content %}
-<div class="page-header">
-    <div class="page-header-row library-header-row">
-        <div>
+<div class="page-header library-header">
+    {# ── Row 1: identity + primary. Title with ambient collection
+       counts on the left; search (the highest-frequency control) and
+       the page's one primary action on the right. Each row has ONE
+       flexible element (here: the search input) so resizing never
+       wraps controls into ambiguous positions. #}
+    <div class="library-identity-row">
+        <div class="library-title-group">
             <h2>Anime Library</h2>
+            <span class="library-count">{{ total_count }} series{% if airing_count > 0 %} &middot; {{ airing_count }} airing{% endif %}</span>
         </div>
-        <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap">
-            {# All filter controls in one form so they share state
-               without hidden-input mirrors. Visual order is list →
-               search → sort → clear, putting the search box between
-               the two dropdowns. Each control auto-submits on its
-               own native event; the search input uses a 250ms
-               debounce on `input` so each keystroke isn't a fresh
-               navigation. #}
-            <form method="get" action="/" class="library-filter-form" style="display:flex;gap:6px;align-items:center;flex-wrap:wrap">
-                {% if !custom_list_names.is_empty() %}
-                <label for="library-list-filter" class="visually-hidden">Filter by custom list</label>
-                <select id="library-list-filter" name="list" class="folder-select" onchange="this.form.submit()">
-                    <option value="">All custom lists</option>
-                    {% for name in custom_list_names %}
-                    <option value="{{ name }}"{% if name.as_str() == custom_list_filter.as_str() %} selected{% endif %}>{{ name }}</option>
-                    {% endfor %}
-                </select>
+        {# Search form: the server GET is the no-JS fallback; with JS,
+           liveLibrarySearch filters the rendered grid client-side and
+           mirrors ?search= into the URL via replaceState. Hidden
+           inputs carry scope + sort so a no-JS submit doesn't drop
+           them. Enter is prevented so the live filter stays canonical
+           when JS runs. Press / anywhere on the page to focus. #}
+        <form method="get" action="/" class="library-search-form">
+            {% if !custom_list_filter.is_empty() %}<input type="hidden" name="list" value="{{ custom_list_filter }}">{% endif %}
+            {% if sort_value.as_str() != "recent" %}<input type="hidden" name="sort" value="{{ sort_value }}">{% endif %}
+            <label for="library-search" class="visually-hidden">Search library</label>
+            <input type="search"
+                   id="library-search"
+                   name="search"
+                   placeholder="Search library&hellip;"
+                   title="Press / to search"
+                   class="library-search-input"
+                   value="{{ search_query }}"
+                   autocomplete="off"
+                   oninput="liveLibrarySearch(this)"
+                   onkeydown="if(event.key==='Enter'){event.preventDefault();}">
+        </form>
+        <button class="btn btn-primary library-add-btn" onclick="openAddModal()">+ Add Series</button>
+    </div>
+    {# ── Row 2: scope + presentation. Custom-list chips make the
+       active scope visible at a glance (the old closed dropdown hid
+       the one piece of state that changes what the whole grid means)
+       and replace the Clear pill outright: clearing is clicking
+       "All". Chip hrefs carry sort through because sort is
+       presentation, not a filter; search is deliberately NOT carried
+       because switching scope restarts browsing. The chip strip
+       scrolls horizontally when space runs out. #}
+    <div class="library-scope-row">
+        {% if !list_counts.is_empty() %}
+        <nav class="library-chips" aria-label="Filter by custom list">
+            <a class="library-chip{% if custom_list_filter.is_empty() %} active{% endif %}" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}">All <span class="library-chip-count">{{ total_count }}</span></a>
+            {% for (name, count) in list_counts %}
+            <a class="library-chip{% if name.as_str() == custom_list_filter.as_str() %} active{% endif %}" href="/?list={{ name|urlencode }}{% if sort_value.as_str() != "recent" %}&amp;sort={{ sort_value }}{% endif %}">{{ name }} <span class="library-chip-count">{{ count }}</span></a>
+            {% endfor %}
+        </nav>
+        {% else %}
+        {# No lists synced yet: a lone "All" chip would be noise, but
+           the row itself stays so sort + Select keep a stable
+           position. The spacer holds them against the right edge. #}
+        <div class="library-chips-spacer"></div>
+        {% endif %}
+        <div class="library-scope-tools">
+            {# Two-part sort: key select + direction toggle. Option
+               values are each key's DEFAULT direction (recent =
+               newest first, title = A to Z, score = high first) so
+               picking a key is one interaction; the arrow flips
+               within the key. librarySortNavigate in index.js
+               recomposes the canonical ?sort= value and preserves
+               ?list= + the live search text. #}
+            <label for="library-sort-key" class="visually-hidden">Sort</label>
+            <select id="library-sort-key" class="folder-select library-sort-key" onchange="librarySortKeyChanged(this)">
+                <option value="recent"{% if sort_key.as_str() == "recent" %} selected{% endif %}>Recently added</option>
+                <option value="title"{% if sort_key.as_str() == "title" %} selected{% endif %}>Title</option>
+                {% if !score_format.is_empty() %}
+                <option value="score"{% if sort_key.as_str() == "score" %} selected{% endif %}>My score</option>
                 {% endif %}
-                <label for="library-search" class="visually-hidden">Search library</label>
-                {# Search runs entirely client-side: `liveLibrarySearch`
-                   filters the already-rendered .series-card grid in
-                   place and stamps `?search=foo` into the URL via
-                   replaceState, so a reload still loads the right
-                   subset (the server handler stays as the no-JS
-                   fallback). Enter is prevented on the input so the
-                   form doesn't navigate; the dropdowns still
-                   submit-on-change because list and sort genuinely
-                   need server work. #}
-                <input type="search"
-                       id="library-search"
-                       name="search"
-                       placeholder="Search library…"
-                       class="library-search-input{% if custom_list_names.is_empty() %} library-search-input-wide{% endif %}"
-                       value="{{ search_query }}"
-                       autocomplete="off"
-                       oninput="liveLibrarySearch(this)"
-                       onkeydown="if(event.key==='Enter'){event.preventDefault();}">
-                {# Sort dropdown always renders so the universal
-                   options (Recently added, oldest first, A→Z, Z→A)
-                   stay available regardless of linkage. The two
-                   score-based options only appear when an external
-                   account is linked (`score_format` non-empty);
-                   without one there's nothing to sort against. #}
-                <label for="library-sort" class="visually-hidden">Sort</label>
-                <select id="library-sort" name="sort" class="folder-select" onchange="this.form.submit()">
-                    <option value="recent"{% if sort_value.as_str() == "recent" %} selected{% endif %}>Recently added</option>
-                    <option value="oldest"{% if sort_value.as_str() == "oldest" %} selected{% endif %}>Oldest first</option>
-                    <option value="title_asc"{% if sort_value.as_str() == "title_asc" %} selected{% endif %}>Title (A → Z)</option>
-                    <option value="title_desc"{% if sort_value.as_str() == "title_desc" %} selected{% endif %}>Title (Z → A)</option>
-                    {% if !score_format.is_empty() %}
-                    <option value="score"{% if sort_value.as_str() == "score" %} selected{% endif %}>My score (high → low)</option>
-                    <option value="score_asc"{% if sort_value.as_str() == "score_asc" %} selected{% endif %}>My score (low → high)</option>
-                    {% endif %}
-                </select>
-                {# Always rendered so its layout slot is reserved;
-                   visibility flips on/off so its presence doesn't
-                   shift neighbors when a filter becomes active. The
-                   element is also aria-hidden + tabindex=-1 in the
-                   inactive state so a screen-reader / keyboard user
-                   can't reach a "Clear" link that does nothing.
-
-                   The href carries the current sort through because
-                   sort is presentation, not a filter — clearing
-                   filters shouldn't snap the user back to the
-                   default "Recently added" order. The default
-                   ("recent") is omitted to keep the cleared URL
-                   tidy. #}
-                {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
-                <a class="btn btn-pill library-filter-clear" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}" title="Clear filters">Clear</a>
-                {% else %}
-                <a class="btn btn-pill library-filter-clear library-filter-clear-hidden" href="/{% if sort_value.as_str() != "recent" %}?sort={{ sort_value }}{% endif %}" tabindex="-1" aria-hidden="true">Clear</a>
-                {% endif %}
-            </form>
-            <button class="btn btn-primary" style="margin-left: 32px;" onclick="openAddModal()">+ Add Series</button>
+            </select>
+            <button type="button"
+                    id="library-sort-dir"
+                    class="library-sort-dir"
+                    data-desc="{{ sort_desc }}"
+                    onclick="librarySortDirToggled(this)"
+                    title="{% if sort_desc %}Descending; click for ascending{% else %}Ascending; click for descending{% endif %}"
+                    aria-label="Toggle sort direction">
+                <svg class="library-sort-dir-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
+            </button>
+            {# Bulk-select toggle (issue #125): a mode, not an action,
+               so it sits last among the quiet tools. index.js owns
+               the mode; this button gets .active + the "Cancel" label
+               swap while selecting. #}
+            <button type="button" id="bulk-select-toggle" class="btn btn-secondary bulk-select-toggle" onclick="toggleBulkSelectMode()" title="Select multiple series for bulk actions">
+                <svg class="bulk-select-toggle-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polyline points="9 11 12 14 22 4"/>
+                    <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/>
+                </svg>
+                <span class="bulk-select-toggle-label">Select</span>
+            </button>
         </div>
     </div>
 </div>
 
-{% if library.is_empty() %}
+{% if cards.is_empty() %}
 <div class="empty-state">
     {% if !search_query.is_empty() || !custom_list_filter.is_empty() %}
     {# Distinguish "filter excluded everything" from "library is
@@ -117,7 +130,7 @@
 </div>
 {% else %}
 <div class="library-grid" id="library-grid">
-    {% for s in library %}
+    {% for (s, prog) in cards %}
     <a href="/series/{{ s.id }}" class="series-card" id="series-{{ s.id }}">
         {# Bulk-select checkbox overlay (issue #125). Hidden until the
            library grid enters .selecting mode (see static/js/index.js
@@ -144,6 +157,18 @@
             <div class="series-cover-placeholder">No Image</div>
             {% endif %}
         </div>
+        {# Completeness bar: its own strip between poster and card
+           body (not overlaid on the artwork, which buried the color
+           against busy posters). One question — "do I have what's
+           aired?" — in three states that reuse the episode table's
+           vocabulary: green = every aired episode on disk, green
+           fill with red remainder = missing aired episodes, accent
+           pulse = download in flight. Airing status is NOT encoded
+           here; the RELEASING/FINISHED chip below already carries
+           it. Unmonitored series render the bar dimmed. #}
+        <div class="card-progress card-progress-{{ prog.state }}{% if !prog.monitored %} card-progress-unmonitored{% endif %}" title="{{ prog.label }}">
+            <div class="card-progress-fill" style="width: {{ prog.pct }}%"></div>
+        </div>
         <div class="series-info">
             <p class="series-title title-switcher" title="{{ s.title }}">
                 <span class="title-option" data-title-lang="english">{% if !s.title_english.is_empty() %}{{ s.title_english }}{% else if !s.title_romaji.is_empty() %}{{ s.title_romaji }}{% else if !s.title_native.is_empty() %}{{ s.title_native }}{% else %}{{ s.title }}{% endif %}</span>
@@ -153,6 +178,11 @@
             <div class="series-meta">
                 <span class="tag tag-res">{% if !s.format.is_empty() %}{{ s.format.replace("_", " ") }}{% else %}TBA{% endif %}</span>
                 {% if let Some(eps) = s.episodes %}<span class="tag tag-res series-eps">{{ eps }} eps</span>{% endif %}
+                {# Numeric readout for the bar's missing state — the
+                   colorblind-safe fallback and the "how bad" answer.
+                   Complete/idle cards skip it; absence means nothing
+                   to act on. #}
+                {% if prog.state.as_str() == "missing" %}<span class="tag tag-progress-missing" title="{{ prog.label }}">{{ prog.downloaded }}/{{ prog.aired }}</span>{% endif %}
                 <span class="tag tag-status-{{ s.status|lowercase }}">{{ s.status.replace("_", " ") }}</span>
                 {# #62 — user's personal score from their linked
                    AL/MAL account. Hidden when no account is linked or

--- a/templates/partials/series/interactive_search_table.html
+++ b/templates/partials/series/interactive_search_table.html
@@ -7,7 +7,10 @@
    `grabInteractiveBatchResult` can read it on click without keeping a
    `_isearchResults` JS array in lockstep with the rendered DOM. #}
 {% if rows.is_empty() %}
-<div class="isearch-empty">{{ empty_message }}</div>
+<div class="isearch-empty">
+    <p>{{ empty_message }}</p>
+    <p class="isearch-empty-hint">{{ empty_hint }}</p>
+</div>
 {% else %}
 <table class="interactive-search-table">
     <thead>

--- a/templates/partials/settings/indexers/list.html
+++ b/templates/partials/settings/indexers/list.html
@@ -85,13 +85,13 @@
                         {% if !idx.enabled %}
                         <span class="dc-status-pill dc-status-pill-disabled">Disabled</span>
                         {% else if !idx.rss_enabled %}
-                        <span class="dc-status-pill dc-status-pill-ok" title="Search-only — RSS auto-sync off for this indexer">Enabled</span>
+                        <span class="dc-status-pill dc-status-pill-ok" title="Search-only; RSS auto-sync off for this indexer">Enabled</span>
                         {% else if !idx.rss_last_poll_error.is_empty() %}
                         <span class="dc-status-pill dc-status-pill-err" title="{{ idx.rss_last_poll_error }}">RSS error</span>
                         {% else if let Some(_) = idx.rss_last_polled_at %}
                         <span class="dc-status-pill dc-status-pill-ok" title="Last poll returned {{ idx.rss_last_item_count }} item{% if idx.rss_last_item_count == 1 %}{% else %}s{% endif %}">&#10003; RSS ({{ idx.rss_last_item_count }})</span>
                         {% else %}
-                        <span class="dc-status-pill dc-status-pill-loading" title="RSS enabled but not yet polled — first sync runs on the next interval">RSS idle</span>
+                        <span class="dc-status-pill dc-status-pill-loading" title="RSS enabled but not yet polled; first sync runs on the next interval">RSS idle</span>
                         {% endif %}
                     </div>
                     <dl class="dc-card-meta">

--- a/templates/partials/settings/quality.html
+++ b/templates/partials/settings/quality.html
@@ -122,6 +122,6 @@
             <div class="form-group">
                 <label for="default_restrict_to_uploader">Default Restrict to Uploader</label>
                 <input type="text" name="default_restrict_to_uploader" id="default_restrict_to_uploader" value="{{ config.default_restrict_to_uploader }}" placeholder="SubsPlease">
-                <span class="form-hint">When set, every Nyaa search is scoped to <code>?u=&lt;name&gt;</code> so only this uploader's releases come back. Tighter and faster than a title-contains group filter. Must match an actual Nyaa account — groups without a dedicated uploader return zero results. Per-series overrides on the series page beat this default.</span>
+                <span class="form-hint">When set, every Nyaa search is scoped to <code>?u=&lt;name&gt;</code> so only this uploader's releases come back. Tighter and faster than a title-contains group filter. Must match an actual Nyaa account; groups without a dedicated uploader return zero results. Per-series overrides on the series page beat this default.</span>
             </div>
         </fieldset>

--- a/templates/search.html
+++ b/templates/search.html
@@ -72,7 +72,7 @@
                                     </li>
                                     {% endfor %}
                                 </ul>
-                                <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page — open the series page's interactive search for the full breakdown.</div>
+                                <div class="form-hint">CF contributions shown here are evaluated against the release's classification alone. SeaDex-based CFs need a tracked AniList series to resolve, so they never fire on the manual search page; open the series page's interactive search for the full breakdown.</div>
                                 {% endif %}
                             </div>
                         </details>

--- a/templates/series.html
+++ b/templates/series.html
@@ -393,7 +393,11 @@
                    because the post-processing-off case
                    (`downloaded=true, on_disk=false, quality_state="completed"`)
                    should render as on-hand, not queued. #}
-                <tr class="{% if ep.downloaded %}ep-row-have{% else if ep.quality_state == "grabbed" %}ep-row-queued{% else %}ep-row-missing{% endif %}">
+                {# `data-unaired` mirrors Episode.unaired so client-side
+                   optimistic patches (cancel-pending's "deleted" flip in
+                   series.js) can restore the correct no-file state
+                   without waiting for the next /episodes poll. #}
+                <tr class="{% if ep.downloaded %}ep-row-have{% else if ep.quality_state == "grabbed" %}ep-row-queued{% else if ep.unaired %}ep-row-unaired{% else %}ep-row-missing{% endif %}" data-unaired="{{ ep.unaired }}">
                     <td class="ep-col-status">
                         {% if ep.on_disk %}
                         <span class="ep-status-icon ep-have" title="On disk">
@@ -402,6 +406,13 @@
                         {% else if ep.downloaded %}
                         <span class="ep-status-icon ep-have" title="Downloaded (post-processing disabled; file not in library root)">
                             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+                        </span>
+                        {% else if ep.unaired %}
+                        {# Clock icon, neutral color: nothing is wrong,
+                           the episode just hasn't aired yet. Red X is
+                           reserved for aired-but-absent (actionable). #}
+                        <span class="ep-status-icon ep-unaired" title="Unaired">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>
                         </span>
                         {% else %}
                         <span class="ep-status-icon ep-missing" title="Missing">
@@ -479,11 +490,13 @@
                             {% endif %}
                         {% else if ep.on_disk %}
                         <span class="tag tag-quality">UNKNOWN</span>
+                        {% else if ep.unaired %}
+                        <span class="ep-unaired-label">Unaired</span>
                         {% else %}
                         <span class="ep-missing-label">Missing</span>
                         {% endif %}
                         {% if ep.needs_review && !ep.manual_override %}
-                        <span class="tag tag-needs-review" title="Classifier wasn't confident — click override to tag manually">⚠ review</span>
+                        <span class="tag tag-needs-review" title="Classifier wasn't confident; click override to tag manually">⚠ review</span>
                         {% endif %}
                     </td>
                     <td class="ep-col-actions">
@@ -650,7 +663,7 @@
                 hx-target="#override-status"
                 hx-swap="innerHTML"
                 hx-on::after-request="if (event.detail.successful) setTimeout(function(){ window.location.reload(); }, 600)"
-                title="Re-run the full-pipeline classifier against this episode's on-disk file. Useful after editing Release Groups or Custom Formats — skip the 6-hour sweep. Pinned rows are rejected; clear the override first.">Re-classify</button>
+                title="Re-run the full-pipeline classifier against this episode's on-disk file. Useful after editing Release Groups or Custom Formats; skips the 6-hour sweep. Pinned rows are rejected; clear the override first.">Re-classify</button>
             {# Clear + Apply both POST to manual-override; the server
                returns `HX-Refresh: true` so htmx triggers a full page
                reload, equivalent to the prior JS `location.reload()`. #}

--- a/templates/system.html
+++ b/templates/system.html
@@ -466,7 +466,7 @@
         <div class="cf-section-header">
             <h3>Maintenance actions</h3>
         </div>
-        <p class="cf-section-desc">One-shot operations against the library and metadata cache. Each runs immediately — independent of the Save button below.</p>
+        <p class="cf-section-desc">One-shot operations against the library and metadata cache. Each runs immediately, independent of the Save button below.</p>
         <div class="debug-actions-group">
             <div class="debug-action-row">
                 <button type="button" class="btn btn-secondary" onclick="rebuildAniListCache(this)">Rebuild metadata cache</button>


### PR DESCRIPTION
A UI-focused batch from a Claude-in-Chrome design review of the running app, in five commits:

**Layout fixes**
- `fix(ui)`: kill the horizontal scrollbar minted by the two `100vw` viewport-breakout shapes (series banner, Settings/System tabbed pages) via `html, body { overflow-x: clip }`, and cap `.tabbed-page` so ultrawide monitors center the sidebar+content unit.
- `fix(ui)`: the topbar no longer shifts between pages (the library-only Select toggle moved out of persistent nav), and the 641-900px band compresses (kanji-only brand, tighter links) instead of clipping Logout off the viewport.

**Unaired vs Missing** — episode rows on a releasing series no longer scream red "Missing" for episodes that haven't aired. New neutral Unaired state (dim clock) when there's no file and the air date is in the future or unknown on a non-finished series; red stays reserved for aired-but-absent. Client pollers mirror the split. Same shape as Sonarr's distinction.

**Interface voice** — Downloads queue errors name the failing client by configured name and kind and point at Settings (raw reqwest errors demoted to System → Logs); interactive-search empty states gained next-step direction; user-facing em dashes swept per house style.

**Library page redesign**
- Two-row header split by role: title + collection counts + search + Add Series, then custom-list chips (member counts, one-click scope, no more Clear pill) + two-part sort (key select + direction arrow; URL keeps the canonical `?sort=` vocabulary) + Select. `/` focuses search. Layout holds its shape at every width; verified at 1600/1050/820/660/420px.
- Per-card completeness bars answering "do I have what's aired?": green complete, red gap for missing aired episodes (with an N/M chip as the colorblind-safe readout), pulsing accent while a grab is in flight. Fill counts against aired episodes so a current releasing series reads complete. Data from one batched folder scan + two aggregate queries, computed only for rendered cards.

Full suite green at every commit boundary that compiles a distinct state (2548 passed, 24 skipped), fmt + clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)